### PR TITLE
feat: 4-tier capability resolution chain, ipv4/ipv6 hints (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-03-06
+
+### Added
+- **`ipv4_hint` / `ipv6_hint` publish parameters** — `publish()`, CLI (`--ipv4hint`, `--ipv6hint`), and MCP server now accept address hints for SVCB records (RFC 9460 SvcParamKey 4 and 6), reducing follow-up A/AAAA query round trips
+- **4-tier capability resolution chain** — Capabilities now resolve with priority: SVCB `cap` URI → A2A Agent Card skills (`.well-known/agent-card.json`) → HTTP Index → TXT record fallback. New `capability_source` values: `agent_card`, `http_index`
+- **Multi-format capability document parsing** — `cap_fetcher` handles three JSON formats: DNS-AID native string list, non-standard object list (`[{"name": "..."}]`), and A2A skills array (`[{"id": "...", "name": "..."}]`)
+- **Single-fetch optimization** — When a `cap` URI points to an A2A Agent Card, the document is parsed once and reused as `agent_card` — no redundant HTTP fetch for `.well-known/agent-card.json`
+
+### Changed
+- **A2A Agent Card well-known path** — Changed from `/.well-known/agent.json` to `/.well-known/agent-card.json` per the A2A specification
+- **`capability_source` expanded** — Now a 5-value Literal: `cap_uri`, `agent_card`, `http_index`, `txt_fallback`, `none`
+- **HTTP Index capabilities** — `Capability` dataclass now carries a `capabilities: list[str]` field, merged into agent records during HTTP index discovery
+
 ## [0.9.0] - 2026-02-24
 
 ### Changed
@@ -184,7 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **A2A Agent Card Support** (`src/dns_aid/core/a2a_card.py`)
   - Typed dataclasses: `A2AAgentCard`, `A2ASkill`, `A2AAuthentication`, `A2AProvider`
-  - `fetch_agent_card()` — fetches from `/.well-known/agent.json`
+  - `fetch_agent_card()` — fetches from `/.well-known/agent-card.json`
   - `fetch_agent_card_from_domain()` — convenience wrapper
   - `card.to_capabilities()` — converts A2A skills to DNS-AID capability format
   - Discovery automatically attaches `agent_card` to discovered agents
@@ -466,7 +479,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.3...v0.8.0
 [0.7.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.1...v0.7.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.8.0"
-date-released: "2026-02-21"
+version: "0.10.0"
+date-released: "2026-03-06"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ dns-aid publish \
     --protocol mcp \
     --endpoint agent.example.com \
     --capability chat \
-    --capability code-review
+    --capability code-review \
+    --ipv4hint 203.0.113.10 \
+    --ipv6hint 2001:db8::1
 
 # Publish with DNS-AID custom SVCB parameters
 dns-aid publish \
@@ -234,13 +236,14 @@ agents = await dns_aid.discover("example.com", use_http_index=True)
 
 | Field | Values | Description |
 |-------|--------|-------------|
-| `endpoint_source` | `dns_svcb`, `http_index_fallback`, `direct` | How the endpoint was resolved |
-| `capability_source` | `cap_uri`, `txt_fallback`, `none` | How capabilities were discovered |
+| `endpoint_source` | `dns_svcb`, `dns_svcb_enriched`, `http_index`, `http_index_fallback`, `direct` | How the endpoint was resolved |
+| `capability_source` | `cap_uri`, `agent_card`, `http_index`, `txt_fallback`, `none` | How capabilities were discovered |
 
 **Capability Resolution:** Capabilities are resolved with the following priority:
-1. **SVCB `cap` URI** → fetch capability document (JSON with capabilities, version, description)
-2. **TXT record fallback** → `capabilities=chat,support` from DNS TXT record
-3. **HTTP Index inline** → capabilities embedded in the index JSON response
+1. **SVCB `cap` URI** → fetch capability document (JSON with capabilities, version, description). If the cap document is an A2A Agent Card, skills are also extracted and the card is reused (no redundant HTTP fetch).
+2. **A2A Agent Card** → skills from `/.well-known/agent-card.json` (skill IDs become capabilities)
+3. **HTTP Index** → capabilities embedded in the index JSON response
+4. **TXT record fallback** → `capabilities=chat,support` from DNS TXT record
 
 ## MCP Server
 
@@ -342,6 +345,8 @@ _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
 | `bap` | Supported bulk agent protocols with versioning |
 | `policy` | URI to agent policy document |
 | `realm` | Multi-tenant scope identifier |
+| `ipv4hint` | IPv4 address hint to reduce follow-up A queries (RFC 9460 SvcParamKey 4) |
+| `ipv6hint` | IPv6 address hint to reduce follow-up AAAA queries (RFC 9460 SvcParamKey 6) |
 
 > **Note:** Route 53 and Cloudflare do not support private-use SVCB SvcParamKeys (`key65400`–`key65405`).
 > DNS-AID automatically demotes these parameters to TXT records with a `dnsaid_` prefix (e.g.,
@@ -398,7 +403,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
 ```
 
 **Index Resolution Priority:** HTTP index endpoint → TXT index record → common name probing.
-**Capability Resolution Priority:** SVCB `cap` URI → capability document → TXT record fallback.
+**Capability Resolution Priority:** SVCB `cap` URI → A2A Agent Card skills → HTTP Index → TXT record fallback.
 Each discovered agent includes `endpoint_source` and `capability_source` showing which path was used.
 
 ## Security: DNSSEC and DANE

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -89,6 +89,8 @@ async def publish(
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
+    ipv4_hint: str | None = None,
+    ipv6_hint: str | None = None,
 ) -> PublishResult
 ```
 
@@ -111,6 +113,8 @@ async def publish(
 | `bap` | `list[str]` | No | `None` | Supported protocols with versions (e.g., `["mcp/1", "a2a/1"]`) |
 | `policy_uri` | `str` | No | `None` | URI to agent policy document |
 | `realm` | `str` | No | `None` | Multi-tenant scope identifier |
+| `ipv4_hint` | `str` | No | `None` | IPv4 address hint for SVCB record (reduces A query round trips) |
+| `ipv6_hint` | `str` | No | `None` | IPv6 address hint for SVCB record (reduces AAAA query round trips) |
 
 #### Returns
 
@@ -280,8 +284,8 @@ agent = AgentRecord(
 | `bap` | `list[str]` | No | `[]` | Supported protocols with versions |
 | `policy_uri` | `str` | No | `None` | URI to agent policy document |
 | `realm` | `str` | No | `None` | Multi-tenant scope identifier |
-| `capability_source` | `str` | No | `None` | Where capabilities came from: `cap_uri`, `txt_fallback`, `none` |
-| `endpoint_source` | `str` | No | `None` | Where endpoint came from: `dns_svcb`, `http_index_fallback`, `direct` |
+| `capability_source` | `str` | No | `None` | Where capabilities came from: `cap_uri`, `agent_card`, `http_index`, `txt_fallback`, `none` |
+| `endpoint_source` | `str` | No | `None` | Where endpoint came from: `dns_svcb`, `dns_svcb_enriched`, `http_index`, `http_index_fallback`, `direct` |
 
 #### Properties
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,12 +30,22 @@ Agent discovered via SVCB record
 ├─ SVCB has cap= parameter?
 │  YES → Fetch capability document from cap URI
 │        Parse: capabilities, version, description, use_cases, category
+│        If document is an A2A Agent Card → also attach agent_card (reuse, no second fetch)
 │        Set capability_source = "cap_uri"
 │
-├─ cap URI missing or fetch failed?
-│  → Query TXT record for capabilities= field
-│    Parse: capabilities only
-│    Set capability_source = "txt_fallback"
+├─ cap URI missing or fetch failed? → Try A2A Agent Card
+│  Fetch /.well-known/agent-card.json from target host
+│  If skills present → extract skill IDs as capabilities
+│  Set capability_source = "agent_card"
+│
+├─ No agent card? → Try HTTP Index
+│  If agent has capabilities from HTTP index response
+│  Set capability_source = "http_index"
+│
+├─ No HTTP index? → TXT record fallback
+│  Query TXT record for capabilities= field
+│  Parse: capabilities only
+│  Set capability_source = "txt_fallback"
 │
 └─ No TXT record either?
    → capabilities = [], capability_source = "none"
@@ -68,7 +78,7 @@ SVCB record found?
 ├─ YES → endpoint from SVCB target + port
 │        Set endpoint_source = "dns_svcb"
 │        │
-│        └─ .well-known/agent.json has endpoints.{protocol}?
+│        └─ .well-known/agent-card.json has endpoints.{protocol}?
 │           YES → append path to endpoint
 │                 Set endpoint_source = "dns_svcb_enriched"
 │
@@ -212,18 +222,18 @@ SDK invoke() → InvocationSignal
 ### Endpoint Path Resolution
 
 DNS SVCB records provide host + port but no HTTP path. The discoverer now
-enriches endpoints by fetching `.well-known/agent.json` from each agent's
+enriches endpoints by fetching `.well-known/agent-card.json` from each agent's
 target host:
 
 ```
 DNS SVCB → booking.example.com:443    (host + port)
-.well-known/agent.json → endpoints.mcp = "/mcp"
+.well-known/agent-card.json → endpoints.mcp = "/mcp"
 Result → https://booking.example.com:443/mcp
          endpoint_source = "dns_svcb_enriched"
 ```
 
 Enrichment runs concurrently for all discovered agents, deduplicates by host,
-and gracefully skips hosts that don't serve `.well-known/agent.json`.
+and gracefully skips hosts that don't serve `.well-known/agent-card.json`.
 
 ---
 

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -183,7 +183,7 @@ dns-aid discover example.com --use-http-index
 # Fetch the A2A agent card from discovered endpoint
 # Note: ngrok free tier requires the skip-browser-warning header
 curl -H "ngrok-skip-browser-warning: true" \
-  https://abc123.ngrok-free.app/.well-known/agent.json | jq .
+  https://abc123.ngrok-free.app/.well-known/agent-card.json | jq .
 
 # Chat with the agent
 curl -X POST https://abc123.ngrok-free.app/api/chat \
@@ -265,7 +265,7 @@ async def discover_and_connect():
 
     async with httpx.AsyncClient(timeout=30) as client:
         # Fetch A2A agent card
-        resp = await client.get(f"{endpoint}/.well-known/agent.json")
+        resp = await client.get(f"{endpoint}/.well-known/agent-card.json")
         agent_card = resp.json()
 
         print(f"   Agent: {agent_card['name']}")
@@ -330,7 +330,7 @@ async def main():
     # Connect and interact
     print(f"\n🔗 Connecting to {agent.endpoint_url}...")
     async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.get(f"{agent.endpoint_url}/.well-known/agent.json")
+        resp = await client.get(f"{agent.endpoint_url}/.well-known/agent-card.json")
         card = resp.json()
         print(f"   Agent: {card['name']} v{card['version']}")
         print(f"   Tools: {sum(s['tools_count'] for s in card['skills'])} total")
@@ -381,7 +381,7 @@ echo "Endpoint: $ENDPOINT"
 # Fetch agent card (ngrok free tier needs this header)
 echo ""
 echo "Agent Card:"
-curl -s -H "ngrok-skip-browser-warning: true" "$ENDPOINT/.well-known/agent.json" | jq '{name, version, skills: [.skills[].name]}'
+curl -s -H "ngrok-skip-browser-warning: true" "$ENDPOINT/.well-known/agent-card.json" | jq '{name, version, skills: [.skills[].name]}'
 
 # Check health
 echo ""
@@ -573,7 +573,7 @@ async def run_demo():
             health = resp.json()
             print(f"   ✓ Health: {health.get('status', 'unknown')}")
 
-            resp = await client.get(f"{agent.endpoint_url}/.well-known/agent.json")
+            resp = await client.get(f"{agent.endpoint_url}/.well-known/agent-card.json")
             card = resp.json()
             print(f"   ✓ Agent: {card['name']} v{card['version']}")
         except Exception as e:
@@ -715,8 +715,8 @@ Found 5 flights from NYC to London on March 15:
 | **MCP Path Routing** | Endpoint URLs like `https://host/mcp` route correctly |
 | **Agent Proxying** | `call_agent_tool` and `list_agent_tools` for remote agents |
 | **Fallback Logic** | Uses domain:443 if no explicit endpoint provided |
-| **endpoint_source** | Shows where endpoint came from: `dns_svcb`, `http_index_fallback`, or `direct` |
-| **capability_source** | Shows where capabilities came from: `cap_uri`, `txt_fallback`, or `none` |
+| **endpoint_source** | Shows where endpoint came from: `dns_svcb`, `dns_svcb_enriched`, `http_index`, `http_index_fallback`, `direct`, or `directory` |
+| **capability_source** | Shows where capabilities came from: `cap_uri`, `agent_card`, `http_index`, `txt_fallback`, or `none` |
 
 ### Capability Discovery Flow
 
@@ -726,16 +726,23 @@ Capabilities are resolved with the following priority, aligned with the DNS-AID 
 ┌─────────────────────────────────────────────────────────────────┐
 │              Capability Resolution Priority                      │
 │                                                                 │
-│  1. SVCB cap URI    ──►  GET /cap/{agent}  ──►  Capability JSON │
+│  1. SVCB cap URI    ──►  GET cap document  ──►  Capability JSON │
 │     (key65400)           (fetch document)       (authoritative) │
 │         │                                                       │
 │         ▼ (fallback if cap URI absent or fetch fails)           │
-│  2. TXT Record      ──►  "capabilities=travel,booking"          │
-│                          (inline in DNS)                        │
+│  2. A2A Agent Card  ──►  /.well-known/agent-card.json skills    │
+│                          (extracted from A2A card)              │
 │         │                                                       │
-│         ▼ (HTTP Index path)                                     │
+│         ▼ (fallback if no agent card)                           │
 │  3. HTTP Index      ──►  capabilities array inline in JSON      │
 │                          (ANS-compatible, richest metadata)     │
+│         │                                                       │
+│         ▼ (fallback if no HTTP index)                           │
+│  4. TXT Record      ──►  "capabilities=travel,booking"          │
+│                          (inline in DNS, basic)                 │
+│         │                                                       │
+│         ▼ (if all fail)                                         │
+│  5. none            ──►  No capabilities resolved               │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -765,9 +772,14 @@ Each discovered agent includes transparency fields showing how data was resolved
 | Field | Values | Meaning |
 |-------|--------|---------|
 | `endpoint_source` | `dns_svcb` | Endpoint from authoritative DNS SVCB lookup (proper DNS-AID flow) |
+| | `dns_svcb_enriched` | DNS SVCB + `.well-known/agent-card.json` path appended |
+| | `http_index` | DNS + HTTP index provided the endpoint |
 | | `http_index_fallback` | DNS lookup failed, using HTTP index data only |
 | | `direct` | Endpoint was explicitly provided |
+| | `directory` | From directory API search (Phase 5.7) |
 | `capability_source` | `cap_uri` | Capabilities fetched from SVCB `cap` URI document |
+| | `agent_card` | Capabilities extracted from A2A `.well-known/agent-card.json` skills |
+| | `http_index` | Capabilities from HTTP index inline array |
 | | `txt_fallback` | Capabilities from DNS TXT record |
 | | `none` | No capabilities found |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1045,12 +1045,14 @@ Each discovered agent includes transparency fields showing how data was resolved
 | | `http_index_fallback` | DNS lookup failed, using HTTP index data only |
 | | `direct` | Endpoint was explicitly provided |
 | `capability_source` | `cap_uri` | Capabilities fetched from SVCB `cap` URI document |
+| | `agent_card` | Capabilities from A2A Agent Card skills (`.well-known/agent-card.json`) |
+| | `http_index` | Capabilities from HTTP index response |
 | | `txt_fallback` | Capabilities from DNS TXT record |
 | | `none` | No capabilities found |
 
 Agent name and protocol are extracted from the FQDN in the HTTP index — no separate `protocols` field needed. The FQDN is the single source of truth.
 
-Capabilities are resolved with priority: SVCB `cap` URI → capability document → TXT record fallback. The HTTP index also includes capabilities inline per agent.
+Capabilities are resolved with priority: SVCB `cap` URI → A2A Agent Card skills → HTTP Index → TXT record fallback. When the cap URI points to an A2A Agent Card, the document is parsed once and reused — no redundant HTTP fetch for `.well-known/agent-card.json`.
 
 ### DNS-AID Custom SVCB Parameters
 
@@ -1078,8 +1080,10 @@ dns-aid publish \
 | `bap` | `--bap` | Supported protocols with versions (comma-separated) |
 | `policy` | `--policy-uri` | URI to agent policy document |
 | `realm` | `--realm` | Multi-tenant scope identifier |
+| `ipv4hint` | `--ipv4hint` | IPv4 address hint (RFC 9460 SvcParamKey 4) |
+| `ipv6hint` | `--ipv6hint` | IPv6 address hint (RFC 9460 SvcParamKey 6) |
 
-**Discovery priority:** When discovering agents, DNS-AID fetches capabilities from the `cap` URI first, falling back to TXT record capabilities if the fetch fails. The `capability_source` field shows the source: `cap_uri` or `txt_fallback`.
+**Discovery priority:** When discovering agents, DNS-AID resolves capabilities with the following chain: SVCB `cap` URI → A2A Agent Card (`.well-known/agent-card.json`) skills → HTTP Index → TXT record fallback. The `capability_source` field shows the source: `cap_uri`, `agent_card`, `http_index`, or `txt_fallback`.
 
 ### Live Demo with Claude Desktop
 
@@ -1184,7 +1188,7 @@ python examples/demo_full.py
 
 ## Experimental Models
 
-The following modules define forward-looking data models for `.well-known/agent.json`
+The following modules define forward-looking data models for `.well-known/agent-card.json`
 enrichment. They are **defined but not yet wired** into `discover()` or `publish()`:
 
 - `dns_aid.core.agent_metadata` — `AgentMetadata` schema (identity, connection, auth, capabilities, contact)
@@ -1192,7 +1196,7 @@ enrichment. They are **defined but not yet wired** into `discover()` or `publish
 
 These models are available for import and experimentation but are not part of the
 stable public API. They will be integrated in a future release once the
-`.well-known/agent.json` enrichment pipeline is finalized.
+`.well-known/agent-card.json` enrichment pipeline is finalized.
 
 ## Next Steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.9.0"
+version = "0.10.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -121,6 +121,14 @@ def publish(
         str | None,
         typer.Option("--realm", help="Multi-tenant scope identifier (e.g., 'production', 'demo')"),
     ] = None,
+    ipv4hint: Annotated[
+        list[str] | None,
+        typer.Option("--ipv4hint", help="IPv4 address hint for SVCB record (repeatable)"),
+    ] = None,
+    ipv6hint: Annotated[
+        list[str] | None,
+        typer.Option("--ipv6hint", help="IPv6 address hint for SVCB record (repeatable)"),
+    ] = None,
     no_update_index: Annotated[
         bool,
         typer.Option("--no-update-index", help="Don't update the domain's agent index record"),
@@ -152,6 +160,10 @@ def publish(
         dns-aid publish -n booking -d example.com -p mcp \\
           --cap-uri https://mcp.example.com/.well-known/agent-cap.json \\
           --bap mcp --realm production
+
+        # With address hints (skip extra A/AAAA lookup):
+        dns-aid publish -n triage -d example.com -p a2a \\
+          --ipv4hint 203.0.113.10 --ipv4hint 203.0.113.11
 
         # With JWS signing (alternative to DNSSEC):
         dns-aid publish -n booking -d example.com -p mcp \\
@@ -195,6 +207,8 @@ def publish(
             bap=bap_list,
             policy_uri=policy_uri,
             realm=realm,
+            ipv4_hint=",".join(ipv4hint) if ipv4hint else None,
+            ipv6_hint=",".join(ipv6hint) if ipv6hint else None,
             sign=sign,
             private_key_path=private_key,
         )

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -4,7 +4,7 @@
 """
 A2A Agent Card — Google's Agent-to-Agent protocol agent description format.
 
-The Agent Card is a JSON document served at `/.well-known/agent.json` that
+The Agent Card is a JSON document served at `/.well-known/agent-card.json` that
 describes an agent's capabilities, authentication requirements, and metadata.
 
 Reference: https://google.github.io/A2A/
@@ -22,7 +22,7 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 # Well-known path for A2A Agent Cards
-A2A_AGENT_CARD_PATH = "/.well-known/agent.json"
+A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
 
 
 @dataclass
@@ -78,7 +78,7 @@ class A2AAgentCard:
     """
     Google A2A Agent Card — the canonical agent description format.
 
-    Fetched from: https://{domain}/.well-known/agent.json
+    Fetched from: https://{domain}/.well-known/agent-card.json
 
     Attributes:
         name: Human-readable agent name.
@@ -175,7 +175,7 @@ async def fetch_agent_card(
     Fetch an A2A Agent Card from the well-known location.
 
     Given an agent endpoint (e.g., "https://agent.example.com"), fetches
-    the Agent Card from "https://agent.example.com/.well-known/agent.json".
+    the Agent Card from "https://agent.example.com/.well-known/agent-card.json".
 
     Args:
         endpoint: Agent's base URL (scheme + host).

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -41,6 +41,7 @@ class CapabilityDocument:
     description: str | None = None
     use_cases: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    raw_data: dict[str, Any] = field(default_factory=dict)
 
 
 def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bool:
@@ -70,6 +71,47 @@ def _extract_string_list(data: dict[str, Any], key: str) -> list[str]:
     value = data.get(key, [])
     if isinstance(value, list):
         return [str(item) for item in value if item]
+    return []
+
+
+def _extract_capabilities_multi_format(data: dict[str, Any]) -> list[str]:
+    """Extract capabilities from multiple JSON formats.
+
+    Handles three formats encountered in the wild:
+    1. DNS-AID native: {"capabilities": ["travel", "booking"]}
+    2. Non-standard object list: {"capabilities": [{"name": "travel"}]}
+    3. A2A agent card: {"skills": [{"id": "travel", "name": "Travel Booking"}]}
+
+    Priority: capabilities (string list) > capabilities (object list) > skills
+    """
+    # Try "capabilities" field first
+    caps = data.get("capabilities")
+    if isinstance(caps, list) and caps:
+        first = caps[0]
+        if isinstance(first, str):
+            # Format 1: string list — DNS-AID native
+            return [str(c) for c in caps if c]
+        elif isinstance(first, dict):
+            # Format 2: object list — extract "name" or "id"
+            result = []
+            for item in caps:
+                if isinstance(item, dict):
+                    name = item.get("name") or item.get("id") or ""
+                    if name:
+                        result.append(str(name))
+            return result
+
+    # Try A2A "skills" field
+    skills = data.get("skills")
+    if isinstance(skills, list) and skills:
+        result = []
+        for skill in skills:
+            if isinstance(skill, dict):
+                skill_id = skill.get("id") or skill.get("name") or ""
+                if skill_id:
+                    result.append(str(skill_id))
+        return result
+
     return []
 
 
@@ -130,7 +172,7 @@ async def fetch_cap_document(
                 )
                 return None
 
-            capabilities = _extract_string_list(data, "capabilities")
+            capabilities = _extract_capabilities_multi_format(data)
             use_cases = _extract_string_list(data, "use_cases")
 
             known_keys = {"capabilities", "version", "description", "use_cases"}
@@ -142,6 +184,7 @@ async def fetch_cap_document(
                 description=data.get("description"),
                 use_cases=use_cases,
                 metadata=metadata,
+                raw_data=data,
             )
 
             logger.debug(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -20,7 +20,7 @@ import dns.rdatatype
 import dns.resolver
 import structlog
 
-from dns_aid.core.a2a_card import fetch_agent_card
+from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
 from dns_aid.core.http_index import HttpIndexAgent, fetch_http_index_or_empty
 from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol
@@ -120,7 +120,7 @@ async def discover(
         use_http_index: If True, fetch agent list from HTTP endpoint
                         (/.well-known/agents-index.json) instead of using
                         DNS-only discovery. Default False (pure DNS).
-        enrich_endpoints: If True (default), fetch .well-known/agent.json
+        enrich_endpoints: If True (default), fetch .well-known/agent-card.json
                          from each discovered agent's host to resolve
                          protocol-specific endpoint paths (e.g., /mcp).
         verify_signatures: If True, verify JWS signatures on agents that have
@@ -281,7 +281,10 @@ async def _query_single_agent(
 
             # Discovery priority: cap URI first, then TXT fallback
             capabilities: list[str] = []
-            capability_source: Literal["cap_uri", "txt_fallback", "none"] = "none"
+            capability_source: Literal[
+                "cap_uri", "agent_card", "http_index", "txt_fallback", "none"
+            ] = "none"
+            agent_card = None
 
             if cap_uri:
                 cap_doc = await fetch_cap_document(cap_uri, expected_sha256=cap_sha256)
@@ -294,6 +297,19 @@ async def _query_single_agent(
                         cap_uri=cap_uri,
                         capabilities=capabilities,
                     )
+
+                # Reuse raw data as A2AAgentCard (avoids redundant fetch later)
+                if cap_doc and cap_doc.raw_data:
+                    try:
+                        agent_card = A2AAgentCard.from_dict(cap_doc.raw_data)
+                        logger.debug(
+                            "Parsed A2A Agent Card from cap URI response",
+                            fqdn=fqdn,
+                            card_name=agent_card.name,
+                            skills_count=len(agent_card.skills),
+                        )
+                    except Exception:
+                        pass  # Not an agent card format — that's fine
 
             if not capabilities:
                 capabilities = await _query_capabilities(fqdn)
@@ -316,6 +332,7 @@ async def _query_single_agent(
                 realm=realm,
                 capability_source=capability_source,
                 endpoint_source="dns_svcb",  # Endpoint resolved via DNS SVCB lookup
+                agent_card=agent_card,
             )
 
     except Exception as e:
@@ -513,6 +530,16 @@ def _enrich_from_http_index(agent: AgentRecord, http_agent: HttpIndexAgent) -> N
     ):
         agent.use_cases.append(f"modality:{http_agent.capability.modality}")
 
+    # Merge HTTP index capabilities (only if agent has none from higher-priority source)
+    if not agent.capabilities and http_agent.capability and http_agent.capability.capabilities:
+        agent.capabilities = http_agent.capability.capabilities
+        agent.capability_source = "http_index"
+        logger.debug(
+            "Merged HTTP index capabilities",
+            agent=agent.name,
+            capabilities=agent.capabilities,
+        )
+
     if http_agent.endpoint and not agent.endpoint_override:
         parsed = urlparse(http_agent.endpoint)
         if parsed.path and parsed.path != "/":
@@ -660,24 +687,73 @@ def _http_agent_to_record(
         ):
             target_host = http_agent.fqdn.rstrip(".")
 
+    # Extract capabilities from HTTP index if available
+    http_capabilities: list[str] = []
+    cap_source: Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] = "none"
+    if http_agent.capability and http_agent.capability.capabilities:
+        http_capabilities = http_agent.capability.capabilities
+        cap_source = "http_index"
+
     return AgentRecord(
         name=agent_name,
         domain=domain,
         protocol=agent_protocol,
         target_host=target_host,
         port=port,
-        capabilities=[],
+        capabilities=http_capabilities,
+        capability_source=cap_source,
         description=http_agent.description,
         endpoint_override=http_agent.endpoint,
         endpoint_source="http_index_fallback",
     )
 
 
+def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
+    """Apply A2A Agent Card data to an agent record.
+
+    Stores the card, wires skills → capabilities (if not already set),
+    and extracts endpoint paths from card metadata.
+    """
+    agent.agent_card = card
+
+    # Wire agent card skills → capabilities (if not already set by cap_uri)
+    if not agent.capabilities and card.skills:
+        agent.capabilities = card.to_capabilities()
+        agent.capability_source = "agent_card"
+        logger.debug(
+            "Capabilities from A2A Agent Card skills",
+            agent=agent.name,
+            capabilities=agent.capabilities,
+        )
+
+    # Extract endpoint path from card metadata if available
+    endpoints = card.metadata.get("endpoints")
+    if isinstance(endpoints, dict) and not agent.endpoint_override:
+        protocol_key = agent.protocol.value  # "mcp", "a2a", "https"
+        path = endpoints.get(protocol_key)
+        if path and isinstance(path, str):
+            agent.endpoint_override = f"https://{agent.target_host}:{agent.port}{path}"
+            agent.endpoint_source = "dns_svcb_enriched"
+            logger.debug(
+                "Enriched agent endpoint from agent card",
+                agent=agent.name,
+                endpoint=agent.endpoint_override,
+                path=path,
+            )
+
+    logger.debug(
+        "Applied A2A Agent Card to agent",
+        agent=agent.name,
+        card_name=card.name,
+        skills_count=len(card.skills),
+    )
+
+
 async def _enrich_agents_with_endpoint_paths(agents: list[AgentRecord]) -> None:
     """
-    Enrich discovered agents with data from .well-known/agent.json (A2A Agent Card).
+    Enrich discovered agents with data from .well-known/agent-card.json (A2A Agent Card).
 
-    For agents without an endpoint_override, fetches .well-known/agent.json
+    For agents without an endpoint_override, fetches .well-known/agent-card.json
     from their target host and:
     1. Extracts protocol-specific endpoint path (e.g., endpoints.mcp = "/mcp")
     2. Stores the full A2AAgentCard on the agent for skills, auth, etc.
@@ -689,12 +765,23 @@ async def _enrich_agents_with_endpoint_paths(agents: list[AgentRecord]) -> None:
     if not agents_to_enrich:
         return
 
+    # Apply already-fetched agent cards (from cap_uri optimization) to
+    # agents that need endpoint enrichment but already have card data
+    for agent in agents_to_enrich:
+        if agent.agent_card:
+            _apply_agent_card(agent, agent.agent_card)
+
+    # Filter to agents still needing a fetch (no agent_card yet)
+    agents_needing_fetch = [a for a in agents_to_enrich if not a.agent_card]
+    if not agents_needing_fetch:
+        return
+
     # Deduplicate by target_host to avoid redundant fetches
     hosts_to_agents: dict[str, list[AgentRecord]] = {}
-    for agent in agents_to_enrich:
+    for agent in agents_needing_fetch:
         hosts_to_agents.setdefault(agent.target_host, []).append(agent)
 
-    # Fetch .well-known/agent.json concurrently for all unique hosts
+    # Fetch .well-known/agent-card.json concurrently for all unique hosts
     async def _fetch_and_enrich(host: str, host_agents: list[AgentRecord]) -> None:
         # Use typed A2AAgentCard fetcher
         card = await fetch_agent_card(f"https://{host}")
@@ -702,31 +789,7 @@ async def _enrich_agents_with_endpoint_paths(agents: list[AgentRecord]) -> None:
             return
 
         for agent in host_agents:
-            # Store the full agent card for downstream use
-            agent.agent_card = card
-
-            # Extract endpoint path from card metadata if available
-            endpoints = card.metadata.get("endpoints")
-            if isinstance(endpoints, dict):
-                protocol_key = agent.protocol.value  # "mcp", "a2a", "https"
-                path = endpoints.get(protocol_key)
-                if path and isinstance(path, str):
-                    # Construct full endpoint URL with path
-                    agent.endpoint_override = f"https://{agent.target_host}:{agent.port}{path}"
-                    agent.endpoint_source = "dns_svcb_enriched"
-                    logger.debug(
-                        "Enriched agent endpoint from .well-known/agent.json",
-                        agent=agent.name,
-                        endpoint=agent.endpoint_override,
-                        path=path,
-                    )
-
-            logger.debug(
-                "Attached A2A Agent Card to agent",
-                agent=agent.name,
-                card_name=card.name,
-                skills_count=len(card.skills),
-            )
+            _apply_agent_card(agent, card)
 
     await asyncio.gather(
         *[_fetch_and_enrich(host, host_agents) for host, host_agents in hosts_to_agents.items()],

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -77,6 +77,7 @@ class Capability:
     cost: str | None = None  # free, paid, usage-based
     rate_limit: str | None = None
     authentication: str | None = None  # none, api_key, oauth
+    capabilities: list[str] = field(default_factory=list)  # agent capabilities
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> Capability:
@@ -86,12 +87,16 @@ class Capability:
         protocols = data.get("protocols", [])
         if isinstance(protocols, str):
             protocols = [protocols]
+        capabilities = data.get("capabilities", [])
+        if isinstance(capabilities, str):
+            capabilities = [capabilities]
         return cls(
             modality=data.get("modality"),
             protocols=protocols,
             cost=data.get("cost"),
             rate_limit=data.get("rate_limit") or data.get("rateLimit"),
             authentication=data.get("authentication"),
+            capabilities=[str(c) for c in capabilities if c],
         )
 
 

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -183,9 +183,13 @@ class AgentRecord(BaseModel):
     )
 
     # Capability source tracking
-    capability_source: Literal["cap_uri", "txt_fallback", "none"] | None = Field(
+    capability_source: (
+        Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] | None
+    ) = Field(
         default=None,
         description="Where capabilities were sourced from: 'cap_uri' (SVCB cap param), "
+        "'agent_card' (A2A /.well-known/agent-card.json skills), "
+        "'http_index' (HTTP index capabilities), "
         "'txt_fallback' (TXT record), or 'none'",
     )
 
@@ -211,16 +215,16 @@ class AgentRecord(BaseModel):
     ) = Field(
         default=None,
         description="Source of endpoint: 'dns_svcb' (from DNS SVCB record), "
-        "'dns_svcb_enriched' (DNS + .well-known/agent.json path), "
+        "'dns_svcb_enriched' (DNS + .well-known/agent-card.json path), "
         "'http_index' (DNS + HTTP index endpoint), "
         "'http_index_fallback' (HTTP index without DNS), 'direct' (explicitly provided), "
         "'directory' (from directory API search, Phase 5.7)",
     )
 
-    # A2A Agent Card (populated from .well-known/agent.json when available)
+    # A2A Agent Card (populated from .well-known/agent-card.json when available)
     agent_card: Any | None = Field(
         default=None,
-        description="Full A2A Agent Card from .well-known/agent.json. "
+        description="Full A2A Agent Card from .well-known/agent-card.json. "
         "Contains skills, authentication, provider info. Type: A2AAgentCard",
         exclude=True,  # Exclude from serialization by default
     )

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -82,6 +82,8 @@ async def publish(
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
+    ipv4_hint: str | None = None,
+    ipv6_hint: str | None = None,
     sign: bool = False,
     private_key_path: str | None = None,
 ) -> PublishResult:
@@ -109,6 +111,8 @@ async def publish(
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
+        ipv4_hint: IPv4 address hints for SVCB record (RFC 9460 key 4)
+        ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6)
         sign: If True, sign the record with JWS (requires private_key_path)
         private_key_path: Path to EC P-256 private key PEM file for signing
 
@@ -175,6 +179,8 @@ async def publish(
         bap=bap or [],
         policy_uri=policy_uri,
         realm=realm,
+        ipv4_hint=ipv4_hint,
+        ipv6_hint=ipv6_hint,
         sig=sig,
     )
 

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -358,7 +358,7 @@ async def _check_endpoint(target: str, port: int) -> dict:
             verify=True,
         ) as client:
             # Try health endpoint first, then root
-            for path in ["/health", "/.well-known/agent.json", "/"]:
+            for path in ["/health", "/.well-known/agent-card.json", "/"]:
                 try:
                     response = await client.get(f"{endpoint}{path}")
                     latency_ms = (time.perf_counter() - start_time) * 1000

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -216,6 +216,8 @@ def publish_agent_to_dns(
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
+    ipv4_hint: list[str] | None = None,
+    ipv6_hint: list[str] | None = None,
 ) -> dict:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -254,6 +256,10 @@ def publish_agent_to_dns(
             a `policy` parameter.
         realm: Multi-tenant scope identifier (e.g., "production", "staging").
             Included in the SVCB record as a `realm` parameter.
+        ipv4_hint: IPv4 address hints for SVCB record (RFC 9460 key 4).
+            Eliminates extra A record lookup for the target hostname.
+        ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6).
+            Eliminates extra AAAA record lookup for the target hostname.
 
     Returns:
         dict with:
@@ -307,6 +313,8 @@ def publish_agent_to_dns(
             bap=bap,
             policy_uri=policy_uri,
             realm=realm,
+            ipv4_hint=ipv4_hint,
+            ipv6_hint=ipv6_hint,
         )
 
     try:

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -224,7 +224,7 @@ class TestFetchAgentCard:
 
             # Verify the URL was constructed correctly
             call_args = mock_instance.get.call_args[0][0]
-            assert call_args == "https://agent.example.com/.well-known/agent.json"
+            assert call_args == "https://agent.example.com/.well-known/agent-card.json"
 
     @pytest.mark.asyncio
     async def test_fetch_404(self) -> None:
@@ -334,4 +334,4 @@ class TestFetchAgentCardFromDomain:
             await fetch_agent_card_from_domain("example.com")
 
             call_args = mock_instance.get.call_args[0][0]
-            assert call_args == "https://example.com/.well-known/agent.json"
+            assert call_args == "https://example.com/.well-known/agent-card.json"

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **4-tier capability resolution chain**: `cap_uri` > `agent_card` > `http_index` > `txt_fallback` > `none` — each agent now transparently reports where its capabilities came from via `capability_source`
- **ipv4hint/ipv6hint support**: New `--ipv4hint` and `--ipv6hint` flags for `dns-aid publish` (CLI, Python API, MCP server) per RFC 9460 SvcParamKeys 4 and 6
- **A2A agent-card.json path fix**: Corrected `.well-known/agent.json` → `.well-known/agent-card.json` per A2A spec
- **Single-fetch optimization**: When `cap_uri` points to an A2A Agent Card, the document is parsed once and reused as both capability source and `agent_card`
- **Documentation**: Updated README, getting-started, api-reference, architecture, demo-guide, CHANGELOG, and CITATION.cff

## Changes

### Code (12 files)
- `discoverer.py` — 4-tier capability chain with `_apply_agent_card()` helper, single-fetch optimization
- `cap_fetcher.py` — Multi-format capability parsing (native string list, object list, A2A skills array)
- `http_index.py` — `capabilities` field added to `Capability` dataclass
- `a2a_card.py` — Path corrected to `/.well-known/agent-card.json`
- `publisher.py` — `ipv4_hint`/`ipv6_hint` parameters
- `cli/main.py` — `--ipv4hint`/`--ipv6hint` CLI flags
- `mcp/server.py` — `ipv4_hint`/`ipv6_hint` in MCP publish tool
- `models.py` — Docstring updates for agent-card.json path
- `validator.py` — Probe path updated
- `__init__.py` — Version bump to 0.10.0
- `pyproject.toml` — Version bump to 0.10.0

### Docs (7 files)
- README.md, getting-started.md, api-reference.md, architecture.md, demo-guide.md — Updated resolution diagrams, transparency tables, CLI examples
- CHANGELOG.md — v0.10.0 entry
- CITATION.cff — Version and date updated

### Tests (1 file)
- `test_a2a_card.py` — Path assertion updated

## Test plan

- [x] 734 unit tests passing
- [x] ruff lint clean
- [x] ruff format clean