### PR TITLE
fix: upload dist artifact before signing for clean PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Build wheel and sdist
         run: python -m build
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Install package for SBOM
         run: pip install dist/*.whl
 
@@ -60,12 +66,6 @@ jobs:
             sbom.json
             sbom.json.sig
             sbom.json.pem
-
-      - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
   publish-to-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## Summary

Move `upload-artifact` step to right after `python -m build`, before Cosign signing adds `.sig` and `.pem` files to `dist/`. The PyPI publish action only accepts valid Python distributions (`.whl`, `.tar.gz`) and fails on signature files.

## What happened

The v0.6.3 release workflow failed at the PyPI publish step:
```
Checking dist/dns_aid-0.6.3-py3-none-any.whl.pem: ERROR InvalidDistribution: Unknown distribution format
```

## Fix

Upload the dist artifact **before** signing, so only `.whl` and `.tar.gz` are included.

Signed-off-by: Igor Racic <iracic82@gmail.com>