### PR TITLE
docs: remove stale version references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dns-aid publish \
     --capability chat \
     --capability code-review
 
-# Publish with BANDAID custom SVCB parameters (v0.4.8+)
+# Publish with BANDAID custom SVCB parameters
 dns-aid publish \
     --name booking \
     --domain example.com \
@@ -103,7 +103,7 @@ dns-aid zones
 # Delete an agent
 dns-aid delete --name my-agent --domain example.com --protocol mcp
 
-# Index Management (v0.3.0+)
+# Index Management
 # List agents in a domain's index record
 dns-aid index list example.com
 
@@ -117,7 +117,7 @@ dns-aid publish --name internal-bot --domain example.com --protocol mcp --no-upd
 
 ### Agent Index Records
 
-DNS-AID v0.3.0 automatically maintains an index record at `_index._agents.{domain}` for efficient discovery:
+DNS-AID automatically maintains an index record at `_index._agents.{domain}` for efficient discovery:
 
 ```
 _index._agents.example.com. TXT "agents=chat:mcp,billing:a2a,support:https"
@@ -139,7 +139,7 @@ DNS-AID also supports HTTP-based agent discovery for compatibility with ANS-styl
 2. `https://_index._aiagents.{domain}/index-wellknown` (ANS-style)
 3. `https://{domain}/.well-known/agents-index.json` (well-known path)
 
-**Capability Document endpoint (v0.4.8+):**
+**Capability Document endpoint:**
 - `https://index.aiagents.{domain}/cap/{agent-name}` — returns a capability document JSON per agent
 
 ```bash
@@ -163,16 +163,16 @@ agents = await dns_aid.discover("highvelocitynetworking.com", use_http_index=Tru
 | **DNS (default)** | Maximum decentralization, offline caching, minimal round trips |
 | **HTTP Index** | Rich metadata upfront, ANS compatibility, model cards, capabilities, direct endpoints |
 
-**FQDN as Source of Truth (v0.4.7):** The HTTP index only needs to provide each agent's FQDN (e.g., `_booking._mcp._agents.example.com`). Agent name and protocol are extracted from the FQDN — no separate `protocols` field needed. DNS SVCB lookup then resolves the authoritative endpoint.
+**FQDN as Source of Truth:** The HTTP index only needs to provide each agent's FQDN (e.g., `_booking._mcp._agents.example.com`). Agent name and protocol are extracted from the FQDN — no separate `protocols` field needed. DNS SVCB lookup then resolves the authoritative endpoint.
 
-**Discovery Transparency (v0.4.6+):** Each discovered agent includes source fields showing how data was resolved:
+**Discovery Transparency:** Each discovered agent includes source fields showing how data was resolved:
 
 | Field | Values | Description |
 |-------|--------|-------------|
 | `endpoint_source` | `dns_svcb`, `http_index_fallback`, `direct` | How the endpoint was resolved |
-| `capability_source` | `cap_uri`, `txt_fallback`, `none` | How capabilities were discovered (v0.4.8+) |
+| `capability_source` | `cap_uri`, `txt_fallback`, `none` | How capabilities were discovered |
 
-**Capability Resolution (v0.4.8+):** Capabilities are resolved with the following priority:
+**Capability Resolution:** Capabilities are resolved with the following priority:
 1. **SVCB `cap` URI** → fetch capability document (JSON with capabilities, version, description)
 2. **TXT record fallback** → `capabilities=chat,support` from DNS TXT record
 3. **HTTP Index inline** → capabilities embedded in the index JSON response
@@ -260,7 +260,7 @@ _chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port
 _chat._a2a._agents.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
 ```
 
-**BANDAID Custom SVCB Parameters (v0.4.8+):** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
+**BANDAID Custom SVCB Parameters:** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
 
 ```
 _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -793,7 +793,7 @@ dns-aid delete --name my-agent --domain example.com --protocol mcp --force --no-
 # List available DNS zones
 dns-aid zones
 
-# Agent Index Commands (new in v0.3.0)
+# Agent Index Commands
 dns-aid index list example.com           # List agents in domain's index
 dns-aid index sync example.com           # Sync index with actual DNS records
 ```
@@ -862,8 +862,8 @@ dns-aid-mcp --transport http --host 0.0.0.0 --port 8000
 | `verify_agent_dns` | Verify agent DNS records |
 | `list_published_agents` | List all agents in a zone |
 | `delete_agent_from_dns` | Delete an agent from DNS (auto-updates index) |
-| `list_agent_index` | List agents in domain's index (new in v0.3.0) |
-| `sync_agent_index` | Sync index with actual DNS records (new in v0.3.0) |
+| `list_agent_index` | List agents in domain's index |
+| `sync_agent_index` | Sync index with actual DNS records |
 
 ### Health Endpoints (HTTP Transport)
 
@@ -915,7 +915,7 @@ except Exception as e:
 
 ## SDK: Invocation & Telemetry
 
-The Tier 1 SDK (v0.6.0+) provides agent invocation with automatic telemetry capture, and community-wide ranking queries.
+The Tier 1 SDK provides agent invocation with automatic telemetry capture, and community-wide ranking queries.
 
 ### Top-Level Functions
 
@@ -977,10 +977,10 @@ async with AgentClient(config=config) as client:
 |--------|-------------|
 | `invoke(agent, method, arguments, timeout)` | Invoke agent, return `InvocationResult` |
 | `rank(strategy)` | Rank all invoked agents by composite score |
-| `fetch_rankings(fqdns, limit)` | Fetch community-wide rankings from telemetry API (v0.6.0+) |
+| `fetch_rankings(fqdns, limit)` | Fetch community-wide rankings from telemetry API |
 | `signals` | Property: list of all collected `InvocationSignal` objects |
 
-#### fetch_rankings() (v0.6.0+)
+#### fetch_rankings()
 
 ```python
 async def fetch_rankings(
@@ -1032,8 +1032,8 @@ config = SDKConfig(
     otel_enabled=False,          # Enable OpenTelemetry export
     otel_endpoint=None,          # OTLP endpoint URL
     otel_export_format="otlp",   # "otlp" or "console"
-    http_push_url=None,          # POST signals to remote telemetry API (v0.5.5+)
-    telemetry_api_url=None,      # Base URL for fetch_rankings() queries (v0.6.0+)
+    http_push_url=None,          # POST signals to remote telemetry API
+    telemetry_api_url=None,      # Base URL for fetch_rankings() queries
 )
 
 # Or from environment variables:
@@ -1050,8 +1050,8 @@ config = SDKConfig.from_env()
 | `DATABASE_URL` | None | PostgreSQL connection URL |
 | `DNS_AID_SDK_OTEL_ENABLED` | false | Enable OpenTelemetry |
 | `DNS_AID_SDK_OTEL_ENDPOINT` | None | OTLP collector URL |
-| `DNS_AID_SDK_HTTP_PUSH_URL` | None | POST signals to this URL (v0.5.5+) |
-| `DNS_AID_SDK_TELEMETRY_API_URL` | None | Base URL for fetch_rankings() queries (v0.6.0+) |
+| `DNS_AID_SDK_HTTP_PUSH_URL` | None | POST signals to this URL |
+| `DNS_AID_SDK_TELEMETRY_API_URL` | None | Base URL for fetch_rankings() queries |
 
 ### InvocationResult
 
@@ -1108,7 +1108,7 @@ composite = 0.40 * reliability   (success_rate * 100)
 - `LatencyFirstStrategy` — prioritizes lowest latency
 - `ReliabilityFirstStrategy` — prioritizes highest success rate
 
-### HTTP Telemetry Push (v0.5.5+)
+### HTTP Telemetry Push
 
 The SDK can push signals to a remote telemetry API for centralized monitoring:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ SVCB record found?
          Set endpoint_source = "http_index_fallback"
 ```
 
-### Custom SVCB Parameters (BANDAID v0.4.8)
+### Custom SVCB Parameters (BANDAID)
 
 The BANDAID draft defines custom SVCB parameters:
 
@@ -152,7 +152,7 @@ DNS/HTTP Discovery → AgentRecord → DiscoveredAgent → Repository → Databa
 ---
 
 
-## Tier 1: Execution Telemetry SDK (v0.6.0)
+## Tier 1: Execution Telemetry SDK
 
 The SDK wraps agent invocations with telemetry capture, enabling performance
 monitoring, agent ranking, community-wide ranking queries, and observability export.
@@ -195,7 +195,7 @@ dns_aid.invoke(agent)
     → InvocationResult (data + signal)
 ```
 
-### HTTP Telemetry Push (v0.5.5+)
+### HTTP Telemetry Push
 
 The SDK can push telemetry signals to a remote API endpoint for centralized monitoring:
 
@@ -224,7 +224,7 @@ Claude Desktop MCP Server
 | A2A | `A2AProtocolHandler` | JSON-RPC 2.0 / HTTPS | `tasks/send`, `tasks/get` |
 | HTTPS | `HTTPSProtocolHandler` | REST / HTTPS | Method appended to URL path |
 
-### Endpoint Path Resolution (v0.5.0)
+### Endpoint Path Resolution
 
 DNS SVCB records provide host + port but no HTTP path. The discoverer now
 enriches endpoints by fetching `.well-known/agent.json` from each agent's
@@ -246,13 +246,13 @@ and gracefully skips hosts that don't serve `.well-known/agent.json`.
 
 See `alembic/versions/` for migration history:
 - `e2058c20b856` — Baseline schema (domains, agents, crawl_history)
-- `2e439fab6e3b` — BANDAID v0.4.8 columns (cap_uri, cap_sha256, bap,
+- `2e439fab6e3b` — BANDAID columns (cap_uri, cap_sha256, bap,
   policy_uri, realm, endpoint_source, capability_source)
-- `a1b2c3d4e5f6` — Invocation signals table (telemetry SDK v0.5.5)
+- `a1b2c3d4e5f6` — Invocation signals table (telemetry SDK)
 
 ---
 
-## Community Rankings (v0.6.0)
+## Community Rankings
 
 The SDK can fetch community-wide telemetry rankings from the central API:
 
@@ -407,7 +407,7 @@ dns-aid-k8s
 
 ---
 
-## JWS Signature Verification (v0.5.0)
+## JWS Signature Verification
 
 DNS-AID provides application-layer signature verification as an alternative to
 DNSSEC for environments where DNSSEC cannot be enabled.
@@ -585,7 +585,7 @@ significantly easier to deploy for organizations without DNSSEC capability.
 
 ---
 
-## Backend API: get_record() Method (v0.6.0)
+## Backend API: get_record() Method
 
 All DNS backends now implement `get_record()` for direct API-based record lookup:
 

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -93,7 +93,7 @@ dns-aid publish \
 # ✓ Updated index at _index._agents.highvelocitynetworking.com (1 agent(s))
 ```
 
-> **New in v0.3.0:** The index record is automatically created/updated when you publish. This enables single-query discovery of all agents at a domain.
+> The index record is automatically created/updated when you publish. This enables single-query discovery of all agents at a domain.
 
 > **Option B: MCP Protocol** — To publish an MCP agent instead, use `--protocol mcp`. The SVCB record will have `alpn="mcp"`. MCP agents use different connection patterns (see Demo 2, Option D for MCP server integration).
 
@@ -120,7 +120,7 @@ dns-aid verify _multiagent._a2a._agents.highvelocitynetworking.com
 #   Security Score: 55/100 (Fair)
 ```
 
-### Step 4b: View the Agent Index (New in v0.3.0)
+### Step 4b: View the Agent Index
 
 ```bash
 # List all agents in the domain's index
@@ -154,11 +154,11 @@ dns-aid discover highvelocitynetworking.com --protocol a2a --name multiagent
 # └────────────┴──────────┴─────────────────────────┴──────────────────┘
 ```
 
-### Step 5b: HTTP Index Discovery (ANS-Style) - v0.4.1+
+### Step 5b: HTTP Index Discovery (ANS-Style)
 
 DNS-AID supports HTTP index discovery for ANS compatibility. This provides richer metadata than DNS TXT records.
 
-**v0.4.2 Enhancement:** HTTP index can now include direct `endpoint` URLs for MCP path routing (e.g., `https://booking.example.com/mcp`).
+HTTP index can also include direct `endpoint` URLs for MCP path routing (e.g., `https://booking.example.com/mcp`).
 
 ```bash
 # Discover using HTTP index endpoint
@@ -632,7 +632,7 @@ dns-aid publish \
 
 ### Step 2: Verify Index Record (Auto-Created)
 
-**New in v0.3.0:** The index is automatically created when you publish. Verify it:
+The index is automatically created when you publish. Verify it:
 
 ```bash
 dns-aid index list highvelocitynetworking.com
@@ -662,7 +662,7 @@ dns-aid index sync highvelocitynetworking.com
 
 ### Step 3: Submit & Verify Domain (Triggers Auto-Crawl)
 
-**New in v1.2.0:** Verification automatically triggers crawling - no manual SQS needed!
+Verification automatically triggers crawling - no manual SQS needed!
 
 ```bash
 # Submit domain to directory
@@ -736,11 +736,11 @@ dns-aid delete \
 # ✓ Updated index at _index._agents.highvelocitynetworking.com (0 agent(s))
 ```
 
-> **Note:** In v0.3.0+, the delete command automatically updates the index. No manual cleanup needed!
+> **Note:** The delete command automatically updates the index. No manual cleanup needed!
 
 ---
 
-## Demo 5: MCP Agent Proxying (v0.4.2+)
+## Demo 5: MCP Agent Proxying
 
 This demo shows the new MCP agent proxying feature: discover an agent and call its tools directly through Claude Desktop.
 
@@ -836,7 +836,7 @@ Found 5 flights from NYC to London on March 15:
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Key Features (v0.4.8)
+### Key Features
 
 | Feature | Description |
 |---------|-------------|
@@ -851,7 +851,7 @@ Found 5 flights from NYC to London on March 15:
 | **endpoint_source** | Shows where endpoint came from: `dns_svcb`, `http_index_fallback`, or `direct` |
 | **capability_source** | Shows where capabilities came from: `cap_uri`, `txt_fallback`, or `none` |
 
-### Capability Discovery Flow (v0.4.8)
+### Capability Discovery Flow
 
 Capabilities are resolved with the following priority, aligned with the BANDAID draft:
 
@@ -889,9 +889,9 @@ _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. \
     alpn="mcp" port=443 cap="https://index.aiagents.example.com/cap/booking-agent"
 ```
 
-### Discovery Transparency (v0.4.6+)
+### Discovery Transparency
 
-**v0.4.7:** Agent name and protocol are now extracted from the FQDN (e.g., `_booking._mcp._agents.example.com` → name=`booking`, protocol=`mcp`). The HTTP index only needs to provide the FQDN — no separate `protocols` field required.
+Agent name and protocol are now extracted from the FQDN (e.g., `_booking._mcp._agents.example.com` → name=`booking`, protocol=`mcp`). The HTTP index only needs to provide the FQDN — no separate `protocols` field required.
 
 Each discovered agent includes transparency fields showing how data was resolved:
 
@@ -1160,7 +1160,7 @@ kubectl delete service payment-agent
 
 ---
 
-## Demo 7: JWS Signatures (v0.5.0+)
+## Demo 7: JWS Signatures
 
 JWS (JSON Web Signature) provides application-layer verification when DNSSEC isn't available (~70% of domains).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -352,7 +352,7 @@ dns-aid publish \
 # Verify it was created
 dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
 
-# View the agent index (v0.3.0+)
+# View the agent index
 dns-aid index list $DNS_AID_TEST_ZONE --backend cloudflare
 
 # Clean up (auto-removes from index)
@@ -541,7 +541,7 @@ dns-aid delete --name test-agent --domain $DNS_AID_TEST_ZONE --protocol mcp --fo
 
 ## Agent Index Management
 
-DNS-AID v0.3.0 introduces automatic index management. The `_index._agents.{domain}` TXT record lists all agents at a domain, enabling efficient single-query discovery.
+DNS-AID provides automatic index management. The `_index._agents.{domain}` TXT record lists all agents at a domain, enabling efficient single-query discovery.
 
 ### Automatic Index Updates
 
@@ -587,9 +587,9 @@ The index is stored as a TXT record:
 _index._agents.example.com. TXT "agents=chat:mcp,billing:a2a,support:https"
 ```
 
-## Submitting Domains to the Agent Directory (v0.4.0+)
+## Submitting Domains to the Agent Directory
 
-DNS-AID v0.4.0 introduces the Agent Directory - a searchable index of DNS-published agents.
+The Agent Directory is a searchable index of DNS-published agents.
 
 ### Submit Your Domain via CLI
 
@@ -727,7 +727,7 @@ The controller uses the `apply()` idempotent reconciliation pattern — all life
 
 ---
 
-## JWS Signatures (v0.5.0+)
+## JWS Signatures
 
 JWS (JSON Web Signature) provides application-layer verification when DNSSEC isn't available (~70% of domains). Signatures are embedded in SVCB records and verified against a JWKS published at `.well-known/dns-aid-jwks.json`.
 
@@ -799,7 +799,7 @@ is_valid = await verify_signature(
 
 ---
 
-## SDK: Agent Invocation & Telemetry (v0.5.5+)
+## SDK: Agent Invocation & Telemetry
 
 The Tier 1 SDK adds invocation with telemetry capture, agent ranking, and optional OpenTelemetry export.
 
@@ -873,7 +873,7 @@ curl http://localhost:8000/api/v1/telemetry/signals?limit=10
 curl http://localhost:8000/api/v1/telemetry/agents/{fqdn}/scorecard
 ```
 
-**Production Telemetry (v0.5.5+):**
+**Production Telemetry:**
 - **Dashboard:** [directory.velosecurity-ai.io/telemetry](https://directory.velosecurity-ai.io/telemetry)
 - **API:** `https://api.velosecurity-ai.io/api/v1/telemetry/signals`
 
@@ -932,7 +932,7 @@ Restart Claude Desktop, then ask:
 - "Discover agents at example.com"
 - "Publish my agent to DNS"
 
-### MCP Agent Proxying (v0.4.2+)
+### MCP Agent Proxying
 
 The MCP server can now proxy tool calls to discovered agents:
 
@@ -950,7 +950,7 @@ Available MCP tools for agent proxying:
 - `list_agent_tools`: List available tools from a discovered agent
 - `call_agent_tool`: Call a specific tool on a discovered agent
 
-### Discovery Transparency (v0.4.6+)
+### Discovery Transparency
 
 Each discovered agent includes transparency fields showing how data was resolved:
 
@@ -959,15 +959,15 @@ Each discovered agent includes transparency fields showing how data was resolved
 | `endpoint_source` | `dns_svcb` | Endpoint resolved via DNS SVCB lookup (proper BANDAID flow) |
 | | `http_index_fallback` | DNS lookup failed, using HTTP index data only |
 | | `direct` | Endpoint was explicitly provided |
-| `capability_source` | `cap_uri` | Capabilities fetched from SVCB `cap` URI document (v0.4.8+) |
+| `capability_source` | `cap_uri` | Capabilities fetched from SVCB `cap` URI document |
 | | `txt_fallback` | Capabilities from DNS TXT record |
 | | `none` | No capabilities found |
 
-**v0.4.7:** Agent name and protocol are extracted from the FQDN in the HTTP index — no separate `protocols` field needed. The FQDN is the single source of truth.
+Agent name and protocol are extracted from the FQDN in the HTTP index — no separate `protocols` field needed. The FQDN is the single source of truth.
 
-**v0.4.8:** Capabilities are resolved with priority: SVCB `cap` URI → capability document → TXT record fallback. The HTTP index also includes capabilities inline per agent.
+Capabilities are resolved with priority: SVCB `cap` URI → capability document → TXT record fallback. The HTTP index also includes capabilities inline per agent.
 
-### BANDAID Custom SVCB Parameters (v0.4.8+)
+### BANDAID Custom SVCB Parameters
 
 Per the IETF draft, SVCB records can carry custom parameters for richer agent metadata:
 


### PR DESCRIPTION
## Summary
- Remove internal version annotations (v0.3.0+, v0.4.x, v0.5.x) from README.md and all docs/ files
- Features are part of the current release; changelog-style markers belong in CHANGELOG.md, not user-facing documentation
- 5 files updated, 55 lines cleaned

## Files Changed
- `README.md`
- `docs/api-reference.md`
- `docs/architecture.md`
- `docs/demo-guide.md`
- `docs/getting-started.md`