### PR TITLE
feat: add NIOS WAPI backend and live test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Infoblox NIOS backend** — Production implementation for on-prem NIOS WAPI with SVCB/TXT upsert, delete, list, and zone checks/listing
+- **Backend wiring for NIOS** — `DNS_AID_BACKEND=nios` support in publisher backend selection
+- **NIOS unit tests** — Coverage for constructor validation, SVC parameter mapping, strict-fail behavior, record lifecycle methods, and zone operations
+- **NIOS live integration tests** — Optional live test harness using `tests/live_targets.json` with read-only and mutation coverage
+
+### Changed
+- **SVC parameter compatibility for NIOS** — Maps custom BANDAID SVC keys to NIOS-compatible `keyNNNNN` keys and maps back on read formatting
+- **Documentation** — README, getting started, and API reference now document NIOS backend setup and strict SVCB behavior
+
 ## [0.6.6] - 2026-02-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ DNS-AID supports multiple DNS backends:
 | DDNS | RFC 2136 Dynamic DNS (BIND, etc.) | ✅ Production |
 | Cloudflare | Cloudflare DNS | ✅ Production |
 | Mock | In-memory (testing) | ✅ Production |
-| NIOS | Infoblox NIOS (on-prem) | 🚧 Planned |
+| NIOS | Infoblox NIOS (on-prem) | ✅ Production |
 
 ### Route 53 Setup
 
@@ -653,6 +653,47 @@ async with InfobloxBloxOneBackend() as backend:
     async for record in backend.list_records("example.com", name_pattern="my-agent"):
         print(f"{record['type']}: {record['fqdn']}")
 ```
+
+### Infoblox NIOS Setup (9.0.7+)
+
+Infoblox NIOS is the on-premises DDI platform. DNS-AID supports creating `record:svcb` and
+`record:txt` records via NIOS WAPI (tested against WAPI `v2.13.7`, suitable for NIOS 9.0.7+).
+
+#### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NIOS_HOST` | Yes | - | NIOS Grid Master hostname |
+| `NIOS_USERNAME` | Yes | - | WAPI username |
+| `NIOS_PASSWORD` | Yes | - | WAPI password |
+| `NIOS_WAPI_VERSION` | No | `2.13.7` | WAPI version |
+| `NIOS_VERIFY_SSL` | No | `true` | Verify TLS certificates |
+| `NIOS_DNS_VIEW` | No | `default` | DNS view containing the authoritative zone |
+| `NIOS_TIMEOUT` | No | `30.0` | HTTP timeout (seconds) |
+
+#### Quick Setup
+
+```bash
+export DNS_AID_BACKEND="nios"
+export NIOS_HOST="nios.example.com"
+export NIOS_USERNAME="admin"
+export NIOS_PASSWORD="your-secret"
+export NIOS_DNS_VIEW="default"
+```
+
+```python
+from dns_aid.backends.infoblox import InfobloxNIOSBackend
+from dns_aid.core.publisher import set_default_backend
+
+backend = InfobloxNIOSBackend()
+set_default_backend(backend)
+```
+
+#### Strict SVCB Parameter Handling
+
+NIOS publication is **strict** for SVCB parameters. If WAPI rejects any SVC parameter
+(for example `cap`, `cap-sha256`, `bap`, `policy`, `realm`, `sig`), DNS-AID raises an
+error and does not silently degrade the SVCB write.
 
 ### DDNS Setup (RFC 2136)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,7 @@ Complete API documentation for DNS-AID - DNS-based Agent Identification and Disc
   - [DNSBackend Interface](#dnsbackend-interface)
   - [Route53Backend](#route53backend)
   - [InfobloxBloxOneBackend](#infobloxbloxonebackend)
+  - [InfobloxNIOSBackend](#infobloxniosbackend)
   - [CloudflareBackend](#cloudflarebackend)
   - [DDNSBackend](#ddnsbackend)
   - [MockBackend](#mockbackend)
@@ -475,6 +476,49 @@ async with InfobloxBloxOneBackend() as backend:
 
 **⚠️ BANDAID Compliance**: Infoblox UDDI is **not fully compliant** with the [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend or DDNSBackend.
 
+### InfobloxNIOSBackend
+
+Infoblox NIOS (on-premises) implementation using WAPI.
+
+```python
+from dns_aid.backends.infoblox import InfobloxNIOSBackend
+
+# From environment variables (recommended)
+backend = InfobloxNIOSBackend()
+
+# Or with explicit configuration
+backend = InfobloxNIOSBackend(
+    host="nios.example.com",
+    username="admin",
+    password="secret",
+    wapi_version="2.13.7",  # default
+    dns_view="default",     # default
+    verify_ssl=True,        # default
+    timeout=30.0,           # default
+)
+```
+
+**Environment Variables**:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NIOS_HOST` | Yes | - | NIOS Grid Master hostname |
+| `NIOS_USERNAME` | Yes | - | WAPI username |
+| `NIOS_PASSWORD` | Yes | - | WAPI password |
+| `NIOS_WAPI_VERSION` | No | `2.13.7` | WAPI version |
+| `NIOS_VERIFY_SSL` | No | `true` | Verify TLS certificates |
+| `NIOS_DNS_VIEW` | No | `default` | DNS view |
+| `NIOS_TIMEOUT` | No | `30.0` | Request timeout in seconds |
+
+**Strict SVCB Validation**: NIOS SVCB publication is strict. If NIOS rejects any SVC parameter
+(`cap`, `cap-sha256`, `bap`, `policy`, `realm`, `sig`, etc.), publish fails with an error.
+
+Use the default backend selector:
+
+```bash
+export DNS_AID_BACKEND=nios
+```
+
 ### DDNSBackend
 
 RFC 2136 Dynamic DNS implementation. Works with BIND, Windows DNS, PowerDNS, Knot DNS, and any RFC 2136 compliant server.
@@ -726,7 +770,7 @@ dns-aid index sync example.com           # Sync index with actual DNS records
 
 | Variable | Description |
 |----------|-------------|
-| `DNS_AID_BACKEND` | Default backend: "route53", "bloxone", "ddns", or "mock" |
+| `DNS_AID_BACKEND` | Default backend: "route53", "cloudflare", "infoblox", "nios", "ddns", or "mock" |
 | `DNS_AID_LOG_LEVEL` | Logging level: DEBUG, INFO, WARNING, ERROR |
 
 **AWS Route 53:**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,6 +301,46 @@ async with InfobloxBloxOneBackend() as backend:
             print(f"{record['type']}: {record['fqdn']}")
 ```
 
+## Infoblox NIOS Setup (9.0.7+)
+
+Infoblox NIOS is the on-premises DDI platform. DNS-AID supports publishing SVCB/TXT records
+via WAPI.
+
+### 1. Configure Environment Variables
+
+```bash
+export DNS_AID_BACKEND="nios"
+export NIOS_HOST="nios.example.com"
+export NIOS_USERNAME="admin"
+export NIOS_PASSWORD="your-secret"
+
+# Optional
+export NIOS_WAPI_VERSION="2.13.7"
+export NIOS_DNS_VIEW="default"
+export NIOS_VERIFY_SSL="true"
+export NIOS_TIMEOUT="30.0"
+```
+
+### 2. Verify Connection (Python)
+
+```python
+import asyncio
+from dns_aid.backends.infoblox import InfobloxNIOSBackend
+
+async def verify_connection():
+    backend = InfobloxNIOSBackend()
+    exists = await backend.zone_exists("your-zone.com")
+    print(f"Zone exists in configured view: {exists}")
+    await backend.close()
+
+asyncio.run(verify_connection())
+```
+
+### 3. Important Behavior: Strict SVCB Parameters
+
+NIOS writes are strict for SVCB parameters. If NIOS rejects a parameter (for example custom
+BANDAID keys), DNS-AID returns an error and does not silently downgrade the SVCB write.
+
 ## DDNS Setup (RFC 2136)
 
 DDNS (Dynamic DNS) works with any DNS server supporting RFC 2136, including BIND9, Windows DNS, PowerDNS, and Knot DNS. This is ideal for on-premise infrastructure without vendor-specific APIs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ packages = ["src/dns_aid"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-addopts = "-v"
+addopts = "-v --import-mode=importlib"
 markers = [
     "live: tests requiring real infrastructure (Route53, Infoblox, DDNS, etc.)",
 ]

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -21,9 +21,10 @@ try:
     from dns_aid.backends.infoblox import (  # noqa: F401
         InfobloxBackend,
         InfobloxBloxOneBackend,
+        InfobloxNIOSBackend,
     )
 
-    __all__.extend(["InfobloxBackend", "InfobloxBloxOneBackend"])
+    __all__.extend(["InfobloxBackend", "InfobloxBloxOneBackend", "InfobloxNIOSBackend"])
 except ImportError:
     pass
 

--- a/src/dns_aid/backends/infoblox/__init__.py
+++ b/src/dns_aid/backends/infoblox/__init__.py
@@ -6,7 +6,7 @@ Infoblox DNS backends for DNS-AID.
 
 Supports both Infoblox platforms:
 - BloxOne DDI (cloud): InfobloxBloxOneBackend
-- NIOS (on-prem): InfobloxNIOSBackend (planned)
+- NIOS (on-prem): InfobloxNIOSBackend
 
 Example:
     >>> from dns_aid.backends.infoblox import InfobloxBloxOneBackend
@@ -15,12 +15,13 @@ Example:
 """
 
 from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
 
 # Alias for convenience
 InfobloxBackend = InfobloxBloxOneBackend
 
 __all__ = [
     "InfobloxBloxOneBackend",
+    "InfobloxNIOSBackend",
     "InfobloxBackend",
-    # "InfobloxNIOSBackend",  # Coming soon
 ]

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -8,73 +8,334 @@ Creates DNS-AID records via the NIOS WAPI (Web API).
 This is the traditional on-premises DDI platform from Infoblox.
 
 API Documentation: https://docs.infoblox.com/display/nios/WAPI+Versioning
-
-Status: PLANNED - Not yet implemented
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import os
+import re
 from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import structlog
 
 from dns_aid.backends.base import DNSBackend
+
+logger = structlog.get_logger(__name__)
 
 
 class InfobloxNIOSBackend(DNSBackend):
     """
     Infoblox NIOS WAPI backend (on-premises).
 
-    NOT YET IMPLEMENTED - Placeholder for future development.
-
-    This backend will support:
-    - NIOS WAPI v2.x authentication (basic auth or certificate)
-    - SVCB record creation (requires NIOS 8.6+)
-    - TXT record creation
-    - Zone management via WAPI
-
-    Example (planned):
-        >>> backend = InfobloxNIOSBackend(
-        ...     host="nios.example.com",
-        ...     username="admin",
-        ...     password=os.environ["NIOS_PASSWORD"],
-        ...     wapi_version="2.12",
-        ... )
-        >>> await backend.create_svcb_record(...)
-
-    Environment Variables (planned):
+    Environment Variables:
         NIOS_HOST: NIOS Grid Master hostname
         NIOS_USERNAME: WAPI username
         NIOS_PASSWORD: WAPI password
-        NIOS_WAPI_VERSION: WAPI version (default: 2.12)
+        NIOS_WAPI_VERSION: WAPI version (default: 2.13.7)
         NIOS_VERIFY_SSL: Verify SSL certificates (default: true)
+        NIOS_DNS_VIEW: DNS view name (default: default)
+        NIOS_TIMEOUT: HTTP request timeout in seconds (default: 30.0)
     """
+
+    _SPLIT_VALUE_KEYS = {"alpn", "bap", "ipv4hint", "ipv6hint"}
+    # NIOS only accepts registered SVC keys or keyNNNNN numeric keys.
+    # Map draft custom names to private-use keyNNNNN aliases for compatibility.
+    _CUSTOM_PARAM_TO_NUMERIC_KEY = {
+        "cap": "key65001",
+        "cap-sha256": "key65002",
+        "bap": "key65003",
+        "policy": "key65004",
+        "realm": "key65005",
+        "sig": "key65006",
+    }
+    _NUMERIC_KEY_TO_CUSTOM_PARAM = {
+        value: key for key, value in _CUSTOM_PARAM_TO_NUMERIC_KEY.items()
+    }
+    _KEY_NNNNN_RE = re.compile(r"^key[1-9][0-9]{0,4}$")
 
     def __init__(
         self,
         host: str | None = None,
         username: str | None = None,
         password: str | None = None,
-        wapi_version: str = "2.12",
-        verify_ssl: bool = True,
+        wapi_version: str | None = None,
+        verify_ssl: bool | None = None,
+        dns_view: str | None = None,
+        timeout: float | None = None,
     ):
-        """
-        Initialize NIOS backend.
+        """Initialize NIOS backend."""
+        self._host = (host or os.environ.get("NIOS_HOST", "")).strip()
+        self._username = (username or os.environ.get("NIOS_USERNAME", "")).strip()
+        password_value = password or os.environ.get("NIOS_PASSWORD")
+        self._wapi_version = (
+            wapi_version or os.environ.get("NIOS_WAPI_VERSION") or "2.13.7"
+        ).strip()
 
-        Args:
-            host: NIOS Grid Master hostname
-            username: WAPI username
-            password: WAPI password
-            wapi_version: WAPI version (e.g., "2.12")
-            verify_ssl: Whether to verify SSL certificates
-        """
-        raise NotImplementedError(
-            "InfobloxNIOSBackend is not yet implemented. "
-            "Use InfobloxBloxOneBackend for cloud deployments, "
-            "or contribute the NIOS implementation!"
-        )
+        env_verify_ssl = os.environ.get("NIOS_VERIFY_SSL")
+        if verify_ssl is None:
+            self._verify_ssl = self._parse_bool_env(env_verify_ssl, default=True)
+        else:
+            self._verify_ssl = verify_ssl
+
+        self._dns_view = (dns_view or os.environ.get("NIOS_DNS_VIEW") or "default").strip()
+
+        env_timeout = os.environ.get("NIOS_TIMEOUT")
+        if timeout is None:
+            self._timeout = float(env_timeout) if env_timeout else 30.0
+        else:
+            self._timeout = timeout
+
+        if not self._host:
+            raise ValueError("NIOS host required. Set NIOS_HOST or pass host parameter.")
+        if not self._username:
+            raise ValueError(
+                "NIOS username required. Set NIOS_USERNAME or pass username parameter."
+            )
+        if not password_value:
+            raise ValueError(
+                "NIOS password required. Set NIOS_PASSWORD or pass password parameter."
+            )
+        self._password = password_value
+
+        self._base_url = f"https://{self._host.rstrip('/')}/wapi/v{self._wapi_version}"
+        self._client: httpx.AsyncClient | None = None
+        self._client_loop_id: int | None = None
+
+    @staticmethod
+    def _parse_bool_env(value: str | None, default: bool) -> bool:
+        """Parse boolean environment variable values."""
+        if value is None:
+            return default
+
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(f"Invalid boolean value: {value}")
 
     @property
     def name(self) -> str:
         return "nios"
+
+    @property
+    def dns_view(self) -> str:
+        """Get configured DNS view."""
+        return self._dns_view
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create async HTTP client for this event loop."""
+        current_loop_id = id(asyncio.get_running_loop())
+
+        if self._client is not None and self._client_loop_id != current_loop_id:
+            with contextlib.suppress(Exception):
+                await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                auth=(self._username, self._password),
+                verify=self._verify_ssl,
+                timeout=self._timeout,
+                headers={"Content-Type": "application/json"},
+            )
+            self._client_loop_id = current_loop_id
+
+        return self._client
+
+    async def close(self) -> None:
+        """Close underlying HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | list[Any]:
+        """Execute a WAPI request with centralized error handling."""
+        client = await self._get_client()
+        cleaned_endpoint = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+
+        try:
+            response = await client.request(
+                method=method,
+                url=cleaned_endpoint,
+                params=params,
+                json=json,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
+            logger.error(
+                "NIOS WAPI request failed",
+                method=method,
+                endpoint=cleaned_endpoint,
+                status_code=exc.response.status_code,
+                response_body=body,
+            )
+            raise RuntimeError(
+                f"NIOS WAPI request failed ({method} {cleaned_endpoint}): "
+                f"status={exc.response.status_code} body={body}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            logger.error(
+                "NIOS WAPI transport error",
+                method=method,
+                endpoint=cleaned_endpoint,
+                error=str(exc),
+            )
+            raise RuntimeError(
+                f"NIOS WAPI transport error ({method} {cleaned_endpoint}): {exc}"
+            ) from exc
+
+        if not response.content:
+            return {}
+
+        content_type = response.headers.get("content-type", "")
+        if "application/json" not in content_type:
+            return {"raw": response.text}
+
+        parsed = response.json()
+        if isinstance(parsed, (dict, list)):
+            return parsed
+
+        return {"raw": parsed}
+
+    @staticmethod
+    def _to_fqdn(name: str, zone: str) -> str:
+        """Build fully qualified owner name for a record."""
+        zone_clean = zone.rstrip(".")
+        name_clean = name.rstrip(".")
+        if name_clean.endswith(f".{zone_clean}"):
+            return name_clean
+        return f"{name_clean}.{zone_clean}"
+
+    @staticmethod
+    def _normalize_target(target: str) -> str:
+        """Normalize SVCB target for NIOS WAPI FQDN validation."""
+        return target.strip().rstrip(".")
+
+    @classmethod
+    def _to_nios_svc_key(cls, key: str) -> str:
+        """Map user-facing key names to NIOS-compatible keys."""
+        normalized = key.strip().lower()
+        if cls._KEY_NNNNN_RE.match(normalized):
+            return normalized
+        return cls._CUSTOM_PARAM_TO_NUMERIC_KEY.get(normalized, normalized)
+
+    @classmethod
+    def _from_nios_svc_key(cls, key: str) -> str:
+        """Map NIOS keyNNNNN aliases back to user-facing key names."""
+        normalized = key.strip().lower()
+        return cls._NUMERIC_KEY_TO_CUSTOM_PARAM.get(normalized, normalized)
+
+    @classmethod
+    def _mandatory_keys(cls, params: dict[str, str]) -> set[str]:
+        """Parse mandatory keys from SVCB params map."""
+        raw = params.get("mandatory", "")
+        keys = set()
+        for item in raw.split(","):
+            key = item.strip()
+            if key:
+                keys.add(cls._to_nios_svc_key(key))
+        return keys
+
+    @classmethod
+    def _svc_parameters_from_params(cls, params: dict[str, str]) -> list[dict[str, Any]]:
+        """Convert DNS-AID SVCB params into NIOS svc_parameters format."""
+        mandatory_keys = cls._mandatory_keys(params)
+        svc_parameters: list[dict[str, Any]] = []
+
+        for key, value in params.items():
+            if key == "mandatory":
+                continue
+            mapped_key = cls._to_nios_svc_key(key)
+
+            key_for_split = cls._from_nios_svc_key(mapped_key)
+            if key_for_split in cls._SPLIT_VALUE_KEYS:
+                svc_value = [entry.strip() for entry in value.split(",") if entry.strip()]
+            else:
+                svc_value = [value]
+
+            svc_parameters.append(
+                {
+                    "svc_key": mapped_key,
+                    "svc_value": svc_value,
+                    "mandatory": mapped_key in mandatory_keys,
+                }
+            )
+
+        return svc_parameters
+
+    @classmethod
+    def _format_svc_parameters_for_value(cls, svc_parameters: Any) -> str:
+        """Format NIOS svc_parameters list to SVCB presentation tokens."""
+        if not isinstance(svc_parameters, list):
+            return ""
+
+        mandatory_keys: list[str] = []
+        seen_mandatory: set[str] = set()
+        param_parts: list[str] = []
+
+        for item in svc_parameters:
+            if not isinstance(item, dict):
+                continue
+
+            raw_key = str(item.get("svc_key", "")).strip()
+            if not raw_key:
+                continue
+            key = cls._from_nios_svc_key(raw_key)
+
+            raw_values = item.get("svc_value", [])
+            if isinstance(raw_values, list):
+                values = [str(value).strip() for value in raw_values if str(value).strip()]
+            elif raw_values is None:
+                values = []
+            else:
+                value = str(raw_values).strip()
+                values = [value] if value else []
+
+            if item.get("mandatory") and key not in seen_mandatory:
+                mandatory_keys.append(key)
+                seen_mandatory.add(key)
+
+            if values:
+                joined = ",".join(values).replace('"', r"\"")
+                param_parts.append(f'{key}="{joined}"')
+
+        if mandatory_keys:
+            mandatory_value = ",".join(mandatory_keys).replace('"', r"\"")
+            param_parts.insert(0, f'mandatory="{mandatory_value}"')
+
+        return " ".join(param_parts)
+
+    async def _find_record_ref(self, zone: str, name: str, record_type: str) -> str | None:
+        """Find record reference by owner name, type, and configured DNS view."""
+        fqdn = self._to_fqdn(name, zone)
+        params = {
+            "name": fqdn,
+            "view": self._dns_view,
+        }
+
+        results = await self._request("GET", f"record:{record_type.lower()}", params=params)
+        if isinstance(results, list) and results:
+            ref = results[0].get("_ref")
+            if isinstance(ref, str):
+                return ref
+
+        return None
 
     async def create_svcb_record(
         self,
@@ -86,7 +347,30 @@ class InfobloxNIOSBackend(DNSBackend):
         ttl: int = 3600,
     ) -> str:
         """Create SVCB record in NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        fqdn = self._to_fqdn(name, zone)
+        svc_parameters = self._svc_parameters_from_params(params)
+
+        payload: dict[str, Any] = {
+            "name": fqdn,
+            "view": self._dns_view,
+            "priority": priority,
+            "target_name": self._normalize_target(target),
+            "svc_parameters": svc_parameters,
+            "ttl": ttl,
+            "use_ttl": True,
+            "comment": f"DNS-AID: SVCB record for {name}",
+        }
+
+        record_ref = await self._find_record_ref(zone, name, "svcb")
+
+        if record_ref:
+            logger.info("Updating SVCB record in NIOS", fqdn=fqdn, record_ref=record_ref)
+            await self._request("PUT", record_ref, json=payload)
+        else:
+            logger.info("Creating SVCB record in NIOS", fqdn=fqdn)
+            await self._request("POST", "record:svcb", json=payload)
+
+        return fqdn
 
     async def create_txt_record(
         self,
@@ -96,7 +380,27 @@ class InfobloxNIOSBackend(DNSBackend):
         ttl: int = 3600,
     ) -> str:
         """Create TXT record in NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        fqdn = self._to_fqdn(name, zone)
+
+        payload: dict[str, Any] = {
+            "name": fqdn,
+            "view": self._dns_view,
+            "text": " ".join(f'"{value}"' for value in values),
+            "ttl": ttl,
+            "use_ttl": True,
+            "comment": f"DNS-AID: TXT record for {name}",
+        }
+
+        record_ref = await self._find_record_ref(zone, name, "txt")
+
+        if record_ref:
+            logger.info("Updating TXT record in NIOS", fqdn=fqdn, record_ref=record_ref)
+            await self._request("PUT", record_ref, json=payload)
+        else:
+            logger.info("Creating TXT record in NIOS", fqdn=fqdn)
+            await self._request("POST", "record:txt", json=payload)
+
+        return fqdn
 
     async def delete_record(
         self,
@@ -105,18 +409,118 @@ class InfobloxNIOSBackend(DNSBackend):
         record_type: str,
     ) -> bool:
         """Delete a DNS record from NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        record_ref = await self._find_record_ref(zone, name, record_type)
+        if not record_ref:
+            logger.warning(
+                "Record not found in NIOS", zone=zone, name=name, record_type=record_type
+            )
+            return False
+
+        await self._request("DELETE", record_ref)
+        logger.info("Deleted record from NIOS", zone=zone, name=name, record_type=record_type)
+        return True
 
     async def list_records(
         self,
         zone: str,
         name_pattern: str | None = None,
         record_type: str | None = None,
-    ) -> AsyncIterator[dict]:
-        """List DNS records in NIOS zone."""
-        raise NotImplementedError("NIOS backend not yet implemented")
-        yield  # Make this a generator
+    ) -> AsyncIterator[dict[str, Any]]:
+        """List DNS records in NIOS zone/view."""
+        supported_types = [record_type.upper()] if record_type else ["SVCB", "TXT"]
+
+        for rtype in supported_types:
+            endpoint = f"record:{rtype.lower()}"
+            params = {
+                "zone": zone.rstrip("."),
+                "view": self._dns_view,
+            }
+
+            results = await self._request("GET", endpoint, params=params)
+            if not isinstance(results, list):
+                continue
+
+            for record in results:
+                fqdn = str(record.get("name", "")).rstrip(".")
+                if not fqdn:
+                    continue
+
+                if name_pattern and name_pattern not in fqdn:
+                    continue
+
+                values: list[str]
+                ttl = int(record.get("ttl", 0))
+
+                if rtype == "TXT":
+                    values = [str(record.get("text", ""))]
+                else:
+                    priority = int(record.get("priority", 0))
+                    target_name = str(record.get("target_name", ""))
+                    svc_parameters_text = self._format_svc_parameters_for_value(
+                        record.get("svc_parameters", [])
+                    )
+                    values = [f"{priority} {target_name} {svc_parameters_text}".strip()]
+
+                yield {
+                    "name": fqdn.split(f".{zone.rstrip('.')}", 1)[0],
+                    "fqdn": fqdn,
+                    "type": rtype,
+                    "ttl": ttl,
+                    "values": values,
+                    "id": record.get("_ref"),
+                }
 
     async def zone_exists(self, zone: str) -> bool:
-        """Check if zone exists in NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        """Check if authoritative zone exists in the configured DNS view."""
+        zone_name = zone.rstrip(".")
+        params = {
+            "fqdn": zone_name,
+            "view": self._dns_view,
+        }
+
+        results = await self._request("GET", "zone_auth", params=params)
+        if isinstance(results, list) and len(results) > 0:
+            return True
+
+        # Some NIOS deployments store/expect trailing-dot zone fqdn values.
+        params["fqdn"] = f"{zone_name}."
+        results = await self._request("GET", "zone_auth", params=params)
+        return isinstance(results, list) and len(results) > 0
+
+    async def list_zones(self) -> list[dict[str, Any]]:
+        """List authoritative zones in the configured DNS view."""
+        params = {
+            "view": self._dns_view,
+        }
+        results = await self._request("GET", "zone_auth", params=params)
+
+        if not isinstance(results, list):
+            return []
+
+        zones: list[dict[str, Any]] = []
+        for zone in results:
+            if not isinstance(zone, dict):
+                continue
+
+            fqdn = str(zone.get("fqdn", ""))
+            zones.append(
+                {
+                    "id": zone.get("_ref"),
+                    "name": fqdn.rstrip("."),
+                    "fqdn": fqdn,
+                    "view": zone.get("view", self._dns_view),
+                    "comment": zone.get("comment", ""),
+                    "disabled": bool(zone.get("disable", False)),
+                    "zone_format": zone.get("zone_format", ""),
+                }
+            )
+
+        return zones
+
+    async def __aenter__(self) -> InfobloxNIOSBackend:
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        """Async context manager exit."""
+        await self.close()

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -37,7 +37,7 @@ def reset_default_backend() -> None:
 def get_default_backend() -> DNSBackend:
     """Get the default DNS backend based on DNS_AID_BACKEND env var.
 
-    Supported values: route53, cloudflare, infoblox, ddns, mock
+    Supported values: route53, cloudflare, infoblox, nios, ddns, mock
 
     Raises:
         ValueError: If DNS_AID_BACKEND is not set (no silent fallback to mock).
@@ -51,7 +51,7 @@ def get_default_backend() -> DNSBackend:
         if not backend_type:
             raise ValueError(
                 "DNS_AID_BACKEND must be set. "
-                "Supported values: route53, cloudflare, infoblox, ddns, mock"
+                "Supported values: route53, cloudflare, infoblox, nios, ddns, mock"
             )
 
         if backend_type == "route53":
@@ -66,6 +66,10 @@ def get_default_backend() -> DNSBackend:
             from dns_aid.backends.infoblox import InfobloxBackend
 
             _default_backend = InfobloxBackend()
+        elif backend_type == "nios":
+            from dns_aid.backends.infoblox import InfobloxNIOSBackend
+
+            _default_backend = InfobloxNIOSBackend()
         elif backend_type == "ddns":
             from dns_aid.backends.ddns import DDNSBackend
 
@@ -75,7 +79,7 @@ def get_default_backend() -> DNSBackend:
         else:
             raise ValueError(
                 f"Unknown DNS_AID_BACKEND: '{backend_type}'. "
-                "Supported values: route53, cloudflare, infoblox, ddns, mock"
+                "Supported values: route53, cloudflare, infoblox, nios, ddns, mock"
             )
 
         logger.info(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-# Copyright 2024-2026 The DNS-AID Authors
-# SPDX-License-Identifier: Apache-2.0
-
-"""DNS-AID test suite."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,0 @@
-# Copyright 2024-2026 The DNS-AID Authors
-# SPDX-License-Identifier: Apache-2.0
-
-"""Integration tests."""

--- a/tests/integration/test_infoblox_nios_live.py
+++ b/tests/integration/test_infoblox_nios_live.py
@@ -1,0 +1,119 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+from tests.live_targets import (
+    LiveNiosTarget,
+    live_mutation_tests_enabled,
+    live_tests_enabled,
+    load_live_nios_targets,
+)
+
+pytestmark = [pytest.mark.live]
+
+
+def _require_live_targets() -> list[LiveNiosTarget]:
+    if not live_tests_enabled():
+        pytest.skip("Live tests disabled. Set DNS_AID_LIVE_TESTS=1 to enable.")
+
+    targets = load_live_nios_targets()
+    if not targets:
+        pytest.skip(
+            "No live NIOS targets configured. "
+            "Create tests/live_targets.json (see tests/live_targets.example.json)."
+        )
+    return targets
+
+
+@pytest.mark.asyncio
+async def test_live_nios_read_only_connectivity() -> None:
+    targets = _require_live_targets()
+
+    for target in targets:
+        backend = InfobloxNIOSBackend(
+            host=target.host,
+            username=target.username,
+            password=target.password,
+            wapi_version=target.wapi_version,
+            verify_ssl=target.verify_ssl,
+            dns_view=target.dns_view,
+            timeout=target.timeout,
+        )
+        try:
+            zones = await backend.list_zones()
+            assert isinstance(zones, list)
+
+            if target.test_zone:
+                assert await backend.zone_exists(target.test_zone)
+                assert await backend.zone_exists(f"{target.test_zone}.")
+        finally:
+            await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_live_nios_create_delete_cycle() -> None:
+    targets = _require_live_targets()
+    if not live_mutation_tests_enabled():
+        pytest.skip("Mutation tests disabled. Set DNS_AID_LIVE_MUTATION_TESTS=1 to enable.")
+
+    exercised_targets = 0
+    for target in targets:
+        if not target.test_zone:
+            continue
+
+        exercised_targets += 1
+        backend = InfobloxNIOSBackend(
+            host=target.host,
+            username=target.username,
+            password=target.password,
+            wapi_version=target.wapi_version,
+            verify_ssl=target.verify_ssl,
+            dns_view=target.dns_view,
+            timeout=target.timeout,
+        )
+
+        suffix = uuid.uuid4().hex[:8]
+        record_name = f"_live-nios-{suffix}._mcp._agents"
+        zone = target.test_zone
+
+        try:
+            await backend.create_svcb_record(
+                zone=zone,
+                name=record_name,
+                priority=1,
+                target=f"live-target.{zone}",
+                params={
+                    "mandatory": "alpn,port",
+                    "alpn": "mcp",
+                    "port": "443",
+                    "realm": "live-test",
+                },
+                ttl=120,
+            )
+            await backend.create_txt_record(
+                zone=zone,
+                name=record_name,
+                values=["capabilities=live-test", "version=0.0.1"],
+                ttl=120,
+            )
+
+            svcb = await backend.get_record(zone, record_name, "SVCB")
+            txt = await backend.get_record(zone, record_name, "TXT")
+            assert svcb is not None
+            assert txt is not None
+        finally:
+            await backend.delete_record(zone, record_name, "SVCB")
+            await backend.delete_record(zone, record_name, "TXT")
+            await backend.close()
+
+    if exercised_targets == 0:
+        pytest.skip(
+            "No targets with test_zone configured for mutation tests. "
+            "Set 'test_zone' in tests/live_targets.json."
+        )

--- a/tests/live_targets.example.json
+++ b/tests/live_targets.example.json
@@ -1,0 +1,15 @@
+{
+  "nios": [
+    {
+      "name": "lab-nios",
+      "host": "10.100.0.100",
+      "username": "admin",
+      "password_env": "NIOS_LAB_PASSWORD",
+      "verify_ssl": false,
+      "wapi_version": "2.13.7",
+      "dns_view": "default",
+      "timeout": 15.0,
+      "test_zone": "example.com"
+    }
+  ]
+}

--- a/tests/live_targets.py
+++ b/tests/live_targets.py
@@ -1,0 +1,145 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LiveNiosTarget:
+    """Configuration for one live NIOS target."""
+
+    name: str
+    host: str
+    username: str
+    password: str
+    verify_ssl: bool = True
+    wapi_version: str = "2.13.7"
+    dns_view: str = "default"
+    timeout: float = 15.0
+    test_zone: str | None = None
+
+
+def _parse_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _live_targets_file() -> Path:
+    configured = os.environ.get("DNS_AID_LIVE_TARGETS_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    return Path(__file__).resolve().parent / "live_targets.json"
+
+
+def _as_str(value: Any, default: str = "") -> str:
+    return str(value if value is not None else default).strip()
+
+
+def load_live_nios_targets() -> list[LiveNiosTarget]:
+    """
+    Load live NIOS targets from JSON config.
+
+    Expected file shape:
+    {
+      "nios": [
+        {
+          "name": "lab-nios",
+          "host": "10.100.0.100",
+          "username": "admin",
+          "password_env": "NIOS_LAB_PASSWORD",
+          "verify_ssl": false,
+          "wapi_version": "2.13.7",
+          "dns_view": "default",
+          "timeout": 15.0,
+          "test_zone": "example.com"
+        }
+      ]
+    }
+    """
+    path = _live_targets_file()
+    if not path.exists():
+        return []
+
+    try:
+        payload = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        warnings.warn(f"Failed to parse live targets file {path}: {exc}", stacklevel=2)
+        return []
+
+    raw_targets = payload.get("nios", [])
+    if not isinstance(raw_targets, list):
+        warnings.warn(f"Invalid live targets format in {path}: 'nios' must be a list", stacklevel=2)
+        return []
+
+    targets: list[LiveNiosTarget] = []
+    for index, raw in enumerate(raw_targets):
+        if not isinstance(raw, dict):
+            warnings.warn(f"Skipping non-object nios target at index {index}", stacklevel=2)
+            continue
+
+        name = _as_str(raw.get("name"), default=f"nios-{index}")
+        host = _as_str(raw.get("host"))
+        username = _as_str(raw.get("username"))
+
+        password = raw.get("password")
+        password_env = _as_str(raw.get("password_env"))
+        if not password and password_env:
+            password = os.environ.get(password_env)
+
+        if not host or not username or not password:
+            warnings.warn(
+                f"Skipping nios target '{name}': host/username/password missing. "
+                "Use password or password_env.",
+                stacklevel=2,
+            )
+            continue
+
+        timeout_value = raw.get("timeout", 15.0)
+        try:
+            timeout = float(timeout_value)
+        except (TypeError, ValueError):
+            timeout = 15.0
+
+        test_zone = _as_str(raw.get("test_zone")) or None
+        if test_zone:
+            test_zone = test_zone.rstrip(".")
+
+        targets.append(
+            LiveNiosTarget(
+                name=name,
+                host=host,
+                username=username,
+                password=str(password),
+                verify_ssl=_parse_bool(raw.get("verify_ssl"), default=True),
+                wapi_version=_as_str(raw.get("wapi_version"), default="2.13.7"),
+                dns_view=_as_str(raw.get("dns_view"), default="default"),
+                timeout=timeout,
+                test_zone=test_zone,
+            )
+        )
+
+    return targets
+
+
+def live_tests_enabled() -> bool:
+    return _parse_bool(os.environ.get("DNS_AID_LIVE_TESTS"), default=False)
+
+
+def live_mutation_tests_enabled() -> bool:
+    return _parse_bool(os.environ.get("DNS_AID_LIVE_MUTATION_TESTS"), default=False)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,0 @@
-# Copyright 2024-2026 The DNS-AID Authors
-# SPDX-License-Identifier: Apache-2.0
-
-"""Unit tests."""

--- a/tests/unit/core/__init__.py
+++ b/tests/unit/core/__init__.py
@@ -1,3 +1,0 @@
-# Copyright 2024-2026 The DNS-AID Authors
-# SPDX-License-Identifier: Apache-2.0
-

--- a/tests/unit/sdk/__init__.py
+++ b/tests/unit/sdk/__init__.py
@@ -1,3 +1,0 @@
-# Copyright 2024-2026 The DNS-AID Authors
-# SPDX-License-Identifier: Apache-2.0
-

--- a/tests/unit/test_infoblox_backend.py
+++ b/tests/unit/test_infoblox_backend.py
@@ -324,11 +324,11 @@ class TestInfobloxBloxOneBackendAsync:
 
 
 class TestInfobloxNIOSBackend:
-    """Tests for InfobloxNIOSBackend (placeholder)."""
+    """Smoke tests for InfobloxNIOSBackend import and initialization."""
 
-    def test_nios_not_implemented(self):
-        """Test that NIOS backend raises NotImplementedError."""
+    def test_nios_init(self):
+        """Test NIOS backend initializes with explicit credentials."""
         from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
 
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
-            InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
+        backend = InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
+        assert backend.name == "nios"

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -1,0 +1,333 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_match"),
+    [
+        ({"host": "", "username": "admin", "password": "secret"}, "NIOS host required"),
+        ({"host": "nios.local", "username": "", "password": "secret"}, "NIOS username required"),
+        ({"host": "nios.local", "username": "admin", "password": ""}, "NIOS password required"),
+    ],
+)
+def test_constructor_validation_errors(kwargs: dict[str, str], error_match: str) -> None:
+    with pytest.raises(ValueError, match=error_match):
+        InfobloxNIOSBackend(**kwargs)
+
+
+def test_svc_parameters_conversion() -> None:
+    params = {
+        "mandatory": "alpn,port,cap",
+        "alpn": "h2,h3",
+        "port": "443",
+        "bap": "mcp/1,a2a/1",
+        "cap": "https://example.com/.well-known/agent-cap.json",
+        "sig": "abc123",
+    }
+
+    converted = InfobloxNIOSBackend._svc_parameters_from_params(params)
+    as_map = {item["svc_key"]: item for item in converted}
+
+    assert as_map["alpn"]["svc_value"] == ["h2", "h3"]
+    assert as_map["alpn"]["mandatory"] is True
+    assert as_map["key65003"]["svc_value"] == ["mcp/1", "a2a/1"]
+    assert as_map["port"]["svc_value"] == ["443"]
+    assert as_map["key65001"]["mandatory"] is True
+    assert as_map["key65006"]["svc_value"] == ["abc123"]
+
+
+def test_svc_parameters_conversion_preserves_numeric_keys() -> None:
+    converted = InfobloxNIOSBackend._svc_parameters_from_params(
+        {"mandatory": "key65003,port", "key65003": "mcp/1,a2a/1", "port": "443"}
+    )
+    as_map = {item["svc_key"]: item for item in converted}
+
+    assert as_map["key65003"]["mandatory"] is True
+    assert as_map["key65003"]["svc_value"] == ["mcp/1", "a2a/1"]
+    assert as_map["port"]["mandatory"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_svcb_record_payload_contains_mapped_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+    calls: list[tuple[str, str, dict | None]] = []
+
+    async def fake_find_record_ref(zone: str, name: str, record_type: str) -> None:
+        return None
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> dict:
+        calls.append((method, endpoint, json))
+        return {}
+
+    monkeypatch.setattr(backend, "_find_record_ref", fake_find_record_ref)
+    monkeypatch.setattr(backend, "_request", fake_request)
+
+    await backend.create_svcb_record(
+        zone="example.com",
+        name="_agent._mcp._agents",
+        priority=1,
+        target="mcp.example.com",
+        params={"mandatory": "alpn,port", "alpn": "mcp", "port": "443", "realm": "prod"},
+        ttl=900,
+    )
+
+    assert calls
+    method, endpoint, payload = calls[0]
+    assert method == "POST"
+    assert endpoint == "record:svcb"
+    assert payload is not None
+    assert payload["priority"] == 1
+    assert payload["target_name"] == "mcp.example.com"
+    assert payload["ttl"] == 900
+    assert payload["use_ttl"] is True
+    assert payload["view"] == "default"
+    assert any(param["svc_key"] == "key65005" for param in payload["svc_parameters"])
+
+
+@pytest.mark.asyncio
+async def test_find_record_ref_does_not_use_ref_return_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> list[dict[str, str]]:
+        assert method == "GET"
+        assert endpoint == "record:svcb"
+        assert params is not None
+        assert "_return_fields" not in params
+        return [{"_ref": "record:svcb/ZG5z..."}]
+
+    monkeypatch.setattr(backend, "_request", fake_request)
+    ref = await backend._find_record_ref("example.com", "_agent._mcp._agents", "SVCB")
+    assert ref == "record:svcb/ZG5z..."
+
+
+@pytest.mark.asyncio
+async def test_strict_fail_on_svcb_validation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+    async def fake_find_record_ref(zone: str, name: str, record_type: str) -> None:
+        return None
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> dict:
+        raise RuntimeError("NIOS validation failed: invalid svc_key cap")
+
+    monkeypatch.setattr(backend, "_find_record_ref", fake_find_record_ref)
+    monkeypatch.setattr(backend, "_request", fake_request)
+
+    with pytest.raises(RuntimeError, match="validation failed"):
+        await backend.create_svcb_record(
+            zone="example.com",
+            name="_agent._mcp._agents",
+            priority=1,
+            target="mcp.example.com",
+            params={"mandatory": "alpn,port", "alpn": "mcp", "port": "443", "cap": "https://x"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_txt_create_and_update_upsert(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+    calls: list[tuple[str, str, dict | None]] = []
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> dict:
+        calls.append((method, endpoint, json))
+        return {}
+
+    monkeypatch.setattr(backend, "_request", fake_request)
+
+    async def missing_ref(zone: str, name: str, record_type: str) -> None:
+        return None
+
+    monkeypatch.setattr(backend, "_find_record_ref", missing_ref)
+    await backend.create_txt_record("example.com", "_agent._mcp._agents", ["capabilities=chat"], ttl=1200)
+    assert calls[-1][0] == "POST"
+    assert calls[-1][1] == "record:txt"
+
+    async def existing_ref(zone: str, name: str, record_type: str) -> str:
+        return "record:txt/ZG5z..."
+
+    monkeypatch.setattr(backend, "_find_record_ref", existing_ref)
+    await backend.create_txt_record("example.com", "_agent._mcp._agents", ["version=1.0.0"], ttl=1200)
+    assert calls[-1][0] == "PUT"
+    assert calls[-1][1] == "record:txt/ZG5z..."
+
+
+@pytest.mark.asyncio
+async def test_delete_record_found_and_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+    calls: list[tuple[str, str]] = []
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> dict:
+        calls.append((method, endpoint))
+        return {}
+
+    monkeypatch.setattr(backend, "_request", fake_request)
+
+    async def found_ref(zone: str, name: str, record_type: str) -> str:
+        return "record:svcb/ZG5z..."
+
+    monkeypatch.setattr(backend, "_find_record_ref", found_ref)
+    deleted = await backend.delete_record("example.com", "_agent._mcp._agents", "SVCB")
+    assert deleted is True
+    assert calls[-1] == ("DELETE", "record:svcb/ZG5z...")
+
+    async def missing_ref(zone: str, name: str, record_type: str) -> None:
+        return None
+
+    monkeypatch.setattr(backend, "_find_record_ref", missing_ref)
+    deleted = await backend.delete_record("example.com", "_agent._mcp._agents", "SVCB")
+    assert deleted is False
+
+
+@pytest.mark.asyncio
+async def test_zone_exists_true_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+    async def request_found(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"_ref": "zone_auth/ZG5z..."}]
+
+    monkeypatch.setattr(backend, "_request", request_found)
+    assert await backend.zone_exists("example.com") is True
+
+    async def request_missing(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> list[dict[str, str]]:
+        return []
+
+    monkeypatch.setattr(backend, "_request", request_missing)
+    assert await backend.zone_exists("example.com") is False
+
+
+@pytest.mark.asyncio
+async def test_list_zones_returns_normalized_zone_objects(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> list[dict[str, object]]:
+        assert method == "GET"
+        assert endpoint == "zone_auth"
+        assert params is not None
+        assert params["view"] == "default"
+        assert "_return_fields" not in params
+        return [
+            {
+                "_ref": "zone_auth/ZG5zLmF1dGhfem9uZSQuX2RlZmF1bHQuZXhhbXBsZS5jb20:example.com/default",
+                "fqdn": "example.com.",
+                "view": "default",
+                "comment": "Primary zone",
+                "disable": False,
+                "zone_format": "FORWARD",
+            }
+        ]
+
+    monkeypatch.setattr(backend, "_request", fake_request)
+    zones = await backend.list_zones()
+
+    assert len(zones) == 1
+    assert zones[0]["name"] == "example.com"
+    assert zones[0]["fqdn"] == "example.com."
+    assert zones[0]["view"] == "default"
+    assert zones[0]["comment"] == "Primary zone"
+    assert zones[0]["zone_format"] == "FORWARD"
+
+
+@pytest.mark.asyncio
+async def test_list_records_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+    async def fake_request(
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict | None = None,
+    ) -> list[dict[str, object]]:
+        if endpoint == "record:svcb":
+            return [
+                {
+                    "_ref": "record:svcb/abc",
+                    "name": "_agent._mcp._agents.example.com",
+                    "ttl": 3600,
+                    "priority": 1,
+                    "target_name": "mcp.example.com",
+                    "svc_parameters": [
+                        {"svc_key": "alpn", "svc_value": ["mcp"], "mandatory": True},
+                        {"svc_key": "port", "svc_value": ["443"], "mandatory": True},
+                        {"svc_key": "key65005", "svc_value": ["prod"], "mandatory": False},
+                    ],
+                }
+            ]
+
+        return [
+            {
+                "_ref": "record:txt/def",
+                "name": "_agent._mcp._agents.example.com",
+                "ttl": 3600,
+                "text": '"capabilities=chat" "version=1.0.0"',
+            }
+        ]
+
+    monkeypatch.setattr(backend, "_request", fake_request)
+
+    records = [record async for record in backend.list_records("example.com")]
+
+    assert len(records) == 2
+    assert records[0]["type"] == "SVCB"
+    assert records[1]["type"] == "TXT"
+    assert records[0]["fqdn"] == "_agent._mcp._agents.example.com"
+    assert 'port="443"' in records[0]["values"][0]
+    assert 'realm="prod"' in records[0]["values"][0]

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -326,6 +326,38 @@ class TestDefaultBackend:
             backend = get_default_backend()
             assert backend.name == "cloudflare"
 
+    def test_get_default_backend_infoblox_alias(self):
+        """Test DNS_AID_BACKEND=infoblox keeps BloxOne alias behavior."""
+        from unittest.mock import patch
+
+        from dns_aid.core.publisher import get_default_backend
+
+        with (
+            patch.dict("os.environ", {"DNS_AID_BACKEND": "infoblox"}),
+            patch("dns_aid.backends.infoblox.InfobloxBackend") as mock_infoblox,
+        ):
+            mock_instance = mock_infoblox.return_value
+            mock_instance.name = "bloxone"
+
+            backend = get_default_backend()
+            assert backend is mock_instance
+
+    def test_get_default_backend_nios(self):
+        """Test get_default_backend with DNS_AID_BACKEND=nios."""
+        from unittest.mock import patch
+
+        from dns_aid.core.publisher import get_default_backend
+
+        with (
+            patch.dict("os.environ", {"DNS_AID_BACKEND": "nios"}),
+            patch("dns_aid.backends.infoblox.InfobloxNIOSBackend") as mock_nios,
+        ):
+            mock_instance = mock_nios.return_value
+            mock_instance.name = "nios"
+
+            backend = get_default_backend()
+            assert backend is mock_instance
+
     def test_get_default_backend_no_env_raises(self):
         """Test get_default_backend raises when DNS_AID_BACKEND is not set."""
         from unittest.mock import patch


### PR DESCRIPTION
## Description

Implement Infoblox NIOS (on-prem) as a production DNS backend for DNS-AID, with SVCB/TXT publish support, backend wiring, comprehensive unit coverage, optional live integration tests, and documentation updates.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #

## Changes Made

- Implemented `InfobloxNIOSBackend` in `src/dns_aid/backends/infoblox/nios.py`:
  - async `httpx` client reuse with event-loop safety
  - centralized request/error handling
  - SVCB create/update (upsert), TXT create/update (upsert), delete, list, zone checks/listing
  - strict-fail behavior on provider SVCB validation errors
- Added NIOS-compatible SVC parameter handling:
  - custom keys mapped to `keyNNNNN` for NIOS writes (`cap`, `cap-sha256`, `bap`, `policy`, `realm`, `sig`)
  - reverse mapping on readback formatting
  - compatibility fixes from live runs (`_return_fields` handling and `target_name` normalization)
- Wired backend selection and exports:
  - `DNS_AID_BACKEND=nios` in publisher
  - `InfobloxNIOSBackend` exported in infoblox backend modules
  - retained `InfobloxBackend = InfobloxBloxOneBackend` alias behavior
- Added tests:
  - new unit suite for NIOS backend behavior
  - publisher backend selection tests for `nios` and `infoblox` aliasing
  - optional live integration tests using `tests/live_targets.json`
- Updated docs:
  - `README.md`, `docs/getting-started.md`, `docs/api-reference.md`
- Added changelog entry under `Unreleased`.
- Test layout compliance:
  - removed `__init__.py` files from test directories
  - set pytest import mode to importlib (`--import-mode=importlib`) in `pyproject.toml`

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

### Test Commands Run
```bash
uv run pytest tests/unit/ -q
uv run ruff check src/
uv run ruff format --check src/
uv run mypy src/dns_aid
uv run bandit -r src/dns_aid -c pyproject.toml
uv run pip-audit
```

## Checklist

- [x] My code follows the project's style guidelines (ruff)
- [x] I have performed a self-review of my code
- [x] I have added/updated docstrings for public APIs
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] All existing tests pass
- [x] I have added tests that prove my fix/feature works

## Security Considerations

- [x] No hardcoded credentials or secrets
- [x] Input validation implemented where needed
- [x] No new security vulnerabilities introduced

## Additional Notes

- Commit is DCO signed (`Signed-off-by`) and uses a conventional commit title.
- Live integration tests are opt-in (`@pytest.mark.live`) and require explicit target configuration (`tests/live_targets.json`).
