### PR TITLE
feat: add --domain option to doctor, backfill versioning files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2026-02-19
+
+### Added
+- **`--domain` option for `dns-aid doctor`** — Explicit domain parameter across all three interfaces: CLI (`--domain`), Python (`run_checks(domain=...)`), MCP (`diagnose_environment(domain=...)`)
+- Falls back to `DNS_AID_DOCTOR_DOMAIN` env var; agent discovery check is skipped if neither is set
+
+### Changed
+- **Removed hardcoded default domain** from doctor's agent discovery check — users must explicitly specify their domain
+
+## [0.7.2] - 2026-02-18
+
+### Fixed
+- **Doctor version comparison** — Used `packaging.version.Version` for proper PEP 440 comparison instead of string `!=`, which incorrectly suggested downgrades (e.g., `0.7.1 → 0.7.0 available`)
+
+## [0.7.1] - 2026-02-18
+
+### Fixed
+- **Rich markup escaping** — `pip install "dns-aid[mcp]"` hints in doctor output were silently consumed as Rich markup tags. Fixed with `rich.markup.escape()`
+- **Shell-safe install hints** — Changed single quotes to double quotes in pip install hints for zsh/bash compatibility
+
+## [0.7.0] - 2026-02-18
+
+### Added
+- **Structured diagnostics API** (`dns_aid.doctor`) — `run_checks()` returns `DiagnosticReport` with `CheckResult` dataclass, consumed by CLI (Rich), MCP (JSON dict), and Python
+- **`diagnose_environment` MCP tool** — 10th MCP tool, returns environment diagnostics as structured dict
+- **PyPI version check** — Doctor checks latest version on PyPI and warns if outdated
+- **`_get_module_version()` helper** — Falls back to `importlib.metadata` for packages without `__version__` (e.g., rich)
+
+### Changed
+- **CLI doctor refactored** — Thin Rich renderer over `dns_aid.doctor.run_checks()` instead of monolithic function
+
+## [0.6.9] - 2026-02-18
+
+### Fixed
+- **`zone_exists()` pre-flight checks** — All interfaces (CLI, Python API, MCP) now validate zone existence before destructive or listing operations. Previously, specifying a non-existent zone produced raw Python tracebacks or cryptic backend errors
+- **Indexer error logging** — Changed `logger.exception` to `logger.error` in `sync_index()` for cleaner output
+
 ## [0.6.8] - 2026-02-18
 
 ### Changed
@@ -412,10 +449,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.8...HEAD
-[0.4.8]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.7...v0.4.8
-[0.3.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.2.1...v0.3.0
+[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.9...v0.7.0
+[0.6.9]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.8...v0.6.9
+[0.6.8]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.7...v0.6.8
+[0.6.7]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.6...v0.6.7
+[0.6.6]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.5...v0.6.6
+[0.6.5]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.4...v0.6.5
+[0.6.4]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.9...v0.5.0
+[0.4.9]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.8...v0.4.9
+[0.4.8]: https://github.com/infobloxopen/dns-aid-core/compare/v0.3.1...v0.4.8
+[0.3.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.3.1...v0.3.1
+[0.3.0]: https://github.com/infobloxopen/dns-aid-core/releases/tag/v0.3.1
 [0.2.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/infobloxopen/dns-aid-core/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.6.8"
-date-released: "2026-02-18"
+version: "0.7.3"
+date-released: "2026-02-19"
 
 keywords:
   - dns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ uv run pytest tests/unit/ -q
 dns-aid-core/
 ├── src/dns_aid/
 │   ├── core/           # Discovery, publishing, validation (Tier 0)
-│   ├── backends/       # DNS backends (Route 53, Cloudflare, Infoblox, DDNS, Mock)
+│   ├── backends/       # DNS backends (Route 53, Cloudflare, Infoblox BloxOne, NIOS, DDNS, Mock)
 │   ├── sdk/            # Telemetry SDK, ranking, protocol handlers (Tier 1)
 │   ├── cli/            # CLI commands (publish, discover, verify, list, init, doctor)
 │   ├── mcp/            # MCP server for AI agents
@@ -60,7 +60,7 @@ git checkout -b feat/your-feature-name
 ### 2. Make changes and run checks locally
 
 ```bash
-# Tests (730+ unit tests, ~4 seconds)
+# Tests (750+ unit tests, ~4 seconds)
 uv run pytest tests/unit/ -q
 
 # Linting
@@ -182,7 +182,7 @@ uv run pytest tests/integration/test_infoblox.py -v
 
 Releases are handled by maintainers:
 
-1. Version is bumped in 4 files: `pyproject.toml`, `src/dns_aid/__init__.py`, `CITATION.cff`, `CHANGELOG.md`
+1. Version is bumped in 5 files: `pyproject.toml`, `src/dns_aid/__init__.py`, `CITATION.cff`, `CHANGELOG.md`, `CONTRIBUTING.md`
 2. `uv lock` updates the lockfile
 3. A `v*` tag triggers the [Release workflow](.github/workflows/release.yml):
    - Builds wheel + sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.7.2"
+version = "0.7.3"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/cli/doctor.py
+++ b/src/dns_aid/cli/doctor.py
@@ -74,15 +74,21 @@ def _render_report(report: DiagnosticReport) -> None:
 # ── main command ───────────────────────────────────────────────────
 
 
-def doctor() -> None:
+def doctor(
+    domain: str | None = None,
+) -> None:
     """
     Diagnose your DNS-AID environment.
 
     Checks Python, dependencies, DNS resolution, backend credentials,
     optional features, and .env configuration.
 
+    The --domain flag sets the domain used for the agent discovery check.
+    Falls back to DNS_AID_DOCTOR_DOMAIN env var. Skipped if neither is set.
+
     Example:
         dns-aid doctor
+        dns-aid doctor --domain example.com
     """
-    report = run_checks()
+    report = run_checks(domain=domain)
     _render_report(report)

--- a/src/dns_aid/doctor.py
+++ b/src/dns_aid/doctor.py
@@ -157,7 +157,7 @@ def _check_core(current_version: str) -> list[CheckResult]:
     return results
 
 
-def _check_dns() -> list[CheckResult]:
+def _check_dns(domain: str | None = None) -> list[CheckResult]:
     """DNS: resolution, SVCB support, and agent discovery via TXT index."""
     results: list[CheckResult] = []
 
@@ -181,12 +181,22 @@ def _check_dns() -> list[CheckResult]:
         results.append(CheckResult("warn", "SVCB support", "dnspython may not support SVCB"))
 
     # Agent discovery via lightweight TXT index check
+    domain = domain or os.environ.get("DNS_AID_DOCTOR_DOMAIN")
+    if not domain:
+        results.append(
+            CheckResult(
+                "warn",
+                "Agent discovery",
+                "no domain specified (use --domain or DNS_AID_DOCTOR_DOMAIN)",
+            )
+        )
+        return results
+
     try:
         import asyncio
 
         from dns_aid.core.indexer import read_index_via_dns
 
-        domain = os.environ.get("DNS_AID_DOCTOR_DOMAIN", "highvelocitynetworking.com")
         start = time.perf_counter()
         with _suppress_logs():
             entries = asyncio.run(read_index_via_dns(domain))
@@ -310,14 +320,18 @@ def _check_dotenv() -> list[CheckResult]:
 # ── public API ────────────────────────────────────────────────────
 
 
-def run_checks() -> DiagnosticReport:
+def run_checks(*, domain: str | None = None) -> DiagnosticReport:
     """Run all environment diagnostics and return structured results.
+
+    Args:
+        domain: Domain to test agent discovery against.  Falls back to
+            ``DNS_AID_DOCTOR_DOMAIN`` env var.  Skipped if neither is set.
 
     Example::
 
         from dns_aid.doctor import run_checks
 
-        report = run_checks()
+        report = run_checks(domain="example.com")
         if report.fail_count:
             print(f"{report.fail_count} checks failed")
         for section, checks in report.sections.items():
@@ -328,7 +342,7 @@ def run_checks() -> DiagnosticReport:
 
     report = DiagnosticReport(version=__version__)
     report.sections["Core"] = _check_core(__version__)
-    report.sections["DNS"] = _check_dns()
+    report.sections["DNS"] = _check_dns(domain=domain)
     report.sections["Backends"] = _check_backends()
     report.sections["Optional Features"] = _check_optional()
     report.sections["Configuration"] = _check_dotenv()

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1152,7 +1152,7 @@ def sync_agent_index(
 
 
 @mcp.tool()
-def diagnose_environment() -> dict:
+def diagnose_environment(domain: str | None = None) -> dict:
     """
     Run DNS-AID environment diagnostics.
 
@@ -1160,6 +1160,11 @@ def diagnose_environment() -> dict:
     credentials, optional features, and .env configuration.  Use this
     before publish/discover operations to verify the environment is
     correctly set up.
+
+    Args:
+        domain: Domain to test agent discovery against (optional).
+                Falls back to DNS_AID_DOCTOR_DOMAIN env var.
+                Discovery check is skipped if neither is set.
 
     Returns:
         dict with:
@@ -1171,7 +1176,7 @@ def diagnose_environment() -> dict:
     """
     from dns_aid.doctor import run_checks
 
-    report = run_checks()
+    report = run_checks(domain=domain)
     return report.to_dict()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.6.8"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- Add explicit `--domain` parameter to doctor across all three interfaces (CLI, Python API, MCP)
- Remove hardcoded default domain — discovery check is skipped with helpful hint if no domain specified
- Backfill CHANGELOG entries for 0.6.9, 0.7.0, 0.7.1, 0.7.2 and fix all missing compare links
- Update CITATION.cff (was stuck at 0.6.8) and CONTRIBUTING.md (test count, NIOS backend, version file list)
- Bump version to 0.7.3

## Usage

```bash
# CLI
dns-aid doctor --domain example.com

# Python
from dns_aid.doctor import run_checks
report = run_checks(domain="example.com")

# MCP
diagnose_environment(domain="example.com")

# Env var fallback
export DNS_AID_DOCTOR_DOMAIN=example.com
dns-aid doctor
```

## Test plan

- [x] 750 tests pass
- [x] `ruff check` clean
- [x] `dns-aid doctor` without domain shows skip hint
- [x] `dns-aid doctor --domain example.com` resolves against specified domain
- [x] `dns-aid doctor --help` shows `--domain` option