### PR TITLE
feat: centralized .env config, CITATION.cff, changelog automation, DX polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,56 @@
+# DNS-AID Configuration
+# Copy to .env and uncomment the variables you need.
+# The CLI, MCP server, and example scripts load this file automatically.
+# Backend-specific variables only needed for the backend you choose.
+
+# ─── General ─────────────────────────────────────────────
+# DNS_AID_BACKEND=mock              # route53 | cloudflare | infoblox | ddns | mock
+# DNS_AID_LOG_LEVEL=INFO            # DEBUG | INFO | WARNING | ERROR
+# DNS_AID_TEST_ZONE=example.com     # Domain to use for publish/discover
+# DNS_AID_SVCB_STRING_KEYS=0        # 1 = human-readable SVCB param names
+
+# ─── AWS Route 53 ───────────────────────────────────────
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_REGION=us-east-1
+# AWS_PROFILE=default               # Or use SSO: aws sso login --profile <name>
+# ROUTE53_ZONE_ID=                   # Optional — auto-discovered from domain
+
+# ─── Cloudflare ─────────────────────────────────────────
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ZONE_ID=                # Optional — auto-discovered from domain
+
+# ─── Infoblox BloxOne ───────────────────────────────────
+# INFOBLOX_API_KEY=
+# INFOBLOX_BASE_URL=https://csp.infoblox.com
+# INFOBLOX_DNS_VIEW=default
+
+# ─── DDNS / RFC 2136 (BIND, Windows DNS, PowerDNS) ─────
+# DDNS_SERVER=ns1.example.com
+# DDNS_KEY_NAME=dns-aid-key
+# DDNS_KEY_SECRET=                   # Base64-encoded TSIG secret
+# DDNS_KEY_ALGORITHM=hmac-sha256
+# DDNS_PORT=53
+# DDNS_TIMEOUT=10
+
+# ─── SDK / Telemetry ────────────────────────────────────
+# DNS_AID_SDK_TIMEOUT=30             # HTTP request timeout (seconds)
+# DNS_AID_SDK_MAX_RETRIES=0          # Retry attempts on transient failures
+# DNS_AID_SDK_CALLER_ID=             # Identifier for the calling service
+# DNS_AID_SDK_HTTP_PUSH_URL=         # Telemetry push endpoint
+# DNS_AID_SDK_CONSOLE_SIGNALS=false  # Print signals to console/log
+# DNS_AID_SDK_TELEMETRY_API_URL=     # Telemetry API URL (community rankings)
+# DNS_AID_SDK_OTEL_ENABLED=false     # Enable OpenTelemetry export
+# DNS_AID_SDK_OTEL_ENDPOINT=         # OTLP collector endpoint
+# DNS_AID_SDK_OTEL_EXPORT_FORMAT=otlp  # otlp | console | noop
+
+# ─── Docker Playground (BIND9) ──────────────────────────
+# Pre-configured for tests/integration/bind/ docker-compose.
+# Uncomment this entire block to use the local playground:
+# DDNS_SERVER=127.0.0.1
+# DDNS_PORT=15353
+# DDNS_KEY_NAME=dns-aid-key
+# DDNS_KEY_SECRET=c2VjcmV0a2V5Zm9yZG5zYWlkdGVzdGluZzEyMzQ1Ng==
+# DDNS_KEY_ALGORITHM=hmac-sha256
+# DNS_AID_TEST_ZONE=test.dns-aid.local
+# DNS_AID_BACKEND=ddns

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Full history needed for git-cliff changelog
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -46,10 +48,18 @@ jobs:
           done
           cosign sign-blob --yes sbom.json --output-signature sbom.json.sig --output-certificate sbom.json.pem
 
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: RELEASE_NOTES.md
           files: |
             dist/*.whl
             dist/*.whl.sig

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+cff-version: 1.2.0
+title: "DNS-AID: DNS-based Agent Identification and Discovery"
+message: "If you use this software, please cite both the software and the IETF draft."
+type: software
+license: Apache-2.0
+repository-code: "https://github.com/infobloxopen/dns-aid-core"
+
+authors:
+  - name: "The DNS-AID Authors"
+
+version: "0.6.2"
+date-released: "2026-02-12"
+
+keywords:
+  - dns
+  - agent-discovery
+  - ietf
+  - svcb
+  - bandaid
+  - ai-agents
+  - mcp
+  - a2a
+
+references:
+  - type: standard
+    title: "BANDAID: Best-practice Approaches for Naming and Discovery of AI-Driven services"
+    authors:
+      - family-names: Mozley
+        given-names: Andrew
+      - family-names: Williams
+        given-names: Brandon
+    url: "https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/"
+    identifiers:
+      - type: other
+        value: "draft-mozleywilliams-dnsop-bandaid-02"
+        description: "IETF Internet-Draft"
+    notes: >
+      This software implements the BANDAID specification (draft-02):
+      SVCB/HTTPS record discovery, TXT capability records,
+      underscored naming (_agent._protocol._agents.domain),
+      custom SVCB parameters (cap, cap-sha256, bap, policy, realm),
+      DNSSEC validation, and DANE certificate matching.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # DNS-AID Core Makefile
 # Usage: make [target]
 
-.PHONY: install install-dev test test-cov lint type-check format clean build help
+.PHONY: install install-dev test test-cov lint type-check format clean build changelog help
 
 help:
 	@echo "DNS-AID Core Development Commands"
@@ -15,6 +15,7 @@ help:
 	@echo "  make format       Format code with ruff"
 	@echo "  make clean        Remove build artifacts"
 	@echo "  make build        Build distribution package"
+	@echo "  make changelog    Preview changelog for next release"
 
 install:
 	pip install -e .
@@ -45,3 +46,6 @@ clean:
 
 build: clean
 	python -m build
+
+changelog:  ## Preview changelog for next release
+	git-cliff --latest --strip header

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ pip install dns-aid[route53]
 pip install dns-aid[all]
 ```
 
+### Configure
+
+```bash
+cp .env.example .env   # All variables documented, uncomment what you need
+```
+
+The CLI, MCP server, and examples load `.env` automatically. Set your backend, credentials, domain, and log level in one place. See [`.env.example`](.env.example) for all options.
+
 ### Python Library
 
 ```python
@@ -62,6 +70,28 @@ agents = await dns_aid.discover("example.com", use_http_index=True)
 result = await dns_aid.verify("_my-agent._mcp._agents.example.com")
 print(f"Security Score: {result.security_score}/100")
 ```
+
+### Try Without Cloud Credentials
+
+No AWS/Cloudflare/Infoblox account? Use the built-in BIND9 playground:
+
+```bash
+# Start local DNS server
+docker compose -f tests/integration/bind/docker-compose.yml up -d
+
+# Copy pre-configured environment
+cp .env.example .env
+# Uncomment the "Docker Playground" section in .env
+
+# Publish and discover agents locally
+dns-aid publish my-agent --domain test.dns-aid.local --backend ddns
+dns-aid discover test.dns-aid.local --backend ddns
+
+# Clean up
+docker compose -f tests/integration/bind/docker-compose.yml down
+```
+
+See the [Getting Started Guide](docs/getting-started.md#docker-playground-zero-credential-setup) for full details.
 
 ## CLI Usage
 
@@ -826,7 +856,7 @@ python examples/demo_full.py
 ```bash
 # Clone the repo
 git clone https://github.com/infobloxopen/dns-aid-core
-cd dns-aid
+cd dns-aid-core
 
 # Create virtual environment
 python -m venv .venv

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,60 @@
+# git-cliff configuration for DNS-AID
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to DNS-AID are documented here.\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/infobloxopen/dns-aid-core
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
+            {{ commit.message | upper_first }}\
+            ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+    {%- endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+postprocessors = []
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^test", group = "Testing" },
+    { message = "^style", group = "Styling" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^security", group = "Security" },
+    { message = "^build", group = "Build" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "newest"
+
+# Skip merge commits and dependabot
+commit_preprocessors = [
+    { pattern = "^Merge", replace = "" },
+]

--- a/examples/demo_ddns.py
+++ b/examples/demo_ddns.py
@@ -7,7 +7,11 @@ using Dynamic DNS updates. Works with BIND9, Windows DNS,
 PowerDNS, Knot DNS, and any RFC 2136 compliant server.
 
 Usage:
-    # Set environment variables
+    # Option 1: Use .env file (recommended)
+    cp .env.example .env
+    # Uncomment the DDNS and Docker Playground sections in .env
+
+    # Option 2: Set environment variables manually
     export DDNS_SERVER="ns1.example.com"
     export DDNS_KEY_NAME="dns-aid-key"
     export DDNS_KEY_SECRET="YourBase64SecretHere=="
@@ -24,8 +28,12 @@ import asyncio
 import os
 import sys
 
+from dotenv import load_dotenv
+
 # Add src to path for development
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+load_dotenv()
 
 
 async def main(zone: str):

--- a/examples/demo_full.py
+++ b/examples/demo_full.py
@@ -9,7 +9,11 @@ This script demonstrates the complete DNS-AID workflow:
 4. Show how another agent would connect
 
 Usage:
-    # Set your zone
+    # Option 1: Use .env file (recommended)
+    cp .env.example .env
+    # Uncomment DNS_AID_TEST_ZONE and your backend section
+
+    # Option 2: Set environment variables manually
     export DNS_AID_TEST_ZONE="example.com"
 
     # Run the demo
@@ -25,8 +29,12 @@ import os
 import sys
 import time
 
+from dotenv import load_dotenv
+
 # Add src to path for development
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+load_dotenv()
 
 
 def print_section(title: str):

--- a/examples/demo_route53.py
+++ b/examples/demo_route53.py
@@ -6,7 +6,11 @@ This script demonstrates publishing and discovering an agent
 using real DNS records in Route 53.
 
 Usage:
-    # Set your zone (or pass as argument)
+    # Option 1: Use .env file (recommended)
+    cp .env.example .env
+    # Uncomment DNS_AID_TEST_ZONE and the Route 53 section
+
+    # Option 2: Set environment variables manually
     export DNS_AID_TEST_ZONE="example.com"
 
     # Run the demo
@@ -20,8 +24,12 @@ import asyncio
 import os
 import sys
 
+from dotenv import load_dotenv
+
 # Add src to path for development
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+load_dotenv()
 
 
 async def main(zone: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "pydantic>=2.5.0",
     "httpx>=0.27.0",
     "structlog>=24.0.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.6.0"
+__version__ = "0.6.2"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -86,11 +86,14 @@ def publish(
     ] = None,
     ttl: Annotated[int, typer.Option("--ttl", help="DNS TTL in seconds")] = 3600,
     backend: Annotated[
-        str,
+        str | None,
         typer.Option(
-            "--backend", "-b", help="DNS backend: route53, cloudflare, infoblox, ddns, mock"
+            "--backend",
+            "-b",
+            help="DNS backend, or set DNS_AID_BACKEND env var",
+            show_default="route53",
         ),
-    ] = "route53",
+    ] = None,
     cap_uri: Annotated[
         str | None,
         typer.Option("--cap-uri", help="URI to capability document (BANDAID draft-compliant)"),
@@ -402,7 +405,15 @@ def verify(
 @app.command("list")
 def list_records(
     domain: Annotated[str, typer.Argument(help="Domain to list records from")],
-    backend: Annotated[str, typer.Option("--backend", "-b", help="DNS backend")] = "route53",
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            "-b",
+            help="DNS backend, or set DNS_AID_BACKEND env var",
+            show_default="route53",
+        ),
+    ] = None,
 ):
     """
     List DNS-AID records in a domain.
@@ -459,7 +470,15 @@ def list_records(
 
 @app.command()
 def zones(
-    backend: Annotated[str, typer.Option("--backend", "-b", help="DNS backend")] = "route53",
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            "-b",
+            help="DNS backend, or set DNS_AID_BACKEND env var",
+            show_default="route53",
+        ),
+    ] = None,
 ):
     """
     List available DNS zones.
@@ -471,16 +490,13 @@ def zones(
     """
     dns_backend = _get_backend(backend)
 
-    console.print(f"\n[bold]Available DNS zones ({backend}):[/bold]\n")
-
-    if backend != "route53":
-        error_console.print("[red]Zone listing only supported for route53 backend[/red]")
-        raise typer.Exit(1)
-
     from dns_aid.backends.route53 import Route53Backend
 
     if not isinstance(dns_backend, Route53Backend):
+        error_console.print("[red]Zone listing only supported for route53 backend[/red]")
         raise typer.Exit(1)
+
+    console.print("\n[bold]Available DNS zones (route53):[/bold]\n")
 
     zone_list = run_async(dns_backend.list_zones())
 
@@ -511,7 +527,15 @@ def delete(
     name: Annotated[str, typer.Option("--name", "-n", help="Agent name")],
     domain: Annotated[str, typer.Option("--domain", "-d", help="Domain")],
     protocol: Annotated[str, typer.Option("--protocol", "-p", help="Protocol")] = "mcp",
-    backend: Annotated[str, typer.Option("--backend", "-b", help="DNS backend")] = "route53",
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            "-b",
+            help="DNS backend, or set DNS_AID_BACKEND env var",
+            show_default="route53",
+        ),
+    ] = None,
     force: Annotated[bool, typer.Option("--force", "-f", help="Skip confirmation")] = False,
     no_update_index: Annotated[
         bool,
@@ -590,7 +614,15 @@ app.add_typer(index_app, name="index")
 @index_app.command("list")
 def index_list(
     domain: Annotated[str, typer.Argument(help="Domain to list index from")],
-    backend: Annotated[str, typer.Option("--backend", "-b", help="DNS backend")] = "route53",
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            "-b",
+            help="DNS backend, or set DNS_AID_BACKEND env var",
+            show_default="route53",
+        ),
+    ] = None,
 ):
     """
     List agents in a domain's index record.
@@ -635,7 +667,15 @@ def index_list(
 @index_app.command("sync")
 def index_sync(
     domain: Annotated[str, typer.Argument(help="Domain to sync index for")],
-    backend: Annotated[str, typer.Option("--backend", "-b", help="DNS backend")] = "route53",
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            "-b",
+            help="DNS backend, or set DNS_AID_BACKEND env var",
+            show_default="route53",
+        ),
+    ] = None,
     ttl: Annotated[int, typer.Option("--ttl", help="TTL for index record")] = 3600,
 ):
     """
@@ -858,8 +898,18 @@ def keys_export_jwks(
 # ============================================================================
 
 
-def _get_backend(backend_name: str):
-    """Get DNS backend by name."""
+def _get_backend(backend_name: str | None):
+    """Get DNS backend by name.
+
+    Falls back to DNS_AID_BACKEND env var when no --backend flag is given.
+    """
+    import os
+
+    if backend_name is None:
+        backend_name = os.environ.get("DNS_AID_BACKEND", "route53")
+
+    backend_name = backend_name.lower()
+
     if backend_name == "route53":
         from dns_aid.backends.route53 import Route53Backend
 
@@ -922,7 +972,9 @@ def main(
 
     Publish and discover AI agents using DNS infrastructure.
     """
-    pass
+    from dotenv import load_dotenv
+
+    load_dotenv()
 
 
 if __name__ == "__main__":

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1233,6 +1233,10 @@ def main():
     """Run the MCP server."""
     import atexit
 
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
     # Register cleanup handler
     atexit.register(_cleanup)
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,12 +445,13 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "structlog" },
 ]
 
@@ -529,6 +530,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=13.0.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'all'", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Summary

- **`.env` support**: Added `python-dotenv` integration — CLI, MCP server, and examples auto-load `.env` files. CLI `--backend` now falls back to `DNS_AID_BACKEND` env var, then `route53`.
- **`.env.example`**: Complete reference file with all backend variables (Route 53, Cloudflare, Infoblox, DDNS, SDK) documented and commented out.
- **`CITATION.cff`**: Software citation with IETF `draft-mozleywilliams-dnsop-bandaid-02` reference — enables GitHub's "Cite this repository" button.
- **Changelog automation**: `cliff.toml` + `orhun/git-cliff-action` in release workflow generates release notes from conventional commits.
- **Docker playground docs**: Added "Try Without Cloud Credentials" section to README and getting-started guide.
- **Configuration docs**: Added "Configure" section explaining `.env` workflow to README and getting-started guide.
- **Bug fixes**: `__version__` 0.6.0 → 0.6.2, clone path `cd dns-aid` → `cd dns-aid-core`.

## Files Changed (15)

| File | Change |
|------|--------|
| `.env.example` | New — all backend config vars |
| `CITATION.cff` | New — IETF draft citation |
| `cliff.toml` | New — git-cliff config |
| `.github/workflows/release.yml` | git-cliff changelog step |
| `Makefile` | `make changelog` target |
| `README.md` | Configure + Docker playground sections |
| `docs/getting-started.md` | Configuration + Docker playground sections |
| `pyproject.toml` | `python-dotenv>=1.0.0` dependency |
| `src/dns_aid/__init__.py` | Version fix 0.6.0 → 0.6.2 |
| `src/dns_aid/cli/main.py` | `load_dotenv()` + `--backend` env var fallback |
| `src/dns_aid/mcp/server.py` | `load_dotenv()` in main() |
| `examples/demo_*.py` | `load_dotenv()` + docstring updates |
| `uv.lock` | Dependency + version update |

## Test Plan

- [x] All 648 unit tests pass (`uv run pytest`)
- [x] `ruff format --check src/` passes
- [x] Live tested: CLI publish/discover/verify/delete on Route 53
- [x] Live tested: Python library discover/verify
- [x] Live tested: MCP server health/ready endpoints
- [x] `.env` loading verified for CLI, MCP, and examples
- [x] CI passing on iracic82/dns-aid-core

Addresses reviewer feedback items: .env configuration, CITATION.cff, Docker playground promotion, changelog automation, version mismatch fix, getting-started path fix.