### PR TITLE
feat: add A2A messaging support across CLI, MCP server, and SDK (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-03-12
+
+### Added
+- **`send_a2a_message` MCP tool** — Send messages to A2A agents directly from Claude Desktop or any MCP client. Sends standard A2A JSON-RPC `message/send` requests with automatic text extraction from response artifacts. Routes through SDK for telemetry capture when available, falls back to raw httpx.
+- **`dns-aid message` CLI command** — Send a message to an A2A agent from the command line. Supports `--json` output and configurable `--timeout`.
+- **`dns-aid call` CLI command** — Call a tool on a remote MCP agent via JSON-RPC `tools/call`. Accepts `--arguments` as JSON string.
+- **`dns-aid list-tools` CLI command** — List available tools on a remote MCP agent via JSON-RPC `tools/list`.
+
+### Fixed
+- **A2A protocol handler JSON-RPC 2.0 compliance** — Standard A2A methods (`message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, etc.) are now wrapped in a proper JSON-RPC 2.0 envelope with `jsonrpc`, `id`, and `params` fields. Previously, all methods used a flat generic payload which real A2A agents rejected. Non-standard methods retain the generic format for backward compatibility.
+
+### Changed
+- **Full agent communication parity** — All three interfaces (CLI, MCP server, Python SDK) now support both MCP tool calling and A2A messaging. Previously, only the MCP server and SDK could communicate with remote agents.
+
 ## [0.10.1] - 2026-03-06
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.10.1"
-date-released: "2026-03-06"
+version: "0.11.0"
+date-released: "2026-03-12"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -180,6 +180,23 @@ dns-aid index sync example.com
 # Publish without updating the index (for internal agents)
 dns-aid publish --name internal-bot --domain example.com --protocol mcp --no-update-index
 
+# =============================================================================
+# Agent Communication (talk to discovered agents)
+# =============================================================================
+
+# Send a message to an A2A agent (Google A2A protocol)
+dns-aid message https://security-analyzer.ai.infoblox.com "Analyze DNS-AID security posture"
+
+# Send a message with JSON output
+dns-aid message https://chat.example.com "Hello" --json
+
+# List tools on an MCP agent
+dns-aid list-tools https://mcp.example.com/mcp
+
+# Call a specific tool on an MCP agent
+dns-aid call https://mcp.example.com/mcp search_flights \
+    --arguments '{"origin": "SFO", "destination": "JFK"}'
+
 ```
 
 ### Agent Index Records
@@ -265,6 +282,7 @@ dns-aid-mcp --transport http --port 8000
 |------|-------------|
 | `publish_agent_to_dns` | Publish an AI agent to DNS (auto-updates index) |
 | `discover_agents_via_dns` | Discover AI agents at a domain (supports `use_http_index` for ANS-compatible discovery) |
+| `send_a2a_message` | Send a message to an A2A agent (Google A2A JSON-RPC `message/send`) |
 | `list_agent_tools` | List available tools on a discovered MCP agent |
 | `call_agent_tool` | Call a tool on a discovered MCP agent (proxy requests) |
 | `verify_agent_dns` | Verify DNS-AID records and security |
@@ -311,9 +329,17 @@ Try the live demo with Claude Desktop:
 }
 ```
 
-Then ask Claude to discover and use the booking agent:
+Then ask Claude to discover and talk to agents:
 
-> "Discover agents at example.com using HTTP index, find a booking agent, and search for flights from SFO to JFK on March 15th 2026"
+> "Discover agents at ai.infoblox.com and ask the security analyzer about DNS-AID"
+
+Claude will:
+1. Call `discover_agents_via_dns` → finds security-analyzer (A2A), marketing (A2A), etc.
+2. Call `send_a2a_message` → sends message to security-analyzer, gets response
+
+For MCP agents:
+
+> "Discover agents at example.com using HTTP index, find a booking agent, and search for flights from SFO to JFK"
 
 Claude will:
 1. Call `discover_agents_via_dns` → finds booking-agent at `https://booking.example.com/mcp`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -908,13 +908,30 @@ async def invoke(
 
 One-shot agent invocation with telemetry. Creates an AgentClient, calls the agent, returns the result with an attached signal.
 
-**Example:**
+**Examples:**
 ```python
 import dns_aid
 
+# MCP agent: list tools
 result = await dns_aid.discover("example.com", protocol="mcp")
 resp = await dns_aid.invoke(result.agents[0], method="tools/list")
 print(resp.signal.invocation_latency_ms)  # 148.2
+
+# A2A agent: send a message (standard JSON-RPC message/send)
+result = await dns_aid.discover("ai.infoblox.com", protocol="a2a")
+resp = await dns_aid.invoke(
+    result.agents[0],
+    method="message/send",
+    arguments={
+        "message": {
+            "messageId": "unique-id",
+            "role": "user",
+            "parts": [{"kind": "text", "text": "What is DNS-AID?"}],
+        }
+    },
+)
+# Standard A2A methods (message/send, tasks/get, etc.) are automatically
+# wrapped in a JSON-RPC 2.0 envelope by the A2A protocol handler.
 ```
 
 #### rank()
@@ -930,6 +947,26 @@ async def rank(
 ```
 
 Invoke multiple agents and rank by telemetry performance (composite score).
+
+### Protocol Handlers
+
+The SDK routes invocations through protocol-specific handlers:
+
+| Protocol | Handler | Wire Format |
+|----------|---------|-------------|
+| MCP | `MCPProtocolHandler` | JSON-RPC 2.0 (`tools/call`, `tools/list`) |
+| A2A | `A2AProtocolHandler` | JSON-RPC 2.0 for standard methods (`message/send`, `tasks/get`); generic payload for custom methods |
+| HTTPS | `HTTPSProtocolHandler` | HTTP POST with JSON body |
+
+**A2A Protocol Handler** automatically wraps standard A2A methods in a JSON-RPC 2.0 envelope:
+
+```python
+# Standard methods (message/send, message/stream, tasks/get, tasks/cancel, etc.)
+# are wrapped in: {"jsonrpc": "2.0", "method": "...", "params": {...}, "id": "..."}
+
+# Non-standard/custom methods use generic format for backward compatibility:
+# {"method": "custom_task", ...arguments}
+```
 
 ### AgentClient
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.10.1"
+version = "0.11.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -13,6 +13,9 @@ Usage:
     dns-aid list            List DNS-AID records
     dns-aid zones           List available DNS zones
     dns-aid delete          Delete an agent from DNS
+    dns-aid message         Send a message to an A2A agent
+    dns-aid call            Call a tool on a remote MCP agent
+    dns-aid list-tools      List tools on a remote MCP agent
     dns-aid index list      List agents in domain's index
     dns-aid index sync      Sync index with actual DNS records
 """
@@ -626,6 +629,299 @@ def delete(
                 console.print(f"[yellow]⚠ Index update failed: {index_result.message}[/yellow]")
     else:
         console.print("[yellow]No records found to delete[/yellow]")
+
+
+# ============================================================================
+# AGENT COMMUNICATION COMMANDS
+# ============================================================================
+
+
+@app.command()
+def message(
+    endpoint: Annotated[str, typer.Argument(help="A2A agent endpoint URL")],
+    text: Annotated[str, typer.Argument(help="Message text to send")],
+    timeout: Annotated[float, typer.Option("--timeout", "-t", help="Timeout in seconds")] = 25.0,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
+):
+    """
+    Send a message to an A2A agent.
+
+    Sends a standard A2A JSON-RPC message/send request to the agent's endpoint
+    and displays the response. Use after discovering agents to talk to them.
+
+    Example:
+        dns-aid message https://security-analyzer.ai.infoblox.com "What is DNS-AID?"
+        dns-aid discover example.com -p a2a  # find agents first
+        dns-aid message https://chat.example.com "Hello" --json
+    """
+    import json
+    import uuid
+
+    import httpx
+
+    if not text.strip():
+        error_console.print("[red]✗ Message cannot be empty[/red]")
+        raise typer.Exit(1)
+
+    # Normalize endpoint URL
+    url = endpoint.rstrip("/")
+    if not url.startswith("http"):
+        url = f"https://{url}"
+
+    # Build A2A JSON-RPC message/send payload
+    a2a_request = {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": str(uuid.uuid4()),
+                "role": "user",
+                "parts": [{"kind": "text", "text": text}],
+            }
+        },
+        "id": str(uuid.uuid4()),
+    }
+
+    console.print(f"\n[bold]Sending message to {endpoint}...[/bold]\n")
+
+    try:
+        with httpx.Client(
+            timeout=timeout,
+            follow_redirects=True,
+            verify=True,
+        ) as client:
+            resp = client.post(
+                url,
+                json=a2a_request,
+                headers={"Content-Type": "application/json"},
+            )
+    except httpx.TimeoutException:
+        error_console.print(f"[red]✗ Agent did not respond within {timeout} seconds[/red]")
+        raise typer.Exit(1) from None
+    except httpx.ConnectError:
+        error_console.print(f"[red]✗ Could not connect to {endpoint}[/red]")
+        raise typer.Exit(1) from None
+
+    if resp.status_code == 403:
+        error_console.print("[red]✗ Agent requires authentication (HTTP 403)[/red]")
+        raise typer.Exit(1)
+
+    if resp.status_code >= 400:
+        error_console.print(f"[red]✗ Agent returned HTTP {resp.status_code}[/red]")
+        error_console.print(f"[dim]{resp.text[:500]}[/dim]")
+        raise typer.Exit(1)
+
+    data = resp.json()
+
+    if json_output:
+        console.print_json(json.dumps(data))
+        return
+
+    # Extract text from A2A response
+    response_text = _extract_a2a_text(data)
+    if response_text:
+        console.print(f"[green]Agent response:[/green]\n\n{response_text}")
+    else:
+        console.print_json(json.dumps(data))
+
+
+@app.command()
+def call(
+    endpoint: Annotated[str, typer.Argument(help="MCP agent endpoint URL")],
+    tool_name: Annotated[str, typer.Argument(help="Name of the tool to call")],
+    arguments: Annotated[
+        str | None,
+        typer.Option("--arguments", "-a", help="Tool arguments as JSON string"),
+    ] = None,
+    timeout: Annotated[float, typer.Option("--timeout", "-t", help="Timeout in seconds")] = 30.0,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
+):
+    """
+    Call a tool on a remote MCP agent.
+
+    Sends an MCP JSON-RPC tools/call request to the agent's endpoint.
+    Use 'dns-aid list-tools' first to see available tools.
+
+    Example:
+        dns-aid call https://mcp.example.com/mcp analyze_security --arguments '{"domain":"example.com"}'
+        dns-aid list-tools https://mcp.example.com/mcp  # see available tools first
+    """
+    import json as json_mod
+
+    import httpx
+
+    # Parse arguments
+    tool_args = {}
+    if arguments:
+        try:
+            tool_args = json_mod.loads(arguments)
+        except json_mod.JSONDecodeError:
+            error_console.print("[red]✗ Invalid JSON in --arguments[/red]")
+            raise typer.Exit(1) from None
+
+    # Build MCP JSON-RPC request
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": tool_args,
+        },
+        "id": 1,
+    }
+
+    # Normalize endpoint
+    url = endpoint.rstrip("/")
+    if not url.startswith("http"):
+        url = f"https://{url}"
+
+    console.print(f"\n[bold]Calling {tool_name} on {endpoint}...[/bold]\n")
+
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True, verify=True) as client:
+            resp = client.post(
+                url,
+                json=mcp_request,
+                headers={"Content-Type": "application/json"},
+            )
+    except httpx.TimeoutException:
+        error_console.print(f"[red]✗ Agent did not respond within {timeout} seconds[/red]")
+        raise typer.Exit(1) from None
+    except httpx.ConnectError:
+        error_console.print(f"[red]✗ Could not connect to {endpoint}[/red]")
+        raise typer.Exit(1) from None
+
+    if resp.status_code >= 400:
+        error_console.print(f"[red]✗ Agent returned HTTP {resp.status_code}[/red]")
+        error_console.print(f"[dim]{resp.text[:500]}[/dim]")
+        raise typer.Exit(1)
+
+    data = resp.json()
+
+    if json_output:
+        console.print_json(json_mod.dumps(data))
+        return
+
+    # Display result
+    result = data.get("result", data)
+    if isinstance(result, dict) and "content" in result:
+        for item in result["content"]:
+            if isinstance(item, dict) and "text" in item:
+                console.print(f"[green]{item['text']}[/green]")
+            else:
+                console.print(str(item))
+    else:
+        console.print_json(json_mod.dumps(result))
+
+
+@app.command("list-tools")
+def list_tools(
+    endpoint: Annotated[str, typer.Argument(help="MCP agent endpoint URL")],
+    timeout: Annotated[float, typer.Option("--timeout", "-t", help="Timeout in seconds")] = 30.0,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
+):
+    """
+    List available tools on a remote MCP agent.
+
+    Sends an MCP JSON-RPC tools/list request to discover what tools
+    the agent exposes.
+
+    Example:
+        dns-aid list-tools https://mcp.example.com/mcp
+        dns-aid list-tools https://mcp.example.com/mcp --json
+    """
+    import json
+
+    import httpx
+
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "params": {},
+        "id": 1,
+    }
+
+    url = endpoint.rstrip("/")
+    if not url.startswith("http"):
+        url = f"https://{url}"
+
+    console.print(f"\n[bold]Listing tools on {endpoint}...[/bold]\n")
+
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True, verify=True) as client:
+            resp = client.post(
+                url,
+                json=mcp_request,
+                headers={"Content-Type": "application/json"},
+            )
+    except httpx.TimeoutException:
+        error_console.print(f"[red]✗ Agent did not respond within {timeout} seconds[/red]")
+        raise typer.Exit(1) from None
+    except httpx.ConnectError:
+        error_console.print(f"[red]✗ Could not connect to {endpoint}[/red]")
+        raise typer.Exit(1) from None
+
+    if resp.status_code >= 400:
+        error_console.print(f"[red]✗ Agent returned HTTP {resp.status_code}[/red]")
+        raise typer.Exit(1)
+
+    data = resp.json()
+
+    if json_output:
+        console.print_json(json.dumps(data))
+        return
+
+    # Extract tools from MCP response
+    result = data.get("result", data)
+    tools_list = result.get("tools", [])
+
+    if not tools_list:
+        console.print("[yellow]No tools found[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Tool Name")
+    table.add_column("Description")
+
+    for tool in tools_list:
+        table.add_row(
+            tool.get("name", "-"),
+            tool.get("description", "-")[:80],
+        )
+
+    console.print(table)
+    console.print(f"\n[dim]Total: {len(tools_list)} tool(s)[/dim]")
+
+
+def _extract_a2a_text(data: dict) -> str | None:
+    """Extract text from an A2A JSON-RPC response.
+
+    Handles multiple A2A response formats:
+    - result.artifacts[].parts[].text (standard A2A spec)
+    - result.parts[].text (simplified format)
+    - result.content[].text (alternative implementations)
+    """
+    result = data.get("result", {})
+
+    # Try artifacts[].parts[].text (standard A2A)
+    for artifact in result.get("artifacts", []):
+        for part in artifact.get("parts", []):
+            if "text" in part:
+                return part["text"]
+
+    # Try result.parts[].text
+    for part in result.get("parts", []):
+        if "text" in part:
+            return part["text"]
+
+    # Try result.content[].text
+    for item in result.get("content", []):
+        if isinstance(item, dict) and "text" in item:
+            return item["text"]
+        if isinstance(item, str):
+            return item
+
+    return None
 
 
 # ============================================================================

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1189,6 +1189,253 @@ def diagnose_environment(domain: str | None = None) -> dict:
 
 
 # =============================================================================
+# A2A MESSAGING
+# =============================================================================
+
+
+@mcp.tool()
+def send_a2a_message(
+    endpoint: str,
+    message: str,
+    timeout: float = 25.0,
+) -> dict:
+    """
+    Send a message to an A2A (Agent-to-Agent) agent and get its response.
+
+    Use this to communicate with agents that speak the Google A2A protocol
+    (https://google.github.io/A2A/). This is the primary tool for agent-to-agent
+    conversation — discover an agent via DNS, then talk to it using this tool.
+
+    This sends a standard A2A JSON-RPC ``message/send`` request, which is
+    different from ``call_agent_tool`` (which speaks MCP ``tools/call``).
+
+    Typical workflow:
+        1. discover_agents_via_dns("example.com", protocol="a2a")
+        2. send_a2a_message(endpoint="https://chat.example.com", message="Hello")
+
+    Args:
+        endpoint: The agent's A2A endpoint URL (from discover results).
+                  Example: "https://security-analyzer.ai.infoblox.com"
+        message: The text message to send to the agent.
+        timeout: Request timeout in seconds (default 25, tuned for API Gateway limits).
+
+    Returns:
+        dict with:
+        - success: Whether the call succeeded
+        - response: The agent's text response
+        - agent_endpoint: The endpoint that was called
+        - telemetry: Invocation telemetry (latency, status) when SDK is available
+        - error: Error message if failed
+    """
+    # Route through SDK for telemetry capture when available
+    if _sdk_available:
+        return _send_a2a_message_via_sdk(endpoint, message, timeout)
+    return _send_a2a_message_raw(endpoint, message, timeout)
+
+
+def _build_a2a_payload(message: str) -> dict:
+    """Build a standard A2A JSON-RPC message/send payload.
+
+    Constructs the request format defined by the Google A2A specification:
+    - jsonrpc: "2.0" (JSON-RPC version)
+    - method: "message/send" (A2A method for sending messages)
+    - params.message: Contains messageId, role, and parts array
+    - parts[]: Array of content parts, each with kind="text" and text content
+    """
+    import uuid
+
+    return {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": str(uuid.uuid4()),
+                "role": "user",
+                "parts": [{"kind": "text", "text": message}],
+            }
+        },
+        "id": str(uuid.uuid4()),
+    }
+
+
+def _send_a2a_message_via_sdk(endpoint: str, message: str, timeout: float = 25.0) -> dict:
+    """Send A2A message through the SDK for automatic telemetry capture.
+
+    The SDK's A2AProtocolHandler automatically wraps standard methods
+    (message/send) in a JSON-RPC 2.0 envelope, so we just pass the
+    method name and params — the handler adds jsonrpc, id, etc.
+    """
+    import os
+    import uuid
+
+    agent = _build_agent_record_from_endpoint(endpoint, protocol="a2a")
+    config = SDKConfig(
+        timeout_seconds=timeout,
+        console_signals=False,
+        caller_id="dns-aid-mcp-server",
+        http_push_url=os.getenv("DNS_AID_SDK_HTTP_PUSH_URL", _DEFAULT_HTTP_PUSH_URL),
+    )
+
+    # Build the params dict that goes inside the JSON-RPC envelope.
+    # The SDK A2A handler wraps this in {"jsonrpc": "2.0", "method": ..., "params": ...}
+    a2a_params = {
+        "message": {
+            "messageId": str(uuid.uuid4()),
+            "role": "user",
+            "parts": [{"kind": "text", "text": message}],
+        }
+    }
+
+    async def _invoke():
+        async with AgentClient(config=config) as client:
+            return await client.invoke(
+                agent,
+                method="message/send",
+                arguments=a2a_params,
+            )
+
+    try:
+        result = _run_async(_invoke())
+        response: dict = {"success": result.success, "agent_endpoint": endpoint}
+
+        if result.success and isinstance(result.data, dict):
+            text = _extract_a2a_response_text(result.data)
+            response["response"] = text or str(result.data)
+        elif result.success:
+            response["response"] = str(result.data)
+        else:
+            response["error"] = str(result.data) if result.data else "Invocation failed"
+
+        response["telemetry"] = {
+            "latency_ms": round(result.signal.invocation_latency_ms, 2),
+            "status": result.signal.status.value,
+        }
+        return response
+    except Exception as e:
+        return {"success": False, "agent_endpoint": endpoint, "error": str(e)}
+
+
+def _send_a2a_message_raw(endpoint: str, message: str, timeout: float = 25.0) -> dict:
+    """Fallback: send A2A message with raw httpx (no telemetry)."""
+    import httpx
+
+    a2a_request = _build_a2a_payload(message)
+
+    # Normalize endpoint URL
+    url = endpoint.rstrip("/")
+    if not url.startswith("http"):
+        url = f"https://{url}"
+
+    try:
+        with httpx.Client(
+            timeout=timeout,
+            follow_redirects=True,
+            verify=True,
+        ) as client:
+            resp = client.post(
+                url,
+                json=a2a_request,
+                headers={"Content-Type": "application/json"},
+            )
+
+        if resp.status_code == 403:
+            return {
+                "success": False,
+                "agent_endpoint": endpoint,
+                "error": "Agent requires authentication (HTTP 403). "
+                "The endpoint is reachable but blocks unauthenticated requests.",
+            }
+
+        if resp.status_code >= 400:
+            return {
+                "success": False,
+                "agent_endpoint": endpoint,
+                "error": f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}",
+            }
+
+        data = resp.json()
+        response_text = _extract_a2a_response_text(data)
+
+        if response_text:
+            return {
+                "success": True,
+                "response": response_text,
+                "agent_endpoint": endpoint,
+            }
+
+        return {
+            "success": True,
+            "response": str(data),
+            "agent_endpoint": endpoint,
+            "note": "Could not extract text from response, returning raw JSON-RPC result.",
+        }
+
+    except httpx.TimeoutException:
+        return {
+            "success": False,
+            "agent_endpoint": endpoint,
+            "error": f"Agent did not respond within {timeout} seconds.",
+        }
+    except httpx.ConnectError:
+        return {
+            "success": False,
+            "agent_endpoint": endpoint,
+            "error": f"Could not connect to agent at {endpoint}.",
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "agent_endpoint": endpoint,
+            "error": f"Unexpected error: {e}",
+        }
+
+
+def _extract_a2a_response_text(data: dict) -> str | None:
+    """Extract text from an A2A JSON-RPC response.
+
+    Handles both standard A2A response formats:
+    - result.artifacts[].parts[].text
+    - result.parts[].text
+    """
+    result = data.get("result", {})
+
+    # Try artifacts[].parts[].text (standard A2A)
+    artifacts = result.get("artifacts", [])
+    if artifacts:
+        texts = []
+        for artifact in artifacts:
+            for part in artifact.get("parts", []):
+                if part.get("kind") == "text" or "text" in part:
+                    texts.append(part.get("text", ""))
+        if texts:
+            return "\n".join(texts)
+
+    # Try result.parts[].text (alternative format)
+    parts = result.get("parts", [])
+    if parts:
+        texts = []
+        for part in parts:
+            if part.get("kind") == "text" or "text" in part:
+                texts.append(part.get("text", ""))
+        if texts:
+            return "\n".join(texts)
+
+    # Try result.content[].text (some implementations)
+    content = result.get("content", [])
+    if content:
+        texts = []
+        for item in content:
+            if isinstance(item, dict) and "text" in item:
+                texts.append(item["text"])
+            elif isinstance(item, str):
+                texts.append(item)
+        if texts:
+            return "\n".join(texts)
+
+    return None
+
+
+# =============================================================================
 # HEALTH ENDPOINTS (for HTTP transport)
 # =============================================================================
 
@@ -1220,6 +1467,7 @@ try:
                     "delete_agent_from_dns",
                     "list_agent_index",
                     "sync_agent_index",
+                    "send_a2a_message",
                 ],
             }
         )

--- a/src/dns_aid/sdk/protocols/a2a.py
+++ b/src/dns_aid/sdk/protocols/a2a.py
@@ -4,22 +4,67 @@
 """
 A2A (Agent-to-Agent) protocol handler.
 
-Implements Google's A2A protocol — HTTP POST with JSON payload.
+Implements Google's A2A protocol (https://google.github.io/A2A/) using
+JSON-RPC 2.0 over HTTP POST.
+
+Standard A2A methods (message/send, message/stream, tasks/get, etc.) are
+wrapped in a proper JSON-RPC 2.0 envelope with jsonrpc version and request ID.
+Non-standard methods use a simpler generic payload for backward compatibility.
+
+Example standard A2A request:
+    {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "...",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "Hello"}]
+            }
+        },
+        "id": "unique-request-id"
+    }
 """
 
 from __future__ import annotations
 
 import json
 import time
+import uuid
 
 import httpx
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
 
+# Standard A2A JSON-RPC methods per the Google A2A specification.
+# These get wrapped in a proper JSON-RPC 2.0 envelope automatically.
+_A2A_JSONRPC_METHODS = frozenset(
+    {
+        "message/send",
+        "message/stream",
+        "tasks/get",
+        "tasks/cancel",
+        "tasks/pushNotificationConfig/set",
+        "tasks/pushNotificationConfig/get",
+        "tasks/resubscribe",
+    }
+)
+
 
 class A2AProtocolHandler(ProtocolHandler):
-    """Handles A2A agent invocations over HTTPS."""
+    """Handles A2A agent invocations over HTTPS.
+
+    Supports two modes:
+
+    1. **Standard A2A** (recommended): When ``method`` is a recognized A2A
+       JSON-RPC method (e.g., ``message/send``), the request is wrapped in a
+       proper JSON-RPC 2.0 envelope with ``jsonrpc``, ``id``, and ``params``.
+       Arguments are placed inside ``params``.
+
+    2. **Generic**: For non-standard methods, arguments are spread into the
+       payload directly for backward compatibility with custom agents.
+    """
 
     @property
     def protocol_name(self) -> str:
@@ -36,12 +81,35 @@ class A2AProtocolHandler(ProtocolHandler):
         """
         Send an A2A request to an agent.
 
-        A2A uses HTTP POST with a JSON body containing the task/method.
+        For standard A2A methods (message/send, tasks/get, etc.), builds a
+        JSON-RPC 2.0 envelope. For other methods, sends a generic payload.
+
+        Args:
+            client: httpx async client for making the request.
+            endpoint: Agent's A2A endpoint URL.
+            method: A2A method name (e.g., "message/send").
+            arguments: Method parameters (placed in "params" for JSON-RPC).
+            timeout: Request timeout in seconds.
+
+        Returns:
+            RawResponse with success/failure status, response data, and telemetry.
         """
-        payload = {
-            "method": method or "task",
-            **(arguments or {}),
-        }
+        resolved_method = method or "message/send"
+
+        if resolved_method in _A2A_JSONRPC_METHODS:
+            # Standard A2A: proper JSON-RPC 2.0 envelope
+            payload = {
+                "jsonrpc": "2.0",
+                "method": resolved_method,
+                "params": arguments or {},
+                "id": str(uuid.uuid4()),
+            }
+        else:
+            # Generic/legacy: flat payload for backward compatibility
+            payload = {
+                "method": resolved_method,
+                **(arguments or {}),
+            }
 
         start = time.perf_counter()
 

--- a/tests/unit/sdk/test_a2a_handler.py
+++ b/tests/unit/sdk/test_a2a_handler.py
@@ -30,7 +30,7 @@ class TestA2AProtocolHandler:
             raw = await handler.invoke(
                 client=client,
                 endpoint="https://a2a.example.com/agent",
-                method="task",
+                method="custom_task",
                 arguments={"input": "hello"},
                 timeout=5.0,
             )
@@ -38,6 +38,92 @@ class TestA2AProtocolHandler:
         assert raw.success is True
         assert raw.status == InvocationStatus.SUCCESS
         assert raw.data == {"task_id": "abc", "result": "done"}
+
+    @pytest.mark.asyncio
+    async def test_standard_a2a_jsonrpc_envelope(self, handler: A2AProtocolHandler) -> None:
+        """Standard A2A methods (message/send) must use JSON-RPC 2.0 envelope."""
+        captured = {}
+
+        def capture_request(req: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["body"] = json.loads(req.content)
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "result": {"artifacts": [{"parts": [{"kind": "text", "text": "Hello!"}]}]},
+                    "id": "test",
+                },
+            )
+
+        transport = httpx.MockTransport(capture_request)
+        async with httpx.AsyncClient(transport=transport) as client:
+            raw = await handler.invoke(
+                client=client,
+                endpoint="https://a2a.example.com/agent",
+                method="message/send",
+                arguments={"message": {"role": "user", "parts": [{"kind": "text", "text": "Hi"}]}},
+                timeout=5.0,
+            )
+
+        assert raw.success is True
+        body = captured["body"]
+        assert body["jsonrpc"] == "2.0"
+        assert body["method"] == "message/send"
+        assert "id" in body
+        assert body["params"]["message"]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_generic_method_no_jsonrpc_wrapper(self, handler: A2AProtocolHandler) -> None:
+        """Non-standard methods use generic flat payload (backward compatibility)."""
+        captured = {}
+
+        def capture_request(req: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["body"] = json.loads(req.content)
+            return httpx.Response(200, json={"ok": True})
+
+        transport = httpx.MockTransport(capture_request)
+        async with httpx.AsyncClient(transport=transport) as client:
+            await handler.invoke(
+                client=client,
+                endpoint="https://a2a.example.com/agent",
+                method="custom_task",
+                arguments={"input": "hello"},
+                timeout=5.0,
+            )
+
+        body = captured["body"]
+        assert body["method"] == "custom_task"
+        assert body["input"] == "hello"
+        assert "jsonrpc" not in body
+
+    @pytest.mark.asyncio
+    async def test_default_method_is_message_send(self, handler: A2AProtocolHandler) -> None:
+        """When method is None, defaults to message/send with JSON-RPC envelope."""
+        captured = {}
+
+        def capture_request(req: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["body"] = json.loads(req.content)
+            return httpx.Response(200, json={"jsonrpc": "2.0", "result": {}, "id": "1"})
+
+        transport = httpx.MockTransport(capture_request)
+        async with httpx.AsyncClient(transport=transport) as client:
+            await handler.invoke(
+                client=client,
+                endpoint="https://a2a.example.com/agent",
+                method=None,
+                arguments=None,
+                timeout=5.0,
+            )
+
+        body = captured["body"]
+        assert body["jsonrpc"] == "2.0"
+        assert body["method"] == "message/send"
 
     @pytest.mark.asyncio
     async def test_server_error(self, handler: A2AProtocolHandler) -> None:
@@ -66,7 +152,7 @@ class TestA2AProtocolHandler:
             raw = await handler.invoke(
                 client=client,
                 endpoint="https://a2a.example.com/agent",
-                method="task",
+                method="message/send",
                 arguments=None,
                 timeout=0.1,
             )


### PR DESCRIPTION
## Summary

- Add `send_a2a_message` MCP tool for talking to A2A agents from Claude Desktop
- Fix A2A protocol handler to send proper JSON-RPC 2.0 envelope for standard methods
- Add CLI commands (`message`, `call`, `list-tools`) for feature parity across all interfaces
- Bump version to v0.11.0

## Changes

### MCP Server (`src/dns_aid/mcp/server.py`)
- New `send_a2a_message` tool — sends A2A JSON-RPC `message/send`, extracts text from response artifacts, routes through SDK for telemetry when available
- Updated health endpoint tools list

### SDK A2A Protocol Handler (`src/dns_aid/sdk/protocols/a2a.py`)
- **Fix**: Standard A2A methods (`message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, etc.) now wrapped in proper JSON-RPC 2.0 envelope with `jsonrpc`, `id`, and `params`
- Non-standard/custom methods retain generic flat payload for backward compatibility

### CLI (`src/dns_aid/cli/main.py`)
- `dns-aid message <endpoint> <text>` — send a message to an A2A agent
- `dns-aid call <endpoint> <tool-name>` — call a tool on a remote MCP agent
- `dns-aid list-tools <endpoint>` — list tools on a remote MCP agent

### Docs
- `README.md` — added CLI agent communication section, updated MCP tools table, added A2A demo flow
- `docs/api-reference.md` — added protocol handlers section, A2A invoke example

### Version Bump
- `pyproject.toml`, `__init__.py`, `CITATION.cff`, `CHANGELOG.md` → 0.11.0

## Coverage Matrix (after this PR)

| Interface | MCP tools/call | A2A message/send | MCP tools/list |
|-----------|---------------|-----------------|---------------|
| MCP Server | `call_agent_tool` | `send_a2a_message` | `list_agent_tools` |
| CLI | `dns-aid call` | `dns-aid message` | `dns-aid list-tools` |
| Python SDK | `invoke()` | `invoke()` | `invoke(method="tools/list")` |

## Test plan

- [x] 753 tests passing, 0 failures
- [x] ruff lint clean (src/)
- [x] ruff format clean (src/)
- [x] mypy clean (50 files, 0 issues)
- [x] New tests for JSON-RPC 2.0 envelope, generic fallback, default method
- [x] Live tested: `dns-aid message https://security-analyzer.ai.infoblox.com "Hello"` works