### PR TITLE
fix: escape Rich markup in doctor output, shell-safe install hints (v0.7.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.7.0"
+version = "0.7.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __all__ = [
     # Core functions (Tier 0)
     "publish",


### PR DESCRIPTION
## Summary

- **Rich markup escape** — Brackets in `pip install "dns-aid[mcp]"` were silently stripped because Rich interprets `[mcp]` as a markup tag. Fixed with `rich.markup.escape()`.
- **Shell-safe hints** — Changed single quotes to double quotes in install commands so they work in zsh/bash/fish without glob expansion issues.
- **Version bump** to 0.7.1

### Before
```
○ MCP server  pip install 'dns-aid'      ← [mcp] silently eaten
```

### After
```
○ MCP server  pip install "dns-aid[mcp]"  ← brackets visible, copy-pasteable
```

## Test plan

- [x] 734 unit tests pass
- [x] Ruff lint clean
- [x] Verified bracket rendering in terminal output
- [x] `pip install "dns-aid[mcp]"` command works in zsh