### PR TITLE
fix: use semantic version comparison in doctor PyPI check (v0.7.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.7.1"
+version = "0.7.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/doctor.py
+++ b/src/dns_aid/doctor.py
@@ -114,11 +114,12 @@ def _check_core(current_version: str) -> list[CheckResult]:
     # dns-aid version + PyPI check
     try:
         import httpx
+        from packaging.version import Version
 
         resp = httpx.get("https://pypi.org/pypi/dns-aid/json", timeout=3)
         if resp.status_code == 200:
             latest = resp.json()["info"]["version"]
-            if latest != current_version:
+            if Version(latest) > Version(current_version):
                 results.append(
                     CheckResult(
                         "fail",


### PR DESCRIPTION
## Summary

- **Bug**: `dns-aid doctor` showed `0.7.1 → 0.7.0 available (pip install --upgrade dns-aid)` — suggesting a downgrade
- **Cause**: Used `!=` string comparison instead of proper version ordering
- **Fix**: Use `packaging.version.Version` for PEP 440 semantic comparison — only shows update when PyPI has a genuinely newer version
- **Version bump** to 0.7.2

## Test plan

- [x] 734 unit tests pass
- [x] Ruff lint clean
- [x] Running 0.7.2 with PyPI at 0.7.1 correctly shows `(latest)` instead of downgrade suggestion