### PR TITLE
chore: release v0.6.2 — documentation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-02-12
+
+### Changed
+- **Documentation Cleanup** — Removed references to server-side modules not present in dns-aid-core: Agent Directory submission, crawler pipeline, Kubernetes controller, database schema, and production telemetry endpoints
+- **SDK Telemetry Docs** — Clarified HTTP push and community rankings as optional client-side features with user-configured endpoints
+
+### Notes
+- No functional code changes — documentation-only release aligning docs with actual dns-aid-core scope
+
 ## [0.6.1] - 2026-02-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.6.1"
+version = "0.6.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version to 0.6.2
- Add CHANGELOG entry for documentation-only release

Follows PR #9 which removed server-side references from core docs. No functional code changes.

## Test plan

- [x] All 664 tests pass
- [x] Commit includes `Signed-off-by` (DCO compliant)