### PR TITLE
chore: LF readiness — SPDX headers, neutral branding, governance templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug in DNS-AID
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Environment
+
+- **Python version**:
+- **DNS-AID version**:
+- **OS**:
+- **DNS backend**: (route53 / infoblox / cloudflare / ddns / mock)
+
+## Logs / Error Output
+
+```
+<!-- Paste relevant logs or error messages -->
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+<!-- Brief description of the feature -->
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- How should this work? -->
+
+## Alternatives Considered
+
+<!-- Any alternative approaches you've considered -->
+
+## Additional Context
+
+<!-- Any other context, mockups, or references -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Description
+
+<!-- Brief description of the changes in this PR -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have added tests that prove my fix is effective or my feature works
+- [ ] All new and existing tests pass (`pytest`)
+- [ ] I have run `ruff check` and `ruff format --check` with no errors
+- [ ] I have run `mypy src/` with no errors
+- [ ] I have updated documentation as needed
+- [ ] My commits include a `Signed-off-by` line (DCO)
+
+## Related Issues
+
+<!-- Link any related issues: Fixes #123, Relates to #456 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,10 +326,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/iracic82/dns-aid/compare/v0.4.8...HEAD
-[0.4.8]: https://github.com/iracic82/dns-aid/compare/v0.4.7...v0.4.8
-[0.3.1]: https://github.com/iracic82/dns-aid/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/iracic82/dns-aid/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/iracic82/dns-aid/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/iracic82/dns-aid/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/iracic82/dns-aid/releases/tag/v0.1.0
+[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.8...HEAD
+[0.4.8]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.7...v0.4.8
+[0.3.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/infobloxopen/dns-aid-core/releases/tag/v0.1.0

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM python:3.11-slim@sha256:6ed5bff4d7396e3244b0f3c2fe578c87862efedd3e5e8cebd14
 
 LABEL org.opencontainers.image.title="DNS-AID MCP Server"
 LABEL org.opencontainers.image.description="DNS-based Agent Identification and Discovery"
-LABEL org.opencontainers.image.source="https://github.com/iracic82/dns-aid-core"
+LABEL org.opencontainers.image.source="https://github.com/infobloxopen/dns-aid-core"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.sbom="cyclonedx"
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,5 +30,5 @@ See [GOVERNANCE.md](GOVERNANCE.md) for the process. In brief:
 
 ## Contact
 
-- GitHub Issues: [dns-aid-core/issues](https://github.com/iracic82/dns-aid-core/issues)
-- Discussions: [dns-aid-core/discussions](https://github.com/iracic82/dns-aid-core/discussions)
+- GitHub Issues: [dns-aid-core/issues](https://github.com/infobloxopen/dns-aid-core/issues)
+- Discussions: [dns-aid-core/discussions](https://github.com/infobloxopen/dns-aid-core/discussions)

--- a/README.md
+++ b/README.md
@@ -144,18 +144,18 @@ DNS-AID also supports HTTP-based agent discovery for compatibility with ANS-styl
 
 ```bash
 # Fetch HTTP index directly
-curl https://index.aiagents.highvelocitynetworking.com/index-wellknown
+curl https://index.aiagents.example.com/index-wellknown
 
 # Fetch capability document for a specific agent
-curl https://index.aiagents.highvelocitynetworking.com/cap/booking-agent
+curl https://index.aiagents.example.com/cap/booking-agent
 
 # CLI with HTTP index
-dns-aid discover highvelocitynetworking.com --use-http-index
+dns-aid discover example.com --use-http-index
 ```
 
 ```python
 # Python with HTTP index
-agents = await dns_aid.discover("highvelocitynetworking.com", use_http_index=True)
+agents = await dns_aid.discover("example.com", use_http_index=True)
 ```
 
 | Discovery Method | When to Use |
@@ -225,7 +225,7 @@ Then Claude can discover and connect to AI agents:
 >
 > "Publish my chat agent to DNS at mycompany.com"
 >
-> "Discover agents at highvelocitynetworking.com and search for flights from SFO to JFK"
+> "Discover agents at example.com and search for flights from SFO to JFK"
 
 #### Live Demo
 
@@ -244,10 +244,10 @@ Try the live demo with Claude Desktop:
 
 Then ask Claude to discover and use the booking agent:
 
-> "Discover agents at highvelocitynetworking.com using HTTP index, find a booking agent, and search for flights from SFO to JFK on March 15th 2026"
+> "Discover agents at example.com using HTTP index, find a booking agent, and search for flights from SFO to JFK on March 15th 2026"
 
 Claude will:
-1. Call `discover_agents_via_dns` → finds booking-agent at `https://booking.highvelocitynetworking.com/mcp`
+1. Call `discover_agents_via_dns` → finds booking-agent at `https://booking.example.com/mcp`
 2. Call `list_agent_tools` → sees search_flights, get_flight_details, check_availability, create_reservation
 3. Call `call_agent_tool` → searches for flights and returns results
 
@@ -816,7 +816,7 @@ python examples/demo_full.py
 
 ```bash
 # Clone the repo
-git clone https://github.com/iracic82/dns-aid-core
+git clone https://github.com/infobloxopen/dns-aid-core
 cd dns-aid
 
 # Create virtual environment

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,8 +11,8 @@
 
 ## Asking Questions
 
-- **GitHub Discussions** — for questions, ideas, and general conversation: [Discussions](https://github.com/iracic82/dns-aid-core/discussions)
-- **GitHub Issues** — for bug reports and feature requests: [Issues](https://github.com/iracic82/dns-aid-core/issues)
+- **GitHub Discussions** — for questions, ideas, and general conversation: [Discussions](https://github.com/infobloxopen/dns-aid-core/discussions)
+- **GitHub Issues** — for bug reports and feature requests: [Issues](https://github.com/infobloxopen/dns-aid-core/issues)
 
 ## Reporting Bugs
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1114,7 +1114,7 @@ The SDK can push signals to a remote telemetry API for centralized monitoring:
 
 ```python
 config = SDKConfig(
-    http_push_url="https://api.velosecurity-ai.io/api/v1/telemetry/signals"
+    http_push_url="https://api.example.com/api/v1/telemetry/signals"
 )
 
 async with AgentClient(config=config) as client:
@@ -1123,15 +1123,15 @@ async with AgentClient(config=config) as client:
 ```
 
 **Production Endpoints:**
-- **POST signals:** `https://api.velosecurity-ai.io/api/v1/telemetry/signals`
-- **Dashboard:** [directory.velosecurity-ai.io/telemetry](https://directory.velosecurity-ai.io/telemetry)
+- **POST signals:** `https://api.example.com/api/v1/telemetry/signals`
+- **Dashboard:** [directory.example.com/telemetry](https://directory.example.com/telemetry)
 
 **POST /api/v1/telemetry/signals**
 
 Accepts telemetry signals from SDK clients.
 
 ```bash
-curl -X POST https://api.velosecurity-ai.io/api/v1/telemetry/signals \
+curl -X POST https://api.example.com/api/v1/telemetry/signals \
   -H "Content-Type: application/json" \
   -d '{
     "agent_fqdn": "_booking._mcp._agents.example.com",
@@ -1164,4 +1164,4 @@ print(dns_aid.__version__)  # "0.6.0"
 - [Getting Started Guide](getting-started.md)
 - [IETF Draft: BANDAID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
-- [GitHub Repository](https://github.com/iracic82/dns-aid)
+- [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,7 +204,7 @@ Claude Desktop MCP Server
   │
   └─ SDK invoke() → InvocationSignal
        │
-       └─ HTTP POST (daemon thread) → https://api.velosecurity-ai.io/api/v1/telemetry/signals
+       └─ HTTP POST (daemon thread) → https://api.example.com/api/v1/telemetry/signals
                          │
                          └─ API inserts into invocation_signals table
                               │

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -74,7 +74,7 @@ DNS-AID supports two protocols: **A2A** (Google's Agent-to-Agent) and **MCP** (A
 # Publish your agent to DNS via Route 53 (A2A protocol)
 dns-aid publish \
   --name multiagent \
-  --domain highvelocitynetworking.com \
+  --domain example.com \
   --protocol a2a \
   --endpoint abc123.ngrok-free.app \
   --port 443 \
@@ -86,11 +86,11 @@ dns-aid publish \
 
 # Expected output:
 # ✓ Agent published successfully!
-#   FQDN: _multiagent._a2a._agents.highvelocitynetworking.com
+#   FQDN: _multiagent._a2a._agents.example.com
 #   Records created:
-#     • SVCB _multiagent._a2a._agents.highvelocitynetworking.com  (alpn="a2a")
-#     • TXT _multiagent._a2a._agents.highvelocitynetworking.com
-# ✓ Updated index at _index._agents.highvelocitynetworking.com (1 agent(s))
+#     • SVCB _multiagent._a2a._agents.example.com  (alpn="a2a")
+#     • TXT _multiagent._a2a._agents.example.com
+# ✓ Updated index at _index._agents.example.com (1 agent(s))
 ```
 
 > The index record is automatically created/updated when you publish. This enables single-query discovery of all agents at a domain.
@@ -105,11 +105,11 @@ dns-aid publish \
 
 ```bash
 # Using dig
-dig _multiagent._a2a._agents.highvelocitynetworking.com SVCB +short
-dig _multiagent._a2a._agents.highvelocitynetworking.com TXT +short
+dig _multiagent._a2a._agents.example.com SVCB +short
+dig _multiagent._a2a._agents.example.com TXT +short
 
 # Using DNS-AID verify (shows security score)
-dns-aid verify _multiagent._a2a._agents.highvelocitynetworking.com
+dns-aid verify _multiagent._a2a._agents.example.com
 
 # Expected:
 #   ✓ DNS record exists
@@ -124,10 +124,10 @@ dns-aid verify _multiagent._a2a._agents.highvelocitynetworking.com
 
 ```bash
 # List all agents in the domain's index
-dns-aid index list highvelocitynetworking.com
+dns-aid index list example.com
 
 # Expected output:
-# Agent index for highvelocitynetworking.com:
+# Agent index for example.com:
 #
 # ┌────────────┬──────────┬─────────────────────────────────────────────┐
 # │ Name       │ Protocol │ FQDN                                        │
@@ -144,7 +144,7 @@ dns-aid index list highvelocitynetworking.com
 
 ```bash
 # Discover the agent
-dns-aid discover highvelocitynetworking.com --protocol a2a --name multiagent
+dns-aid discover example.com --protocol a2a --name multiagent
 
 # Expected:
 # ┌────────────┬──────────┬─────────────────────────┬──────────────────┐
@@ -162,9 +162,9 @@ HTTP index can also include direct `endpoint` URLs for MCP path routing (e.g., `
 
 ```bash
 # Discover using HTTP index endpoint
-dns-aid discover highvelocitynetworking.com --use-http-index
+dns-aid discover example.com --use-http-index
 
-# This queries: https://_index._aiagents.highvelocitynetworking.com/index-wellknown
+# This queries: https://_index._aiagents.example.com/index-wellknown
 # With fallback to: /.well-known/agents-index.json
 
 # Expected output includes additional metadata:
@@ -198,13 +198,13 @@ curl -X POST https://abc123.ngrok-free.app/api/chat \
 # Delete the DNS records when done
 dns-aid delete \
   --name multiagent \
-  --domain highvelocitynetworking.com \
+  --domain example.com \
   --protocol a2a \
   --force
 
 # Expected output:
 # ✓ Agent deleted successfully
-# ✓ Updated index at _index._agents.highvelocitynetworking.com (0 agent(s))
+# ✓ Updated index at _index._agents.example.com (0 agent(s))
 
 # Stop ngrok
 pkill ngrok
@@ -236,7 +236,7 @@ async def discover_and_connect():
     # === STEP 1: DNS Discovery ===
     print("🔍 Step 1: Querying DNS for agent...")
 
-    fqdn = "_multiagent._a2a._agents.highvelocitynetworking.com"
+    fqdn = "_multiagent._a2a._agents.example.com"
 
     # Query SVCB record
     answers = dns.resolver.resolve(fqdn, "SVCB")
@@ -312,9 +312,9 @@ import dns_aid
 
 async def main():
     # Discover agent via DNS-AID
-    print("🔍 Discovering agents at highvelocitynetworking.com...")
+    print("🔍 Discovering agents at example.com...")
     result = await dns_aid.discover(
-        "highvelocitynetworking.com",
+        "example.com",
         protocol="a2a",
         name="multiagent"
     )
@@ -347,7 +347,7 @@ asyncio.run(main())
 #!/bin/bash
 # discover_agent.sh - Discover and connect to a DNS-AID agent
 
-DOMAIN="highvelocitynetworking.com"
+DOMAIN="example.com"
 AGENT_NAME="multiagent"
 PROTOCOL="a2a"
 
@@ -402,7 +402,7 @@ If you have DNS-AID MCP server configured in Claude Desktop:
    ```
 
 2. In Claude Desktop, ask:
-   > "Discover agents at highvelocitynetworking.com using the a2a protocol"
+   > "Discover agents at example.com using the a2a protocol"
 
 3. Claude will use the `discover_agents_via_dns` tool and return the results.
 
@@ -443,7 +443,7 @@ ngrok http 8000
 # Run MCP E2E test (with auto-start)
 python scripts/test_mcp_e2e.py \
   --endpoint abc123.ngrok-free.app \
-  --domain highvelocitynetworking.com \
+  --domain example.com \
   --agent-name multiagent \
   --protocol a2a \
   --auto-start
@@ -488,7 +488,7 @@ from dns_aid.backends import Route53Backend
 
 async def run_demo():
     # Configuration
-    DOMAIN = os.environ.get("DNS_AID_TEST_ZONE", "highvelocitynetworking.com")
+    DOMAIN = os.environ.get("DNS_AID_TEST_ZONE", "example.com")
     AGENT_NAME = "demo-agent"
     PROTOCOL = "a2a"
     ENDPOINT = os.environ.get("AGENT_ENDPOINT")  # e.g., abc123.ngrok-free.app
@@ -622,9 +622,9 @@ This demo tests the full crawler pipeline deployed to AWS: publish → index →
 ```bash
 dns-aid publish \
   --name network-assistant \
-  --domain highvelocitynetworking.com \
+  --domain example.com \
   --protocol mcp \
-  --endpoint mcp.highvelocitynetworking.com \
+  --endpoint mcp.example.com \
   --capability network \
   --capability dns \
   --ttl 300
@@ -635,10 +635,10 @@ dns-aid publish \
 The index is automatically created when you publish. Verify it:
 
 ```bash
-dns-aid index list highvelocitynetworking.com
+dns-aid index list example.com
 
 # Expected output:
-# Agent index for highvelocitynetworking.com:
+# Agent index for example.com:
 #
 # ┌───────────────────┬──────────┬─────────────────────────────────────────────┐
 # │ Name              │ Protocol │ FQDN                                        │
@@ -656,7 +656,7 @@ dns-aid index list highvelocitynetworking.com
 If you have existing agents without an index, sync them:
 
 ```bash
-dns-aid index sync highvelocitynetworking.com
+dns-aid index sync example.com
 # Scans DNS for all _agents.* records and rebuilds the index
 ```
 
@@ -666,20 +666,20 @@ Verification automatically triggers crawling - no manual SQS needed!
 
 ```bash
 # Submit domain to directory
-curl -X POST https://api.velosecurity-ai.io/api/v1/domains/submit \
+curl -X POST https://api.example.com/api/v1/domains/submit \
   -H "Content-Type: application/json" \
-  -d '{"domain": "highvelocitynetworking.com"}'
+  -d '{"domain": "example.com"}'
 
 # Create verification TXT record (if not already done)
-# _dns-aid-verify.highvelocitynetworking.com TXT "<token>"
+# _dns-aid-verify.example.com TXT "<token>"
 
 # Verify domain - THIS TRIGGERS AUTO-CRAWL
-curl -X POST https://api.velosecurity-ai.io/api/v1/domains/verify \
+curl -X POST https://api.example.com/api/v1/domains/verify \
   -H "Content-Type: application/json" \
-  -d '{"domain": "highvelocitynetworking.com"}'
+  -d '{"domain": "example.com"}'
 
 # Response shows auto-crawl was queued:
-# {"domain": "highvelocitynetworking.com", "verified": true,
+# {"domain": "example.com", "verified": true,
 #  "message": "Domain verified successfully! Crawl job queued - your agents will be indexed shortly."}
 ```
 
@@ -688,7 +688,7 @@ curl -X POST https://api.velosecurity-ai.io/api/v1/domains/verify \
 ```bash
 aws sqs send-message \
   --queue-url https://sqs.eu-west-2.amazonaws.com/905418046272/dns-aid-dev-crawl-jobs \
-  --message-body '{"domain": "highvelocitynetworking.com", "source": "manual"}' \
+  --message-body '{"domain": "example.com", "source": "manual"}' \
   --profile okta-sso --region eu-west-2
 ```
 
@@ -704,9 +704,9 @@ Expected output:
 Index record parsed            agent_count=1
 Discovering agent from index   name=network-assistant protocol=mcp
 Discovery complete             agents_found=1 time_ms=24.94
-SVCB record found              target=mcp.highvelocitynetworking.com port=443
+SVCB record found              target=mcp.example.com port=443
 Verification complete          rating=Poor score=40
-Agent discovered via index     fqdn=_network-assistant._mcp._agents.highvelocitynetworking.com
+Agent discovered via index     fqdn=_network-assistant._mcp._agents.example.com
 
 Crawler batch complete         succeeded=1 failed=0
 ```
@@ -715,10 +715,10 @@ Crawler batch complete         succeeded=1 failed=0
 
 ```bash
 # Check SVCB record exists
-dig _network-assistant._mcp._agents.highvelocitynetworking.com SVCB +short
+dig _network-assistant._mcp._agents.example.com SVCB +short
 
 # Check security score via CLI
-dns-aid verify _network-assistant._mcp._agents.highvelocitynetworking.com
+dns-aid verify _network-assistant._mcp._agents.example.com
 ```
 
 ### Cleanup
@@ -727,13 +727,13 @@ dns-aid verify _network-assistant._mcp._agents.highvelocitynetworking.com
 # Delete the agent records (automatically removes from index)
 dns-aid delete \
   --name network-assistant \
-  --domain highvelocitynetworking.com \
+  --domain example.com \
   --protocol mcp \
   --force
 
 # Expected output:
 # ✓ Agent deleted successfully
-# ✓ Updated index at _index._agents.highvelocitynetworking.com (0 agent(s))
+# ✓ Updated index at _index._agents.example.com (0 agent(s))
 ```
 
 > **Note:** The delete command automatically updates the index. No manual cleanup needed!
@@ -747,7 +747,7 @@ This demo shows the new MCP agent proxying feature: discover an agent and call i
 ### Prerequisites
 
 - DNS-AID MCP server configured in Claude Desktop
-- Live demo agent at highvelocitynetworking.com (already deployed)
+- Live demo agent at example.com (already deployed)
 
 ### Step 1: Configure Claude Desktop
 
@@ -769,14 +769,14 @@ Restart Claude Desktop.
 
 In Claude Desktop, ask:
 
-> "Discover agents at highvelocitynetworking.com"
+> "Discover agents at example.com"
 
 Claude will use the `discover_agents_via_dns` tool and return:
 
 ```
-Found 1 agent(s) at highvelocitynetworking.com:
+Found 1 agent(s) at example.com:
 - booking-agent (MCP protocol)
-  Endpoint: https://booking.highvelocitynetworking.com/mcp
+  Endpoint: https://booking.example.com/mcp
   Capabilities: travel, booking
 ```
 
@@ -822,7 +822,7 @@ Found 5 flights from NYC to London on March 15:
 │  ┌─────────────────────────────────────────────────────────┐   │
 │  │                  DNS-AID MCP Server                      │   │
 │  │                                                          │   │
-│  │  1. discover_agents_via_dns("highvelocitynetworking.com")│   │
+│  │  1. discover_agents_via_dns("example.com")│   │
 │  │     └─► DNS query for _booking._mcp._agents.*.com       │   │
 │  │     └─► Returns: endpoint_url from SVCB/HTTP index      │   │
 │  │                                                          │   │
@@ -909,7 +909,7 @@ This is visible in Claude Desktop when you discover agents:
 ```
 Found 1 agent(s):
 - booking-agent (MCP protocol)
-  Endpoint: https://booking.highvelocitynetworking.com/mcp
+  Endpoint: https://booking.example.com/mcp
   Endpoint Source: dns_svcb         ← Confirms DNS SVCB was used
   Capability Source: cap_uri        ← Capabilities from cap document
   Capabilities: travel, booking, reservations
@@ -918,8 +918,8 @@ Found 1 agent(s):
 ### Troubleshooting Agent Proxying
 
 #### "Agent not found" error
-- Verify the agent is published: `dns-aid discover highvelocitynetworking.com`
-- Check HTTP index is accessible: `curl https://highvelocitynetworking.com/.well-known/agents-index.json`
+- Verify the agent is published: `dns-aid discover example.com`
+- Check HTTP index is accessible: `curl https://example.com/.well-known/agents-index.json`
 
 #### "Connection refused" to agent
 - Verify endpoint URL is correct in HTTP index
@@ -994,7 +994,7 @@ Found 1 agent(s):
 6. Show it's real HTTP traffic to real agent
 
 ### The Magic Moment
-> "Notice we never hardcoded the URL. We asked DNS 'where is the multiagent at highvelocitynetworking.com?' and DNS told us. Any agent, anywhere in the world, can now discover this agent using standard DNS queries."
+> "Notice we never hardcoded the URL. We asked DNS 'where is the multiagent at example.com?' and DNS told us. Any agent, anywhere in the world, can now discover this agent using standard DNS queries."
 
 ### Security (30 seconds)
 > "DNS-AID supports DNSSEC for tamper-proof records and DANE for certificate binding. The verification shows a security score. Production deployments should enable DNSSEC for full security."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ This guide will walk you through installing, configuring, and testing DNS-AID.
 
 ```bash
 # Clone the repository
-git clone https://github.com/iracic82/dns-aid.git
+git clone https://github.com/infobloxopen/dns-aid-core.git
 cd dns-aid
 
 # Create virtual environment
@@ -620,7 +620,7 @@ print(f"Verification token: {result.verification_token}")
 
 ### Submit via Web UI
 
-Visit [directory.velosecurity-ai.io/submit](https://directory.velosecurity-ai.io/submit) to submit your domain through the web interface.
+Visit [directory.example.com/submit](https://directory.example.com/submit) to submit your domain through the web interface.
 
 ### Verification Process
 
@@ -811,7 +811,7 @@ import dns_aid
 
 async def main():
     # Discover agents
-    result = await dns_aid.discover("highvelocitynetworking.com", protocol="mcp")
+    result = await dns_aid.discover("example.com", protocol="mcp")
     agent = result.agents[0]
 
     # Invoke and capture telemetry
@@ -874,20 +874,20 @@ curl http://localhost:8000/api/v1/telemetry/agents/{fqdn}/scorecard
 ```
 
 **Production Telemetry:**
-- **Dashboard:** [directory.velosecurity-ai.io/telemetry](https://directory.velosecurity-ai.io/telemetry)
-- **API:** `https://api.velosecurity-ai.io/api/v1/telemetry/signals`
+- **Dashboard:** [directory.example.com/telemetry](https://directory.example.com/telemetry)
+- **API:** `https://api.example.com/api/v1/telemetry/signals`
 
 The MCP server automatically pushes telemetry signals to the production API. To enable HTTP push in custom SDK usage:
 
 ```python
 config = SDKConfig(
-    http_push_url="https://api.velosecurity-ai.io/api/v1/telemetry/signals"
+    http_push_url="https://api.example.com/api/v1/telemetry/signals"
 )
 ```
 
 Or via environment variable:
 ```bash
-export DNS_AID_SDK_HTTP_PUSH_URL="https://api.velosecurity-ai.io/api/v1/telemetry/signals"
+export DNS_AID_SDK_HTTP_PUSH_URL="https://api.example.com/api/v1/telemetry/signals"
 ```
 
 ## Using the MCP Server
@@ -937,7 +937,7 @@ Restart Claude Desktop, then ask:
 The MCP server can now proxy tool calls to discovered agents:
 
 ```
-You: "What tools does the booking agent at highvelocitynetworking.com have?"
+You: "What tools does the booking agent at example.com have?"
 Claude: [uses list_agent_tools] "The booking-agent has 3 tools: search_flights,
         book_flight, and get_booking_status..."
 
@@ -1001,9 +1001,9 @@ dns-aid publish \
 Try it now with our live demo agent:
 
 ```
-You: "Discover agents at highvelocitynetworking.com"
+You: "Discover agents at example.com"
 Claude: [uses discover_agents_via_dns] "Found 1 agent: booking-agent (MCP protocol)
-        at https://booking.highvelocitynetworking.com/mcp"
+        at https://booking.example.com/mcp"
 
 You: "What tools does the booking agent have?"
 Claude: [uses list_agent_tools] "The booking-agent has these tools: ..."

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -72,7 +72,7 @@ client = MultiServerMCPClient({
 })
 tools = await client.get_tools()
 model = ChatAnthropic(model="claude-sonnet-4-20250514").bind_tools(tools)
-response = await model.ainvoke("Find booking agents at highvelocitynetworking.com")
+response = await model.ainvoke("Find booking agents at example.com")
 ```
 
 ### CrewAI
@@ -96,7 +96,7 @@ with MCPServerAdapter(server_params) as tools:
         tools=tools,
     )
     task = Task(
-        description="Discover all MCP agents at highvelocitynetworking.com",
+        description="Discover all MCP agents at example.com",
         agent=agent,
     )
     Crew(agents=[agent], tasks=[task]).kickoff()
@@ -120,7 +120,7 @@ agent = AssistantAgent(
     model_client=OpenAIChatCompletionClient(model="gpt-4o"),
     tools=tools,
 )
-result = await agent.run(task="Discover agents at highvelocitynetworking.com")
+result = await agent.run(task="Discover agents at example.com")
 ```
 
 ### Google ADK
@@ -238,7 +238,7 @@ For frameworks without MCP support — or when you want direct programmatic acce
 ```python
 from dns_aid.core.discoverer import discover
 
-result = await discover("highvelocitynetworking.com", protocol="mcp")
+result = await discover("example.com", protocol="mcp")
 for agent in result.agents:
     print(f"{agent.name}: {agent.endpoint_url}")
 ```
@@ -259,9 +259,9 @@ from dns_aid.core.publisher import publish
 
 await publish(
     name="network-specialist",
-    domain="highvelocitynetworking.com",
+    domain="example.com",
     protocol="mcp",
-    endpoint="mcp.highvelocitynetworking.com",
+    endpoint="mcp.example.com",
 )
 ```
 
@@ -270,7 +270,7 @@ await publish(
 ```python
 from dns_aid.core.validator import verify
 
-result = await verify("_network-specialist._mcp._agents.highvelocitynetworking.com")
+result = await verify("_network-specialist._mcp._agents.example.com")
 print(f"DNSSEC valid: {result.dnssec_valid}")
 print(f"Security rating: {result.security_rating}")
 ```

--- a/examples/demo_full.py
+++ b/examples/demo_full.py
@@ -10,7 +10,7 @@ This script demonstrates the complete DNS-AID workflow:
 
 Usage:
     # Set your zone
-    export DNS_AID_TEST_ZONE="highvelocitynetworking.com"
+    export DNS_AID_TEST_ZONE="example.com"
 
     # Run the demo
     python examples/demo_full.py

--- a/examples/demo_route53.py
+++ b/examples/demo_route53.py
@@ -7,13 +7,13 @@ using real DNS records in Route 53.
 
 Usage:
     # Set your zone (or pass as argument)
-    export DNS_AID_TEST_ZONE="highvelocitynetworking.com"
+    export DNS_AID_TEST_ZONE="example.com"
 
     # Run the demo
     python examples/demo_route53.py
 
     # Or specify zone directly
-    python examples/demo_route53.py highvelocitynetworking.com
+    python examples/demo_route53.py example.com
 """
 
 import asyncio

--- a/examples/discover_remote_agent.py
+++ b/examples/discover_remote_agent.py
@@ -6,7 +6,7 @@ This script demonstrates how any agent can discover another agent
 using only DNS - no hardcoded URLs needed!
 
 Usage:
-    python discover_remote_agent.py highvelocitynetworking.com multiagent a2a
+    python discover_remote_agent.py example.com multiagent a2a
 
 Or with defaults:
     python discover_remote_agent.py
@@ -145,7 +145,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s highvelocitynetworking.com multiagent a2a
+  %(prog)s example.com multiagent a2a
   %(prog)s example.com chat mcp
   %(prog)s  # uses defaults
         """,
@@ -153,8 +153,8 @@ Examples:
     parser.add_argument(
         "domain",
         nargs="?",
-        default="highvelocitynetworking.com",
-        help="Domain to search (default: highvelocitynetworking.com)",
+        default="example.com",
+        help="Domain to search (default: example.com)",
     )
     parser.add_argument(
         "agent_name",

--- a/examples/integration_autogen.py
+++ b/examples/integration_autogen.py
@@ -56,7 +56,7 @@ async def main() -> int:
     discover_tool = next(t for t in tools if t.name == "discover_agents_via_dns")
     result = await discover_tool.run_json(
         {
-            "domain": "highvelocitynetworking.com",
+            "domain": "example.com",
             "protocol": "mcp",
             "name": "booking",
         },
@@ -73,7 +73,7 @@ async def main() -> int:
         print(f"  Got: {result_str[:200]}")
         errors += 1
 
-    if "highvelocitynetworking.com" in result_str:
+    if "example.com" in result_str:
         print("  OK: Result contains domain reference")
     else:
         print("  WARN: Domain not found in result")

--- a/examples/integration_google_adk.py
+++ b/examples/integration_google_adk.py
@@ -65,7 +65,7 @@ async def main() -> int:
     result = await session.call_tool(
         "discover_agents_via_dns",
         {
-            "domain": "highvelocitynetworking.com",
+            "domain": "example.com",
             "protocol": "mcp",
             "name": "booking",
         },
@@ -85,7 +85,7 @@ async def main() -> int:
         print(f"  Got: {result_text[:200]}")
         errors += 1
 
-    if "highvelocitynetworking.com" in result_text:
+    if "example.com" in result_text:
         print("  OK: Result contains domain reference")
     else:
         print("  WARN: Domain not found in result")

--- a/examples/integration_langchain.py
+++ b/examples/integration_langchain.py
@@ -61,7 +61,7 @@ async def main() -> int:
     discover_tool = next(t for t in tools if t.name == "discover_agents_via_dns")
     result = await discover_tool.ainvoke(
         {
-            "domain": "highvelocitynetworking.com",
+            "domain": "example.com",
             "protocol": "mcp",
             "name": "booking",
         }
@@ -76,7 +76,7 @@ async def main() -> int:
         print(f"  Got: {result_str[:200]}")
         errors += 1
 
-    if "highvelocitynetworking.com" in result_str:
+    if "example.com" in result_str:
         print("  OK: Result contains domain reference")
     else:
         print("  WARN: Domain not found in result")

--- a/examples/integration_openai_agents.py
+++ b/examples/integration_openai_agents.py
@@ -59,7 +59,7 @@ async def main() -> int:
         result = await server.call_tool(
             "discover_agents_via_dns",
             {
-                "domain": "highvelocitynetworking.com",
+                "domain": "example.com",
                 "protocol": "mcp",
                 "name": "booking",
             },
@@ -80,7 +80,7 @@ async def main() -> int:
             print(f"  Got: {result_text[:200]}")
             errors += 1
 
-        if "highvelocitynetworking.com" in result_text:
+        if "example.com" in result_text:
             print("  OK: Result contains domain reference")
         else:
             print("  WARN: Domain not found in result")

--- a/examples/integration_python_library.py
+++ b/examples/integration_python_library.py
@@ -3,7 +3,7 @@
 Integration Test: DNS-AID Python Library
 
 Validates the Python library integration pattern from docs/integrations.md.
-Discovers the booking agent at highvelocitynetworking.com via DNS,
+Discovers the booking agent at example.com via DNS,
 then calls its MCP endpoint directly.
 
 Usage:
@@ -29,7 +29,7 @@ async def main() -> int:
     # ── Step 1: Discover booking agent via DNS ──────────────────
     print("\n[1/4] Discovering booking agent via DNS...")
     result = await discover(
-        "highvelocitynetworking.com", protocol="mcp", name="booking"
+        "example.com", protocol="mcp", name="booking"
     )
 
     if result.count == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,10 @@ dns-aid = "dns_aid.cli.main:app"
 dns-aid-mcp = "dns_aid.mcp.server:main"
 
 [project.urls]
-Homepage = "https://github.com/iracic82/dns-aid-core"
-Documentation = "https://github.com/iracic82/dns-aid-core#readme"
-Repository = "https://github.com/iracic82/dns-aid-core"
+Homepage = "https://github.com/infobloxopen/dns-aid-core"
+Documentation = "https://github.com/infobloxopen/dns-aid-core#readme"
+Repository = "https://github.com/infobloxopen/dns-aid-core"
+Changelog = "https://github.com/infobloxopen/dns-aid-core/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dns_aid"]

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,7 +12,7 @@ click==8.3.1
 colorama==0.4.6
 coverage==7.13.3
 cryptography==46.0.4
--e git+https://github.com/iracic82/dns-aid-core.git@7f68fd8a56584a8208a7054deb0ab1c907de6319#egg=dns_aid
+-e git+https://github.com/infobloxopen/dns-aid-core.git#egg=dns_aid
 dnspython==2.8.0
 h11==0.16.0
 httpcore==1.0.9

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID: DNS-based Agent Identification and Discovery
 

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """DNS backend implementations: Route53, Infoblox BloxOne, DDNS, Mock."""
 
 from dns_aid.backends.base import DNSBackend

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Abstract base class for DNS backends.
 

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Cloudflare DNS backend.
 

--- a/src/dns_aid/backends/ddns.py
+++ b/src/dns_aid/backends/ddns.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DDNS (Dynamic DNS) backend using RFC 2136.
 

--- a/src/dns_aid/backends/infoblox/__init__.py
+++ b/src/dns_aid/backends/infoblox/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Infoblox DNS backends for DNS-AID.
 

--- a/src/dns_aid/backends/infoblox/bloxone.py
+++ b/src/dns_aid/backends/infoblox/bloxone.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Infoblox BloxOne DDI backend for DNS-AID.
 

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Infoblox NIOS (on-premises) backend for DNS-AID.
 

--- a/src/dns_aid/backends/mock.py
+++ b/src/dns_aid/backends/mock.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Mock DNS backend for testing.
 

--- a/src/dns_aid/backends/route53.py
+++ b/src/dns_aid/backends/route53.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 AWS Route 53 DNS backend.
 
@@ -47,19 +50,19 @@ class Route53Backend(DNSBackend):
     Creates and manages DNS-AID records in Route 53 hosted zones.
 
     Example:
-        >>> backend = Route53Backend(zone_id="Z0586652231EFJ5ITAAGP")
+        >>> backend = Route53Backend(zone_id="ZEXAMPLEZONEID")
         >>> await backend.create_svcb_record(
-        ...     zone="highvelocitynetworking.com",
+        ...     zone="example.com",
         ...     name="_chat._a2a._agents",
         ...     priority=1,
-        ...     target="chat.highvelocitynetworking.com.",
+        ...     target="chat.example.com.",
         ...     params={"alpn": "a2a", "port": "443"}
         ... )
 
         >>> # Or use domain name to auto-discover zone
         >>> backend = Route53Backend()
         >>> await backend.create_svcb_record(
-        ...     zone="highvelocitynetworking.com",  # Will find zone ID automatically
+        ...     zone="example.com",  # Will find zone ID automatically
         ...     ...
         ... )
     """
@@ -75,7 +78,7 @@ class Route53Backend(DNSBackend):
         Initialize Route 53 backend.
 
         Args:
-            zone_id: Optional hosted zone ID (e.g., "Z0586652231EFJ5ITAAGP").
+            zone_id: Optional hosted zone ID (e.g., "ZEXAMPLEZONEID").
                      If not provided, will be looked up by domain name.
             region: AWS region (defaults to us-east-1 for Route 53)
             aws_access_key_id: AWS access key (defaults to env/credentials)
@@ -114,7 +117,7 @@ class Route53Backend(DNSBackend):
             zone: Domain name (e.g., "example.com")
 
         Returns:
-            Zone ID (e.g., "Z0586652231EFJ5ITAAGP")
+            Zone ID (e.g., "ZEXAMPLEZONEID")
 
         Raises:
             ValueError: If zone not found

--- a/src/dns_aid/cli/__init__.py
+++ b/src/dns_aid/cli/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Command-line interface for DNS-AID."""

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID Command Line Interface.
 

--- a/src/dns_aid/core/__init__.py
+++ b/src/dns_aid/core/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Core DNS-AID functionality: models, publisher, discoverer, validator."""
 
 from dns_aid.core.a2a_card import (

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 A2A Agent Card — Google's Agent-to-Agent protocol agent description format.
 

--- a/src/dns_aid/core/agent_metadata.py
+++ b/src/dns_aid/core/agent_metadata.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Agent Metadata Contract — the `.well-known/agent.json` schema for DNS-AID.
 

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Fetch agent capability document from cap URI (IETF draft-compliant).
 

--- a/src/dns_aid/core/capability_model.py
+++ b/src/dns_aid/core/capability_model.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Machine-readable capability model for DNS-AID Agent Metadata Contract.
 

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID Discoverer: Query DNS to find AI agents.
 

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 HTTP Index discovery for ANS-style compatibility.
 

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID Indexer: Manage _index._agents.* TXT records.
 

--- a/src/dns_aid/core/jwks.py
+++ b/src/dns_aid/core/jwks.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 JWS Signature Support for DNS-AID.
 

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Data models for DNS-AID.
 

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID Publisher: Create DNS records for AI agent discovery.
 

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID Validator: Verify agent DNS records and security.
 

--- a/src/dns_aid/mcp/__init__.py
+++ b/src/dns_aid/mcp/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 MCP server for DNS-AID - enables AI agents to publish/discover via DNS.
 

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID MCP Server.
 
@@ -76,7 +79,7 @@ _start_time = time.time()
 _executor: ThreadPoolExecutor | None = None
 
 # Default telemetry push URL (overridden by DNS_AID_SDK_HTTP_PUSH_URL env var)
-_DEFAULT_HTTP_PUSH_URL = "https://api.velosecurity-ai.io/api/v1/telemetry/signals"
+_DEFAULT_HTTP_PUSH_URL: str | None = None  # Set via DNS_AID_SDK_HTTP_PUSH_URL env var
 
 # Optionally delegate to SDK for telemetry capture
 _sdk_available = False
@@ -1208,7 +1211,7 @@ try:
                     "/health": "Health check (GET)",
                     "/ready": "Readiness check (GET)",
                 },
-                "documentation": "https://github.com/iracic82/dns-aid-core",
+                "documentation": "https://github.com/infobloxopen/dns-aid-core",
                 "specification": "IETF draft-mozleywilliams-dnsop-bandaid-02",
             }
         )

--- a/src/dns_aid/sdk/__init__.py
+++ b/src/dns_aid/sdk/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 DNS-AID Tier 1 Execution Telemetry SDK.
 

--- a/src/dns_aid/sdk/_config.py
+++ b/src/dns_aid/sdk/_config.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SDK configuration.
 
@@ -47,7 +50,7 @@ class SDKConfig(BaseModel):
     # HTTP push (fire-and-forget POST to telemetry API)
     http_push_url: str | None = Field(
         default=None,
-        description="URL to POST signals to (e.g., https://api.velosecurity-ai.io/api/v1/telemetry/signals). "
+        description="URL to POST signals to (e.g., https://api.example.com/api/v1/telemetry/signals). "
         "If set, enables HTTP push automatically.",
     )
 

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 AgentClient — main entry point for the DNS-AID Tier 1 SDK.
 

--- a/src/dns_aid/sdk/models.py
+++ b/src/dns_aid/sdk/models.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SDK telemetry models.
 

--- a/src/dns_aid/sdk/protocols/__init__.py
+++ b/src/dns_aid/sdk/protocols/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Protocol handlers for agent invocation."""
 
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse

--- a/src/dns_aid/sdk/protocols/a2a.py
+++ b/src/dns_aid/sdk/protocols/a2a.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 A2A (Agent-to-Agent) protocol handler.
 

--- a/src/dns_aid/sdk/protocols/base.py
+++ b/src/dns_aid/sdk/protocols/base.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Base protocol handler abstraction.
 

--- a/src/dns_aid/sdk/protocols/https.py
+++ b/src/dns_aid/sdk/protocols/https.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 HTTPS protocol handler.
 

--- a/src/dns_aid/sdk/protocols/mcp.py
+++ b/src/dns_aid/sdk/protocols/mcp.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 MCP (Model Context Protocol) handler.
 

--- a/src/dns_aid/sdk/ranking/__init__.py
+++ b/src/dns_aid/sdk/ranking/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Agent ranking engine."""
 
 from dns_aid.sdk.ranking.ranker import AgentRanker

--- a/src/dns_aid/sdk/ranking/ranker.py
+++ b/src/dns_aid/sdk/ranking/ranker.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 AgentRanker — ranks agents by their telemetry scorecards.
 

--- a/src/dns_aid/sdk/ranking/strategies.py
+++ b/src/dns_aid/sdk/ranking/strategies.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Ranking strategies for agent scoring.
 

--- a/src/dns_aid/sdk/signals/__init__.py
+++ b/src/dns_aid/sdk/signals/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Signal collection and storage."""
 
 from dns_aid.sdk.signals.collector import SignalCollector

--- a/src/dns_aid/sdk/signals/collector.py
+++ b/src/dns_aid/sdk/signals/collector.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 In-memory signal collector.
 

--- a/src/dns_aid/sdk/telemetry/__init__.py
+++ b/src/dns_aid/sdk/telemetry/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenTelemetry integration for DNS-AID SDK (opt-in)."""
 
 from dns_aid.sdk.telemetry.otel import TelemetryManager

--- a/src/dns_aid/sdk/telemetry/otel.py
+++ b/src/dns_aid/sdk/telemetry/otel.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 OpenTelemetry integration for DNS-AID SDK.
 

--- a/src/dns_aid/utils/__init__.py
+++ b/src/dns_aid/utils/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Utility functions: logging, config, helpers, validation."""
 
 from dns_aid.utils.validation import (

--- a/src/dns_aid/utils/logging.py
+++ b/src/dns_aid/utils/logging.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Logging configuration for DNS-AID.
 

--- a/src/dns_aid/utils/url_safety.py
+++ b/src/dns_aid/utils/url_safety.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 URL safety validation for DNS-AID.
 

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Input validation utilities for DNS-AID.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """DNS-AID test suite."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Pytest fixtures for DNS-AID tests."""
 
 import pytest

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Fixtures for mock integration tests.
 

--- a/tests/integration/test_ddns.py
+++ b/tests/integration/test_ddns.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests for DDNS backend using Docker BIND9.
 

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end integration tests for DNS-AID.
 
@@ -7,7 +10,7 @@ using real DNS infrastructure.
 Set environment variables:
   - AWS_ACCESS_KEY_ID
   - AWS_SECRET_ACCESS_KEY
-  - DNS_AID_TEST_ZONE (e.g., "highvelocitynetworking.com")
+  - DNS_AID_TEST_ZONE (e.g., "example.com")
 
 Run with: pytest tests/integration/test_e2e.py -v
 

--- a/tests/integration/test_infoblox.py
+++ b/tests/integration/test_infoblox.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests for Infoblox BloxOne backend.
 

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Mock integration tests — Tier A (always runs in CI, no credentials needed).
 

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests for Route 53 backend.
 
@@ -5,7 +8,7 @@ These tests require AWS credentials and a real Route 53 zone.
 Set environment variables:
   - AWS_ACCESS_KEY_ID
   - AWS_SECRET_ACCESS_KEY
-  - DNS_AID_TEST_ZONE (e.g., "highvelocitynetworking.com")
+  - DNS_AID_TEST_ZONE (e.g., "example.com")
 
 Run with: pytest tests/integration/test_route53.py -v
 """

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests."""

--- a/tests/unit/core/__init__.py
+++ b/tests/unit/core/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+

--- a/tests/unit/core/test_agent_metadata.py
+++ b/tests/unit/core/test_agent_metadata.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the Agent Metadata Contract (Phase 5.5)."""
 
 from datetime import datetime, timezone

--- a/tests/unit/core/test_capability_model.py
+++ b/tests/unit/core/test_capability_model.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the capability model (Phase 5.5)."""
 
 from dns_aid.core.capability_model import (

--- a/tests/unit/sdk/__init__.py
+++ b/tests/unit/sdk/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared fixtures for SDK tests."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_a2a_handler.py
+++ b/tests/unit/sdk/test_a2a_handler.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for A2A and HTTPS protocol handlers."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for AgentClient."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_mcp_handler.py
+++ b/tests/unit/sdk/test_mcp_handler.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for MCP protocol handler."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_models.py
+++ b/tests/unit/sdk/test_models.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for SDK models."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_otel.py
+++ b/tests/unit/sdk/test_otel.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for OTEL telemetry integration."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_ranking.py
+++ b/tests/unit/sdk/test_ranking.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the ranking engine."""
 
 from __future__ import annotations

--- a/tests/unit/sdk/test_sdk_client.py
+++ b/tests/unit/sdk/test_sdk_client.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for dns_aid.sdk.client module — uncovered paths."""
 
 from __future__ import annotations
@@ -114,9 +117,7 @@ class TestFetchRankings:
 
         async with AgentClient(config=_config) as client:
             client._http_client.get = AsyncMock(return_value=mock_resp)
-            rankings = await client.fetch_rankings(
-                fqdns=["_chat._a2a._agents.example.com"]
-            )
+            rankings = await client.fetch_rankings(fqdns=["_chat._a2a._agents.example.com"])
 
         assert len(rankings) == 1
         assert rankings[0]["agent_fqdn"] == "_chat._a2a._agents.example.com"

--- a/tests/unit/sdk/test_top_level_api.py
+++ b/tests/unit/sdk/test_top_level_api.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the top-level dns_aid.invoke() and dns_aid.rank() convenience API."""
 
 from __future__ import annotations

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for A2A Agent Card parsing and fetching."""
 
 from __future__ import annotations

--- a/tests/unit/test_cap_fetcher.py
+++ b/tests/unit/test_cap_fetcher.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DNS-AID capability document fetcher."""
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for CLI commands."""
 
 import re
@@ -239,7 +242,10 @@ def _make_publish_result(success=True, message=None):
 
     return PublishResult(
         agent=_make_agent(),
-        records_created=["SVCB _chat._mcp._agents.example.com", "TXT _chat._mcp._agents.example.com"],
+        records_created=[
+            "SVCB _chat._mcp._agents.example.com",
+            "TXT _chat._mcp._agents.example.com",
+        ],
         zone="example.com",
         backend="mock",
         success=success,
@@ -273,9 +279,12 @@ class TestPublishCommand:
             app,
             [
                 "publish",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
             ],
         )
         assert result.exit_code == 0
@@ -294,9 +303,12 @@ class TestPublishCommand:
             app,
             [
                 "publish",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
             ],
         )
         assert result.exit_code == 0
@@ -311,9 +323,12 @@ class TestPublishCommand:
             app,
             [
                 "publish",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
                 "--no-update-index",
             ],
         )
@@ -330,9 +345,12 @@ class TestPublishCommand:
             app,
             [
                 "publish",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
             ],
         )
         assert result.exit_code == 1
@@ -343,9 +361,12 @@ class TestPublishCommand:
             app,
             [
                 "publish",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
                 "--sign",
             ],
         )
@@ -371,9 +392,12 @@ class TestDeleteCommand:
             app,
             [
                 "delete",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
                 "--force",
             ],
         )
@@ -389,9 +413,12 @@ class TestDeleteCommand:
             app,
             [
                 "delete",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
                 "--force",
             ],
         )
@@ -410,9 +437,12 @@ class TestDeleteCommand:
             app,
             [
                 "delete",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
                 "--force",
             ],
         )
@@ -426,9 +456,12 @@ class TestDeleteCommand:
             app,
             [
                 "delete",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
                 "--force",
                 "--no-update-index",
             ],
@@ -442,9 +475,12 @@ class TestDeleteCommand:
             app,
             [
                 "delete",
-                "--name", "chat",
-                "--domain", "example.com",
-                "--backend", "mock",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
             ],
             input="n\n",
         )
@@ -555,9 +591,7 @@ class TestIndexListCommand:
             IndexEntry(name="chat", protocol="mcp"),
             IndexEntry(name="network", protocol="a2a"),
         ]
-        result = runner.invoke(
-            app, ["index", "list", "example.com", "--backend", "mock"]
-        )
+        result = runner.invoke(app, ["index", "list", "example.com", "--backend", "mock"])
         assert result.exit_code == 0
         plain = _strip_ansi(result.output)
         assert "2 agent(s)" in plain
@@ -566,9 +600,7 @@ class TestIndexListCommand:
     def test_index_list_empty_both(self, mock_run_async):
         """Index list with no entries from backend or DNS."""
         mock_run_async.return_value = []
-        result = runner.invoke(
-            app, ["index", "list", "example.com", "--backend", "mock"]
-        )
+        result = runner.invoke(app, ["index", "list", "example.com", "--backend", "mock"])
         assert result.exit_code == 0
         plain = _strip_ansi(result.output)
         assert "No index record found" in plain
@@ -588,9 +620,7 @@ class TestIndexSyncCommand:
         mock_run_async.return_value = _make_index_result(
             success=True, created=True, message="Synced 1 agent(s)"
         )
-        result = runner.invoke(
-            app, ["index", "sync", "example.com", "--backend", "mock"]
-        )
+        result = runner.invoke(app, ["index", "sync", "example.com", "--backend", "mock"])
         assert result.exit_code == 0
         plain = _strip_ansi(result.output)
         assert "Synced" in plain or "agent" in plain.lower()
@@ -606,9 +636,7 @@ class TestIndexSyncCommand:
             success=True,
             message="No agents",
         )
-        result = runner.invoke(
-            app, ["index", "sync", "example.com", "--backend", "mock"]
-        )
+        result = runner.invoke(app, ["index", "sync", "example.com", "--backend", "mock"])
         assert result.exit_code == 0
         plain = _strip_ansi(result.output)
         assert "No agents found" in plain
@@ -624,9 +652,7 @@ class TestIndexSyncCommand:
             success=False,
             message="Backend unreachable",
         )
-        result = runner.invoke(
-            app, ["index", "sync", "example.com", "--backend", "mock"]
-        )
+        result = runner.invoke(app, ["index", "sync", "example.com", "--backend", "mock"])
         assert result.exit_code == 1
 
 

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for dns_aid.backends.cloudflare module."""
 
 from __future__ import annotations
@@ -706,7 +709,15 @@ class TestCloudflarePublishAgentParamDemotion:
         # SVCB params should NOT contain custom keys
         svcb_params = svcb_calls[0]["params"]
         for key in svcb_params:
-            assert key in {"mandatory", "alpn", "no-default-alpn", "port", "ipv4hint", "ipv6hint", "ech"}
+            assert key in {
+                "mandatory",
+                "alpn",
+                "no-default-alpn",
+                "port",
+                "ipv4hint",
+                "ipv6hint",
+                "ech",
+            }
 
         # TXT should contain demoted bandaid params
         txt_values = txt_calls[0]["values"]

--- a/tests/unit/test_ddns_backend.py
+++ b/tests/unit/test_ddns_backend.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for dns_aid.backends.ddns module."""
 
 from __future__ import annotations

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DNS-AID discoverer module."""
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/unit/test_http_index.py
+++ b/tests/unit/test_http_index.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for HTTP Index discovery (ANS-style compatibility)."""
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DNS-AID indexer."""
 
 import pytest

--- a/tests/unit/test_infoblox_backend.py
+++ b/tests/unit/test_infoblox_backend.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for Infoblox BloxOne backend.
 

--- a/tests/unit/test_jws.py
+++ b/tests/unit/test_jws.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for JWS signing and verification."""
 
 import json

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for dns_aid.utils.logging module."""
 
 from __future__ import annotations

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for MCP server tools.
 

--- a/tests/unit/test_mock_backend.py
+++ b/tests/unit/test_mock_backend.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for mock DNS backend."""
 
 import pytest

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DNS-AID data models."""
 
 import pytest

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DNS-AID publisher."""
 
 import pytest

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for dns_aid.backends.route53 module."""
 
 from __future__ import annotations
@@ -14,8 +17,8 @@ class TestRoute53BackendInit:
 
     def test_init_with_zone_id(self):
         """Test initialization with zone ID."""
-        backend = Route53Backend(zone_id="Z0586652231EFJ5ITAAGP")
-        assert backend._zone_id == "Z0586652231EFJ5ITAAGP"
+        backend = Route53Backend(zone_id="ZEXAMPLEZONEID")
+        assert backend._zone_id == "ZEXAMPLEZONEID"
 
     def test_init_with_credentials(self):
         """Test initialization with AWS credentials."""
@@ -580,9 +583,7 @@ class TestRoute53PublishAgentParamDemotion:
 
         backend = Route53Backend(zone_id="Z123")
         mock_client = MagicMock()
-        mock_client.change_resource_record_sets.return_value = {
-            "ChangeInfo": {"Id": "/change/C1"}
-        }
+        mock_client.change_resource_record_sets.return_value = {"ChangeInfo": {"Id": "/change/C1"}}
 
         with patch.object(backend, "_get_client", return_value=mock_client):
             records = await backend.publish_agent(agent)
@@ -625,9 +626,7 @@ class TestRoute53PublishAgentParamDemotion:
 
         backend = Route53Backend(zone_id="Z123")
         mock_client = MagicMock()
-        mock_client.change_resource_record_sets.return_value = {
-            "ChangeInfo": {"Id": "/change/C2"}
-        }
+        mock_client.change_resource_record_sets.return_value = {"ChangeInfo": {"Id": "/change/C2"}}
 
         with patch.object(backend, "_get_client", return_value=mock_client):
             records = await backend.publish_agent(agent)
@@ -660,9 +659,7 @@ class TestRoute53PublishAgentParamDemotion:
 
         backend = Route53Backend(zone_id="Z123")
         mock_client = MagicMock()
-        mock_client.change_resource_record_sets.return_value = {
-            "ChangeInfo": {"Id": "/change/C3"}
-        }
+        mock_client.change_resource_record_sets.return_value = {"ChangeInfo": {"Id": "/change/C3"}}
 
         with patch.object(backend, "_get_client", return_value=mock_client):
             await backend.publish_agent(agent)

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for URL safety validation (SSRF protection)."""
 
 from __future__ import annotations

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for input validation utilities."""
 
 import pytest

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DNS-AID validator module."""
 
 from unittest.mock import AsyncMock, MagicMock, patch


### PR DESCRIPTION
## Summary

Prepares the repository for Linux Foundation submission by addressing all remaining compliance gaps identified during the LF readiness audit.

### Changes

**License Compliance (REUSE/SPDX)**
- Add `# SPDX-License-Identifier: Apache-2.0` headers to all 88 Python source and test files
- Add `DCO` file (Developer Certificate of Origin text) at repository root

**Neutral Branding**
- Remove hardcoded `velosecurity-ai.io` default URL from MCP server — telemetry push URL is now `None` by default, configured via `DNS_AID_SDK_HTTP_PUSH_URL` environment variable
- Replace all `highvelocitynetworking.com` references with `example.com` (RFC 2606) across docs, examples, and docstrings
- Replace real AWS Zone ID (`Z058...`) with `ZEXAMPLEZONEID` placeholder in docstrings and tests
- Update all repository URLs from `iracic82/dns-aid-core` to `infobloxopen/dns-aid-core` (pyproject.toml, Dockerfile, CHANGELOG, SUPPORT, MAINTAINERS, docs)

**Governance Templates**
- Add `.github/PULL_REQUEST_TEMPLATE.md` with checklist (tests, lint, DCO)
- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`
- Add `Changelog` URL to `[project.urls]` in pyproject.toml

### Verification

- 664 tests pass (`pytest tests/ -m "not live"`)
- `ruff check` and `ruff format --check` clean
- `mypy src/` clean
- `bandit -r src/` clean

### Files Changed

112 files (88 SPDX headers + 20 content edits + 4 new governance files)