### PR TITLE
fix: add zone_exists() pre-flight checks to prevent tracebacks on invalid domains

### DIFF
--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -430,12 +430,22 @@ def list_records(
     console.print(f"\n[bold]DNS-AID records in {domain}:[/bold]\n")
 
     async def list_all():
+        if not await dns_backend.zone_exists(domain):
+            return None  # sentinel: zone not found
         records = []
         async for record in dns_backend.list_records(domain, name_pattern="_agents"):
             records.append(record)
         return records
 
-    records = run_async(list_all())
+    try:
+        records = run_async(list_all())
+    except Exception as e:
+        error_console.print(f"[red]✗ Failed to list records in {domain}: {e}[/red]")
+        raise typer.Exit(1) from None
+
+    if records is None:
+        error_console.print(f"[red]✗ Zone '{domain}' does not exist or is not accessible[/red]")
+        raise typer.Exit(1)
 
     if not records:
         console.print(f"[yellow]No DNS-AID records found in {domain}[/yellow]")
@@ -566,14 +576,18 @@ def delete(
 
     console.print(f"\n[bold]Deleting {fqdn}...[/bold]\n")
 
-    result = run_async(
-        unpublish(
-            name=name,
-            domain=domain,
-            protocol=protocol,
-            backend=dns_backend,
+    try:
+        result = run_async(
+            unpublish(
+                name=name,
+                domain=domain,
+                protocol=protocol,
+                backend=dns_backend,
+            )
         )
-    )
+    except Exception as e:
+        error_console.print(f"[red]✗ Failed to delete {fqdn}: {e}[/red]")
+        raise typer.Exit(1) from None
 
     if result:
         console.print("[green]✓ Agent deleted successfully[/green]")
@@ -694,7 +708,11 @@ def index_sync(
 
     console.print(f"\n[bold]Syncing index for {domain}...[/bold]\n")
 
-    result = run_async(sync_index(domain, dns_backend, ttl=ttl))
+    try:
+        result = run_async(sync_index(domain, dns_backend, ttl=ttl))
+    except Exception as e:
+        error_console.print(f"[red]✗ Failed to sync index for {domain}: {e}[/red]")
+        raise typer.Exit(1) from None
 
     if result.success:
         if result.entries:

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -334,6 +334,16 @@ async def sync_index(
     """
     logger.info("Syncing index", domain=domain)
 
+    # Check zone exists before scanning
+    if not await backend.zone_exists(domain):
+        logger.error("Zone does not exist", zone=domain)
+        return IndexResult(
+            domain=domain,
+            entries=[],
+            success=False,
+            message=f"Zone '{domain}' does not exist or is not accessible",
+        )
+
     # Pattern to match agent records: _{name}._{protocol}._agents
     agent_pattern = re.compile(r"^_([a-z0-9-]+)\._([a-z0-9]+)\._agents$", re.IGNORECASE)
 
@@ -366,7 +376,7 @@ async def sync_index(
                 )
 
     except Exception as e:
-        logger.exception("Failed to scan for agents", domain=domain, error=str(e))
+        logger.error("Failed to scan for agents", domain=domain, error=str(e))
         return IndexResult(
             domain=domain,
             entries=[],

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -268,6 +268,11 @@ async def unpublish(
         record_name=record_name,
     )
 
+    # Check zone exists before attempting deletion
+    if not await dns_backend.zone_exists(domain):
+        logger.error("Zone does not exist", zone=domain)
+        return False
+
     # Delete both record types
     svcb_deleted = await dns_backend.delete_record(domain, record_name, "SVCB")
     txt_deleted = await dns_backend.delete_record(domain, record_name, "TXT")

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -871,6 +871,8 @@ def list_published_agents(
     dns_backend = _get_dns_backend(backend)
 
     async def _list():
+        if not await dns_backend.zone_exists(domain):
+            return None  # sentinel: zone not found
         records = []
         async for record in dns_backend.list_records(domain, name_pattern="_agents"):
             records.append(record)
@@ -878,6 +880,13 @@ def list_published_agents(
 
     try:
         records = _run_async(_list())
+
+        if records is None:
+            return {
+                "success": False,
+                "error": "zone_not_found",
+                "message": f"Zone '{domain}' does not exist or is not accessible",
+            }
 
         formatted_records = []
         for record in records:
@@ -1101,10 +1110,19 @@ def sync_agent_index(
     dns_backend = _get_dns_backend(backend)
 
     async def _sync_index():
+        if not await dns_backend.zone_exists(domain):
+            return None  # sentinel: zone not found
         return await sync_index(domain, dns_backend, ttl=ttl)
 
     try:
         result = _run_async(_sync_index())
+
+        if result is None:
+            return {
+                "success": False,
+                "error": "zone_not_found",
+                "message": f"Zone '{domain}' does not exist or is not accessible",
+            }
 
         return {
             "success": result.success,

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -615,6 +615,7 @@ class TestSyncIndexScanException:
             yield  # pragma: no cover
 
         mock_backend = MagicMock()
+        mock_backend.zone_exists = AsyncMock(return_value=True)
         mock_backend.list_records = _failing_list
 
         result = await sync_index("example.com", mock_backend)


### PR DESCRIPTION
## Summary

- Add `zone_exists()` pre-flight validation before listing, deleting, and indexing operations
- Prevents raw Python tracebacks when users specify non-existent or inaccessible domains
- Produces clean, user-friendly error messages across all interfaces (CLI, Python API, MCP)

### Changes by file

| File | Change |
|------|--------|
| `core/publisher.py` | Zone check before `delete_record()` in `unpublish()` |
| `cli/main.py` | Zone check in `list`, try/except in `delete` and `index sync` |
| `mcp/server.py` | Zone check in `list_published_agents` and `sync_agent_index` |
| `core/indexer.py` | Zone check in `sync_index()`, `logger.exception` → `logger.error` |
| `tests/unit/test_indexer.py` | Add `zone_exists` mock to `TestSyncIndexScanException` |

### Before / After

**Before** (bogus domain):
```
Traceback (most recent call last):
  ...
botocore.exceptions.ClientError: An error occurred (HostedZoneNotFound)
```

**After**:
```
✗ Zone 'bogus-nonexistent.com' does not exist or is not accessible
```

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `pytest tests/unit/ -x -q` — 730/730 pass
- [x] E2E verified across all 4 backends × 3 interfaces (28/28 pass):
  - Route53: 7/7
  - Cloudflare: 7/7
  - DDNS/BIND: 7/7
  - NIOS: 7/7