### PR TITLE
feat: add cloudflare and ddns install extras for backend consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ pip install dns-aid[cli]
 # With MCP server for AI agents
 pip install dns-aid[mcp]
 
-# With Route 53 backend
-pip install dns-aid[route53]
+# With a specific backend
+pip install dns-aid[route53]      # AWS Route 53
+pip install dns-aid[cloudflare]   # Cloudflare DNS
+pip install dns-aid[infoblox]     # Infoblox BloxOne
+pip install dns-aid[ddns]         # RFC 2136 Dynamic DNS (BIND, PowerDNS)
 
 # Everything
 pip install dns-aid[all]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,10 +34,13 @@ pip install -e ".[all]"
 ### Option 2: Install specific components
 
 ```bash
-pip install -e "."           # Core library only
-pip install -e ".[cli]"      # Core + CLI
-pip install -e ".[mcp]"      # Core + MCP server
-pip install -e ".[route53]"  # Core + Route 53 backend
+pip install -e "."              # Core library only
+pip install -e ".[cli]"         # Core + CLI
+pip install -e ".[mcp]"         # Core + MCP server
+pip install -e ".[route53]"     # Core + Route 53 backend
+pip install -e ".[cloudflare]"  # Core + Cloudflare backend
+pip install -e ".[infoblox]"    # Core + Infoblox BloxOne backend
+pip install -e ".[ddns]"        # Core + RFC 2136 Dynamic DNS backend
 ```
 
 ## Quick Test (No AWS needed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ route53 = [
 infoblox = [
     # Uses httpx from core deps
 ]
+cloudflare = [
+    # Uses httpx from core deps
+]
+ddns = [
+    # Uses dnspython from core deps
+]
 jws = [
     # JWS signature support (alternative to DNSSEC)
     "cryptography>=41.0.0",
@@ -86,7 +92,7 @@ all = [
     # MCP
     "mcp>=1.0.0",
     "uvicorn>=0.30.0",
-    # Route53
+    # Backends: Route53, Infoblox, Cloudflare, DDNS (last 3 use core deps)
     "boto3>=1.34.0",
     # JWS
     "cryptography>=41.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -539,7 +539,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "infoblox", "jws", "sdk", "otel", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "infoblox", "cloudflare", "ddns", "jws", "sdk", "otel", "dev", "all"]
 
 [[package]]
 name = "dnspython"


### PR DESCRIPTION
## Summary

- Add `cloudflare` and `ddns` optional-dependency extras (empty markers matching existing `infoblox` pattern — these backends use core deps `httpx`/`dnspython`)
- Update `[all]` comment to reference all four backends
- Document all backend install extras in README and getting-started guide

Users can now install any backend explicitly:
```bash
pip install dns-aid[route53]      # AWS Route 53
pip install dns-aid[cloudflare]   # Cloudflare DNS
pip install dns-aid[infoblox]     # Infoblox BloxOne
pip install dns-aid[ddns]         # RFC 2136 Dynamic DNS
```

## Test Plan

- [x] `uv lock` resolves (94 packages, no changes)
- [x] All 664 tests pass
- [x] `ruff format --check` clean
- [x] New extras visible via `importlib.metadata`