### PR TITLE
fix: capability resolution priority inversion (v0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-03-06
+
+### Fixed
+- **Capability resolution priority inversion** — Agent Card skills now correctly override TXT fallback capabilities. Previously, TXT capabilities were set first in `_query_single_agent`, preventing the higher-priority `agent_card` source from taking effect during endpoint enrichment. The 4-tier chain (`cap_uri` > `agent_card` > `http_index` > `txt_fallback`) now works as documented.
+
 ## [0.10.0] - 2026-03-06
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.10.0"
+version: "0.10.1"
 date-released: "2026-03-06"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.10.0"
+version = "0.10.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -311,6 +311,18 @@ async def _query_single_agent(
                     except Exception:
                         pass  # Not an agent card format — that's fine
 
+            # Tier 2: If cap_uri didn't yield capabilities but we parsed an
+            # A2A Agent Card from it, extract skills → capabilities now
+            if not capabilities and agent_card and agent_card.skills:
+                capabilities = agent_card.to_capabilities()
+                capability_source = "agent_card"
+                logger.debug(
+                    "Capabilities from A2A Agent Card (cap_uri response)",
+                    fqdn=fqdn,
+                    capabilities=capabilities,
+                )
+
+            # Tier 4: TXT record fallback (lowest priority)
             if not capabilities:
                 capabilities = await _query_capabilities(fqdn)
                 if capabilities:
@@ -716,8 +728,10 @@ def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
     """
     agent.agent_card = card
 
-    # Wire agent card skills → capabilities (if not already set by cap_uri)
-    if not agent.capabilities and card.skills:
+    # Wire agent card skills → capabilities
+    # agent_card is higher priority than txt_fallback and http_index,
+    # so override those sources. Only cap_uri takes precedence.
+    if card.skills and agent.capability_source not in ("cap_uri",):
         agent.capabilities = card.to_capabilities()
         agent.capability_source = "agent_card"
         logger.debug(

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **Bug**: Agent Card skills never overrode TXT fallback capabilities — all agents showed `txt_fallback` even when a valid `.well-known/agent-card.json` was fetched
- **Root cause**: TXT capabilities were set first in `_query_single_agent` (between cap_uri and agent_card tiers), and `_apply_agent_card` only set capabilities `if not agent.capabilities` — so txt_fallback blocked agent_card
- **Fix**: (1) Added agent_card extraction between cap_uri and txt_fallback in `_query_single_agent`, (2) Changed `_apply_agent_card` to override txt_fallback/http_index sources since agent_card is higher priority

## Verified

Before fix: `medical-triage` showed `txt_fallback` despite having a reachable agent card
After fix: `medical-triage` shows `agent_card` with skills `assess_symptoms, check_drug_interactions`

## Test plan

- [x] 734 unit tests passing
- [x] ruff lint/format clean
- [x] Live verified against highvelocitynetworking.com