### PR TITLE
feat: publish to PyPI via trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,29 @@ jobs:
             sbom.json
             sbom.json.sig
             sbom.json.pem
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/dns-aid/
+    permissions:
+      id-token: write  # Trusted publisher OIDC
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,4 +88,5 @@ jobs:
           pip install pip-audit
 
       - name: Run pip-audit
-        run: pip-audit --strict
+        # Enable --strict after first PyPI publish (dns-aid not yet on PyPI)
+        run: pip-audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,8 +88,4 @@ jobs:
           pip install pip-audit
 
       - name: Run pip-audit
-        # dns-aid is not on PyPI yet, so --strict would fail on the lookup warning.
-        # Without --strict, vulnerabilities are still hard errors; only the
-        # "not found on PyPI" warning is downgraded. Re-enable --strict once
-        # dns-aid is published to PyPI.
-        run: pip-audit
+        run: pip-audit --strict

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,7 +30,7 @@ Before any release:
 3. **Create a PR** with the version bump
 4. **Merge PR** after CI passes and review approval
 5. **Tag the release** on GitHub with release notes
-6. **Publish to PyPI** (when PyPI publishing is configured)
+6. **Publish to PyPI** — pushing a `v*` tag automatically publishes to PyPI via trusted publisher
 
 ## Hotfix Process
 
@@ -45,7 +45,9 @@ For critical security fixes:
 
 Each release includes:
 
+- **PyPI package** — `pip install dns-aid` (published via trusted publisher)
 - **GitHub Release** with changelog and tag
 - **Source distribution** (sdist)
 - **Wheel distribution** (bdist_wheel)
-- **Docker image** (when Docker publishing is configured)
+- **Sigstore signatures** (`.sig` + `.pem` for each artifact)
+- **SBOM** (CycloneDX JSON)


### PR DESCRIPTION
## Summary

- Add `publish-to-pypi` job to `release.yml` using OIDC-based trusted publisher (`pypa/gh-action-pypi-publish`)
- Enable `pip-audit --strict` in `security.yml` now that dns-aid will be on PyPI
- Update `RELEASE.md` to reflect automated publish flow and current release artifacts

## Prerequisites (manual steps)

1. **Register pending trusted publisher on PyPI** — https://pypi.org/manage/account/publishing/
   - Package: `dns-aid`, Owner: `infobloxopen`, Repo: `dns-aid-core`, Workflow: `release.yml`, Environment: `release`
2. **Create GitHub environment** — Settings → Environments → New: `release`
   - Optional: add deployment protection rule (reviewer approval)

## How it works

On `v*` tag push: `build` job builds wheels, signs with Sigstore, creates GitHub Release, then uploads `dist/` as artifact. The new `publish-to-pypi` job downloads that artifact and publishes to PyPI via OIDC trusted publisher (no API tokens needed).

## Test plan

- [ ] Verify CI passes on this PR (YAML valid, no regressions)
- [ ] Register trusted publisher on PyPI (manual)
- [ ] Create `release` GitHub environment (manual)
- [ ] Tag a release and verify PyPI publish succeeds
- [ ] Confirm `pip install dns-aid` works from PyPI

Signed-off-by: Igor Racic <iracic82@gmail.com>