### PR TITLE
chore: bump version to 0.6.3 for PyPI publishing release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-02-16
+
+### Added
+- **PyPI Publishing** — Release workflow now publishes to PyPI via OIDC trusted publisher (no API tokens)
+- **Cloudflare & DDNS install extras** — `pip install dns-aid[cloudflare]` and `pip install dns-aid[ddns]`
+
+### Changed
+- **pip-audit** — Kept non-strict until first PyPI publish lands
+- **Release artifacts** — Updated RELEASE.md to document Sigstore signatures, SBOM, and PyPI package
+
 ## [0.6.2] - 2026-02-12
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.6.2"
+version = "0.6.3"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.6.0"
+__version__ = "0.6.3"
 __all__ = [
     # Core functions (Tier 0)
     "publish",


### PR DESCRIPTION
## Summary

- Bump version to `0.6.3` in `pyproject.toml`, `src/dns_aid/__init__.py`, and `CHANGELOG.md`
- Changelog includes PyPI publishing and Cloudflare/DDNS extras from recent PRs

After merge, tag `v0.6.3` to trigger the release workflow and first PyPI publish.

Signed-off-by: Igor Racic <iracic82@gmail.com>