### PR TITLE
feat: add Infoblox NIOS WAPI backend (v0.6.7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Backend-specific variables only needed for the backend you choose.
 
 # ─── General ─────────────────────────────────────────────
-# DNS_AID_BACKEND=mock              # route53 | cloudflare | infoblox | ddns | mock
+# DNS_AID_BACKEND=mock              # route53 | cloudflare | infoblox | nios | ddns | mock
 # DNS_AID_LOG_LEVEL=INFO            # DEBUG | INFO | WARNING | ERROR
 # DNS_AID_TEST_ZONE=example.com     # Domain to use for publish/discover
 # DNS_AID_SVCB_STRING_KEYS=0        # 1 = human-readable SVCB param names
@@ -31,6 +31,14 @@
 # INFOBLOX_API_KEY=
 # INFOBLOX_BASE_URL=https://csp.infoblox.com
 # INFOBLOX_DNS_VIEW=default
+
+# ─── Infoblox NIOS (on-prem WAPI) ─────────────────────
+# NIOS_HOST=nios.example.com
+# NIOS_USERNAME=admin
+# NIOS_PASSWORD=
+# NIOS_DNS_VIEW=default
+# NIOS_WAPI_VERSION=2.13.7
+# NIOS_VERIFY_SSL=false
 
 # ─── DDNS / RFC 2136 (BIND, Windows DNS, PowerDNS) ─────
 # DDNS_SERVER=ns1.example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.7] - 2026-02-18
+
+### Added
+- **Infoblox NIOS WAPI backend** — Full on-premise Infoblox support via WAPI v2.13.7+ with SVCB and TXT record management, zone caching, upsert semantics, and `get_record()` override for efficient lookups. Contributed by @IngmarVG-IB (#22)
+- **NIOS in CLI tooling** — `dns-aid doctor` checks NIOS credentials, `dns-aid init` offers NIOS as a backend option, `detect_backend()` auto-detects NIOS from env vars
+- **NIOS pip extra** — `pip install dns-aid[nios]` for explicit dependency declaration
+- **46 unit tests** for NIOS backend covering init, helpers, SVC parameter mapping, async CRUD, zone caching, error handling, and publisher integration
+- **Live integration test harness** for NIOS (env-var gated with `NIOS_HOST`)
+
+### Fixed
+- **`zone_exists()` hardened across all backends** — All backends now return `False` (never raise) on any error: network failures, auth issues, misconfigured DNS views. Documented as a must-not-raise contract in `DNSBackend` base class
+- **NIOS WAPI upsert** — PUT requests correctly exclude immutable fields (`name`, `view`) that WAPI rejects on update
+
 ## [0.6.6] - 2026-02-16
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.6.6"
-date-released: "2026-02-16"
+version: "0.6.7"
+date-released: "2026-02-18"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ pip install dns-aid[mcp]
 # With a specific backend
 pip install dns-aid[route53]      # AWS Route 53
 pip install dns-aid[cloudflare]   # Cloudflare DNS
-pip install dns-aid[infoblox]     # Infoblox BloxOne
+pip install dns-aid[infoblox]     # Infoblox BloxOne (cloud)
+pip install dns-aid[nios]         # Infoblox NIOS (on-prem)
 pip install dns-aid[ddns]         # RFC 2136 Dynamic DNS (BIND, PowerDNS)
 
 # Everything
@@ -85,7 +86,7 @@ print(f"Security Score: {result.security_score}/100")
 
 ### Try Without Cloud Credentials
 
-No AWS/Cloudflare/Infoblox account? Use the built-in BIND9 playground:
+No AWS/Cloudflare/Infoblox/NIOS account? Use the built-in BIND9 playground:
 
 ```bash
 # Start local DNS server
@@ -438,12 +439,12 @@ Each discovered agent includes `capability_source` showing which path was used (
 ┌───────────────────────────────────────────────────────────────────────────────────┐
 │                          DNS BACKEND ABSTRACTION                                  │
 │                                                                                   │
-│  ┌───────────┐  ┌───────────┐  ┌───────────┐  ┌───────────┐  ┌───────────┐      │
-│  │  Route53  │  │ Infoblox  │  │   DDNS    │  │Cloudflare │  │   Mock    │      │
-│  │  (AWS)    │  │   UDDI    │  │ (RFC2136) │  │           │  │ (Testing) │      │
-│  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘      │
-│        │              │              │              │              │             │
-└────────┴──────────────┴──────────────┴──────────────┴──────────────┴─────────────┘
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+│  │ Route53  │ │ Infoblox │ │ Infoblox │ │   DDNS   │ │Cloudflare│ │   Mock   │  │
+│  │  (AWS)   │ │   UDDI   │ │   NIOS   │ │ (RFC2136)│ │          │ │ (Testing)│  │
+│  └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘  │
+│       │            │            │            │            │            │         │
+└───────┴────────────┴────────────┴────────────┴────────────┴────────────┴─────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -525,10 +526,10 @@ DNS-AID supports multiple DNS backends:
 |---------|-------------|--------|
 | Route 53 | AWS Route 53 | ✅ Production |
 | Infoblox UDDI | Infoblox Universal DDI (cloud) | ✅ Production |
+| Infoblox NIOS | Infoblox NIOS (on-prem WAPI) | ✅ Production |
 | DDNS | RFC 2136 Dynamic DNS (BIND, etc.) | ✅ Production |
 | Cloudflare | Cloudflare DNS | ✅ Production |
 | Mock | In-memory (testing) | ✅ Production |
-| NIOS | Infoblox NIOS (on-prem) | 🚧 Planned |
 
 ### Route 53 Setup
 
@@ -629,17 +630,17 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
 > The draft requires ServiceMode SVCB records (priority > 0) with mandatory `alpn` and `port`
 > parameters. Infoblox UDDI's limitation is a platform constraint, not a DNS-AID limitation.
 
-| BANDAID Requirement | Route 53 | Cloudflare | DDNS (BIND) | Infoblox UDDI |
-|---------------------|----------|------------|-------------|---------------|
-| ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ❌ |
-| `alpn` parameter | ✅ | ✅ | ✅ | ❌ |
-| `port` parameter | ✅ | ✅ | ✅ | ❌ |
-| `mandatory` key | ✅ | ✅ | ✅ | ❌ |
-| Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ❌ |
+| BANDAID Requirement | Route 53 | Cloudflare | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
+|---------------------|----------|------------|-------------|---------------|---------------|
+| ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `alpn` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `port` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `mandatory` key | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ✅ Native | ❌ |
 
 **⚠️ TXT** = Custom BANDAID params auto-demoted to TXT records with `bandaid_` prefix (no data loss).
 
-**For full BANDAID compliance with native custom SVCB params, use DDNS (BIND/RFC 2136). Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
+**For full BANDAID compliance with native custom SVCB params, use DDNS (BIND/RFC 2136) or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
 
 DNS-AID stores `alpn` and `port` in TXT records as a fallback for Infoblox UDDI, but this is
 a workaround and not standard-compliant for agent discovery.
@@ -653,6 +654,72 @@ async with InfobloxBloxOneBackend() as backend:
     async for record in backend.list_records("example.com", name_pattern="my-agent"):
         print(f"{record['type']}: {record['fqdn']}")
 ```
+
+### Infoblox NIOS Setup (On-Prem)
+
+Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID creates SVCB and TXT records via WAPI v2.13.7+, with full ServiceMode SVCB support including custom BANDAID parameters.
+
+#### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NIOS_HOST` | Yes | - | Grid Manager hostname or IP |
+| `NIOS_USERNAME` | Yes | - | WAPI username |
+| `NIOS_PASSWORD` | Yes | - | WAPI password |
+| `NIOS_DNS_VIEW` | No | `default` | DNS view name |
+| `NIOS_WAPI_VERSION` | No | `2.13.7` | WAPI version |
+| `NIOS_VERIFY_SSL` | No | `false` | Verify TLS certificate |
+
+#### Step-by-Step Setup
+
+1. **Ensure NIOS Grid Manager is reachable** from the host running DNS-AID.
+
+2. **Configure environment variables**:
+   ```bash
+   export NIOS_HOST="nios.example.com"
+   export NIOS_USERNAME="admin"
+   export NIOS_PASSWORD="your-password"
+   export NIOS_DNS_VIEW="default"       # Or your specific view name
+   export NIOS_VERIFY_SSL="false"       # Set to true with valid TLS certs
+   ```
+
+3. **Verify zone access and publish**:
+   ```bash
+   dns-aid doctor                        # Check NIOS credentials
+   dns-aid publish -n my-agent -d example.com -p mcp -e mcp.example.com --backend nios
+   ```
+
+4. **Use in Python**:
+   ```python
+   from dns_aid.backends.infoblox import InfobloxNIOSBackend
+   from dns_aid.core.publisher import set_default_backend
+   from dns_aid import publish
+
+   # Initialize backend (reads from environment variables)
+   backend = InfobloxNIOSBackend()
+
+   # Or with explicit configuration
+   backend = InfobloxNIOSBackend(
+       host="nios.example.com",
+       username="admin",
+       password="your-password",
+       dns_view="default",
+   )
+
+   set_default_backend(backend)
+
+   await publish(
+       name="my-agent",
+       domain="example.com",
+       protocol="mcp",
+       endpoint="agent.example.com",
+       capabilities=["chat", "code-review"]
+   )
+   ```
+
+#### NIOS BANDAID Compliance
+
+NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters, including custom BANDAID keys natively via `key65001`–`key65006`.
 
 ### DDNS Setup (RFC 2136)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.6.6"
+version = "0.6.7"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -59,6 +59,9 @@ infoblox = [
 cloudflare = [
     # Uses httpx from core deps
 ]
+nios = [
+    # Uses httpx from core deps
+]
 ddns = [
     # Uses dnspython from core deps
 ]
@@ -93,7 +96,7 @@ all = [
     # MCP
     "mcp>=1.0.0",
     "uvicorn>=0.30.0",
-    # Backends: Route53, Infoblox, Cloudflare, DDNS (last 3 use core deps)
+    # Backends: Route53, Infoblox BloxOne, NIOS, Cloudflare, DDNS (last 4 use core deps)
     "boto3>=1.34.0",
     # JWS
     "cryptography>=41.0.0",

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -16,14 +16,15 @@ try:
 except ImportError:
     pass
 
-# Infoblox BloxOne is optional - uses httpx (already a core dep)
+# Infoblox backends are optional - use httpx (already a core dep)
 try:
     from dns_aid.backends.infoblox import (  # noqa: F401
         InfobloxBackend,
         InfobloxBloxOneBackend,
+        InfobloxNIOSBackend,
     )
 
-    __all__.extend(["InfobloxBackend", "InfobloxBloxOneBackend"])
+    __all__.extend(["InfobloxBackend", "InfobloxBloxOneBackend", "InfobloxNIOSBackend"])
 except ImportError:
     pass
 

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -138,11 +138,16 @@ class DNSBackend(ABC):
         """
         Check if a DNS zone exists and is accessible.
 
+        Implementations MUST return False (not raise) on any error —
+        network failures, authentication issues, or misconfigured
+        settings (e.g., invalid DNS view) all mean the zone is
+        effectively inaccessible.
+
         Args:
             zone: DNS zone to check
 
         Returns:
-            True if zone exists and is accessible
+            True if zone exists and is accessible, False otherwise
         """
         ...
 

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -518,11 +518,22 @@ class CloudflareBackend(DNSBackend):
             page += 1
 
     async def zone_exists(self, zone: str) -> bool:
-        """Check if zone exists in Cloudflare."""
+        """Check if zone exists in Cloudflare.
+
+        Returns False (rather than raising) on any API or network error,
+        since the zone is effectively inaccessible.
+        """
         try:
             await self._get_zone_id(zone)
             return True
         except (ValueError, httpx.HTTPStatusError):
+            return False
+        except Exception as exc:
+            logger.warning(
+                "Failed to check zone existence in Cloudflare",
+                zone=zone,
+                error=str(exc),
+            )
             return False
 
     async def get_record(

--- a/src/dns_aid/backends/infoblox/__init__.py
+++ b/src/dns_aid/backends/infoblox/__init__.py
@@ -6,21 +6,26 @@ Infoblox DNS backends for DNS-AID.
 
 Supports both Infoblox platforms:
 - BloxOne DDI (cloud): InfobloxBloxOneBackend
-- NIOS (on-prem): InfobloxNIOSBackend (planned)
+- NIOS (on-prem): InfobloxNIOSBackend
 
 Example:
     >>> from dns_aid.backends.infoblox import InfobloxBloxOneBackend
     >>> backend = InfobloxBloxOneBackend(api_key="your-api-key")
     >>> await backend.create_svcb_record(...)
+
+    >>> from dns_aid.backends.infoblox import InfobloxNIOSBackend
+    >>> backend = InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
+    >>> await backend.create_svcb_record(...)
 """
 
 from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
 
-# Alias for convenience
+# Alias for convenience (BloxOne is the cloud default)
 InfobloxBackend = InfobloxBloxOneBackend
 
 __all__ = [
     "InfobloxBloxOneBackend",
     "InfobloxBackend",
-    # "InfobloxNIOSBackend",  # Coming soon
+    "InfobloxNIOSBackend",
 ]

--- a/src/dns_aid/backends/infoblox/bloxone.py
+++ b/src/dns_aid/backends/infoblox/bloxone.py
@@ -530,11 +530,23 @@ class InfobloxBloxOneBackend(DNSBackend):
             offset += limit
 
     async def zone_exists(self, zone: str) -> bool:
-        """Check if zone exists in BloxOne."""
+        """Check if zone exists in BloxOne.
+
+        Returns False (rather than raising) on any API or network error,
+        since the zone is effectively inaccessible.
+        """
         try:
             await self._get_zone_info(zone)
             return True
         except ValueError:
+            return False
+        except Exception as exc:
+            logger.warning(
+                "Failed to check zone existence in BloxOne",
+                zone=zone,
+                view=self._dns_view,
+                error=str(exc),
+            )
             return False
 
     async def get_record(

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -9,72 +9,368 @@ This is the traditional on-premises DDI platform from Infoblox.
 
 API Documentation: https://docs.infoblox.com/display/nios/WAPI+Versioning
 
-Status: PLANNED - Not yet implemented
+Original implementation by Ingmar Van Glabbeek (PR #20).
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import os
+import re
 from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import structlog
 
 from dns_aid.backends.base import DNSBackend
+
+logger = structlog.get_logger(__name__)
+
+# Record types supported by DNS-AID via NIOS WAPI.
+_SUPPORTED_RECORD_TYPES = {"SVCB", "TXT"}
 
 
 class InfobloxNIOSBackend(DNSBackend):
     """
     Infoblox NIOS WAPI backend (on-premises).
 
-    NOT YET IMPLEMENTED - Placeholder for future development.
-
-    This backend will support:
-    - NIOS WAPI v2.x authentication (basic auth or certificate)
-    - SVCB record creation (requires NIOS 8.6+)
-    - TXT record creation
-    - Zone management via WAPI
-
-    Example (planned):
-        >>> backend = InfobloxNIOSBackend(
-        ...     host="nios.example.com",
-        ...     username="admin",
-        ...     password=os.environ["NIOS_PASSWORD"],
-        ...     wapi_version="2.12",
-        ... )
-        >>> await backend.create_svcb_record(...)
-
-    Environment Variables (planned):
+    Environment Variables:
         NIOS_HOST: NIOS Grid Master hostname
         NIOS_USERNAME: WAPI username
         NIOS_PASSWORD: WAPI password
-        NIOS_WAPI_VERSION: WAPI version (default: 2.12)
+        NIOS_WAPI_VERSION: WAPI version (default: 2.13.7)
         NIOS_VERIFY_SSL: Verify SSL certificates (default: true)
+        NIOS_DNS_VIEW: DNS view name (default: default)
+        NIOS_TIMEOUT: HTTP request timeout in seconds (default: 30.0)
     """
+
+    _SPLIT_VALUE_KEYS = {"alpn", "bap", "ipv4hint", "ipv6hint"}
+    # NIOS only accepts registered SVC keys or keyNNNNN numeric keys.
+    # Map draft custom names to private-use keyNNNNN aliases for compatibility.
+    _CUSTOM_PARAM_TO_NUMERIC_KEY = {
+        "cap": "key65001",
+        "cap-sha256": "key65002",
+        "bap": "key65003",
+        "policy": "key65004",
+        "realm": "key65005",
+        "sig": "key65006",
+    }
+    _NUMERIC_KEY_TO_CUSTOM_PARAM = {
+        value: key for key, value in _CUSTOM_PARAM_TO_NUMERIC_KEY.items()
+    }
+    _KEY_NNNNN_RE = re.compile(r"^key[1-9][0-9]{0,4}$")
 
     def __init__(
         self,
         host: str | None = None,
         username: str | None = None,
         password: str | None = None,
-        wapi_version: str = "2.12",
-        verify_ssl: bool = True,
+        wapi_version: str | None = None,
+        verify_ssl: bool | None = None,
+        dns_view: str | None = None,
+        timeout: float | None = None,
     ):
-        """
-        Initialize NIOS backend.
+        """Initialize NIOS backend."""
+        self._host = (host or os.environ.get("NIOS_HOST", "")).strip()
+        self._username = (username or os.environ.get("NIOS_USERNAME", "")).strip()
+        password_value = password or os.environ.get("NIOS_PASSWORD")
+        self._wapi_version = (
+            wapi_version or os.environ.get("NIOS_WAPI_VERSION") or "2.13.7"
+        ).strip()
 
-        Args:
-            host: NIOS Grid Master hostname
-            username: WAPI username
-            password: WAPI password
-            wapi_version: WAPI version (e.g., "2.12")
-            verify_ssl: Whether to verify SSL certificates
-        """
-        raise NotImplementedError(
-            "InfobloxNIOSBackend is not yet implemented. "
-            "Use InfobloxBloxOneBackend for cloud deployments, "
-            "or contribute the NIOS implementation!"
-        )
+        env_verify_ssl = os.environ.get("NIOS_VERIFY_SSL")
+        if verify_ssl is None:
+            self._verify_ssl = self._parse_bool_env(env_verify_ssl, default=True)
+        else:
+            self._verify_ssl = verify_ssl
+
+        self._dns_view = (dns_view or os.environ.get("NIOS_DNS_VIEW") or "default").strip()
+
+        env_timeout = os.environ.get("NIOS_TIMEOUT")
+        if timeout is None:
+            self._timeout = float(env_timeout) if env_timeout else 30.0
+        else:
+            self._timeout = timeout
+
+        if not self._host:
+            raise ValueError("NIOS host required. Set NIOS_HOST or pass host parameter.")
+        if not self._username:
+            raise ValueError(
+                "NIOS username required. Set NIOS_USERNAME or pass username parameter."
+            )
+        if not password_value:
+            raise ValueError(
+                "NIOS password required. Set NIOS_PASSWORD or pass password parameter."
+            )
+        self._password = password_value
+
+        self._base_url = f"https://{self._host.rstrip('/')}/wapi/v{self._wapi_version}"
+        self._client: httpx.AsyncClient | None = None
+        self._client_loop_id: int | None = None
+        self._zone_cache: dict[str, bool] = {}  # "zone:view" -> exists
+
+    @staticmethod
+    def _parse_bool_env(value: str | None, default: bool) -> bool:
+        """Parse boolean environment variable values."""
+        if value is None:
+            return default
+
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(f"Invalid boolean value: {value}")
 
     @property
     def name(self) -> str:
         return "nios"
+
+    @property
+    def dns_view(self) -> str:
+        """Get configured DNS view."""
+        return self._dns_view
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create async HTTP client for this event loop."""
+        current_loop_id = id(asyncio.get_running_loop())
+
+        if self._client is not None and self._client_loop_id != current_loop_id:
+            logger.debug(
+                "Event loop changed, recreating NIOS HTTP client",
+                old_loop_id=self._client_loop_id,
+                new_loop_id=current_loop_id,
+            )
+            with contextlib.suppress(Exception):
+                await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                auth=(self._username, self._password),
+                verify=self._verify_ssl,
+                timeout=self._timeout,
+                headers={"Content-Type": "application/json"},
+            )
+            self._client_loop_id = current_loop_id
+
+        return self._client
+
+    async def close(self) -> None:
+        """Close underlying HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | list[Any]:
+        """Execute a WAPI request with centralized error handling."""
+        client = await self._get_client()
+        cleaned_endpoint = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+
+        try:
+            response = await client.request(
+                method=method,
+                url=cleaned_endpoint,
+                params=params,
+                json=json,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
+            logger.error(
+                "NIOS WAPI request failed",
+                method=method,
+                endpoint=cleaned_endpoint,
+                status_code=exc.response.status_code,
+                response_body=body,
+            )
+            raise RuntimeError(
+                f"NIOS WAPI request failed ({method} {cleaned_endpoint}): "
+                f"status={exc.response.status_code} body={body}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            logger.error(
+                "NIOS WAPI transport error",
+                method=method,
+                endpoint=cleaned_endpoint,
+                error=str(exc),
+            )
+            raise RuntimeError(
+                f"NIOS WAPI transport error ({method} {cleaned_endpoint}): {exc}"
+            ) from exc
+
+        if not response.content:
+            return {}
+
+        content_type = response.headers.get("content-type", "")
+        if "application/json" not in content_type:
+            return {"raw": response.text}
+
+        parsed = response.json()
+        if isinstance(parsed, (dict, list)):
+            return parsed
+
+        return {"raw": parsed}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_fqdn(name: str, zone: str) -> str:
+        """Build fully qualified owner name for a record."""
+        zone_clean = zone.rstrip(".")
+        name_clean = name.rstrip(".")
+        if name_clean.endswith(f".{zone_clean}"):
+            return name_clean
+        return f"{name_clean}.{zone_clean}"
+
+    @staticmethod
+    def _normalize_target(target: str) -> str:
+        """Normalize SVCB target for NIOS WAPI FQDN validation."""
+        return target.strip().rstrip(".")
+
+    @classmethod
+    def _to_nios_svc_key(cls, key: str) -> str:
+        """Map user-facing key names to NIOS-compatible keys."""
+        normalized = key.strip().lower()
+        if cls._KEY_NNNNN_RE.match(normalized):
+            return normalized
+        return cls._CUSTOM_PARAM_TO_NUMERIC_KEY.get(normalized, normalized)
+
+    @classmethod
+    def _from_nios_svc_key(cls, key: str) -> str:
+        """Map NIOS keyNNNNN aliases back to user-facing key names."""
+        normalized = key.strip().lower()
+        return cls._NUMERIC_KEY_TO_CUSTOM_PARAM.get(normalized, normalized)
+
+    @classmethod
+    def _mandatory_keys(cls, params: dict[str, str]) -> set[str]:
+        """Parse mandatory keys from SVCB params map."""
+        raw = params.get("mandatory", "")
+        keys = set()
+        for item in raw.split(","):
+            key = item.strip()
+            if key:
+                keys.add(cls._to_nios_svc_key(key))
+        return keys
+
+    @classmethod
+    def _svc_parameters_from_params(cls, params: dict[str, str]) -> list[dict[str, Any]]:
+        """Convert DNS-AID SVCB params into NIOS svc_parameters format."""
+        mandatory_keys = cls._mandatory_keys(params)
+        svc_parameters: list[dict[str, Any]] = []
+
+        for key, value in params.items():
+            if key == "mandatory":
+                continue
+            mapped_key = cls._to_nios_svc_key(key)
+
+            key_for_split = cls._from_nios_svc_key(mapped_key)
+            if key_for_split in cls._SPLIT_VALUE_KEYS:
+                svc_value = [entry.strip() for entry in value.split(",") if entry.strip()]
+            else:
+                svc_value = [value]
+
+            svc_parameters.append(
+                {
+                    "svc_key": mapped_key,
+                    "svc_value": svc_value,
+                    "mandatory": mapped_key in mandatory_keys,
+                }
+            )
+
+        return svc_parameters
+
+    @classmethod
+    def _format_svc_parameters_for_value(cls, svc_parameters: Any) -> str:
+        """Format NIOS svc_parameters list to SVCB presentation tokens."""
+        if not isinstance(svc_parameters, list):
+            return ""
+
+        mandatory_keys: list[str] = []
+        seen_mandatory: set[str] = set()
+        param_parts: list[str] = []
+
+        for item in svc_parameters:
+            if not isinstance(item, dict):
+                continue
+
+            raw_key = str(item.get("svc_key", "")).strip()
+            if not raw_key:
+                continue
+            key = cls._from_nios_svc_key(raw_key)
+
+            raw_values = item.get("svc_value", [])
+            if isinstance(raw_values, list):
+                values = [str(value).strip() for value in raw_values if str(value).strip()]
+            elif raw_values is None:
+                values = []
+            else:
+                value = str(raw_values).strip()
+                values = [value] if value else []
+
+            if item.get("mandatory") and key not in seen_mandatory:
+                mandatory_keys.append(key)
+                seen_mandatory.add(key)
+
+            if values:
+                joined = ",".join(values).replace('"', r"\"")
+                param_parts.append(f'{key}="{joined}"')
+
+        if mandatory_keys:
+            mandatory_value = ",".join(mandatory_keys).replace('"', r"\"")
+            param_parts.insert(0, f'mandatory="{mandatory_value}"')
+
+        return " ".join(param_parts)
+
+    @staticmethod
+    def _extract_name_from_fqdn(fqdn: str, zone: str) -> str:
+        """Extract the record name by stripping the zone suffix from the FQDN.
+
+        Returns the FQDN unchanged if it doesn't end with the zone suffix.
+        """
+        zone_suffix = f".{zone.rstrip('.')}"
+        fqdn_clean = fqdn.rstrip(".")
+        if fqdn_clean.endswith(zone_suffix):
+            return fqdn_clean.removesuffix(zone_suffix)
+        return fqdn_clean
+
+    # ------------------------------------------------------------------
+    # Record lookup helpers
+    # ------------------------------------------------------------------
+
+    async def _find_record_ref(self, zone: str, name: str, record_type: str) -> str | None:
+        """Find record reference by owner name, type, and configured DNS view."""
+        fqdn = self._to_fqdn(name, zone)
+        params = {
+            "name": fqdn,
+            "view": self._dns_view,
+        }
+
+        results = await self._request("GET", f"record:{record_type.lower()}", params=params)
+        if isinstance(results, list) and results:
+            ref = results[0].get("_ref")
+            if isinstance(ref, str):
+                return ref
+
+        return None
+
+    # ------------------------------------------------------------------
+    # DNSBackend interface
+    # ------------------------------------------------------------------
 
     async def create_svcb_record(
         self,
@@ -86,7 +382,35 @@ class InfobloxNIOSBackend(DNSBackend):
         ttl: int = 3600,
     ) -> str:
         """Create SVCB record in NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        fqdn = self._to_fqdn(name, zone)
+        svc_parameters = self._svc_parameters_from_params(params)
+
+        # Mutable fields (allowed in both POST and PUT).
+        mutable: dict[str, Any] = {
+            "priority": priority,
+            "target_name": self._normalize_target(target),
+            "svc_parameters": svc_parameters,
+            "ttl": ttl,
+            "use_ttl": True,
+            "comment": f"DNS-AID: SVCB record for {name}",
+        }
+
+        record_ref = await self._find_record_ref(zone, name, "svcb")
+
+        if record_ref:
+            logger.info(
+                "Updating SVCB record in NIOS",
+                fqdn=fqdn,
+                record_ref=record_ref,
+            )
+            await self._request("PUT", record_ref, json=mutable)
+        else:
+            # Immutable fields (name, view) only on creation.
+            payload = {"name": fqdn, "view": self._dns_view, **mutable}
+            logger.info("Creating SVCB record in NIOS", fqdn=fqdn)
+            await self._request("POST", "record:svcb", json=payload)
+
+        return fqdn
 
     async def create_txt_record(
         self,
@@ -96,7 +420,32 @@ class InfobloxNIOSBackend(DNSBackend):
         ttl: int = 3600,
     ) -> str:
         """Create TXT record in NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        fqdn = self._to_fqdn(name, zone)
+
+        # Mutable fields (allowed in both POST and PUT).
+        mutable: dict[str, Any] = {
+            "text": " ".join(f'"{value}"' for value in values),
+            "ttl": ttl,
+            "use_ttl": True,
+            "comment": f"DNS-AID: TXT record for {name}",
+        }
+
+        record_ref = await self._find_record_ref(zone, name, "txt")
+
+        if record_ref:
+            logger.info(
+                "Updating TXT record in NIOS",
+                fqdn=fqdn,
+                record_ref=record_ref,
+            )
+            await self._request("PUT", record_ref, json=mutable)
+        else:
+            # Immutable fields (name, view) only on creation.
+            payload = {"name": fqdn, "view": self._dns_view, **mutable}
+            logger.info("Creating TXT record in NIOS", fqdn=fqdn)
+            await self._request("POST", "record:txt", json=payload)
+
+        return fqdn
 
     async def delete_record(
         self,
@@ -105,18 +454,215 @@ class InfobloxNIOSBackend(DNSBackend):
         record_type: str,
     ) -> bool:
         """Delete a DNS record from NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        record_ref = await self._find_record_ref(zone, name, record_type)
+        if not record_ref:
+            logger.warning(
+                "Record not found in NIOS",
+                zone=zone,
+                name=name,
+                record_type=record_type,
+            )
+            return False
+
+        await self._request("DELETE", record_ref)
+        logger.info(
+            "Deleted record from NIOS",
+            zone=zone,
+            name=name,
+            record_type=record_type,
+        )
+        return True
 
     async def list_records(
         self,
         zone: str,
         name_pattern: str | None = None,
         record_type: str | None = None,
-    ) -> AsyncIterator[dict]:
-        """List DNS records in NIOS zone."""
-        raise NotImplementedError("NIOS backend not yet implemented")
-        yield  # Make this a generator
+    ) -> AsyncIterator[dict[str, Any]]:
+        """List DNS records in NIOS zone/view."""
+        if record_type:
+            upper = record_type.upper()
+            if upper not in _SUPPORTED_RECORD_TYPES:
+                logger.warning(
+                    "Unsupported record type for NIOS list_records",
+                    record_type=record_type,
+                    supported=sorted(_SUPPORTED_RECORD_TYPES),
+                )
+                return
+            supported_types = [upper]
+        else:
+            supported_types = sorted(_SUPPORTED_RECORD_TYPES)
+
+        zone_clean = zone.rstrip(".")
+
+        for rtype in supported_types:
+            endpoint = f"record:{rtype.lower()}"
+            params = {
+                "zone": zone_clean,
+                "view": self._dns_view,
+            }
+
+            results = await self._request("GET", endpoint, params=params)
+            if not isinstance(results, list):
+                continue
+
+            for record in results:
+                fqdn = str(record.get("name", "")).rstrip(".")
+                if not fqdn:
+                    continue
+
+                if name_pattern and name_pattern not in fqdn:
+                    continue
+
+                values: list[str]
+                ttl = int(record.get("ttl", 0))
+
+                if rtype == "TXT":
+                    values = [str(record.get("text", ""))]
+                else:
+                    priority = int(record.get("priority", 0))
+                    target_name = str(record.get("target_name", ""))
+                    svc_parameters_text = self._format_svc_parameters_for_value(
+                        record.get("svc_parameters", [])
+                    )
+                    values = [f"{priority} {target_name} {svc_parameters_text}".strip()]
+
+                yield {
+                    "name": self._extract_name_from_fqdn(fqdn, zone_clean),
+                    "fqdn": fqdn,
+                    "type": rtype,
+                    "ttl": ttl,
+                    "values": values,
+                    "id": record.get("_ref"),
+                }
+
+    async def get_record(
+        self,
+        zone: str,
+        name: str,
+        record_type: str,
+    ) -> dict[str, Any] | None:
+        """Get a specific record by querying NIOS WAPI directly."""
+        fqdn = self._to_fqdn(name, zone)
+        params = {
+            "name": fqdn,
+            "view": self._dns_view,
+        }
+
+        results = await self._request("GET", f"record:{record_type.lower()}", params=params)
+        if not isinstance(results, list) or not results:
+            return None
+
+        record = results[0]
+        zone_clean = zone.rstrip(".")
+        record_fqdn = str(record.get("name", "")).rstrip(".")
+        ttl = int(record.get("ttl", 0))
+        rtype = record_type.upper()
+
+        if rtype == "TXT":
+            values = [str(record.get("text", ""))]
+        else:
+            priority = int(record.get("priority", 0))
+            target_name = str(record.get("target_name", ""))
+            svc_parameters_text = self._format_svc_parameters_for_value(
+                record.get("svc_parameters", [])
+            )
+            values = [f"{priority} {target_name} {svc_parameters_text}".strip()]
+
+        return {
+            "name": self._extract_name_from_fqdn(record_fqdn, zone_clean),
+            "fqdn": record_fqdn,
+            "type": rtype,
+            "ttl": ttl,
+            "values": values,
+            "id": record.get("_ref"),
+        }
 
     async def zone_exists(self, zone: str) -> bool:
-        """Check if zone exists in NIOS."""
-        raise NotImplementedError("NIOS backend not yet implemented")
+        """Check if authoritative zone exists in the configured DNS view.
+
+        Returns False (rather than raising) when the configured DNS view
+        does not exist on the NIOS grid or any other WAPI error occurs,
+        since the zone is effectively inaccessible.
+        """
+        zone_name = zone.rstrip(".")
+        cache_key = f"{zone_name}:{self._dns_view}"
+
+        if cache_key in self._zone_cache:
+            return self._zone_cache[cache_key]
+
+        try:
+            params = {
+                "fqdn": zone_name,
+                "view": self._dns_view,
+            }
+
+            results = await self._request("GET", "zone_auth", params=params)
+            if isinstance(results, list) and len(results) > 0:
+                self._zone_cache[cache_key] = True
+                return True
+
+            # Some NIOS deployments store/expect trailing-dot zone fqdn values.
+            params["fqdn"] = f"{zone_name}."
+            results = await self._request("GET", "zone_auth", params=params)
+            exists = isinstance(results, list) and len(results) > 0
+            self._zone_cache[cache_key] = exists
+            return exists
+
+        except RuntimeError as exc:
+            error_msg = str(exc)
+            if "not found" in error_msg.lower() and "view" in error_msg.lower():
+                logger.error(
+                    "DNS view does not exist on NIOS grid",
+                    view=self._dns_view,
+                    zone=zone_name,
+                    hint="Check NIOS_DNS_VIEW setting. "
+                    "Use list_zones() or the NIOS UI to see available views.",
+                )
+            else:
+                logger.error(
+                    "Failed to check zone existence",
+                    zone=zone_name,
+                    view=self._dns_view,
+                    error=error_msg,
+                )
+            self._zone_cache[cache_key] = False
+            return False
+
+    async def list_zones(self) -> list[dict[str, Any]]:
+        """List authoritative zones in the configured DNS view."""
+        params = {
+            "view": self._dns_view,
+        }
+        results = await self._request("GET", "zone_auth", params=params)
+
+        if not isinstance(results, list):
+            return []
+
+        zones: list[dict[str, Any]] = []
+        for zone in results:
+            if not isinstance(zone, dict):
+                continue
+
+            fqdn = str(zone.get("fqdn", ""))
+            zones.append(
+                {
+                    "id": zone.get("_ref"),
+                    "name": fqdn.rstrip("."),
+                    "fqdn": fqdn,
+                    "view": zone.get("view", self._dns_view),
+                    "comment": zone.get("comment", ""),
+                    "disabled": bool(zone.get("disable", False)),
+                    "zone_format": zone.get("zone_format", ""),
+                }
+            )
+
+        return zones
+
+    async def __aenter__(self) -> InfobloxNIOSBackend:
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        """Async context manager exit."""
+        await self.close()

--- a/src/dns_aid/backends/route53.py
+++ b/src/dns_aid/backends/route53.py
@@ -461,11 +461,22 @@ class Route53Backend(DNSBackend):
                 }
 
     async def zone_exists(self, zone: str) -> bool:
-        """Check if zone exists in Route 53."""
+        """Check if zone exists in Route 53.
+
+        Returns False (rather than raising) on any API or network error,
+        since the zone is effectively inaccessible.
+        """
         try:
             await self._get_zone_id(zone)
             return True
         except ValueError:
+            return False
+        except Exception as exc:
+            logger.warning(
+                "Failed to check zone existence in Route 53",
+                zone=zone,
+                error=str(exc),
+            )
             return False
 
     async def get_record(

--- a/src/dns_aid/cli/backends.py
+++ b/src/dns_aid/cli/backends.py
@@ -97,6 +97,28 @@ BACKEND_REGISTRY: dict[str, BackendInfo] = {
             "Optionally set INFOBLOX_DNS_VIEW if not using 'default'",
         ],
     ),
+    "nios": BackendInfo(
+        name="nios",
+        display_name="Infoblox NIOS (on-prem WAPI)",
+        required_env={
+            "NIOS_HOST": "NIOS Grid Manager hostname or IP",
+            "NIOS_USERNAME": "WAPI username",
+            "NIOS_PASSWORD": "WAPI password",  # nosec B105 — description, not a credential
+        },
+        optional_env={
+            "NIOS_DNS_VIEW": "DNS view name (default: default)",
+            "NIOS_WAPI_VERSION": "WAPI version (default: 2.13.7)",
+            "NIOS_VERIFY_SSL": "Verify TLS certificate (default: false)",
+        },
+        optional_dep="nios",
+        setup_url="https://docs.infoblox.com/space/NIOS",
+        setup_steps=[
+            "Ensure NIOS Grid Manager is reachable from this host",
+            "Set NIOS_HOST, NIOS_USERNAME, and NIOS_PASSWORD",
+            "Optionally set NIOS_DNS_VIEW if not using 'default'",
+            "Set NIOS_VERIFY_SSL=true if you have a valid TLS certificate",
+        ],
+    ),
     "ddns": BackendInfo(
         name="ddns",
         display_name="RFC 2136 Dynamic DNS",

--- a/src/dns_aid/cli/doctor.py
+++ b/src/dns_aid/cli/doctor.py
@@ -123,7 +123,7 @@ def _check_backends(pass_count: list[int], fail_count: list[int]) -> None:
             try:
                 if name == "route53":
                     importlib.import_module("boto3")
-                elif name in ("cloudflare", "infoblox"):
+                elif name in ("cloudflare", "infoblox", "nios"):
                     importlib.import_module("httpx")
                 elif name == "ddns":
                     importlib.import_module("dns.update")

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -37,7 +37,7 @@ def reset_default_backend() -> None:
 def get_default_backend() -> DNSBackend:
     """Get the default DNS backend based on DNS_AID_BACKEND env var.
 
-    Supported values: route53, cloudflare, infoblox, ddns, mock
+    Supported values: route53, cloudflare, infoblox, nios, ddns, mock
 
     Raises:
         ValueError: If DNS_AID_BACKEND is not set (no silent fallback to mock).
@@ -51,7 +51,7 @@ def get_default_backend() -> DNSBackend:
         if not backend_type:
             raise ValueError(
                 "DNS_AID_BACKEND must be set. "
-                "Supported values: route53, cloudflare, infoblox, ddns, mock"
+                "Supported values: route53, cloudflare, infoblox, nios, ddns, mock"
             )
 
         if backend_type == "route53":
@@ -66,6 +66,10 @@ def get_default_backend() -> DNSBackend:
             from dns_aid.backends.infoblox import InfobloxBackend
 
             _default_backend = InfobloxBackend()
+        elif backend_type == "nios":
+            from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+            _default_backend = InfobloxNIOSBackend()
         elif backend_type == "ddns":
             from dns_aid.backends.ddns import DDNSBackend
 
@@ -75,7 +79,7 @@ def get_default_backend() -> DNSBackend:
         else:
             raise ValueError(
                 f"Unknown DNS_AID_BACKEND: '{backend_type}'. "
-                "Supported values: route53, cloudflare, infoblox, ddns, mock"
+                "Supported values: route53, cloudflare, infoblox, nios, ddns, mock"
             )
 
         logger.info(

--- a/tests/integration/test_nios.py
+++ b/tests/integration/test_nios.py
@@ -1,0 +1,178 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for Infoblox NIOS (on-premises) backend.
+
+These tests require NIOS WAPI credentials and a real NIOS zone.
+Set environment variables:
+  - NIOS_HOST (Grid Master hostname)
+  - NIOS_USERNAME (WAPI username)
+  - NIOS_PASSWORD (WAPI password)
+  - NIOS_TEST_ZONE (e.g., "dns-test.com")
+  - NIOS_DNS_VIEW (optional, default: "default")
+  - NIOS_VERIFY_SSL (optional, default: "true")
+  - NIOS_WAPI_VERSION (optional, default: "2.13.7")
+
+Run with: pytest tests/integration/test_nios.py -v
+
+Mutation tests (create/delete) additionally require:
+  - NIOS_MUTATION_TESTS=1
+"""
+
+import os
+import uuid
+
+import pytest
+
+# Live backend tests — run with: pytest -m live
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.environ.get("NIOS_HOST")
+        or not os.environ.get("NIOS_USERNAME")
+        or not os.environ.get("NIOS_PASSWORD")
+        or not os.environ.get("NIOS_TEST_ZONE"),
+        reason="NIOS_HOST, NIOS_USERNAME, NIOS_PASSWORD, or NIOS_TEST_ZONE not set",
+    ),
+]
+
+
+@pytest.fixture
+def test_zone() -> str:
+    """Get test zone from environment."""
+    return os.environ["NIOS_TEST_ZONE"]
+
+
+@pytest.fixture
+async def nios_backend():
+    """Create NIOS backend from environment variables."""
+    from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+    backend = InfobloxNIOSBackend()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+def unique_name() -> str:
+    """Generate unique record name to avoid conflicts."""
+    short_id = str(uuid.uuid4())[:8]
+    return f"_inttest-{short_id}._mcp._agents"
+
+
+class TestInfobloxNIOSReadOnly:
+    """Read-only integration tests for NIOS backend."""
+
+    async def test_zone_exists(self, nios_backend, test_zone):
+        """Test zone existence check."""
+        exists = await nios_backend.zone_exists(test_zone)
+        assert exists is True
+
+    async def test_zone_exists_with_trailing_dot(self, nios_backend, test_zone):
+        """Test zone existence with trailing dot."""
+        exists = await nios_backend.zone_exists(f"{test_zone}.")
+        assert exists is True
+
+    async def test_zone_not_exists(self, nios_backend):
+        """Test zone non-existence."""
+        exists = await nios_backend.zone_exists("nonexistent-zone-xyz123.invalid")
+        assert exists is False
+
+    async def test_list_zones(self, nios_backend, test_zone):
+        """Test listing zones."""
+        zones = await nios_backend.list_zones()
+
+        assert len(zones) > 0
+        zone_names = [z["name"] for z in zones]
+        assert test_zone.rstrip(".") in zone_names
+
+
+class TestInfobloxNIOSMutation:
+    """Mutation integration tests (create/delete) for NIOS backend."""
+
+    pytestmark = pytest.mark.skipif(
+        not os.environ.get("NIOS_MUTATION_TESTS"),
+        reason="NIOS_MUTATION_TESTS not set (set to 1 to enable)",
+    )
+
+    async def test_create_verify_delete_svcb(self, nios_backend, test_zone, unique_name):
+        """Test SVCB record lifecycle: create, verify via API, delete."""
+        try:
+            fqdn = await nios_backend.create_svcb_record(
+                zone=test_zone,
+                name=unique_name,
+                priority=1,
+                target=f"live-target.{test_zone}",
+                params={
+                    "mandatory": "alpn,port",
+                    "alpn": "mcp",
+                    "port": "443",
+                    "realm": "live-test",
+                },
+                ttl=120,
+            )
+
+            assert unique_name in fqdn
+
+            # Verify via get_record
+            record = await nios_backend.get_record(test_zone, unique_name, "SVCB")
+            assert record is not None
+            assert record["type"] == "SVCB"
+        finally:
+            await nios_backend.delete_record(test_zone, unique_name, "SVCB")
+
+    async def test_create_verify_delete_txt(self, nios_backend, test_zone, unique_name):
+        """Test TXT record lifecycle: create, verify via API, delete."""
+        try:
+            fqdn = await nios_backend.create_txt_record(
+                zone=test_zone,
+                name=unique_name,
+                values=["capabilities=live-test", "version=0.0.1"],
+                ttl=120,
+            )
+
+            assert unique_name in fqdn
+
+            # Verify via get_record
+            record = await nios_backend.get_record(test_zone, unique_name, "TXT")
+            assert record is not None
+            assert record["type"] == "TXT"
+        finally:
+            await nios_backend.delete_record(test_zone, unique_name, "TXT")
+
+    async def test_full_dnsaid_publish_workflow(self, nios_backend, test_zone):
+        """Test complete DNS-AID publish: SVCB + TXT records."""
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name=f"inttest-{str(uuid.uuid4())[:8]}",
+            domain=test_zone,
+            protocol=Protocol.MCP,
+            target_host=f"mcp.{test_zone}",
+            port=443,
+            capabilities=["integration", "test", "nios"],
+            version="1.0.0",
+            ttl=120,
+        )
+
+        record_name = f"_{agent.name}._{agent.protocol.value}._agents"
+
+        try:
+            records_created = await nios_backend.publish_agent(agent)
+
+            assert len(records_created) == 2
+            assert any("SVCB" in r for r in records_created)
+            assert any("TXT" in r for r in records_created)
+        finally:
+            await nios_backend.delete_record(test_zone, record_name, "SVCB")
+            await nios_backend.delete_record(test_zone, record_name, "TXT")
+
+    async def test_delete_nonexistent_record(self, nios_backend, test_zone):
+        """Test deleting a record that doesn't exist."""
+        deleted = await nios_backend.delete_record(
+            zone=test_zone,
+            name="_nonexistent-record-xyz._mcp._agents",
+            record_type="SVCB",
+        )
+        assert deleted is False

--- a/tests/unit/test_cli_onboarding.py
+++ b/tests/unit/test_cli_onboarding.py
@@ -22,10 +22,17 @@ runner = CliRunner()
 
 class TestBackendRegistry:
     def test_all_backends_present(self):
-        assert set(ALL_BACKEND_NAMES) == {"route53", "cloudflare", "infoblox", "ddns", "mock"}
+        assert set(ALL_BACKEND_NAMES) == {
+            "route53",
+            "cloudflare",
+            "infoblox",
+            "nios",
+            "ddns",
+            "mock",
+        }
 
     def test_env_based_backends_have_required_env(self):
-        for name in ("cloudflare", "infoblox", "ddns"):
+        for name in ("cloudflare", "infoblox", "nios", "ddns"):
             info = BACKEND_REGISTRY[name]
             assert info.required_env, f"{name} should have required_env"
 
@@ -110,8 +117,9 @@ class TestGetBackendImproved:
 
     def test_no_backend_configured_shows_init_hint(self):
         """When nothing is configured, suggest dns-aid init."""
-        with patch.dict(os.environ, {}, clear=True), patch(
-            "dns_aid.cli.backends._has_boto3_credentials", return_value=False
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("dns_aid.cli.backends._has_boto3_credentials", return_value=False),
         ):
             result = runner.invoke(app, ["list", "example.com"])
             assert result.exit_code != 0

--- a/tests/unit/test_infoblox_backend.py
+++ b/tests/unit/test_infoblox_backend.py
@@ -323,12 +323,12 @@ class TestInfobloxBloxOneBackendAsync:
         assert backend._client is None  # Client should be cleared after close
 
 
-class TestInfobloxNIOSBackend:
-    """Tests for InfobloxNIOSBackend (placeholder)."""
+class TestInfobloxNIOSBackendImport:
+    """Verify NIOS backend is importable via the infoblox package."""
 
-    def test_nios_not_implemented(self):
-        """Test that NIOS backend raises NotImplementedError."""
-        from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+    def test_nios_import(self):
+        """Test that InfobloxNIOSBackend can be imported from infoblox package."""
+        from dns_aid.backends.infoblox import InfobloxNIOSBackend
 
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
-            InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
+        backend = InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
+        assert backend.name == "nios"

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -1,0 +1,838 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for Infoblox NIOS (on-premises) backend.
+
+These tests mock the HTTP API to test the backend logic without
+requiring real NIOS credentials.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+
+class TestInfobloxNIOSInit:
+    """Tests for InfobloxNIOSBackend initialization."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "error_match"),
+        [
+            (
+                {"host": "", "username": "admin", "password": "secret"},
+                "NIOS host required",
+            ),
+            (
+                {"host": "nios.local", "username": "", "password": "secret"},
+                "NIOS username required",
+            ),
+            (
+                {"host": "nios.local", "username": "admin", "password": ""},
+                "NIOS password required",
+            ),
+        ],
+    )
+    def test_constructor_validation_errors(self, kwargs: dict[str, str], error_match: str) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            InfobloxNIOSBackend(**kwargs)
+
+    def test_init_with_explicit_params(self) -> None:
+        backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+        assert backend.name == "nios"
+        assert backend.dns_view == "default"
+        assert backend._host == "nios.local"
+
+    def test_init_custom_wapi_version(self) -> None:
+        backend = InfobloxNIOSBackend(
+            host="nios.local",
+            username="admin",
+            password="secret",
+            wapi_version="2.12",
+        )
+        assert backend._wapi_version == "2.12"
+        assert "v2.12" in backend._base_url
+
+    def test_init_custom_dns_view(self) -> None:
+        backend = InfobloxNIOSBackend(
+            host="nios.local",
+            username="admin",
+            password="secret",
+            dns_view="internal",
+        )
+        assert backend.dns_view == "internal"
+
+    def test_init_from_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NIOS_HOST", "env-nios.local")
+        monkeypatch.setenv("NIOS_USERNAME", "env-admin")
+        monkeypatch.setenv("NIOS_PASSWORD", "env-secret")
+        monkeypatch.setenv("NIOS_WAPI_VERSION", "2.11")
+        monkeypatch.setenv("NIOS_DNS_VIEW", "custom")
+        monkeypatch.setenv("NIOS_TIMEOUT", "60")
+
+        backend = InfobloxNIOSBackend()
+        assert backend._host == "env-nios.local"
+        assert backend._username == "env-admin"
+        assert backend._wapi_version == "2.11"
+        assert backend.dns_view == "custom"
+        assert backend._timeout == 60.0
+
+
+class TestInfobloxNIOSHelpers:
+    """Tests for NIOS backend helper methods."""
+
+    def test_parse_bool_env_true_values(self) -> None:
+        for val in ("1", "true", "True", "YES", "on"):
+            assert InfobloxNIOSBackend._parse_bool_env(val, default=False) is True
+
+    def test_parse_bool_env_false_values(self) -> None:
+        for val in ("0", "false", "False", "NO", "off"):
+            assert InfobloxNIOSBackend._parse_bool_env(val, default=True) is False
+
+    def test_parse_bool_env_none_returns_default(self) -> None:
+        assert InfobloxNIOSBackend._parse_bool_env(None, default=True) is True
+        assert InfobloxNIOSBackend._parse_bool_env(None, default=False) is False
+
+    def test_parse_bool_env_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid boolean value"):
+            InfobloxNIOSBackend._parse_bool_env("maybe", default=True)
+
+    def test_to_fqdn_simple(self) -> None:
+        assert (
+            InfobloxNIOSBackend._to_fqdn("_agent._mcp._agents", "example.com")
+            == "_agent._mcp._agents.example.com"
+        )
+
+    def test_to_fqdn_already_qualified(self) -> None:
+        assert (
+            InfobloxNIOSBackend._to_fqdn("_agent._mcp._agents.example.com", "example.com")
+            == "_agent._mcp._agents.example.com"
+        )
+
+    def test_to_fqdn_strips_trailing_dots(self) -> None:
+        assert (
+            InfobloxNIOSBackend._to_fqdn("_agent._mcp._agents.", "example.com.")
+            == "_agent._mcp._agents.example.com"
+        )
+
+    def test_normalize_target(self) -> None:
+        assert InfobloxNIOSBackend._normalize_target("mcp.example.com.") == "mcp.example.com"
+        assert InfobloxNIOSBackend._normalize_target("  host.com  ") == "host.com"
+
+    def test_extract_name_from_fqdn(self) -> None:
+        assert (
+            InfobloxNIOSBackend._extract_name_from_fqdn(
+                "_agent._mcp._agents.example.com", "example.com"
+            )
+            == "_agent._mcp._agents"
+        )
+
+    def test_extract_name_from_fqdn_no_match(self) -> None:
+        # When zone doesn't match, return FQDN unchanged
+        assert (
+            InfobloxNIOSBackend._extract_name_from_fqdn(
+                "_agent._mcp._agents.other.com", "example.com"
+            )
+            == "_agent._mcp._agents.other.com"
+        )
+
+    def test_extract_name_from_fqdn_trailing_dots(self) -> None:
+        assert (
+            InfobloxNIOSBackend._extract_name_from_fqdn(
+                "_agent._mcp._agents.example.com.", "example.com."
+            )
+            == "_agent._mcp._agents"
+        )
+
+
+class TestInfobloxNIOSSvcParameters:
+    """Tests for SVC parameter conversion."""
+
+    def test_svc_parameters_conversion(self) -> None:
+        params = {
+            "mandatory": "alpn,port,cap",
+            "alpn": "h2,h3",
+            "port": "443",
+            "bap": "mcp/1,a2a/1",
+            "cap": "https://example.com/.well-known/agent-cap.json",
+            "sig": "abc123",
+        }
+
+        converted = InfobloxNIOSBackend._svc_parameters_from_params(params)
+
+        as_map = {item["svc_key"]: item for item in converted}
+        assert as_map["alpn"]["svc_value"] == ["h2", "h3"]
+        assert as_map["alpn"]["mandatory"] is True
+        assert as_map["key65003"]["svc_value"] == ["mcp/1", "a2a/1"]
+        assert as_map["port"]["svc_value"] == ["443"]
+        assert as_map["key65001"]["mandatory"] is True
+        assert as_map["key65006"]["svc_value"] == ["abc123"]
+
+    def test_svc_parameters_preserves_numeric_keys(self) -> None:
+        converted = InfobloxNIOSBackend._svc_parameters_from_params(
+            {"mandatory": "key65003,port", "key65003": "mcp/1,a2a/1", "port": "443"}
+        )
+        as_map = {item["svc_key"]: item for item in converted}
+
+        assert as_map["key65003"]["mandatory"] is True
+        assert as_map["key65003"]["svc_value"] == ["mcp/1", "a2a/1"]
+        assert as_map["port"]["mandatory"] is True
+
+    def test_format_svc_parameters_for_value(self) -> None:
+        svc_params = [
+            {"svc_key": "alpn", "svc_value": ["mcp"], "mandatory": True},
+            {"svc_key": "port", "svc_value": ["443"], "mandatory": True},
+            {"svc_key": "key65005", "svc_value": ["prod"], "mandatory": False},
+        ]
+        result = InfobloxNIOSBackend._format_svc_parameters_for_value(svc_params)
+        assert 'mandatory="alpn,port"' in result
+        assert 'alpn="mcp"' in result
+        assert 'port="443"' in result
+        assert 'realm="prod"' in result
+
+    def test_format_svc_parameters_non_list_returns_empty(self) -> None:
+        assert InfobloxNIOSBackend._format_svc_parameters_for_value(None) == ""
+        assert InfobloxNIOSBackend._format_svc_parameters_for_value("invalid") == ""
+
+
+class TestInfobloxNIOSAsync:
+    """Async tests for InfobloxNIOSBackend."""
+
+    @pytest.fixture
+    def backend(self) -> InfobloxNIOSBackend:
+        return InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+    async def test_create_svcb_record_new(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_find_record_ref(zone: str, name: str, record_type: str) -> None:
+            return None
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            calls.append((method, endpoint, json))
+            return {}
+
+        monkeypatch.setattr(backend, "_find_record_ref", fake_find_record_ref)
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        await backend.create_svcb_record(
+            zone="example.com",
+            name="_agent._mcp._agents",
+            priority=1,
+            target="mcp.example.com",
+            params={
+                "mandatory": "alpn,port",
+                "alpn": "mcp",
+                "port": "443",
+                "realm": "prod",
+            },
+            ttl=900,
+        )
+
+        assert calls
+        method, endpoint, payload = calls[0]
+        assert method == "POST"
+        assert endpoint == "record:svcb"
+        assert payload is not None
+        assert payload["priority"] == 1
+        assert payload["target_name"] == "mcp.example.com"
+        assert payload["ttl"] == 900
+        assert payload["use_ttl"] is True
+        assert payload["view"] == "default"
+        assert any(param["svc_key"] == "key65005" for param in payload["svc_parameters"])
+
+    async def test_create_svcb_record_update(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_find_record_ref(zone: str, name: str, record_type: str) -> str:
+            return "record:svcb/ZG5z..."
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            calls.append((method, endpoint, json))
+            return {}
+
+        monkeypatch.setattr(backend, "_find_record_ref", fake_find_record_ref)
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        await backend.create_svcb_record(
+            zone="example.com",
+            name="_agent._mcp._agents",
+            priority=1,
+            target="mcp.example.com",
+            params={"alpn": "mcp", "port": "443"},
+        )
+
+        assert calls[0][0] == "PUT"
+        assert calls[0][1] == "record:svcb/ZG5z..."
+        # NIOS WAPI rejects immutable fields (name, view) in PUT requests
+        put_payload = calls[0][2]
+        assert "name" not in put_payload
+        assert "view" not in put_payload
+
+    async def test_find_record_ref(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, str]]:
+            assert method == "GET"
+            assert endpoint == "record:svcb"
+            return [{"_ref": "record:svcb/ZG5z..."}]
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        ref = await backend._find_record_ref("example.com", "_agent._mcp._agents", "SVCB")
+        assert ref == "record:svcb/ZG5z..."
+
+    async def test_strict_fail_on_svcb_validation_error(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_find_record_ref(zone: str, name: str, record_type: str) -> None:
+            return None
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            raise RuntimeError("NIOS validation failed: invalid svc_key cap")
+
+        monkeypatch.setattr(backend, "_find_record_ref", fake_find_record_ref)
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        with pytest.raises(RuntimeError, match="validation failed"):
+            await backend.create_svcb_record(
+                zone="example.com",
+                name="_agent._mcp._agents",
+                priority=1,
+                target="mcp.example.com",
+                params={"alpn": "mcp", "port": "443", "cap": "https://x"},
+            )
+
+    async def test_txt_create_and_update_upsert(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            calls.append((method, endpoint, json))
+            return {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        async def missing_ref(zone: str, name: str, record_type: str) -> None:
+            return None
+
+        monkeypatch.setattr(backend, "_find_record_ref", missing_ref)
+        await backend.create_txt_record(
+            "example.com", "_agent._mcp._agents", ["capabilities=chat"], ttl=1200
+        )
+        assert calls[-1][0] == "POST"
+        assert calls[-1][1] == "record:txt"
+
+        async def existing_ref(zone: str, name: str, record_type: str) -> str:
+            return "record:txt/ZG5z..."
+
+        monkeypatch.setattr(backend, "_find_record_ref", existing_ref)
+        await backend.create_txt_record(
+            "example.com", "_agent._mcp._agents", ["version=1.0.0"], ttl=1200
+        )
+        assert calls[-1][0] == "PUT"
+        assert calls[-1][1] == "record:txt/ZG5z..."
+
+    async def test_delete_record_found_and_not_found(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str]] = []
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            calls.append((method, endpoint))
+            return {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        async def found_ref(zone: str, name: str, record_type: str) -> str:
+            return "record:svcb/ZG5z..."
+
+        monkeypatch.setattr(backend, "_find_record_ref", found_ref)
+        deleted = await backend.delete_record("example.com", "_agent._mcp._agents", "SVCB")
+        assert deleted is True
+        assert calls[-1] == ("DELETE", "record:svcb/ZG5z...")
+
+        async def missing_ref(zone: str, name: str, record_type: str) -> None:
+            return None
+
+        monkeypatch.setattr(backend, "_find_record_ref", missing_ref)
+        deleted = await backend.delete_record("example.com", "_agent._mcp._agents", "SVCB")
+        assert deleted is False
+
+    async def test_zone_exists_true_false(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def request_found(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, str]]:
+            return [{"_ref": "zone_auth/ZG5z..."}]
+
+        monkeypatch.setattr(backend, "_request", request_found)
+        assert await backend.zone_exists("example.com") is True
+
+        # Second call should hit the cache
+        assert await backend.zone_exists("example.com") is True
+
+    async def test_zone_exists_false(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def request_missing(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, str]]:
+            return []
+
+        monkeypatch.setattr(backend, "_request", request_missing)
+        assert await backend.zone_exists("nonexistent.com") is False
+
+    async def test_zone_exists_caching(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify zone_exists uses cache on second call."""
+        call_count = 0
+
+        async def counting_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, str]]:
+            nonlocal call_count
+            call_count += 1
+            return [{"_ref": "zone_auth/ZG5z..."}]
+
+        monkeypatch.setattr(backend, "_request", counting_request)
+
+        assert await backend.zone_exists("cached.com") is True
+        first_count = call_count
+        assert await backend.zone_exists("cached.com") is True
+        # Second call should NOT make any HTTP requests (cached)
+        assert call_count == first_count
+
+    async def test_list_zones(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, object]]:
+            assert method == "GET"
+            assert endpoint == "zone_auth"
+            return [
+                {
+                    "_ref": "zone_auth/ZG5z...:example.com/default",
+                    "fqdn": "example.com.",
+                    "view": "default",
+                    "comment": "Primary zone",
+                    "disable": False,
+                    "zone_format": "FORWARD",
+                }
+            ]
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        zones = await backend.list_zones()
+
+        assert len(zones) == 1
+        assert zones[0]["name"] == "example.com"
+        assert zones[0]["fqdn"] == "example.com."
+        assert zones[0]["view"] == "default"
+        assert zones[0]["comment"] == "Primary zone"
+        assert zones[0]["zone_format"] == "FORWARD"
+
+    async def test_list_records_normalization(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, object]]:
+            if endpoint == "record:svcb":
+                return [
+                    {
+                        "_ref": "record:svcb/abc",
+                        "name": "_agent._mcp._agents.example.com",
+                        "ttl": 3600,
+                        "priority": 1,
+                        "target_name": "mcp.example.com",
+                        "svc_parameters": [
+                            {"svc_key": "alpn", "svc_value": ["mcp"], "mandatory": True},
+                            {"svc_key": "port", "svc_value": ["443"], "mandatory": True},
+                            {
+                                "svc_key": "key65005",
+                                "svc_value": ["prod"],
+                                "mandatory": False,
+                            },
+                        ],
+                    }
+                ]
+
+            return [
+                {
+                    "_ref": "record:txt/def",
+                    "name": "_agent._mcp._agents.example.com",
+                    "ttl": 3600,
+                    "text": '"capabilities=chat" "version=1.0.0"',
+                }
+            ]
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        records = [record async for record in backend.list_records("example.com")]
+
+        assert len(records) == 2
+        assert records[0]["type"] == "SVCB"
+        assert records[1]["type"] == "TXT"
+        assert records[0]["fqdn"] == "_agent._mcp._agents.example.com"
+        assert records[0]["name"] == "_agent._mcp._agents"
+        assert 'port="443"' in records[0]["values"][0]
+        assert 'realm="prod"' in records[0]["values"][0]
+
+    async def test_list_records_unsupported_type_warns(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """list_records should yield nothing for unsupported record types."""
+        records = [
+            record async for record in backend.list_records("example.com", record_type="AAAA")
+        ]
+        assert records == []
+
+    async def test_get_record_found(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "_ref": "record:svcb/abc",
+                    "name": "_agent._mcp._agents.example.com",
+                    "ttl": 3600,
+                    "priority": 1,
+                    "target_name": "mcp.example.com",
+                    "svc_parameters": [],
+                }
+            ]
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        result = await backend.get_record("example.com", "_agent._mcp._agents", "SVCB")
+        assert result is not None
+        assert result["name"] == "_agent._mcp._agents"
+        assert result["type"] == "SVCB"
+
+    async def test_get_record_not_found(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list:
+            return []
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        result = await backend.get_record("example.com", "_nonexistent._mcp._agents", "SVCB")
+        assert result is None
+
+    async def test_context_manager(self, backend: InfobloxNIOSBackend) -> None:
+        async with backend as b:
+            assert b is backend
+
+    async def test_close(self, backend: InfobloxNIOSBackend) -> None:
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        mock_client.aclose = AsyncMock()
+        backend._client = mock_client
+
+        await backend.close()
+
+        mock_client.aclose.assert_called_once()
+        assert backend._client is None
+
+    async def test_zone_exists_bad_view_returns_false(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """zone_exists returns False when DNS view doesn't exist (not raise)."""
+        backend._dns_view = "nonexistent-view"
+
+        async def raise_view_not_found(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            raise RuntimeError(
+                "NIOS WAPI request failed (GET /zone_auth): "
+                "status=404 body=View nonexistent-view not found"
+            )
+
+        monkeypatch.setattr(backend, "_request", raise_view_not_found)
+
+        result = await backend.zone_exists("example.com")
+        assert result is False
+        # Should also be cached as False
+        assert backend._zone_cache.get("example.com:nonexistent-view") is False
+
+    async def test_zone_exists_transport_error_returns_false(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """zone_exists returns False on transport errors (network unreachable)."""
+
+        async def raise_transport_error(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            raise RuntimeError("NIOS WAPI transport error (GET /zone_auth): Connection refused")
+
+        monkeypatch.setattr(backend, "_request", raise_transport_error)
+
+        result = await backend.zone_exists("example.com")
+        assert result is False
+
+    async def test_txt_update_excludes_immutable_fields(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PUT for TXT update must NOT include name or view fields."""
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_find_existing(zone: str, name: str, record_type: str) -> str:
+            return "record:txt/ZG5z..."
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            calls.append((method, endpoint, json))
+            return {}
+
+        monkeypatch.setattr(backend, "_find_record_ref", fake_find_existing)
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        await backend.create_txt_record("example.com", "_agent._mcp._agents", ["updated=true"])
+
+        assert calls[0][0] == "PUT"
+        put_payload = calls[0][2]
+        assert "name" not in put_payload
+        assert "view" not in put_payload
+        assert "text" in put_payload
+
+    async def test_list_records_name_pattern_filter(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """list_records with name_pattern filters results correctly."""
+
+        async def fake_request(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "_ref": "record:txt/a",
+                    "name": "_agent1._mcp._agents.example.com",
+                    "ttl": 300,
+                    "text": '"capabilities=a"',
+                },
+                {
+                    "_ref": "record:txt/b",
+                    "name": "_agent2._a2a._agents.example.com",
+                    "ttl": 300,
+                    "text": '"capabilities=b"',
+                },
+            ]
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+
+        # Filter by name_pattern — only _agent1 should match
+        records = [
+            r
+            async for r in backend.list_records(
+                "example.com", name_pattern="_agent1", record_type="TXT"
+            )
+        ]
+        assert len(records) == 1
+        assert "_agent1" in records[0]["fqdn"]
+
+
+class TestPublisherNIOSBackendSelection:
+    """Tests for publisher backend selection with NIOS."""
+
+    def setup_method(self) -> None:
+        from dns_aid.core.publisher import reset_default_backend
+
+        reset_default_backend()
+
+    def teardown_method(self) -> None:
+        from dns_aid.core.publisher import reset_default_backend
+
+        reset_default_backend()
+
+    def test_get_default_backend_nios(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DNS_AID_BACKEND", "nios")
+        monkeypatch.setenv("NIOS_HOST", "nios.local")
+        monkeypatch.setenv("NIOS_USERNAME", "admin")
+        monkeypatch.setenv("NIOS_PASSWORD", "secret")
+
+        from dns_aid.core.publisher import get_default_backend
+
+        backend = get_default_backend()
+
+        assert isinstance(backend, InfobloxNIOSBackend)
+        assert backend.name == "nios"
+
+    def test_get_default_backend_infoblox_stays_bloxone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ensure DNS_AID_BACKEND=infoblox still resolves to BloxOne."""
+        monkeypatch.setenv("DNS_AID_BACKEND", "infoblox")
+        monkeypatch.setenv("INFOBLOX_API_KEY", "token")
+
+        from dns_aid.backends.infoblox import InfobloxBloxOneBackend
+        from dns_aid.core.publisher import get_default_backend
+
+        backend = get_default_backend()
+
+        assert isinstance(backend, InfobloxBloxOneBackend)
+
+    async def test_publish_to_nonexistent_zone_returns_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """publish() returns success=False when zone doesn't exist."""
+        monkeypatch.setenv("DNS_AID_BACKEND", "nios")
+        monkeypatch.setenv("NIOS_HOST", "nios.local")
+        monkeypatch.setenv("NIOS_USERNAME", "admin")
+        monkeypatch.setenv("NIOS_PASSWORD", "secret")
+
+        from dns_aid.core.publisher import publish, reset_default_backend
+
+        reset_default_backend()
+
+        backend = InfobloxNIOSBackend(host="nios.local", username="admin", password="secret")
+
+        # Mock zone_exists to return False
+        async def fake_zone_not_exists(zone: str) -> bool:
+            return False
+
+        monkeypatch.setattr(backend, "zone_exists", fake_zone_not_exists)
+
+        result = await publish(
+            name="test-agent",
+            domain="nonexistent.com",
+            protocol="mcp",
+            endpoint="mcp.nonexistent.com",
+            backend=backend,
+        )
+
+        assert result.success is False
+        assert "does not exist" in result.message
+
+    async def test_publish_to_bad_view_returns_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """publish() returns success=False when DNS view is misconfigured."""
+        backend = InfobloxNIOSBackend(
+            host="nios.local",
+            username="admin",
+            password="secret",
+            dns_view="nonexistent-view",
+        )
+
+        # Simulate WAPI 404 for bad view
+        async def raise_view_not_found(
+            method: str,
+            endpoint: str,
+            *,
+            params: dict[str, str] | None = None,
+            json: dict | None = None,
+        ) -> dict:
+            raise RuntimeError("NIOS WAPI request failed: View nonexistent-view not found")
+
+        monkeypatch.setattr(backend, "_request", raise_view_not_found)
+
+        from dns_aid.core.publisher import publish
+
+        result = await publish(
+            name="test-agent",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="mcp.example.com",
+            backend=backend,
+        )
+
+        assert result.success is False
+        assert "does not exist" in result.message

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -541,7 +541,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "infoblox", "cloudflare", "ddns", "jws", "sdk", "otel", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
 
 [[package]]
 name = "dnspython"


### PR DESCRIPTION
## Summary

Adds production-ready Infoblox NIOS on-premise backend via WAPI v2.13.7+, bringing DNS-AID to **six production backends**. Based on initial contribution by @IngmarVG-IB (#22), reviewed and hardened for core integration.

- **Full NIOS WAPI backend** — SVCB + TXT record CRUD with upsert semantics, zone caching, efficient `get_record()` override, graceful error handling for bad DNS views/network failures
- **Cross-backend hardening** — `zone_exists()` now returns `False` (never raises) across all five real backends. Documented as must-not-raise contract in `DNSBackend` base class
- **CLI integration** — `dns-aid doctor` checks NIOS credentials, `dns-aid init` offers NIOS, `detect_backend()` auto-detects from env vars, `DNS_AID_BACKEND=nios` wired in publisher
- **Full BANDAID compliance** — NIOS supports ServiceMode SVCB (priority > 0) with native custom SvcParamKeys (`key65001`–`key65006`), no TXT demotion needed
- **46 unit tests + live integration test harness** (env-var gated)
- **Docs** — README setup section, architecture diagram, BANDAID compliance table, `.env.example`, CHANGELOG
- **Version bump** — 0.6.6 → 0.6.7

### Files changed (21 files, +1827/-95)

| Category | Files |
|----------|-------|
| Backend | `nios.py` (full impl), `__init__.py` exports, `backends/__init__.py` imports |
| Hardening | `base.py` contract, `route53.py`, `cloudflare.py`, `bloxone.py` zone_exists |
| CLI | `backends.py` registry, `doctor.py` httpx check |
| Publisher | `publisher.py` nios wiring |
| Config | `pyproject.toml`, `.env.example`, `CHANGELOG.md`, `CITATION.cff`, `README.md` |
| Tests | `test_infoblox_nios_backend.py` (46 tests), `test_nios.py` (live), `test_cli_onboarding.py` |

## Test plan

- [x] 716/716 unit tests pass
- [x] `ruff check` clean, `ruff format` clean
- [x] `dns-aid doctor` shows NIOS backend with credential check
- [x] `detect_backend()` auto-detects NIOS from env vars
- [x] Live-tested against NIOS at 52.56.250.37 (14/14 integration tests pass)
- [x] Bad DNS view returns `success=False` with clear error message (not crash)
- [x] Version 0.6.7 loads correctly
- [ ] CI/CD pipeline passes
- [ ] PyPI release via CI tag workflow

Supersedes #22 — Ingmar's contribution is credited in the commit message and CHANGELOG.