### PR TITLE
feat: align with IETF draft-mozleywilliams-dnsop-dnsaid-01 (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-02-21
+
+### Added
+- **SVCB AliasMode handling** — Discoverer follows SVCB priority-0 (AliasMode) records to resolve the canonical ServiceMode target, per RFC 9460 and IETF draft Section 4.4.2
+- **SVCB ipv4hint/ipv6hint extraction** — Discoverer reads SvcParamKey 4 (ipv4hint) and 6 (ipv6hint) from SVCB records to reduce follow-up A/AAAA queries, per IETF draft Section 4.4.2
+- **DANE dynamic verification notes** — `verify()` now returns context-aware `dane_note` messages: advisory-only vs full certificate matching, with DNSSEC coupling warning when DANE is present but DNSSEC is not validated
+- **DANE/DNSSEC security documentation** — README now includes "Security: DNSSEC and DANE" section with TLSA 3 1 1 recommendation, security score table, and verification code examples
+
+### Changed
+- **BANDAID → DNS-AID rename** — All references to "BANDAID" and `bandaid_` updated to "DNS-AID" and `dnsaid_` across source, tests, docs, and metadata files. IETF draft reference updated from `draft-mozleywilliams-dnsop-bandaid-02` to `draft-mozleywilliams-dnsop-dnsaid-01`
+- **`bap` SvcParamKey number** — Changed from `key65003` to `key65010` to match IETF draft Section 4.4.3 example. **Breaking:** existing DNS records with `key65003` for bap will need re-publishing
+
 ## [0.7.3] - 2026-02-19
 
 ### Added
@@ -138,7 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Experimental Models Documentation** — Marked `agent_metadata` and `capability_model` modules as experimental with status docstrings
 
 ### Fixed
-- **Route53 SVCB custom params** — Route53 rejects private-use SvcParamKeys (`key65001`–`key65006`). The Route53 backend now demotes custom BANDAID params to TXT records with `bandaid_` prefix, keeping the publish working without data loss
+- **Route53 SVCB custom params** — Route53 rejects private-use SvcParamKeys (`key65001`–`key65006`). The Route53 backend now demotes custom DNS-AID params to TXT records with `dnsaid_` prefix, keeping the publish working without data loss
 - **Cloudflare SVCB custom params** — Same demotion applied to the Cloudflare backend
 - **CLI `--backend` help text** — Now lists all five backends (route53, cloudflare, infoblox, ddns, mock) instead of just "route53, mock"
 - **SECURITY.md contact** — Updated from placeholder LF mailing list to interim maintainer email
@@ -217,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.8] - 2026-01-27
 
 ### Added
-- **BANDAID Custom SVCB Parameters (IETF Draft Alignment)**
+- **DNS-AID Custom SVCB Parameters (IETF Draft Alignment)**
   - `cap` — URI to capability document (HTTPS endpoint for rich capability metadata)
   - `cap-sha256` — Base64url-encoded SHA-256 digest of capability descriptor for integrity checks
   - `bap` — Supported bulk agent protocols with versioning (e.g., `mcp/1,a2a/1`)
@@ -226,7 +238,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `AgentRecord` fields: `cap_uri`, `cap_sha256`, `bap`, `policy_uri`, `realm`
   - Updated `to_svcb_params()` to include custom params when present (backwards compatible)
   - CLI options: `--cap-uri`, `--cap-sha256`, `--bap`, `--policy-uri`, `--realm`
-  - MCP server: publish and discover tools support all BANDAID custom params
+  - MCP server: publish and discover tools support all DNS-AID custom params
   - Discovery priority: SVCB `cap` URI → fetch capability document → TXT fallback
 
 - **Capability Document Fetcher** (`src/dns_aid/core/cap_fetcher.py`)
@@ -270,7 +282,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Works with BIND9, Windows DNS, PowerDNS, Knot DNS, and any RFC 2136 compliant server
   - TSIG authentication support with multiple algorithms (hmac-sha256, sha384, sha512, sha224, md5)
   - Key file loading support (BIND key file format)
-  - Full BANDAID compliance with ServiceMode SVCB records
+  - Full DNS-AID compliance with ServiceMode SVCB records
   - Docker-based BIND9 integration tests
   - Documentation and examples for on-premise DNS deployments
 
@@ -324,7 +336,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cloudflare DNS Backend**
   - New `CloudflareBackend` for Cloudflare DNS API v4
   - Free tier support - ideal for demos and workshops
-  - Full BANDAID compliance with ServiceMode SVCB records
+  - Full DNS-AID compliance with ServiceMode SVCB records
   - Zone auto-discovery from domain name
   - 32 unit tests with mocked API responses
 
@@ -336,7 +348,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2026-01-13
 
 ### Added
-- **BANDAID Compliance**
+- **DNS-AID Compliance**
   - Added `mandatory="alpn,port"` parameter to SVCB records per IETF draft
   - Ensures proper agent discovery signaling
 
@@ -445,11 +457,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## References
 
-- [IETF draft-mozleywilliams-dnsop-bandaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/)
+- [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.3...HEAD
+[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.3...v0.8.0
 [0.7.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.0...v0.7.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,34 +8,34 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.7.3"
-date-released: "2026-02-19"
+version: "0.8.0"
+date-released: "2026-02-21"
 
 keywords:
   - dns
   - agent-discovery
   - ietf
   - svcb
-  - bandaid
+  - dnsaid
   - ai-agents
   - mcp
   - a2a
 
 references:
   - type: standard
-    title: "BANDAID: Best-practice Approaches for Naming and Discovery of AI-Driven services"
+    title: "DNS-AID: DNS-based Agent Identification and Discovery"
     authors:
       - family-names: Mozley
         given-names: Andrew
       - family-names: Williams
         given-names: Brandon
-    url: "https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/"
+    url: "https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/"
     identifiers:
       - type: other
-        value: "draft-mozleywilliams-dnsop-bandaid-02"
+        value: "draft-mozleywilliams-dnsop-dnsaid-01"
         description: "IETF Internet-Draft"
     notes: >
-      This software implements the BANDAID specification (draft-02):
+      This software implements the DNS-AID specification (draft-01):
       SVCB/HTTPS record discovery, TXT capability records,
       underscored naming (_agent._protocol._agents.domain),
       custom SVCB parameters (cap, cap-sha256, bap, policy, realm),

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation for [IETF draft-mozleywilliams-dnsop-bandaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/).
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
 
@@ -131,7 +131,7 @@ dns-aid publish \
     --capability chat \
     --capability code-review
 
-# Publish with BANDAID custom SVCB parameters
+# Publish with DNS-AID custom SVCB parameters
 dns-aid publish \
     --name booking \
     --domain example.com \
@@ -326,7 +326,7 @@ _chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port
 _chat._a2a._agents.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
 ```
 
-**BANDAID Custom SVCB Parameters:** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
+**DNS-AID Custom SVCB Parameters:** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
 
 ```
 _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
@@ -344,13 +344,13 @@ _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
 | `realm` | Multi-tenant scope identifier |
 
 > **Note:** Route 53 and Cloudflare do not support private-use SVCB SvcParamKeys (`key65001`–`key65006`).
-> DNS-AID automatically demotes these parameters to TXT records with a `bandaid_` prefix (e.g.,
-> `bandaid_realm=production`), preserving all metadata without data loss. BIND/DDNS (RFC 2136)
+> DNS-AID automatically demotes these parameters to TXT records with a `dnsaid_` prefix (e.g.,
+> `dnsaid_realm=production`), preserving all metadata without data loss. BIND/DDNS (RFC 2136)
 > backends natively support custom SVCB params — no demotion needed.
 
 This allows any DNS client to discover agents without proprietary protocols or central registries.
 
-### Discovery Flow (BANDAID Draft Aligned)
+### Discovery Flow (DNS-AID Draft Aligned)
 
 ```
   Agent A                        DNS                           Agent B
@@ -400,6 +400,66 @@ This allows any DNS client to discover agents without proprietary protocols or c
 **Index Resolution Priority:** HTTP index endpoint → TXT index record → common name probing.
 **Capability Resolution Priority:** SVCB `cap` URI → capability document → TXT record fallback.
 Each discovered agent includes `endpoint_source` and `capability_source` showing which path was used.
+
+## Security: DNSSEC and DANE
+
+DNS-AID relies on DNSSEC and DANE for end-to-end trust, as specified in the [IETF draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) Section 4.4.1.
+
+### DNSSEC (Mandatory for Public Zones)
+
+All DNS-AID discovery records **MUST** be signed with DNSSEC. Resolvers consuming DNS-AID data must treat unsigned or DNSSEC-bogus responses as failures.
+
+```bash
+# Verify DNSSEC and security posture for an agent
+dns-aid verify _chat._a2a._agents.example.com
+```
+
+### DANE/TLSA (Recommended)
+
+Where DNS-AID endpoints rely on TLS, DANE TLSA records **SHOULD** be used to bind endpoint certificates to DNSSEC-validated names. This removes reliance on external PKI (certificate authorities) and provides cryptographic proof that the TLS certificate belongs to the intended agent endpoint.
+
+**Recommended TLSA profile** (per IETF draft Section 5.2.3):
+
+```
+_443._tcp.agent-svc.example.com. 1800 IN TLSA 3 1 1 (
+    <SHA-256 hash of endpoint certificate SPKI>
+)
+```
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| Usage | 3 | DANE-EE (end entity, no CA chain needed) |
+| Selector | 1 | SubjectPublicKeyInfo (public key only) |
+| Matching Type | 1 | SHA-256 digest |
+
+**Full DANE certificate verification:**
+
+```python
+# Advisory check (TLSA record exists?)
+result = await dns_aid.verify("_chat._a2a._agents.example.com")
+print(result.dane_valid)  # True/False/None
+
+# Full certificate matching (connect + compare cert against TLSA)
+result = await dns_aid.verify(
+    "_chat._a2a._agents.example.com",
+    verify_dane_cert=True
+)
+print(result.dane_note)   # Detailed verification status
+```
+
+> **Note:** DANE is only meaningful when DNSSEC is also validated. Without DNSSEC, an attacker could spoof both the TLSA record and the endpoint certificate.
+
+### Security Score
+
+The `verify` command returns a security score (0–100) based on:
+
+| Check | Points | Requirement Level |
+|-------|--------|-------------------|
+| DNS record exists | 20 | Required |
+| SVCB record valid | 20 | Required |
+| DNSSEC validated | 30 | MUST (public zones) |
+| DANE/TLSA verified | 15 | SHOULD |
+| Endpoint reachable | 15 | Operational |
 
 ## Architecture
 
@@ -635,16 +695,16 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
    )
    ```
 
-#### Infoblox UDDI Limitations & BANDAID Compliance
+#### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI SVCB records only support "alias mode" (priority 0) and do not
 > support SVC parameters (`alpn`, `port`, `mandatory`). This means **Infoblox UDDI is not fully
-> compliant with the [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/)**.
+> compliant with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)**.
 >
 > The draft requires ServiceMode SVCB records (priority > 0) with mandatory `alpn` and `port`
 > parameters. Infoblox UDDI's limitation is a platform constraint, not a DNS-AID limitation.
 
-| BANDAID Requirement | Route 53 | Cloudflare | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
+| DNS-AID Requirement | Route 53 | Cloudflare | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
 |---------------------|----------|------------|-------------|---------------|---------------|
 | ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ✅ | ❌ |
 | `alpn` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
@@ -652,9 +712,9 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
 | `mandatory` key | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ✅ Native | ❌ |
 
-**⚠️ TXT** = Custom BANDAID params auto-demoted to TXT records with `bandaid_` prefix (no data loss).
+**⚠️ TXT** = Custom DNS-AID params auto-demoted to TXT records with `dnsaid_` prefix (no data loss).
 
-**For full BANDAID compliance with native custom SVCB params, use DDNS (BIND/RFC 2136) or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
+**For full DNS-AID compliance with native custom SVCB params, use DDNS (BIND/RFC 2136) or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
 
 DNS-AID stores `alpn` and `port` in TXT records as a fallback for Infoblox UDDI, but this is
 a workaround and not standard-compliant for agent discovery.
@@ -671,7 +731,7 @@ async with InfobloxBloxOneBackend() as backend:
 
 ### Infoblox NIOS Setup (On-Prem)
 
-Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID creates SVCB and TXT records via WAPI v2.13.7+, with full ServiceMode SVCB support including custom BANDAID parameters.
+Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID creates SVCB and TXT records via WAPI v2.13.7+, with full ServiceMode SVCB support including custom DNS-AID parameters.
 
 #### Environment Variables
 
@@ -731,9 +791,9 @@ Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID create
    )
    ```
 
-#### NIOS BANDAID Compliance
+#### NIOS DNS-AID Compliance
 
-NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters, including custom BANDAID keys natively via `key65001`–`key65006`.
+NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters, including custom DNS-AID keys natively via `key65001`–`key65006`.
 
 ### DDNS Setup (RFC 2136)
 
@@ -800,7 +860,7 @@ DDNS (Dynamic DNS) is a universal backend that works with any DNS server support
 - **Universal**: Works with BIND, Windows DNS, PowerDNS, Knot, and any RFC 2136 server
 - **No vendor lock-in**: Standard protocol, no proprietary APIs
 - **On-premise friendly**: Perfect for enterprise internal DNS
-- **Full BANDAID compliance**: Supports ServiceMode SVCB with all standard parameters (custom BANDAID params auto-demoted to TXT)
+- **Full DNS-AID compliance**: Supports ServiceMode SVCB with all standard parameters (custom DNS-AID params auto-demoted to TXT)
 
 ### Cloudflare Setup
 
@@ -868,7 +928,7 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **SVCB support**: Full RFC 9460 compliance with SVCB Type 64 records
 - **Global anycast**: Fast DNS resolution worldwide
 - **Simple API**: Well-documented REST API v4
-- **Full BANDAID compliance**: Supports ServiceMode SVCB with all standard parameters (custom BANDAID params auto-demoted to TXT)
+- **Full DNS-AID compliance**: Supports ServiceMode SVCB with all standard parameters (custom DNS-AID params auto-demoted to TXT)
 
 ## Why DNS-AID?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,7 +81,7 @@ DNS-AID uses SVCB SvcParamKeys in the **private-use range** (65001–65534) as d
 | ------- | -------- | -------------------------------- |
 | cap     | key65001 | Capability document URI          |
 | cap-sha256 | key65002 | Capability document SHA-256 hash |
-| bap     | key65003 | BANDAID Agent Profile URI        |
+| bap     | key65010 | DNS-AID Agent Profile URI        |
 | policy  | key65004 | Policy document URI              |
 | realm   | key65005 | Administrative realm             |
 | sig     | key65006 | JWS signature                    |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@
 - [API Reference](docs/api-reference.md) — Python library, CLI, and MCP server reference
 - [Framework Integrations](docs/integrations.md) — LangChain, AutoGen, Google ADK, OpenAI Agents
 - [Demo Guide](docs/demo-guide.md) — runnable demos with Route 53, DDNS, Cloudflare
-- [IETF Draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/) — the BANDAID specification
+- [IETF Draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) — the DNS-AID specification
 
 ## Asking Questions
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,7 +106,7 @@ async def publish(
 | `description` | `str` | No | `None` | Human-readable description |
 | `ttl` | `int` | No | 3600 | DNS record TTL in seconds (60-86400) |
 | `backend` | `DNSBackend` | No | `None` | DNS backend to use (uses default if None) |
-| `cap_uri` | `str` | No | `None` | URI to capability document (BANDAID custom param) |
+| `cap_uri` | `str` | No | `None` | URI to capability document (DNS-AID custom param) |
 | `cap_sha256` | `str` | No | `None` | Base64url SHA-256 digest of capability descriptor |
 | `bap` | `list[str]` | No | `None` | Supported protocols with versions (e.g., `["mcp/1", "a2a/1"]`) |
 | `policy_uri` | `str` | No | `None` | URI to agent policy document |
@@ -275,7 +275,7 @@ agent = AgentRecord(
 | `version` | `str` | No | "1.0.0" | Agent version |
 | `description` | `str` | No | `None` | Description |
 | `ttl` | `int` | No | 3600 | DNS TTL (60-86400) |
-| `cap_uri` | `str` | No | `None` | URI to capability document (BANDAID) |
+| `cap_uri` | `str` | No | `None` | URI to capability document (DNS-AID) |
 | `cap_sha256` | `str` | No | `None` | SHA-256 digest of capability descriptor |
 | `bap` | `list[str]` | No | `[]` | Supported protocols with versions |
 | `policy_uri` | `str` | No | `None` | URI to agent policy document |
@@ -474,11 +474,11 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**⚠️ BANDAID Compliance**: Infoblox UDDI is **not fully compliant** with the [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, or DDNSBackend.
+**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, or DDNSBackend.
 
 ### InfobloxNIOSBackend
 
-Infoblox NIOS on-premise WAPI implementation. Supports full ServiceMode SVCB with custom BANDAID parameters.
+Infoblox NIOS on-premise WAPI implementation. Supports full ServiceMode SVCB with custom DNS-AID parameters.
 
 ```python
 from dns_aid.backends.infoblox import InfobloxNIOSBackend
@@ -508,7 +508,7 @@ backend = InfobloxNIOSBackend(
 | `NIOS_WAPI_VERSION` | No | `2.13.7` | WAPI version |
 | `NIOS_VERIFY_SSL` | No | `false` | Verify TLS certificate |
 
-**BANDAID Compliance**: NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters including custom BANDAID keys (`key65001`–`key65006`). Fully compliant with the BANDAID draft.
+**DNS-AID Compliance**: NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters including custom DNS-AID keys (`key65001`–`key65006`). Fully compliant with the DNS-AID draft.
 
 ### DDNSBackend
 
@@ -556,7 +556,7 @@ async with DDNSBackend() as backend:
 - `hmac-sha224`
 - `hmac-md5` (legacy)
 
-**Full BANDAID Compliance**: DDNSBackend supports ServiceMode SVCB records (priority > 0) with all required parameters (`alpn`, `port`, `mandatory`).
+**Full DNS-AID Compliance**: DDNSBackend supports ServiceMode SVCB records (priority > 0) with all required parameters (`alpn`, `port`, `mandatory`).
 
 ### MockBackend
 
@@ -1108,6 +1108,6 @@ print(dns_aid.__version__)  # "0.6.0"
 ## See Also
 
 - [Getting Started Guide](getting-started.md)
-- [IETF Draft: BANDAID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/)
+- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DNS-AID implements the IETF draft-mozleywilliams-dnsop-bandaid-02 protocol for
+DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-01 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
 
 ---
@@ -10,7 +10,7 @@ DNS-based agent discovery. This document covers the key architectural decisions.
 ## Metadata Resolution Strategy
 
 Agent metadata is resolved through a **priority-based strategy** aligned with
-the BANDAID specification. Understanding this hierarchy is critical — it
+the DNS-AID specification. Understanding this hierarchy is critical — it
 explains why certain fields (description, use_cases, category) may appear as
 `null` in the directory even when they exist in DNS TXT records.
 
@@ -47,7 +47,7 @@ The `dns-aid publish` CLI writes description, use_cases, and category to the
 TXT record for **human readability** (useful when running `dig TXT`). However,
 the discoverer intentionally does NOT parse those fields from TXT because:
 
-1. **BANDAID spec compliance** — The draft specifies that rich metadata should
+1. **DNS-AID spec compliance** — The draft specifies that rich metadata should
    come from the capability document (cap URI) or HTTP index, not TXT records.
    TXT records are a lightweight fallback for basic capabilities only.
 
@@ -80,15 +80,15 @@ SVCB record found?
          Set endpoint_source = "http_index_fallback"
 ```
 
-### Custom SVCB Parameters (BANDAID)
+### Custom SVCB Parameters (DNS-AID)
 
-The BANDAID draft defines custom SVCB parameters:
+The DNS-AID draft defines custom SVCB parameters:
 
 | Parameter | SVCB Key | Purpose |
 |-----------|----------|---------|
 | `cap` | `cap_uri` | URI to capability descriptor document |
 | `capsha256` | `cap_sha256` | Integrity hash of capability document |
-| `bap` | `bap` | BANDAID Application Protocols (e.g., `mcp,a2a`) |
+| `bap` | `bap` | DNS-AID Application Protocols (e.g., `mcp,a2a`) |
 | `policy` | `policy_uri` | URI to agent policy document |
 | `realm` | `realm` | Multi-tenant scope / authorization realm |
 
@@ -105,7 +105,7 @@ Route 53 compatibility. This is tracked as a known interoperability issue.
 ```
 1. Query TXT _index._agents.{domain} → list of agent:protocol pairs
 2. For each agent: Query SVCB _{name}._{protocol}._agents.{domain}
-   → extract endpoint, port, ALPN + BANDAID custom params (cap, bap, policy, realm)
+   → extract endpoint, port, ALPN + DNS-AID custom params (cap, bap, policy, realm)
 3. For each agent: If cap URI present → fetch capability document (primary)
    → capabilities, version, description, use_cases, category
 4. For each agent: If no cap URI or fetch failed → query TXT for capabilities= (fallback)
@@ -124,7 +124,7 @@ Route 53 compatibility. This is tracked as a known interoperability issue.
 ### Future Enhancement: HTTP Index Fallback in DNS Mode
 
 Currently the two discovery modes are independent — pure DNS never consults the
-HTTP index and vice versa. Per the BANDAID draft, the HTTP well-known endpoint
+HTTP index and vice versa. Per the DNS-AID draft, the HTTP well-known endpoint
 is a complementary discovery mechanism. A future enhancement should add an
 HTTP index fallback to the DNS discovery path:
 

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -707,7 +707,7 @@ Found 5 flights from NYC to London on March 15:
 
 | Feature | Description |
 |---------|-------------|
-| **BANDAID Custom SVCB Params** | `cap`, `cap-sha256`, `bap`, `policy`, `realm` in SVCB records |
+| **DNS-AID Custom SVCB Params** | `cap`, `cap-sha256`, `bap`, `policy`, `realm` in SVCB records |
 | **Capability Document Fetch** | Fetch rich capabilities from `cap` URI, fall back to TXT |
 | **Capability Document Endpoint** | `/cap/{agent-name}` endpoint serves per-agent capability JSON |
 | **HTTP Index with Capabilities** | HTTP index now includes `capabilities` inline per agent |
@@ -720,7 +720,7 @@ Found 5 flights from NYC to London on March 15:
 
 ### Capability Discovery Flow
 
-Capabilities are resolved with the following priority, aligned with the BANDAID draft:
+Capabilities are resolved with the following priority, aligned with the DNS-AID draft:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -750,7 +750,7 @@ Capabilities are resolved with the following priority, aligned with the BANDAID 
 }
 ```
 
-**SVCB record with cap URI** (per BANDAID draft):
+**SVCB record with cap URI** (per DNS-AID draft):
 ```
 _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. \
     alpn="mcp" port=443 cap="https://index.aiagents.example.com/cap/booking-agent"
@@ -764,7 +764,7 @@ Each discovered agent includes transparency fields showing how data was resolved
 
 | Field | Values | Meaning |
 |-------|--------|---------|
-| `endpoint_source` | `dns_svcb` | Endpoint from authoritative DNS SVCB lookup (proper BANDAID flow) |
+| `endpoint_source` | `dns_svcb` | Endpoint from authoritative DNS SVCB lookup (proper DNS-AID flow) |
 | | `http_index_fallback` | DNS lookup failed, using HTTP index data only |
 | | `direct` | Endpoint was explicitly provided |
 | `capability_source` | `cap_uri` | Capabilities fetched from SVCB `cap` URI document |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -278,13 +278,13 @@ async def verify_connection():
 asyncio.run(verify_connection())
 ```
 
-### Infoblox UDDI Limitations & BANDAID Compliance
+### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI is **not fully compliant** with the
-> [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/).
+> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
 >
 > Infoblox UDDI SVCB only supports "alias mode" (priority 0) and lacks support for required
-> SVC parameters (`alpn`, `port`, `mandatory`). The BANDAID draft requires ServiceMode
+> SVC parameters (`alpn`, `port`, `mandatory`). The DNS-AID draft requires ServiceMode
 > SVCB records (priority > 0) with these parameters.
 >
 > **For full compliance, use Route 53 or another RFC 9460-compliant provider.**
@@ -305,7 +305,7 @@ async with InfobloxBloxOneBackend() as backend:
 
 ## Infoblox NIOS Setup (On-Prem)
 
-Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID creates SVCB and TXT records via WAPI v2.13.7+, with full ServiceMode SVCB support including custom BANDAID parameters.
+Infoblox NIOS is the on-premise DDI platform with WAPI (Web API). DNS-AID creates SVCB and TXT records via WAPI v2.13.7+, with full ServiceMode SVCB support including custom DNS-AID parameters.
 
 ### 1. Configure Environment Variables
 
@@ -378,9 +378,9 @@ dns-aid delete \
     --force
 ```
 
-### NIOS BANDAID Compliance
+### NIOS DNS-AID Compliance
 
-NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters, including custom BANDAID keys natively via `key65001`–`key65006`. This makes it fully compliant with the BANDAID draft.
+NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters, including custom DNS-AID keys natively via `key65001`–`key65006`. This makes it fully compliant with the DNS-AID draft.
 
 ## DDNS Setup (RFC 2136)
 
@@ -455,7 +455,7 @@ asyncio.run(verify_connection())
 ### DDNS Advantages
 
 - **Universal**: Works with BIND, Windows DNS, PowerDNS, Knot, and any RFC 2136 server
-- **Full BANDAID compliance**: Supports ServiceMode SVCB with all parameters
+- **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 - **No vendor lock-in**: Standard protocol, no proprietary APIs
 - **On-premise friendly**: Perfect for enterprise internal DNS
 
@@ -567,7 +567,7 @@ dns-aid delete \
 
 - **Free tier**: DNS hosting is free for unlimited domains
 - **Simple setup**: Just an API token, no IAM policies or TSIG keys
-- **Full BANDAID compliance**: Supports ServiceMode SVCB with all parameters
+- **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 - **Global anycast**: Fast DNS resolution worldwide
 - **Great documentation**: Well-documented REST API
 
@@ -1041,7 +1041,7 @@ Each discovered agent includes transparency fields showing how data was resolved
 
 | Field | Value | Meaning |
 |-------|-------|---------|
-| `endpoint_source` | `dns_svcb` | Endpoint resolved via DNS SVCB lookup (proper BANDAID flow) |
+| `endpoint_source` | `dns_svcb` | Endpoint resolved via DNS SVCB lookup (proper DNS-AID flow) |
 | | `http_index_fallback` | DNS lookup failed, using HTTP index data only |
 | | `direct` | Endpoint was explicitly provided |
 | `capability_source` | `cap_uri` | Capabilities fetched from SVCB `cap` URI document |
@@ -1052,12 +1052,12 @@ Agent name and protocol are extracted from the FQDN in the HTTP index — no sep
 
 Capabilities are resolved with priority: SVCB `cap` URI → capability document → TXT record fallback. The HTTP index also includes capabilities inline per agent.
 
-### BANDAID Custom SVCB Parameters
+### DNS-AID Custom SVCB Parameters
 
 Per the IETF draft, SVCB records can carry custom parameters for richer agent metadata:
 
 ```bash
-# Publish with BANDAID custom SVCB parameters
+# Publish with DNS-AID custom SVCB parameters
 dns-aid publish \
     --name booking \
     --domain example.com \
@@ -1198,4 +1198,4 @@ stable public API. They will be integrated in a future release once the
 
 - Read the [API Reference](api-reference.md)
 - Explore [examples/](../examples/)
-- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/)
+- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)

--- a/docs/rfc/iana-considerations.md
+++ b/docs/rfc/iana-considerations.md
@@ -1,6 +1,6 @@
 # IANA Considerations
 
-This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-bandaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/).
+This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
 
 ## 1. Underscored Node Names Registry
 
@@ -10,8 +10,8 @@ Per [RFC 8552](https://www.rfc-editor.org/rfc/rfc8552.html) (Scoped Interpretati
 
 | RR Type | _NODE NAME | Reference |
 |---------|------------|-----------|
-| SVCB | `_agents` | draft-mozleywilliams-dnsop-bandaid |
-| TXT | `_agents` | draft-mozleywilliams-dnsop-bandaid |
+| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
+| TXT | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
 
 **Purpose:** The `_agents` underscore name designates a subtree for AI agent service discovery records. Records under this name follow the pattern:
 
@@ -34,7 +34,7 @@ This document requests registration of the following ALPN Protocol ID in the "TL
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-bandaid |
+| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-01 |
 
 **Description:** The Model Context Protocol (MCP) is a protocol for AI model context sharing and tool invocation, originally developed by Anthropic. The `mcp` ALPN identifier signals that the TLS connection will carry MCP traffic.
 
@@ -46,7 +46,7 @@ This document requests registration of the following ALPN Protocol ID:
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-bandaid |
+| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-01 |
 
 **Description:** The Agent-to-Agent (A2A) protocol enables direct communication between AI agents, originally developed by Google. The `a2a` ALPN identifier signals that the TLS connection will carry A2A traffic.
 
@@ -62,7 +62,7 @@ This document requests IANA establish a new registry titled "DNS-AID Error Codes
 
 **Registration Procedure:** Specification Required
 
-**Reference:** draft-mozleywilliams-dnsop-bandaid
+**Reference:** draft-mozleywilliams-dnsop-dnsaid-01
 
 ### 3.2 Initial Registry Contents
 
@@ -98,17 +98,17 @@ DNS-AID uses the following existing parameters defined in [RFC 9460](https://www
 | alpn | 1 | RFC 9460 Section 7.1.1 |
 | port | 3 | RFC 9460 Section 7.2 |
 
-### 4.2 BANDAID Custom Parameters (draft-02 Section 4.4.3)
+### 4.2 DNS-AID Custom Parameters (draft-01 Section 4.4.3)
 
 This document requests registration of the following SVCB service parameters in the private-use range (65280-65534) per RFC 9460 Section 14.3.2:
 
 | Parameter | Proposed Key ID | Value Format | Description | Reference |
 |-----------|-----------------|--------------|-------------|-----------|
-| `cap` | 65400 | URI (RFC 3986) | URI to capability descriptor document (JSON). Allows clients to fetch structured agent metadata. | draft-mozleywilliams-dnsop-bandaid Section 4.4.3 |
-| `capsha256` | 65401 | Base64url (RFC 4648 §5) | SHA-256 digest of the capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-bandaid Section 4.4.3 |
-| `bap` | 65402 | Comma-separated tokens | BANDAID Application Protocols — lists protocols the agent supports with optional versions (e.g., `mcp/1,a2a/1`). | draft-mozleywilliams-dnsop-bandaid Section 4.4.3 |
-| `policy` | 65403 | URI (RFC 3986) | URI to agent policy document describing terms of use, data handling, and compliance. | draft-mozleywilliams-dnsop-bandaid Section 4.4.3 |
-| `realm` | 65404 | Token | Multi-tenant scope identifier for authorization (e.g., `production`, `staging`). | draft-mozleywilliams-dnsop-bandaid Section 4.4.3 |
+| `cap` | 65400 | URI (RFC 3986) | URI to capability descriptor document (JSON). Allows clients to fetch structured agent metadata. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `capsha256` | 65401 | Base64url (RFC 4648 §5) | SHA-256 digest of the capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `bap` | 65402 | Comma-separated tokens | DNS-AID Application Protocols — lists protocols the agent supports with optional versions (e.g., `mcp/1,a2a/1`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `policy` | 65403 | URI (RFC 3986) | URI to agent policy document describing terms of use, data handling, and compliance. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `realm` | 65404 | Token | Multi-tenant scope identifier for authorization (e.g., `production`, `staging`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
 
 **Wire Format:** Until IANA allocates permanent key IDs, implementations MUST use the generic `keyNNNNN` presentation format (e.g., `key65400="https://..."`) for interoperability with DNS providers that do not recognize custom parameter names. See Section 2.2 of RFC 9460.
 
@@ -133,6 +133,6 @@ For the DNS-AID Error Code Registry, designated experts SHOULD consider:
 
 ### Informative References
 
-- [draft-mozleywilliams-dnsop-bandaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/) - DNS-based Agent Identification and Discovery (BANDAID)
+- [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/) - DNS-based Agent Identification and Discovery (DNS-AID)
 - [Model Context Protocol](https://spec.modelcontextprotocol.io/) - MCP Specification
 - [A2A Protocol](https://google.github.io/A2A/) - Agent-to-Agent Protocol Documentation

--- a/docs/rfc/privacy-considerations.md
+++ b/docs/rfc/privacy-considerations.md
@@ -1,6 +1,6 @@
 # Privacy Considerations
 
-This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-bandaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/).
+This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
 
 ## 1. Privacy Model
 

--- a/docs/rfc/security-considerations.md
+++ b/docs/rfc/security-considerations.md
@@ -1,6 +1,6 @@
 # Security Considerations
 
-This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-bandaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/).
+This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
 
 ## 1. Threat Model (STRIDE Analysis)
 

--- a/docs/rfc/wire-format.abnf
+++ b/docs/rfc/wire-format.abnf
@@ -1,5 +1,5 @@
 ; DNS-AID Wire Format - ABNF Grammar
-; Reference: draft-mozleywilliams-dnsop-bandaid
+; Reference: draft-mozleywilliams-dnsop-dnsaid-01
 ;
 ; This document defines the wire format for DNS-AID records using
 ; Augmented Backus-Naur Form (ABNF) as specified in RFC 5234.
@@ -78,11 +78,11 @@ svc-param      = mandatory-param
                / port-param
                / ipv4hint-param
                / ipv6hint-param
-               / cap-param           ; BANDAID: capability document URI
-               / capsha256-param     ; BANDAID: capability document hash
-               / bap-param           ; BANDAID: application protocols
-               / policy-param        ; BANDAID: policy document URI
-               / realm-param         ; BANDAID: multi-tenant scope
+               / cap-param           ; DNS-AID: capability document URI
+               / capsha256-param     ; DNS-AID: capability document hash
+               / bap-param           ; DNS-AID: application protocols
+               / policy-param        ; DNS-AID: policy document URI
+               / realm-param         ; DNS-AID: multi-tenant scope
                / unknown-param
 
 ; ==================================================================
@@ -130,7 +130,7 @@ IPv6-compressed = *1(":" 1*4HEXDIG) "::" *1(1*4HEXDIG ":")
                   ; Simplified - full IPv6 grammar is complex
 
 ; ==================================================================
-; BANDAID Custom SVCB Parameters (draft-02 Section 4.4.3)
+; DNS-AID Custom SVCB Parameters (draft-01 Section 4.4.3)
 ; ==================================================================
 
 ; Capability document URI (key 65400)
@@ -145,7 +145,7 @@ base64url      = 1*43(ALPHA / DIGIT / "-" / "_")
                  ; Base64url-encoded SHA-256 digest (RFC 4648 Section 5)
                  ; 32 bytes = 43 base64url characters (no padding)
 
-; BANDAID Application Protocols (key 65402)
+; DNS-AID Application Protocols (key 65402)
 bap-param      = "bap=" DQUOTE bap-list DQUOTE
 bap-list       = bap-entry *("," bap-entry)
 bap-entry      = protocol ["/" version-number]
@@ -310,7 +310,7 @@ verify-token   = 32*64(ALPHA / DIGIT)
 ;     ipv4hint="192.0.2.1"
 ; )
 
-; Example 3: SVCB Record with BANDAID Custom Parameters (v0.4.8)
+; Example 3: SVCB Record with DNS-AID Custom Parameters (v0.4.8)
 ;
 ; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"

--- a/examples/demo_full.py
+++ b/examples/demo_full.py
@@ -282,7 +282,7 @@ Next Steps:
 
   • Try the CLI: dns-aid --help
   • Use the MCP server: dns-aid-mcp
-  • Read the IETF draft: draft-mozleywilliams-dnsop-bandaid-02
+  • Read the IETF draft: draft-mozleywilliams-dnsop-dnsaid-01
 
 """)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.7.3"
+version = "0.8.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -4,7 +4,7 @@
 """
 DNS-AID: DNS-based Agent Identification and Discovery
 
-Reference implementation for IETF draft-mozleywilliams-dnsop-bandaid-02.
+Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-01.
 Enables AI agents to discover each other via DNS using SVCB records.
 
 Example:
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.7.3"
+__version__ = "0.8.0"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -26,7 +26,7 @@ logger = structlog.get_logger(__name__)
 
 # Standard SVCB SvcParamKeys that managed DNS providers accept (RFC 9460).
 # Cloudflare rejects private-use keys (key65001–key65534) the same way
-# Route53 does.  Custom BANDAID params are demoted to TXT automatically.
+# Route53 does.  Custom DNS-AID params are demoted to TXT automatically.
 _CLOUDFLARE_SVCB_KEYS = frozenset(
     {
         "mandatory",
@@ -353,7 +353,7 @@ class CloudflareBackend(DNSBackend):
         """
         Publish an agent to DNS, demoting unsupported SVCB params to TXT.
 
-        Cloudflare only accepts standard RFC 9460 SvcParamKeys. Custom BANDAID
+        Cloudflare only accepts standard RFC 9460 SvcParamKeys. Custom DNS-AID
         params (key65001–key65006) are automatically moved to the TXT record.
         """
         records: list[str] = []
@@ -388,10 +388,10 @@ class CloudflareBackend(DNSBackend):
         )
         records.append(f"SVCB {svcb_fqdn}")
 
-        # Build TXT values: capabilities/metadata + demoted BANDAID params
+        # Build TXT values: capabilities/metadata + demoted DNS-AID params
         txt_values = agent.to_txt_values()
         for key, value in custom_params.items():
-            txt_values.append(f"bandaid_{key}={value}")
+            txt_values.append(f"dnsaid_{key}={value}")
 
         if txt_values:
             txt_fqdn = await self.create_txt_record(

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -52,7 +52,7 @@ class InfobloxNIOSBackend(DNSBackend):
     _CUSTOM_PARAM_TO_NUMERIC_KEY = {
         "cap": "key65001",
         "cap-sha256": "key65002",
-        "bap": "key65003",
+        "bap": "key65010",
         "policy": "key65004",
         "realm": "key65005",
         "sig": "key65006",

--- a/src/dns_aid/backends/route53.py
+++ b/src/dns_aid/backends/route53.py
@@ -28,7 +28,7 @@ logger = structlog.get_logger(__name__)
 # Standard SVCB SvcParamKeys that Route53 accepts (RFC 9460).
 # Route53 rejects private-use keys (key65001–key65534) with
 # "SVCB does not support undefined parameters."
-# When publishing, custom BANDAID params are automatically demoted
+# When publishing, custom DNS-AID params are automatically demoted
 # to TXT records so the publish succeeds.
 _ROUTE53_SVCB_KEYS = frozenset(
     {
@@ -296,7 +296,7 @@ class Route53Backend(DNSBackend):
         """
         Publish an agent to DNS, demoting unsupported SVCB params to TXT.
 
-        Route53 only accepts standard RFC 9460 SvcParamKeys. Custom BANDAID
+        Route53 only accepts standard RFC 9460 SvcParamKeys. Custom DNS-AID
         params (key65001–key65006) are automatically moved to the TXT record
         so the publish succeeds without data loss.
         """
@@ -332,10 +332,10 @@ class Route53Backend(DNSBackend):
         )
         records.append(f"SVCB {svcb_fqdn}")
 
-        # Build TXT values: capabilities/metadata + demoted BANDAID params
+        # Build TXT values: capabilities/metadata + demoted DNS-AID params
         txt_values = agent.to_txt_values()
         for key, value in custom_params.items():
-            txt_values.append(f"bandaid_{key}={value}")
+            txt_values.append(f"dnsaid_{key}={value}")
 
         if txt_values:
             txt_fqdn = await self.create_txt_record(

--- a/src/dns_aid/cli/doctor.py
+++ b/src/dns_aid/cli/doctor.py
@@ -32,7 +32,7 @@ def _render_report(report: DiagnosticReport) -> None:
     console.print(
         Panel(
             f"[bold]dns-aid doctor[/bold]  v{report.version}",
-            subtitle="[dim]IETF draft-mozleywilliams-dnsop-bandaid-02[/dim]",
+            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-01[/dim]",
             width=56,
         )
     )

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -98,7 +98,7 @@ def publish(
     ] = None,
     cap_uri: Annotated[
         str | None,
-        typer.Option("--cap-uri", help="URI to capability document (BANDAID draft-compliant)"),
+        typer.Option("--cap-uri", help="URI to capability document (DNS-AID draft-compliant)"),
     ] = None,
     cap_sha256: Annotated[
         str | None,
@@ -148,7 +148,7 @@ def publish(
           --use-case "Generate invoices" --use-case "Process refunds" \\
           --category finance
 
-        # With BANDAID draft params:
+        # With DNS-AID draft params:
         dns-aid publish -n booking -d example.com -p mcp \\
           --cap-uri https://mcp.example.com/.well-known/agent-cap.json \\
           --bap mcp --realm production

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -4,7 +4,7 @@
 """
 Fetch agent capability document from cap URI (IETF draft-compliant).
 
-Per IETF draft-mozleywilliams-dnsop-bandaid-02, the SVCB record may contain
+Per IETF draft-mozleywilliams-dnsop-dnsaid-01, the SVCB record may contain
 a `cap` parameter with a URI pointing to a JSON capability document. This module
 fetches and parses that document.
 

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -5,7 +5,7 @@
 DNS-AID Discoverer: Query DNS to find AI agents.
 
 This module handles discovering agents via DNS queries for SVCB and TXT
-records as specified in IETF draft-mozleywilliams-dnsop-bandaid-02.
+records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 """
 
 from __future__ import annotations
@@ -212,19 +212,60 @@ async def _query_single_agent(
                 return None
 
         for rdata in answers:
-            # Parse SVCB record
+            # AliasMode (priority 0): follow alias to canonical name
+            # Per RFC 9460 and IETF draft Section 4.4.2, AliasMode maps a
+            # friendly name to a canonical SVCB owner name.
+            if rdata.priority == 0:
+                alias_target = str(rdata.target).rstrip(".")
+                if alias_target and alias_target != ".":
+                    logger.debug(
+                        "Following SVCB AliasMode",
+                        fqdn=fqdn,
+                        alias_target=alias_target,
+                    )
+                    try:
+                        answers = await resolver.resolve(alias_target, "SVCB")
+                        # Recurse into the resolved answers (ServiceMode expected)
+                        for alias_rdata in answers:
+                            if alias_rdata.priority > 0:
+                                rdata = alias_rdata
+                                break
+                        else:
+                            return None  # No ServiceMode record found
+                    except Exception:
+                        logger.debug("AliasMode resolution failed", alias=alias_target)
+                        return None
+
+            # Parse ServiceMode SVCB record
             target = str(rdata.target).rstrip(".")
-            # Note: priority (rdata.priority) available but not currently used
 
             # Extract standard parameters
             port = 443
             ipv4_hint = None
             ipv6_hint = None
 
-            if hasattr(rdata, "port") and rdata.port:
+            if hasattr(rdata, "params") and rdata.params:
+                # Port (SvcParamKey 3)
+                port_param = rdata.params.get(3)
+                if port_param and hasattr(port_param, "port"):
+                    port = port_param.port
+                # ipv4hint (SvcParamKey 4) — per IETF draft Section 4.4.2,
+                # SHOULD be used to reduce follow-up A/AAAA queries
+                ipv4_param = rdata.params.get(4)
+                if ipv4_param:
+                    addrs = getattr(ipv4_param, "addresses", None)
+                    if addrs:
+                        ipv4_hint = str(addrs[0])
+                # ipv6hint (SvcParamKey 6)
+                ipv6_param = rdata.params.get(6)
+                if ipv6_param:
+                    addrs = getattr(ipv6_param, "addresses", None)
+                    if addrs:
+                        ipv6_hint = str(addrs[0])
+            elif hasattr(rdata, "port") and rdata.port:
                 port = rdata.port
 
-            # Extract BANDAID custom params from SVCB presentation format.
+            # Extract DNS-AID custom params from SVCB presentation format.
             # dnspython stores params as a dict keyed by SvcParamKey integers.
             # Custom/private-use params may appear as string keys in the
             # presentation format. We parse the text representation to extract them.
@@ -285,11 +326,11 @@ async def _query_single_agent(
 
 def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
     """
-    Parse BANDAID custom params from SVCB record text representation.
+    Parse DNS-AID custom params from SVCB record text representation.
 
     Accepts both human-readable string names and RFC 9460 keyNNNNN format:
         String form: cap="https://..." bap="mcp,a2a" realm="demo"
-        Numeric form: key65001="https://..." key65003="mcp,a2a" key65005="demo"
+        Numeric form: key65001="https://..." key65010="mcp,a2a" key65005="demo"
 
     Args:
         svcb_text: String representation of an SVCB rdata.
@@ -297,10 +338,10 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
     Returns:
         Dict of custom param names (always string form) to their string values.
     """
-    from dns_aid.core.models import BANDAID_KEY_MAP_REVERSE
+    from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
 
     custom_params: dict[str, str] = {}
-    bandaid_keys = {"cap", "cap-sha256", "bap", "policy", "realm", "sig"}
+    dnsaid_keys = {"cap", "cap-sha256", "bap", "policy", "realm", "sig"}
 
     # Split on spaces, then look for key="value" or key=value patterns
     parts = svcb_text.split()
@@ -311,10 +352,10 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
         key = key.strip().lower()
 
         # Normalize keyNNNNN to string name
-        if key in BANDAID_KEY_MAP_REVERSE:
-            key = BANDAID_KEY_MAP_REVERSE[key]
+        if key in DNS_AID_KEY_MAP_REVERSE:
+            key = DNS_AID_KEY_MAP_REVERSE[key]
 
-        if key in bandaid_keys:
+        if key in dnsaid_keys:
             # Remove surrounding quotes if present
             value = value.strip('"').strip("'")
             custom_params[key] = value
@@ -325,7 +366,7 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
 async def _query_capabilities(fqdn: str) -> list[str]:
     """Query TXT record for agent capabilities (fallback only).
 
-    Per BANDAID draft-02 Section 4.4.3, rich agent metadata (description,
+    Per DNS-AID draft-01 Section 4.4.3, rich agent metadata (description,
     use_cases, category) is sourced from the **capability document** fetched
     via the ``cap`` SVCB parameter URI, or from the HTTP index
     (``/.well-known/agent-index.json``).

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -5,7 +5,7 @@
 Data models for DNS-AID.
 
 These models represent agents, discovery results, and DNS records
-as specified in IETF draft-mozleywilliams-dnsop-bandaid-02.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 """
 
 from __future__ import annotations
@@ -16,19 +16,19 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-# BANDAID custom SVCB param key mapping (IETF draft-02, Section 4.4.3)
+# DNS-AID custom SVCB param key mapping (IETF draft-01, Section 4.4.3)
 # These are provisional private-use key numbers in the range 65001-65534.
 # Once IANA assigns official SvcParamKey numbers, update these values.
-BANDAID_KEY_MAP: dict[str, str] = {
+DNS_AID_KEY_MAP: dict[str, str] = {
     "cap": "key65001",
     "cap-sha256": "key65002",
-    "bap": "key65003",
+    "bap": "key65010",
     "policy": "key65004",
     "realm": "key65005",
     "sig": "key65006",
 }
 
-BANDAID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in BANDAID_KEY_MAP.items()}
+DNS_AID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in DNS_AID_KEY_MAP.items()}
 
 
 def _use_string_keys() -> bool:
@@ -57,7 +57,7 @@ class Protocol(StrEnum):
 
     Per IETF draft, these map to ALPN identifiers in SVCB records.
 
-    BANDAID draft-02 gap (deferred):
+    DNS-AID draft-01 gap (deferred):
         The draft is internally inconsistent on what `alpn` should contain.
         Section 3.1 uses alpn="a2a" (agent protocol), while Section 5.2.3's
         zonefile example uses alpn="h2,h3" (transport protocol) with the agent
@@ -80,7 +80,7 @@ class AgentRecord(BaseModel):
     """
     Represents an AI agent published via DNS-AID.
 
-    Maps to SVCB + TXT records in DNS per the BANDAID specification:
+    Maps to SVCB + TXT records in DNS per the DNS-AID specification:
     - SVCB: _{name}._{protocol}._agents.{domain} → service binding
     - TXT: capabilities, version, metadata
 
@@ -128,11 +128,11 @@ class AgentRecord(BaseModel):
         default=None, description="Agent category (e.g., 'network', 'security')"
     )
 
-    # BANDAID custom SVCB parameters (IETF draft-02 compliant)
+    # DNS-AID custom SVCB parameters (IETF draft-01 compliant)
     #
     # These correspond to provisional SvcParamKeys defined in Section 4.4.3.
     #
-    # BANDAID draft-02 gap (deferred — keyNNNNN encoding):
+    # DNS-AID draft-01 gap (deferred — keyNNNNN encoding):
     #     The draft specifies that unregistered SVCB params MUST use numeric
     #     keyNNNNN presentation form (e.g., key65001="cap=..." instead of
     #     cap="...") until IANA assigns official SvcParamKey numbers.
@@ -143,25 +143,25 @@ class AgentRecord(BaseModel):
     #     Once IANA assigns key numbers, update to_svcb_params() to emit
     #     keyNNNNN format and update _parse_svcb_custom_params() to parse it.
     #
-    # BANDAID draft-02 gap (deferred — mandatory list):
+    # DNS-AID draft-01 gap (deferred — mandatory list):
     #     The draft says clients that require custom params MUST verify their
     #     presence via the `mandatory` key (e.g., mandatory=alpn,port,key65001).
     #     Per RFC 9460, clients that don't understand a mandatory key MUST skip
     #     the record. We currently only set mandatory=alpn,port to avoid breaking
-    #     non-BANDAID-aware clients. Once keyNNNNN encoding is adopted, we should
+    #     non-DNS-AID-aware clients. Once keyNNNNN encoding is adopted, we should
     #     add custom keys to the mandatory list for downgrade safety.
     cap_uri: str | None = Field(
         default=None,
-        description="URI or URN to capability descriptor (per BANDAID draft Section 4.4.3 'cap')",
+        description="URI or URN to capability descriptor (per DNS-AID draft Section 4.4.3 'cap')",
     )
     cap_sha256: str | None = Field(
         default=None,
         description="Base64url-encoded SHA-256 digest of the capability descriptor "
-        "for integrity checks and cache revalidation (per BANDAID draft 'cap-sha256')",
+        "for integrity checks and cache revalidation (per DNS-AID draft 'cap-sha256')",
     )
     bap: list[str] = Field(
         default_factory=list,
-        description="BANDAID Application Protocols with versions understood by the endpoint "
+        description="DNS-AID Application Protocols with versions understood by the endpoint "
         "(e.g., ['mcp/1', 'a2a/1']). Distinct from transport-level alpn per draft Section 4.4.3.",
     )
     policy_uri: str | None = Field(
@@ -268,27 +268,27 @@ class AgentRecord(BaseModel):
         Generate SVCB parameters for DNS record.
 
         Returns dict suitable for creating SVCB record.
-        Per BANDAID draft, includes mandatory parameter to indicate
-        required params for agent discovery, plus custom BANDAID params
+        Per DNS-AID draft, includes mandatory parameter to indicate
+        required params for agent discovery, plus custom DNS-AID params
         (cap, bap, policy, realm) when present.
         """
         params = {
             "alpn": self.protocol.value,
             "port": str(self.port),
-            # BANDAID compliance: indicate alpn and port are mandatory
+            # DNS-AID compliance: indicate alpn and port are mandatory
             "mandatory": "alpn,port",
         }
         if self.ipv4_hint:
             params["ipv4hint"] = self.ipv4_hint
         if self.ipv6_hint:
             params["ipv6hint"] = self.ipv6_hint
-        # BANDAID custom SVCB params (IETF draft-02, Section 4.4.3)
+        # DNS-AID custom SVCB params (IETF draft-01, Section 4.4.3)
         # Emit keyNNNNN format by default (RFC 9460 compliant for unregistered keys).
         # Set DNS_AID_SVCB_STRING_KEYS=1 for human-readable string names.
         use_strings = _use_string_keys()
 
         def _key(name: str) -> str:
-            return name if use_strings else BANDAID_KEY_MAP.get(name, name)
+            return name if use_strings else DNS_AID_KEY_MAP.get(name, name)
 
         if self.cap_uri:
             params[_key("cap")] = self.cap_uri

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -5,7 +5,7 @@
 DNS-AID Publisher: Create DNS records for AI agent discovery.
 
 This module handles publishing agents to DNS using SVCB and TXT records
-as specified in IETF draft-mozleywilliams-dnsop-bandaid-02.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 """
 
 from __future__ import annotations
@@ -104,7 +104,7 @@ async def publish(
         category: Agent category (e.g., "network", "security")
         ttl: DNS record TTL in seconds
         backend: DNS backend to use (defaults to global backend)
-        cap_uri: URI to capability document (BANDAID draft-compliant)
+        cap_uri: URI to capability document (DNS-AID draft-compliant)
         cap_sha256: Base64url-encoded SHA-256 digest of the capability descriptor
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
         policy_uri: URI to agent policy document

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -66,8 +66,31 @@ async def verify(fqdn: str, *, verify_dane_cert: bool = False) -> VerifyResult:
     result.dnssec_valid = await _check_dnssec(fqdn)
 
     # 3. Check DANE/TLSA (if target is available)
+    # Per IETF draft Section 4.4.1, DANE TLSA SHOULD be used to bind
+    # endpoint certificates to DNSSEC-validated names.
     if target:
         result.dane_valid = await _check_dane(target, port, verify_cert=verify_dane_cert)
+
+        # Update dane_note based on actual check performed
+        if result.dane_valid is None:
+            result.dane_note = "No TLSA record configured (DANE not enabled for this endpoint)"
+        elif verify_dane_cert:
+            if result.dane_valid:
+                result.dane_note = "DANE certificate matching verified (TLSA 3 1 1 recommended)"
+            else:
+                result.dane_note = (
+                    "DANE certificate mismatch — endpoint cert does not match TLSA record"
+                )
+        else:
+            result.dane_note = (
+                "TLSA record exists (advisory check only; "
+                "use verify_dane_cert=True for full certificate matching)"
+            )
+
+        # DANE without DNSSEC is meaningless — per RFC 6698 and IETF draft,
+        # TLSA records MUST be DNSSEC-validated to be trusted.
+        if result.dane_valid is not None and not result.dnssec_valid:
+            result.dane_note += " ⚠ DNSSEC not validated — DANE requires DNSSEC to be trustworthy"
 
     # 4. Check endpoint reachability
     if target and port:

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -5,7 +5,7 @@
 DNS-AID MCP Server.
 
 Provides MCP tools for AI agents to publish and discover other agents via DNS.
-Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-bandaid-02).
+Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-01).
 
 Usage:
     # Run with stdio transport (default for MCP)
@@ -241,7 +241,7 @@ def publish_agent_to_dns(
         ttl: DNS record TTL in seconds (default: 3600).
         backend: DNS backend to use - "route53" for AWS Route53 or "mock" for testing.
         update_index: Whether to update the domain's agent index record (default: True).
-        cap_uri: URI to capability document (BANDAID draft-compliant, e.g.,
+        cap_uri: URI to capability document (DNS-AID draft-compliant, e.g.,
             "https://mcp.example.com/.well-known/agent-cap.json"). When set, the
             SVCB record will include a `cap` parameter pointing to a JSON document
             describing the agent's capabilities.
@@ -364,14 +364,14 @@ def discover_agents_via_dns(
     use_http_index: bool = False,
 ) -> dict:
     """
-    Discover AI agents at a domain using the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-bandaid-02).
+    Discover AI agents at a domain using the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-01).
 
     Discovery flow (DNS-only, default):
       1. Query the TXT index record at _index._agents.{domain} to get the list of
          published agent names and their protocols.
       2. For each agent in the index, query the SVCB record at
          _{name}._{protocol}._agents.{domain} to resolve the target host, port,
-         and ALPN protocol — plus BANDAID custom params (cap, bap, policy, realm).
+         and ALPN protocol — plus DNS-AID custom params (cap, bap, policy, realm).
       3. If the SVCB record contains a `cap` param (URI to capability document),
          fetch the capability document via HTTPS for rich capability metadata.
       4. If the cap URI is missing or the fetch fails, fall back to querying the
@@ -1265,7 +1265,7 @@ try:
                     "/ready": "Readiness check (GET)",
                 },
                 "documentation": "https://github.com/infobloxopen/dns-aid-core",
-                "specification": "IETF draft-mozleywilliams-dnsop-bandaid-02",
+                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-01",
             }
         )
 

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -403,18 +403,18 @@ class TestSecurityScoring:
             assert verify.security_score == 0
 
 
-# ── Scenario F: BANDAID Params Roundtrip ───────────────────────────────
+# ── Scenario F: DNS-AID Params Roundtrip ───────────────────────────────
 
 
-class TestBandaidParamsRoundtrip:
-    """Publish with BANDAID custom params → discover retrieves them."""
+class TestDnsaidParamsRoundtrip:
+    """Publish with DNS-AID custom params → discover retrieves them."""
 
-    async def test_full_bandaid_params(
+    async def test_full_dnsaid_params(
         self,
         mock_backend: MockBackend,
         dns_bridge: MockDNSBridge,
     ):
-        """All 6 BANDAID params round-trip through SVCB keyNNNNN encoding."""
+        """All 6 DNS-AID params round-trip through SVCB keyNNNNN encoding."""
         await dns_aid.publish(
             name="rich",
             domain="example.com",
@@ -444,7 +444,7 @@ class TestBandaidParamsRoundtrip:
             assert agent.policy_uri == "https://example.com/policy"
             assert agent.realm == "demo"
 
-    async def test_partial_bandaid_params(
+    async def test_partial_dnsaid_params(
         self,
         mock_backend: MockBackend,
         dns_bridge: MockDNSBridge,
@@ -616,5 +616,5 @@ class TestDANECertMatching:
             assert verify.record_exists
             assert verify.svcb_valid
             assert verify.dane_valid is True
-            # Confirm default note mentions existence-only
-            assert "existence" in verify.dane_note.lower()
+            # Confirm default note mentions advisory (no full cert matching)
+            assert "advisory" in verify.dane_note.lower()

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -670,7 +670,7 @@ class TestCloudflarePublishAgentParamDemotion:
 
     @pytest.mark.asyncio
     async def test_publish_strips_custom_svcb_params(self):
-        """Custom BANDAID params (key65001+) must be demoted to TXT."""
+        """Custom DNS-AID params (key65001+) must be demoted to TXT."""
         from dns_aid.core.models import AgentRecord, Protocol
 
         agent = AgentRecord(
@@ -719,10 +719,10 @@ class TestCloudflarePublishAgentParamDemotion:
                 "ech",
             }
 
-        # TXT should contain demoted bandaid params
+        # TXT should contain demoted dnsaid params
         txt_values = txt_calls[0]["values"]
-        bandaid_txt = [v for v in txt_values if v.startswith("bandaid_")]
-        assert len(bandaid_txt) > 0
+        dnsaid_txt = [v for v in txt_values if v.startswith("dnsaid_")]
+        assert len(dnsaid_txt) > 0
 
     @pytest.mark.asyncio
     async def test_publish_no_custom_params_unchanged(self):
@@ -757,11 +757,11 @@ class TestCloudflarePublishAgentParamDemotion:
         ):
             records = await backend.publish_agent(agent)
 
-        # No bandaid_ entries in TXT
+        # No dnsaid_ entries in TXT
         if txt_calls:
             txt_values = txt_calls[0]["values"]
-            bandaid_txt = [v for v in txt_values if v.startswith("bandaid_")]
-            assert len(bandaid_txt) == 0
+            dnsaid_txt = [v for v in txt_values if v.startswith("dnsaid_")]
+            assert len(dnsaid_txt) == 0
 
     @pytest.mark.asyncio
     async def test_publish_demotes_multiple_params(self):
@@ -801,10 +801,10 @@ class TestCloudflarePublishAgentParamDemotion:
         ):
             await backend.publish_agent(agent)
 
-        # All custom keys should be in TXT as bandaid_ prefixed
+        # All custom keys should be in TXT as dnsaid_ prefixed
         txt_values = txt_calls[0]["values"]
-        bandaid_txt = [v for v in txt_values if v.startswith("bandaid_")]
-        assert len(bandaid_txt) >= 4  # cap, cap-sha256, bap, policy, realm
+        dnsaid_txt = [v for v in txt_values if v.startswith("dnsaid_")]
+        assert len(dnsaid_txt) >= 4  # cap, cap-sha256, bap, policy, realm
 
 
 class TestCloudflareGetRecord:

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -506,7 +506,7 @@ class TestDiscoverViaHttpIndex:
 class TestParseSvcbCustomParams:
     """Tests for _parse_svcb_custom_params."""
 
-    def test_parses_all_bandaid_params(self):
+    def test_parses_all_dnsaid_params(self):
         svcb_text = (
             '1 mcp.example.com. alpn="mcp" port="443" '
             'cap="https://mcp.example.com/.well-known/agent-cap.json" '
@@ -520,14 +520,14 @@ class TestParseSvcbCustomParams:
         assert params["policy"] == "https://example.com/policy"
         assert params["realm"] == "production"
 
-    def test_ignores_non_bandaid_params(self):
+    def test_ignores_non_dnsaid_params(self):
         svcb_text = '1 mcp.example.com. alpn="mcp" port="443" ipv4hint="192.0.2.1"'
         params = _parse_svcb_custom_params(svcb_text)
         assert "alpn" not in params
         assert "port" not in params
         assert "ipv4hint" not in params
 
-    def test_partial_bandaid_params(self):
+    def test_partial_dnsaid_params(self):
         svcb_text = '1 mcp.example.com. alpn="mcp" port="443" cap="https://cap.example.com/cap.json" realm="demo"'
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://cap.example.com/cap.json"
@@ -562,7 +562,7 @@ class TestParseSvcbCustomParams:
 
 
 class TestDiscoveryWithCapUri:
-    """Tests for discovery with cap URI in SVCB (BANDAID draft alignment)."""
+    """Tests for discovery with cap URI in SVCB (DNS-AID draft alignment)."""
 
     @pytest.mark.asyncio
     async def test_discovery_uses_cap_uri_when_present(self):

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -167,19 +167,19 @@ class TestInfobloxNIOSSvcParameters:
         as_map = {item["svc_key"]: item for item in converted}
         assert as_map["alpn"]["svc_value"] == ["h2", "h3"]
         assert as_map["alpn"]["mandatory"] is True
-        assert as_map["key65003"]["svc_value"] == ["mcp/1", "a2a/1"]
+        assert as_map["key65010"]["svc_value"] == ["mcp/1", "a2a/1"]
         assert as_map["port"]["svc_value"] == ["443"]
         assert as_map["key65001"]["mandatory"] is True
         assert as_map["key65006"]["svc_value"] == ["abc123"]
 
     def test_svc_parameters_preserves_numeric_keys(self) -> None:
         converted = InfobloxNIOSBackend._svc_parameters_from_params(
-            {"mandatory": "key65003,port", "key65003": "mcp/1,a2a/1", "port": "443"}
+            {"mandatory": "key65010,port", "key65010": "mcp/1,a2a/1", "port": "443"}
         )
         as_map = {item["svc_key"]: item for item in converted}
 
-        assert as_map["key65003"]["mandatory"] is True
-        assert as_map["key65003"]["svc_value"] == ["mcp/1", "a2a/1"]
+        assert as_map["key65010"]["mandatory"] is True
+        assert as_map["key65010"]["svc_value"] == ["mcp/1", "a2a/1"]
         assert as_map["port"]["mandatory"] is True
 
     def test_format_svc_parameters_for_value(self) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -109,10 +109,10 @@ class TestAgentRecord:
         assert params["alpn"] == "mcp"
         assert params["port"] == "8443"
         assert params["ipv4hint"] == "192.0.2.1"
-        # BANDAID compliance: mandatory param must be set
+        # DNS-AID compliance: mandatory param must be set
         assert params["mandatory"] == "alpn,port"
 
-    def test_svcb_params_with_bandaid_custom_params_keynnnnn(self):
+    def test_svcb_params_with_dnsaid_custom_params_keynnnnn(self):
         """Test SVCB params emit keyNNNNN format by default."""
         agent = AgentRecord(
             name="booking",
@@ -131,14 +131,14 @@ class TestAgentRecord:
         # Default: keyNNNNN format per RFC 9460
         assert params["key65001"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["key65002"] == "abc123base64url"
-        assert params["key65003"] == "mcp/1,a2a/1"
+        assert params["key65010"] == "mcp/1,a2a/1"
         assert params["key65004"] == "https://example.com/agent-policy"
         assert params["key65005"] == "production"
         # Standard params still present
         assert params["alpn"] == "mcp"
         assert params["port"] == "443"
 
-    def test_svcb_params_with_bandaid_custom_params_string_keys(self):
+    def test_svcb_params_with_dnsaid_custom_params_string_keys(self):
         """Test SVCB params emit string names when DNS_AID_SVCB_STRING_KEYS=1."""
         import os
         from unittest.mock import patch
@@ -164,8 +164,8 @@ class TestAgentRecord:
         assert params["policy"] == "https://example.com/agent-policy"
         assert params["realm"] == "production"
 
-    def test_svcb_params_without_bandaid_params(self):
-        """Test SVCB params exclude BANDAID custom params when None/empty."""
+    def test_svcb_params_without_dnsaid_params(self):
+        """Test SVCB params exclude DNS-AID custom params when None/empty."""
         agent = AgentRecord(
             name="chat",
             domain="example.com",
@@ -184,8 +184,8 @@ class TestAgentRecord:
         assert params["alpn"] == "a2a"
         assert params["port"] == "443"
 
-    def test_svcb_params_partial_bandaid_params(self):
-        """Test SVCB params with only some BANDAID params set."""
+    def test_svcb_params_partial_dnsaid_params(self):
+        """Test SVCB params with only some DNS-AID params set."""
         agent = AgentRecord(
             name="booking",
             domain="example.com",
@@ -202,7 +202,7 @@ class TestAgentRecord:
         assert params["key65001"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["key65005"] == "demo"
         assert "key65002" not in params
-        assert "key65003" not in params
+        assert "key65010" not in params
         assert "key65004" not in params
 
     def test_svcb_params_cap_sha256_without_cap_uri(self):

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -141,19 +141,19 @@ class TestPublish:
         assert result.agent.policy_uri == "https://example.com/agent-policy"
         assert result.agent.realm == "production"
 
-        # SVCB params should include custom BANDAID params
+        # SVCB params should include custom DNS-AID params
         svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
         assert svcb is not None
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65001"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65002"] == "dGVzdGhhc2g"
-        assert svcb["params"]["key65003"] == "mcp/1,a2a/1"
+        assert svcb["params"]["key65010"] == "mcp/1,a2a/1"
         assert svcb["params"]["key65004"] == "https://example.com/agent-policy"
         assert svcb["params"]["key65005"] == "production"
 
     @pytest.mark.asyncio
     async def test_publish_without_cap_uri_unchanged(self, mock_backend: MockBackend):
-        """Test publishing without cap_uri doesn't add BANDAID params (backwards compat)."""
+        """Test publishing without cap_uri doesn't add DNS-AID params (backwards compat)."""
         result = await publish(
             name="chat",
             domain="example.com",
@@ -178,8 +178,8 @@ class TestPublish:
         assert "realm" not in svcb["params"]
 
     @pytest.mark.asyncio
-    async def test_publish_with_partial_bandaid_params(self, mock_backend: MockBackend):
-        """Test publishing with only some BANDAID params."""
+    async def test_publish_with_partial_dnsaid_params(self, mock_backend: MockBackend):
+        """Test publishing with only some DNS-AID params."""
         result = await publish(
             name="booking",
             domain="example.com",
@@ -195,7 +195,7 @@ class TestPublish:
         assert svcb is not None
         assert svcb["params"]["key65001"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65005"] == "demo"
-        assert "key65003" not in svcb["params"]
+        assert "key65010" not in svcb["params"]
         assert "key65004" not in svcb["params"]
 
 

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -568,7 +568,7 @@ class TestRoute53PublishAgentParamDemotion:
 
     @pytest.mark.asyncio
     async def test_publish_strips_custom_svcb_params(self):
-        """Custom BANDAID params (key65001+) must not appear in SVCB record."""
+        """Custom DNS-AID params (key65001+) must not appear in SVCB record."""
         from dns_aid.core.models import AgentRecord, Protocol
 
         agent = AgentRecord(
@@ -608,7 +608,7 @@ class TestRoute53PublishAgentParamDemotion:
             "ResourceRecords"
         ]
         txt_strings = [v["Value"] for v in txt_values]
-        assert any("bandaid_key65005=demo" in s for s in txt_strings)
+        assert any("dnsaid_key65005=demo" in s for s in txt_strings)
 
     @pytest.mark.asyncio
     async def test_publish_no_custom_params_unchanged(self):
@@ -632,17 +632,17 @@ class TestRoute53PublishAgentParamDemotion:
             records = await backend.publish_agent(agent)
 
         assert len(records) == 2
-        # No bandaid_ entries in TXT
+        # No dnsaid_ entries in TXT
         txt_call = mock_client.change_resource_record_sets.call_args_list[1]
         txt_values = txt_call[1]["ChangeBatch"]["Changes"][0]["ResourceRecordSet"][
             "ResourceRecords"
         ]
         txt_strings = [v["Value"] for v in txt_values]
-        assert not any("bandaid_" in s for s in txt_strings)
+        assert not any("dnsaid_" in s for s in txt_strings)
 
     @pytest.mark.asyncio
     async def test_publish_demotes_multiple_custom_params(self):
-        """All custom BANDAID params get demoted to TXT."""
+        """All custom DNS-AID params get demoted to TXT."""
         from dns_aid.core.models import AgentRecord, Protocol
 
         agent = AgentRecord(
@@ -669,7 +669,7 @@ class TestRoute53PublishAgentParamDemotion:
         svcb_value = svcb_call[1]["ChangeBatch"]["Changes"][0]["ResourceRecordSet"][
             "ResourceRecords"
         ][0]["Value"]
-        for custom_key in ("key65003", "key65004", "key65005"):
+        for custom_key in ("key65010", "key65004", "key65005"):
             assert custom_key not in svcb_value
 
         # TXT must contain all three demoted params
@@ -678,6 +678,6 @@ class TestRoute53PublishAgentParamDemotion:
             "ResourceRecords"
         ]
         txt_strings = " ".join(v["Value"] for v in txt_values)
-        assert "bandaid_key65003" in txt_strings  # bap
-        assert "bandaid_key65004" in txt_strings  # policy
-        assert "bandaid_key65005" in txt_strings  # realm
+        assert "dnsaid_key65010" in txt_strings  # bap
+        assert "dnsaid_key65004" in txt_strings  # policy
+        assert "dnsaid_key65005" in txt_strings  # realm

--- a/tsc/CHARTER.md
+++ b/tsc/CHARTER.md
@@ -6,7 +6,7 @@ This Technical Charter sets forth the responsibilities and procedures for techni
 
 ## 1. Mission and Scope
 
-The mission of the Project is to provide a reference implementation and open-source toolkit for DNS-based Agent Identification and Discovery (DNS-AID), as specified in IETF draft-mozleywilliams-dnsop-bandaid. The Project enables AI agents to discover each other using existing DNS infrastructure, without centralized registries.
+The mission of the Project is to provide a reference implementation and open-source toolkit for DNS-based Agent Identification and Discovery (DNS-AID), as specified in IETF draft-mozleywilliams-dnsop-dnsaid. The Project enables AI agents to discover each other using existing DNS infrastructure, without centralized registries.
 
 The scope includes:
 
@@ -15,7 +15,7 @@ The scope includes:
 - CLI tool for operators
 - MCP server for AI agent integration
 - Documentation, examples, and test suites
-- Alignment with IETF BANDAID draft specifications
+- Alignment with IETF DNS-AID draft specifications
 
 ## 2. Technical Steering Committee (TSC)
 
@@ -26,7 +26,7 @@ The TSC is responsible for all technical oversight of the Project. Initially, th
 - Setting the technical direction of the Project
 - Approving project releases
 - Creating sub-projects or working groups
-- Managing the project's relationship with the IETF BANDAID draft
+- Managing the project's relationship with the IETF DNS-AID draft
 - Ensuring alignment with Linux Foundation policies
 - Resolving technical disputes
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.7.3"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **SVCB AliasMode (priority 0)** — Discoverer follows alias records to resolve canonical ServiceMode targets per RFC 9460 and IETF draft §4.4.2
- **SVCB ipv4hint/ipv6hint** — Extract address hints (SvcParamKey 4, 6) to reduce follow-up A/AAAA queries per IETF draft §4.4.2
- **DANE dynamic verification** — `verify()` returns context-aware `dane_note` messages (advisory vs full cert matching) with DNSSEC coupling warning per IETF draft §4.4.1
- **BANDAID → DNS-AID rename** — All references updated across 35 files (source, tests, docs, metadata). Draft reference updated from `bandaid-02` to `dnsaid-01`. TXT prefix changed from `bandaid_` to `dnsaid_`
- **`bap` SvcParamKey fix** — Changed from `key65003` to `key65010` to match IETF draft §4.4.3 example
- **Version bump** — 0.7.3 → 0.8.0

### Breaking Changes

- `bap` SvcParamKey changed from `key65003` to `key65010` — existing DNS records using `key65003` for bap must be re-published
- TXT record prefix changed from `bandaid_` to `dnsaid_` — existing demoted TXT records (Route53, Cloudflare) must be re-published

## Test plan

- [x] `uv run pytest tests/ -x -q` — 750 passed, 32 skipped, 0 failures
- [x] `uv run ruff check src/dns_aid/` — all checks passed
- [x] `uv run ruff format --check src/dns_aid/` — 50 files formatted
- [x] `uv run mypy src/dns_aid/` — no issues in 50 source files
- [x] Verified zero remaining `BANDAID`/`bandaid` references via grep
- [x] Verified zero remaining `key65003` references via grep
- [x] Cross-checked all changes against full IETF draft-mozleywilliams-dnsop-dnsaid-01 text