### PR TITLE
docs: document --domain option in doctor examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The CLI, MCP server, and examples load `.env` automatically. Set your backend, c
 ```bash
 # Verify your environment is correctly configured
 dns-aid doctor
+dns-aid doctor --domain example.com    # test agent discovery for your domain
 ```
 
 ### Python Library
@@ -85,7 +86,7 @@ print(f"Security Score: {result.security_score}/100")
 
 # Run environment diagnostics (programmatic access)
 from dns_aid.doctor import run_checks
-report = run_checks()
+report = run_checks(domain="example.com")
 print(f"{report.pass_count} passed, {report.fail_count} failed")
 ```
 
@@ -118,8 +119,8 @@ See the [Getting Started Guide](docs/getting-started.md#docker-playground-zero-c
 dns-aid init
 
 # Diagnose environment (Python, deps, DNS, backends, .env)
-# Checks for updates, SVCB support, agent discovery, and more
-dns-aid doctor
+# Use --domain to test agent discovery for your domain
+dns-aid doctor --domain example.com
 
 # Publish an agent to DNS
 dns-aid publish \
@@ -268,7 +269,7 @@ dns-aid-mcp --transport http --port 8000
 | `delete_agent_from_dns` | Remove an agent from DNS (auto-updates index) |
 | `list_agent_index` | List agents in domain's index record |
 | `sync_agent_index` | Sync index with actual DNS records |
-| `diagnose_environment` | Run environment diagnostics (deps, DNS, backends) |
+| `diagnose_environment` | Run environment diagnostics (deps, DNS, backends). Optional `domain` param for discovery check |
 
 ### Claude Desktop Integration
 
@@ -698,7 +699,7 @@ Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID create
 
 3. **Verify zone access and publish**:
    ```bash
-   dns-aid doctor                        # Check NIOS credentials
+   dns-aid doctor --domain example.com    # Check NIOS credentials + discovery
    dns-aid publish -n my-agent -d example.com -p mcp -e mcp.example.com --backend nios
    ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,9 +141,10 @@ Run the built-in diagnostics to check that everything is configured correctly:
 
 ```bash
 dns-aid doctor
+dns-aid doctor --domain example.com    # also test agent discovery for your domain
 ```
 
-This checks Python version, core dependencies, DNS resolution, backend credentials, optional features (MCP, JWS, OpenTelemetry), and `.env` configuration. Each check shows ✓ (pass), ✗ (fail), or ○ (warning/optional).
+This checks Python version, core dependencies, DNS resolution, backend credentials, optional features (MCP, JWS, OpenTelemetry), and `.env` configuration. Use `--domain` (or `DNS_AID_DOCTOR_DOMAIN` env var) to test agent discovery against your domain. Each check shows ✓ (pass), ✗ (fail), or ○ (warning/optional).
 
 ## Quick Test (No AWS needed)
 
@@ -324,7 +325,7 @@ export NIOS_VERIFY_SSL="false"         # Set to true with valid TLS certs
 
 ```bash
 # Check NIOS credentials and connectivity
-dns-aid doctor
+dns-aid doctor --domain example.com
 ```
 
 ### 3. Set Test Zone


### PR DESCRIPTION
## Summary

- Update README.md and docs/getting-started.md to show `--domain` option in all `dns-aid doctor` examples
- Document `DNS_AID_DOCTOR_DOMAIN` env var fallback
- Update `diagnose_environment` MCP tool description

## Test plan

- [x] Docs-only change, no code modified