### PR TITLE
refactor: centralize backend dispatch with create_backend() factory (v0.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.8] - 2026-02-18
+
+### Changed
+- **Centralized backend dispatch** — Single `create_backend()` factory in `backends/__init__.py` replaces 4 scattered if-elif chains in `publisher.py`, `cli/main.py`, `mcp/server.py`, and inline MCP tools. Adding a new backend now requires updating ONE place instead of four
+- **`VALID_BACKEND_NAMES` frozenset** — Derived from the factory registry, used by `validate_backend()` instead of a hardcoded tuple. Impossible for backend names to drift out of sync
+
+### Fixed
+- **`validate_backend()` missing "nios"** — Hardcoded backend tuple in `utils/validation.py` did not include "nios", causing validation to reject a valid backend name. Now uses `VALID_BACKEND_NAMES` from the factory registry
+
 ## [0.6.7] - 2026-02-18
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.6.7"
+version: "0.6.8"
 date-released: "2026-02-18"
 
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ dns-aid-core/
 ```
 
 **Where does new code go?**
-- New DNS backend → `src/dns_aid/backends/` + register in `cli/backends.py`
+- New DNS backend → `src/dns_aid/backends/` + add to `_BACKEND_CLASSES` in `backends/__init__.py` + register in `cli/backends.py`
 - New CLI command → `src/dns_aid/cli/` + register in `cli/main.py`
 - New SDK feature → `src/dns_aid/sdk/`
 - New MCP tool → `src/dns_aid/mcp/server.py`
@@ -60,7 +60,7 @@ git checkout -b feat/your-feature-name
 ### 2. Make changes and run checks locally
 
 ```bash
-# Tests (686+ unit tests, ~4 seconds)
+# Tests (730+ unit tests, ~4 seconds)
 uv run pytest tests/unit/ -q
 
 # Linting

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,7 @@ Complete API documentation for DNS-AID - DNS-based Agent Identification and Disc
   - [DNSBackend Interface](#dnsbackend-interface)
   - [Route53Backend](#route53backend)
   - [InfobloxBloxOneBackend](#infobloxbloxonebackend)
+  - [InfobloxNIOSBackend](#infobloxniosbackend)
   - [CloudflareBackend](#cloudflarebackend)
   - [DDNSBackend](#ddnsbackend)
   - [MockBackend](#mockbackend)
@@ -473,7 +474,41 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**⚠️ BANDAID Compliance**: Infoblox UDDI is **not fully compliant** with the [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend or DDNSBackend.
+**⚠️ BANDAID Compliance**: Infoblox UDDI is **not fully compliant** with the [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, or DDNSBackend.
+
+### InfobloxNIOSBackend
+
+Infoblox NIOS on-premise WAPI implementation. Supports full ServiceMode SVCB with custom BANDAID parameters.
+
+```python
+from dns_aid.backends.infoblox import InfobloxNIOSBackend
+
+# From environment variables (recommended)
+backend = InfobloxNIOSBackend()
+
+# Or with explicit configuration
+backend = InfobloxNIOSBackend(
+    host="nios.example.com",
+    username="admin",
+    password="your-password",
+    dns_view="default",       # DNS view name
+    wapi_version="2.13.7",    # WAPI version
+    verify_ssl=False,         # TLS certificate verification
+)
+```
+
+**Environment Variables**:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NIOS_HOST` | Yes | - | Grid Manager hostname or IP |
+| `NIOS_USERNAME` | Yes | - | WAPI username |
+| `NIOS_PASSWORD` | Yes | - | WAPI password |
+| `NIOS_DNS_VIEW` | No | `default` | DNS view name |
+| `NIOS_WAPI_VERSION` | No | `2.13.7` | WAPI version |
+| `NIOS_VERIFY_SSL` | No | `false` | Verify TLS certificate |
+
+**BANDAID Compliance**: NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters including custom BANDAID keys (`key65001`–`key65006`). Fully compliant with the BANDAID draft.
 
 ### DDNSBackend
 
@@ -726,7 +761,7 @@ dns-aid index sync example.com           # Sync index with actual DNS records
 
 | Variable | Description |
 |----------|-------------|
-| `DNS_AID_BACKEND` | Default backend: "route53", "bloxone", "ddns", or "mock" |
+| `DNS_AID_BACKEND` | Default backend: "route53", "cloudflare", "infoblox", "nios", "ddns", or "mock" |
 | `DNS_AID_LOG_LEVEL` | Logging level: DEBUG, INFO, WARNING, ERROR |
 
 **AWS Route 53:**
@@ -747,6 +782,17 @@ Route 53 uses boto3's credential chain. No env vars are required if `~/.aws/cred
 | `INFOBLOX_API_KEY` | Infoblox UDDI API key (required) |
 | `INFOBLOX_DNS_VIEW` | DNS view name (default: "default") |
 | `INFOBLOX_BASE_URL` | API URL (default: https://csp.infoblox.com) |
+
+**Infoblox NIOS (On-Prem):**
+
+| Variable | Description |
+|----------|-------------|
+| `NIOS_HOST` | Grid Manager hostname or IP (required) |
+| `NIOS_USERNAME` | WAPI username (required) |
+| `NIOS_PASSWORD` | WAPI password (required) |
+| `NIOS_DNS_VIEW` | DNS view name (default: "default") |
+| `NIOS_WAPI_VERSION` | WAPI version (default: "2.13.7") |
+| `NIOS_VERIFY_SSL` | Verify TLS certificate (default: "false") |
 
 **DDNS (RFC 2136):**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,7 @@ pip install -e ".[mcp]"         # Core + MCP server
 pip install -e ".[route53]"     # Core + Route 53 backend
 pip install -e ".[cloudflare]"  # Core + Cloudflare backend
 pip install -e ".[infoblox]"    # Core + Infoblox BloxOne backend
+pip install -e ".[nios]"        # Core + Infoblox NIOS (on-prem) backend
 pip install -e ".[ddns]"        # Core + RFC 2136 Dynamic DNS backend
 ```
 
@@ -71,7 +72,7 @@ cp .env.example .env
 Then open `.env` and uncomment the variables you need:
 
 1. **General** — pick your backend and set the domain
-2. **Backend section** — uncomment the section matching your backend (Route 53, Cloudflare, Infoblox, or DDNS)
+2. **Backend section** — uncomment the section matching your backend (Route 53, Cloudflare, Infoblox, NIOS, or DDNS)
 3. **Optional** — log level, SDK telemetry, etc.
 
 For example, to use Cloudflare:
@@ -300,6 +301,85 @@ async with InfobloxBloxOneBackend() as backend:
         if "_agents" in record["fqdn"]:
             print(f"{record['type']}: {record['fqdn']}")
 ```
+
+## Infoblox NIOS Setup (On-Prem)
+
+Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID creates SVCB and TXT records via WAPI v2.13.7+, with full ServiceMode SVCB support including custom BANDAID parameters.
+
+### 1. Configure Environment Variables
+
+```bash
+# Required: Grid Manager hostname and credentials
+export NIOS_HOST="nios.example.com"
+export NIOS_USERNAME="admin"
+export NIOS_PASSWORD="your-password"
+
+# Optional: DNS view and WAPI settings
+export NIOS_DNS_VIEW="default"         # Or your specific view name
+export NIOS_WAPI_VERSION="2.13.7"      # Default
+export NIOS_VERIFY_SSL="false"         # Set to true with valid TLS certs
+```
+
+### 2. Verify Connection
+
+```bash
+# Check NIOS credentials and connectivity
+dns-aid doctor
+```
+
+### 3. Set Test Zone
+
+```bash
+export DNS_AID_TEST_ZONE="your-zone.com"
+```
+
+### 4. Verify Connection (Python)
+
+```python
+import asyncio
+from dns_aid.backends.infoblox import InfobloxNIOSBackend
+
+async def verify_connection():
+    backend = InfobloxNIOSBackend()
+
+    # Check if your test zone exists
+    exists = await backend.zone_exists("your-zone.com")
+    print(f"Test zone exists: {exists}")
+
+    # List records
+    async for record in backend.list_records("your-zone.com"):
+        if "_agents" in record["fqdn"]:
+            print(f"  {record['type']}: {record['fqdn']}")
+
+asyncio.run(verify_connection())
+```
+
+### 5. Quick CLI Test
+
+```bash
+# Publish a test agent
+dns-aid publish \
+    --name test-agent \
+    --domain $DNS_AID_TEST_ZONE \
+    --protocol mcp \
+    --endpoint mcp.$DNS_AID_TEST_ZONE \
+    --backend nios
+
+# Verify it was created
+dns-aid list $DNS_AID_TEST_ZONE --backend nios
+
+# Clean up
+dns-aid delete \
+    --name test-agent \
+    --domain $DNS_AID_TEST_ZONE \
+    --protocol mcp \
+    --backend nios \
+    --force
+```
+
+### NIOS BANDAID Compliance
+
+NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters, including custom BANDAID keys natively via `key65001`–`key65006`. This makes it fully compliant with the BANDAID draft.
 
 ## DDNS Setup (RFC 2136)
 
@@ -1074,7 +1154,7 @@ python examples/demo_full.py
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `DNS_AID_BACKEND` | Yes (if no `backend=` arg) | — | DNS backend: `route53`, `cloudflare`, `infoblox`, `ddns`, `mock` |
+| `DNS_AID_BACKEND` | Yes (if no `backend=` arg) | — | DNS backend: `route53`, `cloudflare`, `infoblox`, `nios`, `ddns`, `mock` |
 | `DNS_AID_SVCB_STRING_KEYS` | No | `0` | Set `1` to emit human-readable SVCB param names instead of keyNNNNN |
 | `DNS_AID_FETCH_ALLOWLIST` | No | — | Comma-separated hostnames to bypass SSRF protection (testing only) |
 
@@ -1094,6 +1174,12 @@ python examples/demo_full.py
 | `INFOBLOX_API_KEY` | infoblox | BloxOne DDI API key |
 | `INFOBLOX_DNS_VIEW` | infoblox | DNS view name (default: `default`) |
 | `CLOUDFLARE_API_TOKEN` | cloudflare | Cloudflare API token with DNS edit permissions |
+| `NIOS_HOST` | nios | Grid Manager hostname or IP |
+| `NIOS_USERNAME` | nios | WAPI username |
+| `NIOS_PASSWORD` | nios | WAPI password |
+| `NIOS_DNS_VIEW` | nios | DNS view name (default: `default`) |
+| `NIOS_WAPI_VERSION` | nios | WAPI version (default: `2.13.7`) |
+| `NIOS_VERIFY_SSL` | nios | Verify TLS certificate (default: `false`) |
 
 ## Experimental Models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.6.7"
+version = "0.6.8"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -3,10 +3,60 @@
 
 """DNS backend implementations: Route53, Infoblox BloxOne, DDNS, Mock."""
 
+from __future__ import annotations
+
+import importlib
+
 from dns_aid.backends.base import DNSBackend
 from dns_aid.backends.mock import MockBackend
 
-__all__ = ["DNSBackend", "MockBackend"]
+__all__ = ["DNSBackend", "MockBackend", "create_backend", "VALID_BACKEND_NAMES"]
+
+# ── Backend class registry (lazy imports) ───────────────────────────────
+# Maps backend name → (module_path, class_name).
+# Only the requested backend is imported, so optional deps (e.g. boto3)
+# don't cause failures for users who never use that backend.
+_BACKEND_CLASSES: dict[str, tuple[str, str]] = {
+    "route53": ("dns_aid.backends.route53", "Route53Backend"),
+    "cloudflare": ("dns_aid.backends.cloudflare", "CloudflareBackend"),
+    "infoblox": ("dns_aid.backends.infoblox", "InfobloxBackend"),
+    "nios": ("dns_aid.backends.infoblox.nios", "InfobloxNIOSBackend"),
+    "ddns": ("dns_aid.backends.ddns", "DDNSBackend"),
+    "mock": ("dns_aid.backends.mock", "MockBackend"),
+}
+
+VALID_BACKEND_NAMES: frozenset[str] = frozenset(_BACKEND_CLASSES)
+"""All recognised backend identifiers."""
+
+
+def create_backend(name: str) -> DNSBackend:
+    """Instantiate a DNS backend by name.
+
+    This is the single source of truth for backend name → class mapping.
+    All consumers (publisher, CLI, MCP server) should delegate here.
+
+    Args:
+        name: One of the keys in ``VALID_BACKEND_NAMES``.
+
+    Returns:
+        A ready-to-use :class:`DNSBackend` instance.
+
+    Raises:
+        ValueError: If *name* is not a known backend.
+        ImportError: If the backend's optional dependency is missing.
+    """
+    name = name.lower().strip()
+    if name not in _BACKEND_CLASSES:
+        raise ValueError(
+            f"Unknown backend: '{name}'. Valid backends: {', '.join(sorted(VALID_BACKEND_NAMES))}"
+        )
+    module_path, class_name = _BACKEND_CLASSES[name]
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    return cls()
+
+
+# ── Eager convenience re-exports (optional deps swallowed) ──────────────
 
 # Route53 is optional - requires boto3
 try:

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -20,10 +20,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Annotated
-
-if TYPE_CHECKING:
-    from dns_aid.backends.base import DNSBackend
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -951,36 +948,6 @@ def _get_backend(backend_name: str | None):
 
     info = BACKEND_REGISTRY[backend_name]
 
-    # --- import the backend class ---
-    cls: type[DNSBackend]
-    try:
-        if backend_name == "route53":
-            from dns_aid.backends.route53 import Route53Backend
-
-            cls = Route53Backend
-        elif backend_name == "cloudflare":
-            from dns_aid.backends.cloudflare import CloudflareBackend
-
-            cls = CloudflareBackend
-        elif backend_name == "infoblox":
-            from dns_aid.backends.infoblox import InfobloxBackend
-
-            cls = InfobloxBackend
-        elif backend_name == "ddns":
-            from dns_aid.backends.ddns import DDNSBackend
-
-            cls = DDNSBackend
-        else:  # mock
-            from dns_aid.backends.mock import MockBackend
-
-            cls = MockBackend
-    except ImportError as exc:
-        dep = f"dns-aid[{info.optional_dep}]" if info.optional_dep else "dns-aid"
-        error_console.print(f"[red]✗ Missing dependency for {info.display_name}:[/red]")
-        error_console.print(f"  {exc}\n")
-        error_console.print(f"Install with:  pip install '{dep}'")
-        raise typer.Exit(1) from None
-
     # --- check required env vars ---
     missing = [var for var in info.required_env if not os.environ.get(var)]
     if missing and backend_name != "mock":
@@ -998,9 +965,17 @@ def _get_backend(backend_name: str | None):
             error_console.print(f"\nDocs: {info.setup_url}")
         raise typer.Exit(1)
 
-    # --- instantiate ---
+    # --- import and instantiate via central factory ---
+    from dns_aid.backends import create_backend
+
     try:
-        backend = cls()
+        backend = create_backend(backend_name)
+    except ImportError as exc:
+        dep = f"dns-aid[{info.optional_dep}]" if info.optional_dep else "dns-aid"
+        error_console.print(f"[red]✗ Missing dependency for {info.display_name}:[/red]")
+        error_console.print(f"  {exc}\n")
+        error_console.print(f"Install with:  pip install '{dep}'")
+        raise typer.Exit(1) from None
     except (ValueError, OSError) as exc:
         error_console.print(f"[red]✗ Failed to initialize {info.display_name}:[/red]")
         error_console.print(f"  {exc}")

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import structlog
 
+from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
 from dns_aid.backends.base import DNSBackend
-from dns_aid.backends.mock import MockBackend
 from dns_aid.core.models import AgentRecord, Protocol, PublishResult
 
 logger = structlog.get_logger(__name__)
@@ -51,36 +51,10 @@ def get_default_backend() -> DNSBackend:
         if not backend_type:
             raise ValueError(
                 "DNS_AID_BACKEND must be set. "
-                "Supported values: route53, cloudflare, infoblox, nios, ddns, mock"
+                f"Supported values: {', '.join(sorted(VALID_BACKEND_NAMES))}"
             )
 
-        if backend_type == "route53":
-            from dns_aid.backends.route53 import Route53Backend
-
-            _default_backend = Route53Backend()
-        elif backend_type == "cloudflare":
-            from dns_aid.backends.cloudflare import CloudflareBackend
-
-            _default_backend = CloudflareBackend()
-        elif backend_type == "infoblox":
-            from dns_aid.backends.infoblox import InfobloxBackend
-
-            _default_backend = InfobloxBackend()
-        elif backend_type == "nios":
-            from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
-
-            _default_backend = InfobloxNIOSBackend()
-        elif backend_type == "ddns":
-            from dns_aid.backends.ddns import DDNSBackend
-
-            _default_backend = DDNSBackend()
-        elif backend_type == "mock":
-            _default_backend = MockBackend()
-        else:
-            raise ValueError(
-                f"Unknown DNS_AID_BACKEND: '{backend_type}'. "
-                "Supported values: route53, cloudflare, infoblox, nios, ddns, mock"
-            )
+        _default_backend = create_backend(backend_type)
 
         logger.info(
             "Initialized default DNS backend",

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -150,6 +150,7 @@ def _get_dns_backend(name: str | None = None):
     """
     import os
 
+    from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
     from dns_aid.cli.backends import BACKEND_REGISTRY, detect_backend
 
     # Resolve name
@@ -161,50 +162,27 @@ def _get_dns_backend(name: str | None = None):
         except ValueError:
             name = None
     if not name:
-        from dns_aid.backends.mock import MockBackend
-
-        return MockBackend()
+        return create_backend("mock")
 
     name = name.lower()
 
-    if name not in BACKEND_REGISTRY:
-        from dns_aid.backends.mock import MockBackend
+    if name not in VALID_BACKEND_NAMES:
+        return create_backend("mock")
 
-        return MockBackend()
-
-    info = BACKEND_REGISTRY[name]
+    info = BACKEND_REGISTRY.get(name)
 
     try:
-        if name == "route53":
-            from dns_aid.backends.route53 import Route53Backend
-
-            return Route53Backend()
-        elif name == "cloudflare":
-            from dns_aid.backends.cloudflare import CloudflareBackend
-
-            return CloudflareBackend()
-        elif name == "infoblox":
-            from dns_aid.backends.infoblox import InfobloxBackend
-
-            return InfobloxBackend()
-        elif name == "ddns":
-            from dns_aid.backends.ddns import DDNSBackend
-
-            return DDNSBackend()
-        else:
-            from dns_aid.backends.mock import MockBackend
-
-            return MockBackend()
+        return create_backend(name)
     except ImportError as exc:
-        dep = f"dns-aid[{info.optional_dep}]" if info.optional_dep else "dns-aid"
+        dep = f"dns-aid[{info.optional_dep}]" if info and info.optional_dep else "dns-aid"
+        display = info.display_name if info else name
         raise ValueError(
-            f"Missing dependency for {info.display_name}: {exc}. Install with: pip install '{dep}'"
+            f"Missing dependency for {display}: {exc}. Install with: pip install '{dep}'"
         ) from exc
     except (ValueError, OSError) as exc:
-        setup = " → ".join(info.setup_steps) if info.setup_steps else ""
-        raise ValueError(
-            f"Failed to initialize {info.display_name}: {exc}. Setup: {setup}"
-        ) from exc
+        setup = " → ".join(info.setup_steps) if info and info.setup_steps else ""
+        display = info.display_name if info else name
+        raise ValueError(f"Failed to initialize {display}: {exc}. Setup: {setup}") from exc
 
 
 def _format_validation_error(e: ValidationError) -> dict:
@@ -231,7 +209,7 @@ def publish_agent_to_dns(
     use_cases: list[str] | None = None,
     category: str | None = None,
     ttl: int = 3600,
-    backend: Literal["route53", "cloudflare", "infoblox", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
     update_index: bool = True,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
@@ -295,7 +273,7 @@ def publish_agent_to_dns(
         capabilities = validate_capabilities(capabilities)
         version = validate_version(version)
         ttl = validate_ttl(ttl)
-        backend = validate_backend(backend)
+        validate_backend(backend)
 
         if endpoint:
             endpoint = validate_endpoint(endpoint)
@@ -861,7 +839,7 @@ def verify_agent_dns(fqdn: str) -> dict:
 @mcp.tool()
 def list_published_agents(
     domain: str,
-    backend: Literal["route53", "cloudflare", "infoblox", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
 ) -> dict:
     """
     List all agents published at a domain via DNS-AID.
@@ -885,7 +863,7 @@ def list_published_agents(
     # Validate inputs
     try:
         domain = validate_domain(domain)
-        backend = validate_backend(backend)
+        validate_backend(backend)
     except ValidationError as e:
         return _format_validation_error(e)
 
@@ -933,7 +911,7 @@ def delete_agent_from_dns(
     name: str,
     domain: str,
     protocol: Literal["mcp", "a2a"] = "mcp",
-    backend: Literal["route53", "cloudflare", "infoblox", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
     update_index: bool = True,
 ) -> dict:
     """
@@ -961,21 +939,14 @@ def delete_agent_from_dns(
         name = validate_agent_name(name)
         domain = validate_domain(domain)
         protocol = validate_protocol(protocol)
-        backend = validate_backend(backend)
+        validate_backend(backend)
     except ValidationError as e:
         return _format_validation_error(e)
 
-    from dns_aid.backends.base import DNSBackend
-    from dns_aid.backends.mock import MockBackend
-    from dns_aid.backends.route53 import Route53Backend
     from dns_aid.core.publisher import unpublish
 
     # Get backend
-    dns_backend: DNSBackend
-    if backend == "route53":
-        dns_backend = Route53Backend()
-    else:
-        dns_backend = MockBackend()
+    dns_backend = _get_dns_backend(backend)
 
     async def _unpublish():
         return await unpublish(
@@ -1032,7 +1003,7 @@ def delete_agent_from_dns(
 @mcp.tool()
 def list_agent_index(
     domain: str,
-    backend: Literal["route53", "cloudflare", "infoblox", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
 ) -> dict:
     """
     List agents in a domain's index record.
@@ -1054,21 +1025,14 @@ def list_agent_index(
     # Validate inputs
     try:
         domain = validate_domain(domain)
-        backend = validate_backend(backend)
+        validate_backend(backend)
     except ValidationError as e:
         return _format_validation_error(e)
 
-    from dns_aid.backends.base import DNSBackend
-    from dns_aid.backends.mock import MockBackend
-    from dns_aid.backends.route53 import Route53Backend
     from dns_aid.core.indexer import read_index
 
     # Get backend
-    dns_backend: DNSBackend
-    if backend == "route53":
-        dns_backend = Route53Backend()
-    else:
-        dns_backend = MockBackend()
+    dns_backend = _get_dns_backend(backend)
 
     async def _read_index():
         return await read_index(domain, dns_backend)
@@ -1100,7 +1064,7 @@ def list_agent_index(
 @mcp.tool()
 def sync_agent_index(
     domain: str,
-    backend: Literal["route53", "cloudflare", "infoblox", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
     ttl: int = 3600,
 ) -> dict:
     """
@@ -1126,22 +1090,15 @@ def sync_agent_index(
     # Validate inputs
     try:
         domain = validate_domain(domain)
-        backend = validate_backend(backend)
+        validate_backend(backend)
         ttl = validate_ttl(ttl)
     except ValidationError as e:
         return _format_validation_error(e)
 
-    from dns_aid.backends.base import DNSBackend
-    from dns_aid.backends.mock import MockBackend
-    from dns_aid.backends.route53 import Route53Backend
     from dns_aid.core.indexer import sync_index
 
     # Get backend
-    dns_backend: DNSBackend
-    if backend == "route53":
-        dns_backend = Route53Backend()
-    else:
-        dns_backend = MockBackend()
+    dns_backend = _get_dns_backend(backend)
 
     async def _sync_index():
         return await sync_index(domain, dns_backend, ttl=ttl)

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -392,7 +392,7 @@ def validate_fqdn(fqdn: str) -> str:
 
 def validate_backend(
     backend: str,
-) -> Literal["route53", "cloudflare", "infoblox", "ddns", "mock"]:
+) -> str:
     """
     Validate backend type.
 
@@ -400,22 +400,23 @@ def validate_backend(
         backend: Backend string to validate
 
     Returns:
-        Validated backend literal
+        Validated backend name
 
     Raises:
         ValidationError: If backend is invalid
     """
+    from dns_aid.backends import VALID_BACKEND_NAMES
+
     if not backend:
         raise ValidationError("backend", "Backend cannot be empty")
 
     backend = backend.lower().strip()
 
-    valid_backends = ("route53", "cloudflare", "infoblox", "ddns", "mock")
-    if backend not in valid_backends:
+    if backend not in VALID_BACKEND_NAMES:
         raise ValidationError(
             "backend",
-            f"Backend must be one of: {', '.join(valid_backends)}",
+            f"Backend must be one of: {', '.join(sorted(VALID_BACKEND_NAMES))}",
             backend,
         )
 
-    return backend  # type: ignore
+    return backend

--- a/tests/unit/test_backend_factory.py
+++ b/tests/unit/test_backend_factory.py
@@ -1,0 +1,88 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the centralised backend factory (create_backend)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
+from dns_aid.backends.base import DNSBackend
+
+
+# ---------------------------------------------------------------------------
+# Basic contract
+# ---------------------------------------------------------------------------
+
+
+class TestValidBackendNames:
+    """VALID_BACKEND_NAMES is a frozenset with all expected entries."""
+
+    def test_is_frozenset(self):
+        assert isinstance(VALID_BACKEND_NAMES, frozenset)
+
+    def test_contains_all_backends(self):
+        expected = {"route53", "cloudflare", "infoblox", "nios", "ddns", "mock"}
+        assert VALID_BACKEND_NAMES == expected
+
+
+# ---------------------------------------------------------------------------
+# create_backend — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBackendHappyPath:
+    """create_backend returns a DNSBackend subclass for every known name."""
+
+    def test_mock_backend(self):
+        backend = create_backend("mock")
+        assert isinstance(backend, DNSBackend)
+        assert backend.name == "mock"
+
+    def test_mock_backend_case_insensitive(self):
+        backend = create_backend("Mock")
+        assert isinstance(backend, DNSBackend)
+
+    def test_mock_backend_with_whitespace(self):
+        backend = create_backend("  mock  ")
+        assert isinstance(backend, DNSBackend)
+
+    @pytest.mark.parametrize("name", sorted(VALID_BACKEND_NAMES - {"mock"}))
+    def test_real_backends_return_dns_backend(self, name: str):
+        """Each real backend should either succeed or raise ImportError (missing dep)."""
+        try:
+            backend = create_backend(name)
+            assert isinstance(backend, DNSBackend)
+        except (ImportError, ValueError, OSError):
+            # ImportError = optional dep missing (e.g. boto3)
+            # ValueError/OSError = missing credentials / config, acceptable
+            pass
+
+
+# ---------------------------------------------------------------------------
+# create_backend — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBackendErrors:
+    """create_backend raises clear errors for invalid inputs."""
+
+    def test_unknown_name_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown backend: 'nonexistent'"):
+            create_backend("nonexistent")
+
+    def test_empty_string_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            create_backend("")
+
+    def test_missing_dependency_raises_import_error(self):
+        """Simulate a missing optional dependency."""
+        with patch(
+            "importlib.import_module",
+            side_effect=ImportError("No module named 'boto3'"),
+        ):
+            with pytest.raises(ImportError, match="boto3"):
+                create_backend("route53")

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -346,7 +346,7 @@ class TestDefaultBackend:
 
         with (
             patch.dict("os.environ", {"DNS_AID_BACKEND": "bogus"}),
-            pytest.raises(ValueError, match="Unknown DNS_AID_BACKEND"),
+            pytest.raises(ValueError, match="Unknown backend"),
         ):
             get_default_backend()
 

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -288,6 +288,9 @@ class TestValidateBackend:
     def test_valid_infoblox(self):
         assert validate_backend("infoblox") == "infoblox"
 
+    def test_valid_nios(self):
+        assert validate_backend("nios") == "nios"
+
     def test_valid_ddns(self):
         assert validate_backend("ddns") == "ddns"
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **Single factory function** `create_backend()` in `backends/__init__.py` replaces 4 scattered if-elif dispatch chains across `publisher.py`, `cli/main.py`, `mcp/server.py`, and MCP tools
- **`VALID_BACKEND_NAMES` frozenset** derived from the factory registry — used by `validate_backend()` instead of a hardcoded tuple, making it impossible for backend names to drift out of sync
- **Fixed `validate_backend()` silently rejecting "nios"** — the hardcoded tuple was missing the NIOS backend added in v0.6.7
- **Docs: added missing NIOS sections** to `getting-started.md` (setup guide + env vars) and `api-reference.md` (API docs + env vars)
- **Version bump** 0.6.7 → 0.6.8

### Why

Adding the NIOS backend in v0.6.7 exposed a systemic problem: the backend name→class mapping was duplicated in 4 places, and `validate_backend()` used a separate hardcoded tuple. Forgetting any one during a backend addition causes silent failures. Now there is exactly one place to register a new backend.

### Net diff: −144 / +336 lines (15 files + 1 new test file)

| File | Change |
|------|--------|
| `backends/__init__.py` | +51 — `_BACKEND_CLASSES` registry, `VALID_BACKEND_NAMES`, `create_backend()` |
| `core/publisher.py` | −20 — replaced 30-line if-elif with `create_backend()` |
| `cli/main.py` | −22 — replaced 25-line if-elif import chain |
| `mcp/server.py` | −41 — replaced 25-line if-elif + duplicate validation |
| `utils/validation.py` | +3 — uses `VALID_BACKEND_NAMES` import |
| `docs/getting-started.md` | +90 — NIOS setup section, pip install, env var table |
| `docs/api-reference.md` | +50 — NIOS TOC entry, backend docs, env vars |
| `CONTRIBUTING.md` | Updated backend registration instruction, test count |
| `test_backend_factory.py` | +89 (new) — 13 tests for the factory |

## Test plan

- [x] 730 unit tests passing (`uv run pytest tests/unit/ -x -q`)
- [x] Ruff lint clean on all modified source files
- [x] Smoke test: `from dns_aid.backends import create_backend, VALID_BACKEND_NAMES`
- [x] E2E verified on 4 live backends × 3 interfaces (CLI, Python, MCP):
  - Route53 (highvelocitynetworking.com)
  - Cloudflare (velosecurity-ai.io)
  - DDNS/BIND9 (test.dns-aid.local via Docker)
  - NIOS (dns-aid-test.com @ 52.56.250.37)
- [x] Full operation matrix: publish, discover, verify, list, index, delete