### PR TITLE
feat: Add A2A agent card discovery bridge

### DIFF
--- a/src/dns_aid/a2a/__init__.py
+++ b/src/dns_aid/a2a/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2A (Agent-to-Agent) discovery bridge for DNS-AID.
+
+Bridges DNS-AID agent discovery with the A2A agent card protocol,
+enabling DNS-based discovery of A2A agents and conversion between
+DNS-AID records and A2A agent cards.
+"""
+
+from dns_aid.a2a.bridge import (
+    AgentCard,
+    AgentCardSkill,
+    discover_a2a_agents,
+    fetch_agent_card,
+    publish_a2a_agent,
+    to_agent_card,
+    unpublish_a2a_agent,
+)
+
+__all__ = [
+    "AgentCard",
+    "AgentCardSkill",
+    "discover_a2a_agents",
+    "fetch_agent_card",
+    "publish_a2a_agent",
+    "to_agent_card",
+    "unpublish_a2a_agent",
+]

--- a/src/dns_aid/a2a/bridge.py
+++ b/src/dns_aid/a2a/bridge.py
@@ -31,19 +31,35 @@ Example:
 from __future__ import annotations
 
 import json
-import logging
+import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
+from urllib.parse import urlparse
 
 import httpx
+import structlog
 
+from dns_aid.backends.base import DNSBackend
 from dns_aid.core.discoverer import discover
 from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol
+from dns_aid.core.publisher import publish, unpublish
+from dns_aid.utils.url_safety import validate_fetch_url
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Well-known path for A2A agent cards per the A2A specification.
 A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
+
+# DNS label limit per RFC 1123.
+MAX_DNS_LABEL_LENGTH = 63
+
+# Safety limits for parsing untrusted agent card JSON.
+MAX_SKILLS = 100
+MAX_TAGS_PER_SKILL = 50
+MAX_EXAMPLES_PER_SKILL = 50
+
+# Characters that must NOT appear in a hostname used to build URLs.
+_UNSAFE_HOST_CHARS = re.compile(r"[/@?#]")
 
 
 @dataclass
@@ -106,16 +122,29 @@ class AgentCard:
 
         Returns:
             Parsed AgentCard instance.
+
+        Raises:
+            TypeError: If ``skills`` is not a list.
         """
-        skills = []
-        for skill_data in data.get("skills", []):
+        raw_skills = data.get("skills", [])
+        if not isinstance(raw_skills, list):
+            raise TypeError(
+                f"Expected 'skills' to be a list, got {type(raw_skills).__name__}"
+            )
+
+        skills: list[AgentCardSkill] = []
+        for skill_data in raw_skills[:MAX_SKILLS]:
+            if not isinstance(skill_data, dict):
+                continue
+            tags = skill_data.get("tags", [])
+            examples = skill_data.get("examples", [])
             skills.append(
                 AgentCardSkill(
                     id=skill_data.get("id", ""),
                     name=skill_data.get("name", ""),
                     description=skill_data.get("description", ""),
-                    tags=skill_data.get("tags", []),
-                    examples=skill_data.get("examples", []),
+                    tags=tags[:MAX_TAGS_PER_SKILL] if isinstance(tags, list) else [],
+                    examples=examples[:MAX_EXAMPLES_PER_SKILL] if isinstance(examples, list) else [],
                 )
             )
 
@@ -175,11 +204,27 @@ class AgentCard:
         return result
 
 
+def _validate_endpoint(endpoint: str) -> None:
+    """Validate that an endpoint string is a safe hostname.
+
+    Raises:
+        ValueError: If the endpoint contains characters that could
+            cause URL injection (``/``, ``@``, ``?``, ``#``).
+    """
+    if _UNSAFE_HOST_CHARS.search(endpoint):
+        raise ValueError(
+            f"Endpoint '{endpoint}' contains unsafe characters "
+            "(must not include /, @, ?, or #)"
+        )
+
+
 async def fetch_agent_card(
     endpoint: str,
     port: int = 443,
     *,
     timeout: float = 10.0,
+    allow_http: bool = False,
+    client: Optional[httpx.AsyncClient] = None,
 ) -> AgentCard:
     """Fetch an A2A agent card from a host.
 
@@ -190,21 +235,43 @@ async def fetch_agent_card(
         endpoint: Hostname of the agent.
         port: Port number (default 443).
         timeout: HTTP request timeout in seconds.
+        allow_http: If True, allow cleartext HTTP for non-443 ports.
+            Default is False (always use HTTPS).
+        client: Optional shared ``httpx.AsyncClient`` for connection
+            pooling across multiple calls.
 
     Returns:
         Parsed AgentCard.
 
     Raises:
         httpx.HTTPStatusError: If the HTTP request fails.
-        ValueError: If the response is not valid JSON.
+        ValueError: If the endpoint is malformed or the response is
+            not valid JSON.
     """
-    scheme = "https" if port == 443 else "http"
-    url = f"{scheme}://{endpoint}:{port}{A2A_AGENT_CARD_PATH}"
+    _validate_endpoint(endpoint)
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.get(url)
+    # Validate URL safety (SSRF protection).
+    if allow_http and port != 443:
+        scheme = "http"
+    else:
+        scheme = "https"
+
+    port_suffix = f":{port}" if port not in (443, 80) else ""
+    url = f"{scheme}://{endpoint}{port_suffix}{A2A_AGENT_CARD_PATH}"
+
+    validate_fetch_url(url)
+
+    if client is not None:
+        response = await client.get(url, timeout=timeout)
         response.raise_for_status()
         data = response.json()
+    else:
+        async with httpx.AsyncClient(
+            timeout=timeout, follow_redirects=False
+        ) as _client:
+            response = await _client.get(url)
+            response.raise_for_status()
+            data = response.json()
 
     return AgentCard.from_dict(data)
 
@@ -276,7 +343,7 @@ async def publish_a2a_agent(
     endpoint: str | None = None,
     port: int = 443,
     ttl: int = 3600,
-    backend: Any = None,
+    backend: DNSBackend | None = None,
     backend_name: str | None = None,
 ) -> dict[str, Any]:
     """Publish an A2A agent card as DNS-AID records.
@@ -299,16 +366,21 @@ async def publish_a2a_agent(
 
     Returns:
         Publish result dict.
+
+    Raises:
+        ValueError: If both ``backend`` and ``backend_name`` are set,
+            or if no endpoint can be resolved.
     """
-    from dns_aid.core.publisher import publish
+    if backend is not None and backend_name is not None:
+        raise ValueError(
+            "Specify either 'backend' or 'backend_name', not both."
+        )
 
     agent_name = name or _sanitize_dns_label(card.name)
 
     # Extract endpoint from card URL if not provided
     resolved_endpoint = endpoint
     if resolved_endpoint is None and card.url:
-        from urllib.parse import urlparse
-
         parsed = urlparse(card.url)
         resolved_endpoint = parsed.hostname or ""
         if parsed.port:
@@ -341,9 +413,9 @@ async def publish_a2a_agent(
     )
 
     logger.info(
-        "DNS-AID: Published A2A agent '%s' at %s",
-        agent_name,
-        domain,
+        "Published A2A agent to DNS",
+        agent_name=agent_name,
+        domain=domain,
     )
     return result.model_dump()
 
@@ -352,7 +424,7 @@ async def unpublish_a2a_agent(
     *,
     name: str,
     domain: str,
-    backend: Any = None,
+    backend: DNSBackend | None = None,
     backend_name: str | None = None,
 ) -> bool:
     """Remove an A2A agent's DNS-AID records.
@@ -365,8 +437,14 @@ async def unpublish_a2a_agent(
 
     Returns:
         True if records were deleted, False if not found.
+
+    Raises:
+        ValueError: If both ``backend`` and ``backend_name`` are set.
     """
-    from dns_aid.core.publisher import unpublish
+    if backend is not None and backend_name is not None:
+        raise ValueError(
+            "Specify either 'backend' or 'backend_name', not both."
+        )
 
     resolved_backend = backend
     if resolved_backend is None and backend_name:
@@ -383,9 +461,9 @@ async def unpublish_a2a_agent(
 
     if deleted:
         logger.info(
-            "DNS-AID: Unpublished A2A agent '%s' from %s",
-            name,
-            domain,
+            "Unpublished A2A agent from DNS",
+            agent_name=name,
+            domain=domain,
         )
 
     return deleted
@@ -394,11 +472,13 @@ async def unpublish_a2a_agent(
 def _sanitize_dns_label(name: str) -> str:
     """Convert a human-readable name to a DNS-safe label.
 
+    Truncates to RFC 1123 max label length (63 chars).
+
     Args:
         name: Human-readable agent name.
 
     Returns:
-        DNS label format string.
+        DNS label format string (max 63 chars).
     """
     label = name.lower().strip()
     label = label.replace(" ", "-").replace("_", "-")
@@ -406,4 +486,6 @@ def _sanitize_dns_label(name: str) -> str:
     label = "".join(c for c in label if c.isalnum() or c == "-")
     # Remove leading/trailing hyphens
     label = label.strip("-")
+    # Truncate to DNS label limit
+    label = label[:MAX_DNS_LABEL_LENGTH].rstrip("-")
     return label or "agent"

--- a/src/dns_aid/a2a/bridge.py
+++ b/src/dns_aid/a2a/bridge.py
@@ -1,0 +1,409 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+A2A discovery bridge.
+
+Connects DNS-AID agent discovery (SVCB + TXT records) with Google's
+A2A (Agent-to-Agent) protocol agent card standard. This enables:
+
+1. **DNS → A2A**: Discover A2A agents via DNS and fetch their agent
+   cards from ``/.well-known/agent-card.json``.
+
+2. **A2A → DNS**: Publish A2A agent card information as DNS-AID
+   records so other agents can discover A2A endpoints via DNS.
+
+3. **Conversion**: Convert between DNS-AID ``AgentRecord`` and A2A
+   ``AgentCard`` formats.
+
+A2A Agent Card Spec: https://google.github.io/A2A/specification/
+
+Example:
+    >>> from dns_aid.a2a import discover_a2a_agents, fetch_agent_card
+    >>>
+    >>> # Discover A2A agents via DNS, then fetch their agent cards
+    >>> agents = await discover_a2a_agents("agents.example.com")
+    >>> for agent in agents:
+    ...     card = await fetch_agent_card(agent.endpoint, agent.port)
+    ...     print(f"{card.name}: {card.description}")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from dns_aid.core.discoverer import discover
+from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Well-known path for A2A agent cards per the A2A specification.
+A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
+
+
+@dataclass
+class AgentCardSkill:
+    """An A2A agent card skill (capability).
+
+    Represents a discrete capability that an agent can perform,
+    as defined in the A2A agent card specification.
+
+    Attributes:
+        id: Unique identifier for the skill.
+        name: Human-readable name.
+        description: What this skill does.
+        tags: Categorization tags.
+        examples: Example queries or inputs.
+    """
+
+    id: str
+    name: str
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    examples: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AgentCard:
+    """A2A agent card representation.
+
+    Models the agent card JSON structure served at
+    ``/.well-known/agent-card.json`` per the A2A specification.
+
+    Attributes:
+        name: Agent name.
+        description: Human-readable description.
+        url: Agent endpoint URL.
+        version: Agent version string.
+        skills: List of agent capabilities/skills.
+        provider: Organization providing the agent.
+        documentation_url: Link to documentation.
+        capabilities: Raw capabilities dict from the card.
+        raw: Full raw agent card JSON dict.
+    """
+
+    name: str
+    description: str = ""
+    url: str = ""
+    version: str = ""
+    skills: list[AgentCardSkill] = field(default_factory=list)
+    provider: str = ""
+    documentation_url: str = ""
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AgentCard:
+        """Parse an agent card from its JSON dict representation.
+
+        Args:
+            data: Raw agent card JSON dict.
+
+        Returns:
+            Parsed AgentCard instance.
+        """
+        skills = []
+        for skill_data in data.get("skills", []):
+            skills.append(
+                AgentCardSkill(
+                    id=skill_data.get("id", ""),
+                    name=skill_data.get("name", ""),
+                    description=skill_data.get("description", ""),
+                    tags=skill_data.get("tags", []),
+                    examples=skill_data.get("examples", []),
+                )
+            )
+
+        provider_data = data.get("provider", {})
+        provider_name = ""
+        if isinstance(provider_data, dict):
+            provider_name = provider_data.get("organization", "")
+        elif isinstance(provider_data, str):
+            provider_name = provider_data
+
+        return cls(
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            url=data.get("url", ""),
+            version=data.get("version", ""),
+            skills=skills,
+            provider=provider_name,
+            documentation_url=data.get("documentationUrl", ""),
+            capabilities=data.get("capabilities", {}),
+            raw=data,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the agent card to its JSON dict representation.
+
+        Returns:
+            Agent card as a JSON-serializable dict.
+        """
+        result: dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "url": self.url,
+            "version": self.version,
+        }
+
+        if self.skills:
+            result["skills"] = [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "description": s.description,
+                    **({"tags": s.tags} if s.tags else {}),
+                    **({"examples": s.examples} if s.examples else {}),
+                }
+                for s in self.skills
+            ]
+
+        if self.provider:
+            result["provider"] = {"organization": self.provider}
+
+        if self.documentation_url:
+            result["documentationUrl"] = self.documentation_url
+
+        if self.capabilities:
+            result["capabilities"] = self.capabilities
+
+        return result
+
+
+async def fetch_agent_card(
+    endpoint: str,
+    port: int = 443,
+    *,
+    timeout: float = 10.0,
+) -> AgentCard:
+    """Fetch an A2A agent card from a host.
+
+    Retrieves the agent card JSON from the standard well-known
+    path ``/.well-known/agent-card.json``.
+
+    Args:
+        endpoint: Hostname of the agent.
+        port: Port number (default 443).
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Parsed AgentCard.
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+        ValueError: If the response is not valid JSON.
+    """
+    scheme = "https" if port == 443 else "http"
+    url = f"{scheme}://{endpoint}:{port}{A2A_AGENT_CARD_PATH}"
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+    return AgentCard.from_dict(data)
+
+
+async def discover_a2a_agents(
+    domain: str,
+    *,
+    require_dnssec: bool = False,
+) -> list[AgentRecord]:
+    """Discover A2A agents at a domain via DNS-AID.
+
+    Queries DNS-AID SVCB + TXT records filtered for the A2A protocol.
+
+    Args:
+        domain: Domain to search (e.g. 'agents.example.com').
+        require_dnssec: Require DNSSEC-validated responses.
+
+    Returns:
+        List of AgentRecord instances for A2A agents.
+    """
+    result: DiscoveryResult = await discover(
+        domain=domain,
+        protocol="a2a",
+        require_dnssec=require_dnssec,
+    )
+    return result.agents
+
+
+def to_agent_card(agent: AgentRecord) -> AgentCard:
+    """Convert a DNS-AID AgentRecord to an A2A AgentCard.
+
+    Maps DNS-AID record fields to the A2A agent card format:
+    - ``name`` → ``name``
+    - ``description`` → ``description``
+    - ``endpoint_url`` → ``url``
+    - ``version`` → ``version``
+    - ``capabilities`` → ``skills`` (each capability becomes a skill)
+
+    Args:
+        agent: DNS-AID AgentRecord from discovery.
+
+    Returns:
+        A2A AgentCard with fields populated from the DNS record.
+    """
+    skills = []
+    for cap in agent.capabilities or []:
+        skills.append(
+            AgentCardSkill(
+                id=cap,
+                name=cap.replace("-", " ").replace("_", " ").title(),
+                description=f"Capability: {cap}",
+            )
+        )
+
+    return AgentCard(
+        name=agent.name,
+        description=agent.description or "",
+        url=agent.endpoint_url,
+        version=agent.version or "",
+        skills=skills,
+    )
+
+
+async def publish_a2a_agent(
+    card: AgentCard,
+    *,
+    domain: str,
+    name: str | None = None,
+    endpoint: str | None = None,
+    port: int = 443,
+    ttl: int = 3600,
+    backend: Any = None,
+    backend_name: str | None = None,
+) -> dict[str, Any]:
+    """Publish an A2A agent card as DNS-AID records.
+
+    Creates SVCB + TXT records from A2A agent card information,
+    making the agent discoverable via DNS.
+
+    Args:
+        card: A2A AgentCard to publish.
+        domain: DNS domain to publish under
+            (e.g. 'agents.example.com').
+        name: Agent name for DNS label. Defaults to the card name
+            (sanitized to DNS label format).
+        endpoint: Hostname where the agent is reachable.
+            Defaults to extracting from card.url.
+        port: Port number.
+        ttl: DNS record TTL in seconds.
+        backend: Pre-configured DNSBackend instance.
+        backend_name: DNS backend name (e.g. 'route53').
+
+    Returns:
+        Publish result dict.
+    """
+    from dns_aid.core.publisher import publish
+
+    agent_name = name or _sanitize_dns_label(card.name)
+
+    # Extract endpoint from card URL if not provided
+    resolved_endpoint = endpoint
+    if resolved_endpoint is None and card.url:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(card.url)
+        resolved_endpoint = parsed.hostname or ""
+        if parsed.port:
+            port = parsed.port
+
+    if not resolved_endpoint:
+        raise ValueError(
+            "endpoint must be provided or derivable from card.url"
+        )
+
+    capabilities = [s.id for s in card.skills] if card.skills else None
+
+    resolved_backend = backend
+    if resolved_backend is None and backend_name:
+        from dns_aid.backends import create_backend
+
+        resolved_backend = create_backend(backend_name)
+
+    result = await publish(
+        name=agent_name,
+        domain=domain,
+        protocol="a2a",
+        endpoint=resolved_endpoint,
+        port=port,
+        capabilities=capabilities,
+        version=card.version or "1.0.0",
+        description=card.description,
+        ttl=ttl,
+        backend=resolved_backend,
+    )
+
+    logger.info(
+        "DNS-AID: Published A2A agent '%s' at %s",
+        agent_name,
+        domain,
+    )
+    return result.model_dump()
+
+
+async def unpublish_a2a_agent(
+    *,
+    name: str,
+    domain: str,
+    backend: Any = None,
+    backend_name: str | None = None,
+) -> bool:
+    """Remove an A2A agent's DNS-AID records.
+
+    Args:
+        name: Agent identifier to remove.
+        domain: Domain the agent is published under.
+        backend: Pre-configured DNSBackend instance.
+        backend_name: DNS backend name.
+
+    Returns:
+        True if records were deleted, False if not found.
+    """
+    from dns_aid.core.publisher import unpublish
+
+    resolved_backend = backend
+    if resolved_backend is None and backend_name:
+        from dns_aid.backends import create_backend
+
+        resolved_backend = create_backend(backend_name)
+
+    deleted = await unpublish(
+        name=name,
+        domain=domain,
+        protocol="a2a",
+        backend=resolved_backend,
+    )
+
+    if deleted:
+        logger.info(
+            "DNS-AID: Unpublished A2A agent '%s' from %s",
+            name,
+            domain,
+        )
+
+    return deleted
+
+
+def _sanitize_dns_label(name: str) -> str:
+    """Convert a human-readable name to a DNS-safe label.
+
+    Args:
+        name: Human-readable agent name.
+
+    Returns:
+        DNS label format string.
+    """
+    label = name.lower().strip()
+    label = label.replace(" ", "-").replace("_", "-")
+    # Remove non-alphanumeric chars except hyphens
+    label = "".join(c for c in label if c.isalnum() or c == "-")
+    # Remove leading/trailing hyphens
+    label = label.strip("-")
+    return label or "agent"

--- a/src/dns_aid/core/pre_publish_validator.py
+++ b/src/dns_aid/core/pre_publish_validator.py
@@ -202,6 +202,13 @@ def _validate_uris(agent: AgentRecord, errors: list[ValidationError]) -> None:
                 message=f"URI scheme '{parsed.scheme}' is unusual; expected https, http, or urn",
                 severity="warning",
             ))
+        elif parsed.scheme == "http" and field_name in ("cap_uri", "policy_uri"):
+            errors.append(ValidationError(
+                field=field_name,
+                message=f"Cleartext http:// used for {field_name}; "
+                "this undermines DNSSEC integrity — prefer https://",
+                severity="warning",
+            ))
 
 
 def _validate_capabilities(agent: AgentRecord, errors: list[ValidationError]) -> None:

--- a/src/dns_aid/core/pre_publish_validator.py
+++ b/src/dns_aid/core/pre_publish_validator.py
@@ -1,0 +1,256 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pre-publish validation for DNS-AID records.
+
+Validates SvcParam syntax, TTL compliance, FQDN length limits, and wire-format
+size constraints *before* publishing to DNS, catching errors early rather than
+after a failed DNS update.
+
+Usage:
+    >>> from dns_aid.core.pre_publish_validator import validate_record
+    >>> from dns_aid.core.models import AgentRecord, Protocol
+    >>>
+    >>> agent = AgentRecord(
+    ...     name="my-agent",
+    ...     domain="example.com",
+    ...     protocol=Protocol.A2A,
+    ...     target_host="api.example.com",
+    ... )
+    >>> errors = validate_record(agent)
+    >>> if errors:
+    ...     for e in errors:
+    ...         print(f"{e.field}: {e.message}")
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from dns_aid.core.models import AgentRecord, Protocol
+
+# DNS limits per RFC 1035
+MAX_FQDN_LENGTH = 253
+MAX_LABEL_LENGTH = 63
+
+# SVCB RDATA size limit (uint16 length prefix in wire format)
+MAX_SVCB_RDATA_BYTES = 65535
+
+# TTL bounds (matching AgentRecord model constraints)
+MIN_TTL = 30
+MAX_TTL = 86400
+
+# Valid ALPN values for DNS-AID protocols
+VALID_ALPN_VALUES = {"a2a", "mcp", "https", "h2", "h3"}
+
+# DNS label pattern (RFC 1035 + RFC 5891 for lowercase)
+DNS_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+# Capability string: alphanumeric, hyphens, underscores, dots, slashes
+CAPABILITY_RE = re.compile(r"^[a-zA-Z0-9_./:-]+$")
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    """A single validation error."""
+
+    field: str
+    message: str
+    severity: str = "error"  # "error" or "warning"
+
+
+def validate_record(agent: AgentRecord) -> list[ValidationError]:
+    """Validate an AgentRecord before publishing to DNS.
+
+    Checks:
+    - FQDN total length (max 253 chars)
+    - Individual label lengths (max 63 chars)
+    - TTL within bounds (30-86400s)
+    - ALPN value validity
+    - URI format for cap_uri, policy_uri, enroll_uri
+    - Capability string format
+    - BAP protocol format
+    - Port range (1-65535)
+    - Estimated SVCB RDATA wire size
+
+    Returns:
+        List of ValidationError. Empty list means the record is valid.
+    """
+    errors: list[ValidationError] = []
+
+    _validate_fqdn(agent, errors)
+    _validate_name(agent, errors)
+    _validate_ttl(agent, errors)
+    _validate_protocol(agent, errors)
+    _validate_port(agent, errors)
+    _validate_target_host(agent, errors)
+    _validate_uris(agent, errors)
+    _validate_capabilities(agent, errors)
+    _validate_bap(agent, errors)
+    _validate_wire_size(agent, errors)
+
+    return errors
+
+
+def _validate_fqdn(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check FQDN length and label sizes."""
+    fqdn = agent.fqdn
+    if len(fqdn) > MAX_FQDN_LENGTH:
+        errors.append(ValidationError(
+            field="fqdn",
+            message=f"FQDN '{fqdn}' exceeds {MAX_FQDN_LENGTH} chars ({len(fqdn)} chars)",
+        ))
+
+    for label in fqdn.split("."):
+        if len(label) > MAX_LABEL_LENGTH:
+            errors.append(ValidationError(
+                field="fqdn",
+                message=f"Label '{label}' exceeds {MAX_LABEL_LENGTH} chars ({len(label)} chars)",
+            ))
+
+
+def _validate_name(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check agent name is a valid DNS label."""
+    if not DNS_LABEL_RE.match(agent.name):
+        errors.append(ValidationError(
+            field="name",
+            message=f"Name '{agent.name}' is not a valid DNS label "
+            "(must be lowercase alphanumeric with hyphens, not starting/ending with hyphen)",
+        ))
+
+
+def _validate_ttl(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check TTL is within acceptable bounds."""
+    if agent.ttl < MIN_TTL:
+        errors.append(ValidationError(
+            field="ttl",
+            message=f"TTL {agent.ttl}s is below minimum {MIN_TTL}s",
+        ))
+    elif agent.ttl > MAX_TTL:
+        errors.append(ValidationError(
+            field="ttl",
+            message=f"TTL {agent.ttl}s exceeds maximum {MAX_TTL}s",
+        ))
+
+
+def _validate_protocol(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check protocol/ALPN value."""
+    if agent.protocol.value not in VALID_ALPN_VALUES:
+        errors.append(ValidationError(
+            field="protocol",
+            message=f"Protocol '{agent.protocol.value}' is not a recognized ALPN value. "
+            f"Valid: {', '.join(sorted(VALID_ALPN_VALUES))}",
+        ))
+
+
+def _validate_port(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check port is in valid range."""
+    if not 1 <= agent.port <= 65535:
+        errors.append(ValidationError(
+            field="port",
+            message=f"Port {agent.port} is outside valid range 1-65535",
+        ))
+
+
+def _validate_target_host(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check target host is a valid hostname."""
+    host = agent.target_host
+    if not host:
+        errors.append(ValidationError(
+            field="target_host",
+            message="Target host must not be empty",
+        ))
+        return
+
+    if len(host) > MAX_FQDN_LENGTH:
+        errors.append(ValidationError(
+            field="target_host",
+            message=f"Target host exceeds {MAX_FQDN_LENGTH} chars",
+        ))
+
+    for label in host.rstrip(".").split("."):
+        if len(label) > MAX_LABEL_LENGTH:
+            errors.append(ValidationError(
+                field="target_host",
+                message=f"Target host label '{label}' exceeds {MAX_LABEL_LENGTH} chars",
+            ))
+
+
+def _validate_uris(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Validate URI fields have proper format."""
+    uri_fields = [
+        ("cap_uri", agent.cap_uri),
+        ("policy_uri", agent.policy_uri),
+        ("enroll_uri", agent.enroll_uri),
+    ]
+
+    for field_name, value in uri_fields:
+        if value is None:
+            continue
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            errors.append(ValidationError(
+                field=field_name,
+                message=f"URI '{value}' has no scheme (expected https:// or urn:)",
+            ))
+        elif parsed.scheme not in ("https", "http", "urn"):
+            errors.append(ValidationError(
+                field=field_name,
+                message=f"URI scheme '{parsed.scheme}' is unusual; expected https, http, or urn",
+                severity="warning",
+            ))
+
+
+def _validate_capabilities(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check capability strings are well-formed."""
+    for cap in agent.capabilities:
+        if not cap:
+            errors.append(ValidationError(
+                field="capabilities",
+                message="Empty capability string",
+            ))
+        elif not CAPABILITY_RE.match(cap):
+            errors.append(ValidationError(
+                field="capabilities",
+                message=f"Capability '{cap}' contains invalid characters "
+                "(allowed: alphanumeric, hyphens, underscores, dots, slashes, colons)",
+            ))
+
+
+def _validate_bap(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Check BAP protocol format (e.g. 'a2a/1', 'mcp/1')."""
+    bap_re = re.compile(r"^[a-z0-9-]+(/[a-z0-9.]+)?$")
+    for entry in agent.bap:
+        if not bap_re.match(entry):
+            errors.append(ValidationError(
+                field="bap",
+                message=f"BAP entry '{entry}' has invalid format "
+                "(expected: protocol or protocol/version, e.g. 'a2a/1')",
+            ))
+
+
+def _validate_wire_size(agent: AgentRecord, errors: list[ValidationError]) -> None:
+    """Estimate SVCB RDATA wire size and warn if large."""
+    params = agent.to_svcb_params()
+    # Rough estimate: each param is key(2) + length(2) + value bytes
+    estimated = 4  # priority(2) + target length(1) + target
+    estimated += len(agent.target_host) + 2
+    for key, value in params.items():
+        estimated += 4 + len(value.encode("utf-8"))
+
+    if estimated > MAX_SVCB_RDATA_BYTES:
+        errors.append(ValidationError(
+            field="svcb_rdata",
+            message=f"Estimated SVCB RDATA size ({estimated} bytes) exceeds "
+            f"wire-format limit ({MAX_SVCB_RDATA_BYTES} bytes)",
+        ))
+    elif estimated > 4000:
+        errors.append(ValidationError(
+            field="svcb_rdata",
+            message=f"SVCB RDATA size ({estimated} bytes) is large; "
+            "some DNS providers may truncate or reject records over ~4KB",
+            severity="warning",
+        ))

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -165,11 +165,15 @@ async def publish(
     # Auto-populate A2A SvcParams when protocol is A2A.
     # Per IETF draft Section 4.4.3, the 'bap' param advertises application
     # protocols and the 'cap' param points to the capability descriptor.
-    resolved_bap = bap or []
+    # Only auto-populate when bap is None (not provided); an explicit bap=[]
+    # means the caller intentionally wants no bap entries.
+    resolved_bap = list(bap) if bap is not None else None
     resolved_cap_uri = cap_uri
     if protocol == Protocol.A2A:
-        if not resolved_bap or "a2a/1" not in resolved_bap:
-            resolved_bap = ["a2a/1"] + [b for b in resolved_bap if b != "a2a/1"]
+        if resolved_bap is None:
+            resolved_bap = ["a2a/1"]
+        elif "a2a/1" not in resolved_bap:
+            resolved_bap = ["a2a/1"] + resolved_bap
         if resolved_cap_uri is None:
             # Derive agent card URL from the A2A well-known path
             scheme = "https"
@@ -179,8 +183,12 @@ async def publish(
                 "/.well-known/agent-card.json"
             )
     elif protocol == Protocol.MCP:
-        if not resolved_bap or "mcp/1" not in resolved_bap:
-            resolved_bap = ["mcp/1"] + [b for b in resolved_bap if b != "mcp/1"]
+        if resolved_bap is None:
+            resolved_bap = ["mcp/1"]
+        elif "mcp/1" not in resolved_bap:
+            resolved_bap = ["mcp/1"] + resolved_bap
+    if resolved_bap is None:
+        resolved_bap = []
 
     # Create agent record
     agent = AgentRecord(

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -172,7 +172,7 @@ async def publish(
     if protocol == Protocol.A2A:
         if resolved_bap is None:
             resolved_bap = ["a2a/1"]
-        elif "a2a/1" not in resolved_bap:
+        elif resolved_bap and "a2a/1" not in resolved_bap:
             resolved_bap = ["a2a/1"] + resolved_bap
         if resolved_cap_uri is None:
             # Derive agent card URL from the A2A well-known path
@@ -185,7 +185,7 @@ async def publish(
     elif protocol == Protocol.MCP:
         if resolved_bap is None:
             resolved_bap = ["mcp/1"]
-        elif "mcp/1" not in resolved_bap:
+        elif resolved_bap and "mcp/1" not in resolved_bap:
             resolved_bap = ["mcp/1"] + resolved_bap
     if resolved_bap is None:
         resolved_bap = []

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -15,6 +15,7 @@ import structlog
 from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
 from dns_aid.backends.base import DNSBackend
 from dns_aid.core.models import AgentRecord, Protocol, PublishResult
+from dns_aid.core.pre_publish_validator import validate_record
 
 logger = structlog.get_logger(__name__)
 
@@ -161,6 +162,26 @@ async def publish(
         sig = sign_record(payload, private_key)
         logger.info("Record signed successfully", fqdn=fqdn)
 
+    # Auto-populate A2A SvcParams when protocol is A2A.
+    # Per IETF draft Section 4.4.3, the 'bap' param advertises application
+    # protocols and the 'cap' param points to the capability descriptor.
+    resolved_bap = bap or []
+    resolved_cap_uri = cap_uri
+    if protocol == Protocol.A2A:
+        if not resolved_bap or "a2a/1" not in resolved_bap:
+            resolved_bap = ["a2a/1"] + [b for b in resolved_bap if b != "a2a/1"]
+        if resolved_cap_uri is None:
+            # Derive agent card URL from the A2A well-known path
+            scheme = "https"
+            port_suffix = "" if port == 443 else f":{port}"
+            resolved_cap_uri = (
+                f"{scheme}://{endpoint}{port_suffix}"
+                "/.well-known/agent-card.json"
+            )
+    elif protocol == Protocol.MCP:
+        if not resolved_bap or "mcp/1" not in resolved_bap:
+            resolved_bap = ["mcp/1"] + [b for b in resolved_bap if b != "mcp/1"]
+
     # Create agent record
     agent = AgentRecord(
         name=name,
@@ -174,15 +195,34 @@ async def publish(
         use_cases=use_cases or [],
         category=category,
         ttl=ttl,
-        cap_uri=cap_uri,
+        cap_uri=resolved_cap_uri,
         cap_sha256=cap_sha256,
-        bap=bap or [],
+        bap=resolved_bap,
         policy_uri=policy_uri,
         realm=realm,
         ipv4_hint=ipv4_hint,
         ipv6_hint=ipv6_hint,
         sig=sig,
     )
+
+    # Pre-publish validation
+    validation_errors = validate_record(agent)
+    hard_errors = [e for e in validation_errors if e.severity == "error"]
+    if hard_errors:
+        error_msgs = "; ".join(f"{e.field}: {e.message}" for e in hard_errors)
+        logger.error("Pre-publish validation failed", errors=error_msgs)
+        return PublishResult(
+            agent=agent,
+            records_created=[],
+            zone=domain,
+            backend="(validation failed)",
+            success=False,
+            message=f"Validation failed: {error_msgs}",
+        )
+
+    warnings = [e for e in validation_errors if e.severity == "warning"]
+    for w in warnings:
+        logger.warning("Pre-publish warning", field=w.field, message=w.message)
 
     # Get backend
     dns_backend = backend or get_default_backend()

--- a/src/dns_aid/core/schema_registry.py
+++ b/src/dns_aid/core/schema_registry.py
@@ -1,0 +1,298 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SvcParam Schema Registry — canonical mapping between ecosystem fields and DNS-AID SvcParams.
+
+Provides a declarative registry that maps fields from LangServe, LangSmith, and A2A
+agent cards to DNS-AID SVCB SvcParamKey values, enabling consistent record construction
+across all integration points.
+
+Usage:
+    >>> from dns_aid.core.schema_registry import REGISTRY, from_langserve_route
+    >>>
+    >>> # Convert LangServe route config to SvcParam dict
+    >>> params = from_langserve_route(
+    ...     path="/my-agent",
+    ...     protocol="a2a",
+    ...     endpoint="api.example.com",
+    ...     capabilities=["search", "summarize"],
+    ... )
+    >>>
+    >>> # Look up a specific mapping
+    >>> entry = REGISTRY.lookup("cap_uri")
+    >>> print(entry.svcparam_key)
+    'key65400'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from dns_aid.core.models import DNS_AID_KEY_MAP, Protocol, _svcb_param_key
+
+
+@dataclass(frozen=True)
+class SvcParamEntry:
+    """A single field-to-SvcParam mapping entry.
+
+    Attributes:
+        field_name: Logical field name used in dns-aid-core (e.g. 'cap_uri').
+        svcparam_key: Wire-format key (e.g. 'key65400' or 'cap').
+        svcparam_name: Human-readable SvcParam name from the IETF draft (e.g. 'cap').
+        description: What this parameter represents.
+        sources: Which ecosystem systems populate this field.
+        serializer: Optional callable to convert a value to wire format string.
+    """
+
+    field_name: str
+    svcparam_key: str
+    svcparam_name: str
+    description: str
+    sources: list[str] = field(default_factory=list)
+    serializer: Callable[[Any], str] | None = None
+
+
+def _list_serializer(value: list[str] | str) -> str:
+    """Serialize a list to comma-separated string."""
+    if isinstance(value, list):
+        return ",".join(value)
+    return str(value)
+
+
+def _identity_serializer(value: Any) -> str:
+    return str(value)
+
+
+class SchemaRegistry:
+    """Registry of field-to-SvcParam mappings.
+
+    The registry is populated at module load with all DNS-AID SvcParamKeys
+    and their ecosystem source mappings.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, SvcParamEntry] = {}
+        self._by_svcparam: dict[str, SvcParamEntry] = {}
+
+    def register(self, entry: SvcParamEntry) -> None:
+        """Add or replace a mapping entry."""
+        self._entries[entry.field_name] = entry
+        self._by_svcparam[entry.svcparam_name] = entry
+
+    def lookup(self, field_name: str) -> SvcParamEntry | None:
+        """Look up a mapping by logical field name."""
+        return self._entries.get(field_name)
+
+    def lookup_by_svcparam(self, svcparam_name: str) -> SvcParamEntry | None:
+        """Look up a mapping by SvcParam name (e.g. 'cap', 'bap')."""
+        return self._by_svcparam.get(svcparam_name)
+
+    def all_entries(self) -> list[SvcParamEntry]:
+        """Return all registered entries."""
+        return list(self._entries.values())
+
+    def field_names(self) -> list[str]:
+        """Return all registered field names."""
+        return list(self._entries.keys())
+
+
+# ─── Global registry instance ───────────────────────────────────────────
+
+REGISTRY = SchemaRegistry()
+
+# Standard SVCB params
+REGISTRY.register(SvcParamEntry(
+    field_name="alpn",
+    svcparam_key="alpn",
+    svcparam_name="alpn",
+    description="Application-Layer Protocol Negotiation identifier",
+    sources=["langserve:protocol", "langgraph:protocol", "a2a:url"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="port",
+    svcparam_key="port",
+    svcparam_name="port",
+    description="Port number for the service endpoint",
+    sources=["langserve:port", "langgraph:port"],
+    serializer=lambda v: str(v),
+))
+
+# DNS-AID custom SvcParams (IETF draft-01 Section 4.4.3)
+REGISTRY.register(SvcParamEntry(
+    field_name="cap_uri",
+    svcparam_key=_svcb_param_key("cap"),
+    svcparam_name="cap",
+    description="URI to capability descriptor document",
+    sources=["langserve:cap_uri", "a2a:url+/.well-known/agent-card.json", "langsmith:project.metadata.cap_uri"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="cap_sha256",
+    svcparam_key=_svcb_param_key("cap-sha256"),
+    svcparam_name="cap-sha256",
+    description="SHA-256 digest of the capability descriptor for integrity",
+    sources=["langserve:cap_sha256"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="bap",
+    svcparam_key=_svcb_param_key("bap"),
+    svcparam_name="bap",
+    description="Bulk application protocols with versions (e.g. a2a/1, mcp/1)",
+    sources=["langserve:protocol(auto)", "langgraph:protocol(auto)", "a2a:defaultInputModes"],
+    serializer=_list_serializer,
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="policy_uri",
+    svcparam_key=_svcb_param_key("policy"),
+    svcparam_name="policy",
+    description="URI to agent policy document (jurisdiction, data handling)",
+    sources=["langserve:policy_uri", "langsmith:project.metadata.policy_uri"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="realm",
+    svcparam_key=_svcb_param_key("realm"),
+    svcparam_name="realm",
+    description="Multi-tenant scope or authz realm identifier",
+    sources=["langserve:realm", "langsmith:project.metadata.realm"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="sig",
+    svcparam_key=_svcb_param_key("sig"),
+    svcparam_name="sig",
+    description="JWS compact signature for record verification",
+    sources=["dns-aid-core:jwks.sign_record"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="connect_class",
+    svcparam_key=_svcb_param_key("connect-class"),
+    svcparam_name="connect-class",
+    description="Connection mediation mode (direct, lattice, apphub-psc)",
+    sources=["langserve:connect_class"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="connect_meta",
+    svcparam_key=_svcb_param_key("connect-meta"),
+    svcparam_name="connect-meta",
+    description="Provider-specific connection metadata (e.g. service ARN)",
+    sources=["langserve:connect_meta"],
+))
+REGISTRY.register(SvcParamEntry(
+    field_name="enroll_uri",
+    svcparam_key=_svcb_param_key("enroll-uri"),
+    svcparam_name="enroll-uri",
+    description="Managed enrollment endpoint for overlay access",
+    sources=["langserve:enroll_uri"],
+))
+
+
+# ─── Adapter functions ──────────────────────────────────────────────────
+
+
+def from_langserve_route(
+    *,
+    path: str,
+    protocol: str,
+    endpoint: str,
+    port: int = 443,
+    capabilities: list[str] | None = None,
+    version: str = "1.0.0",
+    cap_uri: str | None = None,
+    policy_uri: str | None = None,
+    realm: str | None = None,
+) -> dict[str, Any]:
+    """Convert LangServe route configuration to DNS-AID publish kwargs.
+
+    Returns a dict suitable for passing to ``dns_aid.publish(**result)``.
+    """
+    name = path.strip("/").replace("/", "-").replace("_", "-").lower() or "default"
+    proto = Protocol(protocol.lower())
+
+    result: dict[str, Any] = {
+        "name": name,
+        "protocol": proto,
+        "endpoint": endpoint,
+        "port": port,
+        "capabilities": capabilities,
+        "version": version,
+        "cap_uri": cap_uri,
+        "policy_uri": policy_uri,
+        "realm": realm,
+    }
+    return {k: v for k, v in result.items() if v is not None}
+
+
+def from_a2a_agent_card(card: Any, *, endpoint: str, port: int = 443) -> dict[str, Any]:
+    """Convert an A2A Agent Card to DNS-AID publish kwargs.
+
+    Args:
+        card: An A2AAgentCard instance.
+        endpoint: Hostname where the agent is reachable.
+        port: Port number.
+
+    Returns:
+        Dict suitable for ``dns_aid.publish(**result)``.
+    """
+    capabilities = []
+    if hasattr(card, "to_capabilities"):
+        capabilities = card.to_capabilities()
+    elif hasattr(card, "skills"):
+        capabilities = [s.id for s in card.skills if hasattr(s, "id")]
+
+    name = getattr(card, "name", "agent").lower().replace(" ", "-")
+    # Sanitize to DNS label format
+    name = "".join(c if c.isalnum() or c == "-" else "-" for c in name).strip("-")[:63]
+
+    return {
+        "name": name,
+        "protocol": Protocol.A2A,
+        "endpoint": endpoint,
+        "port": port,
+        "capabilities": capabilities,
+        "version": getattr(card, "version", "1.0.0"),
+        "description": getattr(card, "description", None),
+    }
+
+
+def from_langsmith_project(
+    project: dict[str, Any],
+    *,
+    domain: str,
+    endpoint: str,
+    protocol: str = "https",
+    port: int = 443,
+) -> dict[str, Any]:
+    """Convert LangSmith project metadata to DNS-AID publish kwargs.
+
+    Expects a project dict with at minimum a 'name' field, and optionally
+    'metadata' containing DNS-AID field overrides.
+
+    Args:
+        project: LangSmith project dict (from webhook payload or SDK).
+        domain: DNS domain to publish under.
+        endpoint: Hostname where the agent is reachable.
+        protocol: Default protocol.
+        port: Port number.
+
+    Returns:
+        Dict suitable for ``dns_aid.publish(**result)``.
+    """
+    metadata = project.get("metadata", {}) or {}
+
+    name = project.get("name", "agent").lower().replace(" ", "-").replace("_", "-")
+    name = "".join(c if c.isalnum() or c == "-" else "-" for c in name).strip("-")[:63]
+
+    result: dict[str, Any] = {
+        "name": name,
+        "domain": domain,
+        "protocol": metadata.get("protocol", protocol),
+        "endpoint": metadata.get("endpoint", endpoint),
+        "port": metadata.get("port", port),
+        "capabilities": metadata.get("capabilities"),
+        "version": metadata.get("version", "1.0.0"),
+        "description": project.get("description"),
+        "cap_uri": metadata.get("cap_uri"),
+        "policy_uri": metadata.get("policy_uri"),
+        "realm": metadata.get("realm"),
+    }
+    return {k: v for k, v in result.items() if v is not None}

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -440,7 +440,7 @@ class TestDnsaidParamsRoundtrip:
             agent = result.agents[0]
             assert agent.cap_uri == "https://cap.example.com/rich.json"
             assert agent.cap_sha256 == "abc123"
-            assert agent.bap == ["mcp", "a2a"]
+            assert agent.bap == ["mcp/1", "mcp", "a2a"]
             assert agent.policy_uri == "https://example.com/policy"
             assert agent.realm == "demo"
 
@@ -472,7 +472,7 @@ class TestDnsaidParamsRoundtrip:
             assert agent.cap_uri == "https://cap.example.com/partial.json"
             assert agent.realm == "staging"
             assert agent.cap_sha256 is None
-            assert agent.bap == []
+            assert agent.bap == ["mcp/1"]
             assert agent.policy_uri is None
 
 

--- a/tests/unit/test_a2a_bridge.py
+++ b/tests/unit/test_a2a_bridge.py
@@ -13,7 +13,9 @@ import pytest
 from dns_aid.a2a.bridge import (
     AgentCard,
     AgentCardSkill,
+    MAX_DNS_LABEL_LENGTH,
     _sanitize_dns_label,
+    _validate_endpoint,
     discover_a2a_agents,
     fetch_agent_card,
     publish_a2a_agent,
@@ -101,6 +103,19 @@ class TestAgentCard:
         card = AgentCard.from_dict(data)
         assert card.provider == "Acme Inc"
 
+    def test_from_dict_malformed_skills_raises(self) -> None:
+        """skills as a string should raise TypeError, not iterate chars."""
+        data = {"name": "Bad", "skills": "not-a-list"}
+        with pytest.raises(TypeError, match="Expected 'skills' to be a list"):
+            AgentCard.from_dict(data)
+
+    def test_from_dict_non_dict_skill_entries_skipped(self) -> None:
+        """Non-dict entries inside the skills list are skipped."""
+        data = {"name": "Test", "skills": [42, "string", {"id": "real", "name": "Real"}]}
+        card = AgentCard.from_dict(data)
+        assert len(card.skills) == 1
+        assert card.skills[0].id == "real"
+
     def test_to_dict(self) -> None:
         card = AgentCard(
             name="Test Agent",
@@ -150,6 +165,29 @@ class TestAgentCard:
         assert len(result["skills"]) == len(original["skills"])
 
 
+class TestValidateEndpoint:
+    """Tests for _validate_endpoint."""
+
+    def test_valid_hostname(self) -> None:
+        _validate_endpoint("api.example.com")
+
+    def test_rejects_slash(self) -> None:
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_endpoint("evil.com/../../bypass")
+
+    def test_rejects_at_sign(self) -> None:
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_endpoint("evil.com@attacker.com")
+
+    def test_rejects_hash(self) -> None:
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_endpoint("evil.com#fragment")
+
+    def test_rejects_question_mark(self) -> None:
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_endpoint("evil.com?query=1")
+
+
 class TestSanitizeDnsLabel:
     """Tests for _sanitize_dns_label."""
 
@@ -176,6 +214,11 @@ class TestSanitizeDnsLabel:
 
     def test_special_only_returns_agent(self) -> None:
         assert _sanitize_dns_label("!!!") == "agent"
+
+    def test_truncates_to_63_chars(self) -> None:
+        long_name = "a" * 100
+        result = _sanitize_dns_label(long_name)
+        assert len(result) <= MAX_DNS_LABEL_LENGTH
 
 
 class TestToAgentCard:
@@ -261,7 +304,7 @@ class TestFetchAgentCard:
     """Tests for fetch_agent_card."""
 
     @pytest.mark.asyncio
-    async def test_fetches_card(self) -> None:
+    async def test_fetches_card_https(self) -> None:
         card_data = {
             "name": "Remote Agent",
             "description": "A remote agent",
@@ -273,7 +316,8 @@ class TestFetchAgentCard:
         mock_response.json.return_value = card_data
         mock_response.raise_for_status = MagicMock()
 
-        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx:
+        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx, \
+             patch("dns_aid.a2a.bridge.validate_fetch_url"):
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -284,19 +328,18 @@ class TestFetchAgentCard:
 
         assert card.name == "Remote Agent"
         assert card.description == "A remote agent"
-        mock_client.get.assert_awaited_once_with(
-            "https://remote.example.com:443/.well-known/agent-card.json"
-        )
 
     @pytest.mark.asyncio
-    async def test_uses_http_for_non_443(self) -> None:
+    async def test_defaults_to_https_for_non_443(self) -> None:
+        """Non-443 ports should still use HTTPS by default."""
         card_data = {"name": "Test"}
 
         mock_response = MagicMock()
         mock_response.json.return_value = card_data
         mock_response.raise_for_status = MagicMock()
 
-        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx:
+        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx, \
+             patch("dns_aid.a2a.bridge.validate_fetch_url"):
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -305,9 +348,57 @@ class TestFetchAgentCard:
 
             await fetch_agent_card("test.example.com", port=8080)
 
-        mock_client.get.assert_awaited_once_with(
-            "http://test.example.com:8080/.well-known/agent-card.json"
-        )
+        # Should be HTTPS, not HTTP
+        mock_client.get.assert_awaited_once()
+        url_called = mock_client.get.call_args[0][0]
+        assert url_called.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_allow_http_enables_cleartext(self) -> None:
+        """allow_http=True for non-443 ports should use HTTP."""
+        card_data = {"name": "Test"}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = card_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx, \
+             patch("dns_aid.a2a.bridge.validate_fetch_url"):
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.AsyncClient.return_value = mock_client
+
+            await fetch_agent_card(
+                "test.example.com", port=8080, allow_http=True
+            )
+
+        url_called = mock_client.get.call_args[0][0]
+        assert url_called.startswith("http://")
+
+    @pytest.mark.asyncio
+    async def test_rejects_unsafe_endpoint(self) -> None:
+        with pytest.raises(ValueError, match="unsafe characters"):
+            await fetch_agent_card("evil.com/../../bypass")
+
+    @pytest.mark.asyncio
+    async def test_uses_shared_client(self) -> None:
+        card_data = {"name": "Shared"}
+        mock_response = MagicMock()
+        mock_response.json.return_value = card_data
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("dns_aid.a2a.bridge.validate_fetch_url"):
+            card = await fetch_agent_card(
+                "test.example.com", client=mock_client
+            )
+
+        assert card.name == "Shared"
+        mock_client.get.assert_awaited_once()
 
 
 class TestPublishA2aAgent:
@@ -330,7 +421,7 @@ class TestPublishA2aAgent:
         )
 
         with patch(
-            "dns_aid.core.publisher.publish", new_callable=AsyncMock
+            "dns_aid.a2a.bridge.publish", new_callable=AsyncMock
         ) as mock_publish:
             mock_publish.return_value = mock_result
 
@@ -358,7 +449,7 @@ class TestPublishA2aAgent:
         )
 
         with patch(
-            "dns_aid.core.publisher.publish", new_callable=AsyncMock
+            "dns_aid.a2a.bridge.publish", new_callable=AsyncMock
         ) as mock_publish:
             mock_publish.return_value = mock_result
 
@@ -383,7 +474,7 @@ class TestPublishA2aAgent:
         )
 
         with patch(
-            "dns_aid.core.publisher.publish", new_callable=AsyncMock
+            "dns_aid.a2a.bridge.publish", new_callable=AsyncMock
         ) as mock_publish:
             mock_publish.return_value = mock_result
 
@@ -404,6 +495,19 @@ class TestPublishA2aAgent:
                 card, domain="agents.example.com"
             )
 
+    @pytest.mark.asyncio
+    async def test_raises_with_both_backend_and_backend_name(self) -> None:
+        card = AgentCard(name="Test", url="https://test.example.com")
+
+        with pytest.raises(ValueError, match="Specify either"):
+            await publish_a2a_agent(
+                card,
+                domain="agents.example.com",
+                endpoint="test.example.com",
+                backend=MagicMock(),
+                backend_name="mock",
+            )
+
 
 class TestUnpublishA2aAgent:
     """Tests for unpublish_a2a_agent."""
@@ -411,7 +515,7 @@ class TestUnpublishA2aAgent:
     @pytest.mark.asyncio
     async def test_unpublishes(self) -> None:
         with patch(
-            "dns_aid.core.publisher.unpublish", new_callable=AsyncMock
+            "dns_aid.a2a.bridge.unpublish", new_callable=AsyncMock
         ) as mock_unpublish:
             mock_unpublish.return_value = True
 
@@ -428,7 +532,7 @@ class TestUnpublishA2aAgent:
     @pytest.mark.asyncio
     async def test_returns_false_when_not_found(self) -> None:
         with patch(
-            "dns_aid.core.publisher.unpublish", new_callable=AsyncMock
+            "dns_aid.a2a.bridge.unpublish", new_callable=AsyncMock
         ) as mock_unpublish:
             mock_unpublish.return_value = False
 
@@ -438,3 +542,13 @@ class TestUnpublishA2aAgent:
             )
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_raises_with_both_backend_and_backend_name(self) -> None:
+        with pytest.raises(ValueError, match="Specify either"):
+            await unpublish_a2a_agent(
+                name="test",
+                domain="agents.example.com",
+                backend=MagicMock(),
+                backend_name="mock",
+            )

--- a/tests/unit/test_a2a_bridge.py
+++ b/tests/unit/test_a2a_bridge.py
@@ -1,0 +1,440 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for A2A discovery bridge."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dns_aid.a2a.bridge import (
+    AgentCard,
+    AgentCardSkill,
+    _sanitize_dns_label,
+    discover_a2a_agents,
+    fetch_agent_card,
+    publish_a2a_agent,
+    to_agent_card,
+    unpublish_a2a_agent,
+)
+from dns_aid.core.models import AgentRecord, DiscoveryResult
+
+
+class TestAgentCardSkill:
+    """Tests for AgentCardSkill dataclass."""
+
+    def test_defaults(self) -> None:
+        skill = AgentCardSkill(id="search", name="Search")
+        assert skill.id == "search"
+        assert skill.name == "Search"
+        assert skill.description == ""
+        assert skill.tags == []
+        assert skill.examples == []
+
+    def test_all_fields(self) -> None:
+        skill = AgentCardSkill(
+            id="search",
+            name="Search",
+            description="Full-text search",
+            tags=["search", "retrieval"],
+            examples=["find papers about AI"],
+        )
+        assert skill.description == "Full-text search"
+        assert skill.tags == ["search", "retrieval"]
+        assert skill.examples == ["find papers about AI"]
+
+
+class TestAgentCard:
+    """Tests for AgentCard dataclass."""
+
+    def test_defaults(self) -> None:
+        card = AgentCard(name="test")
+        assert card.name == "test"
+        assert card.description == ""
+        assert card.url == ""
+        assert card.skills == []
+        assert card.raw == {}
+
+    def test_from_dict(self) -> None:
+        data = {
+            "name": "Research Agent",
+            "description": "A research assistant",
+            "url": "https://research.example.com",
+            "version": "2.0.0",
+            "skills": [
+                {
+                    "id": "search",
+                    "name": "Search",
+                    "description": "Search for papers",
+                    "tags": ["search"],
+                    "examples": ["find papers"],
+                }
+            ],
+            "provider": {"organization": "Example Corp"},
+            "documentationUrl": "https://docs.example.com",
+            "capabilities": {"streaming": True},
+        }
+        card = AgentCard.from_dict(data)
+        assert card.name == "Research Agent"
+        assert card.description == "A research assistant"
+        assert card.url == "https://research.example.com"
+        assert card.version == "2.0.0"
+        assert len(card.skills) == 1
+        assert card.skills[0].id == "search"
+        assert card.skills[0].tags == ["search"]
+        assert card.provider == "Example Corp"
+        assert card.documentation_url == "https://docs.example.com"
+        assert card.capabilities == {"streaming": True}
+
+    def test_from_dict_minimal(self) -> None:
+        data = {"name": "Simple Agent"}
+        card = AgentCard.from_dict(data)
+        assert card.name == "Simple Agent"
+        assert card.skills == []
+        assert card.provider == ""
+
+    def test_from_dict_string_provider(self) -> None:
+        data = {"name": "Test", "provider": "Acme Inc"}
+        card = AgentCard.from_dict(data)
+        assert card.provider == "Acme Inc"
+
+    def test_to_dict(self) -> None:
+        card = AgentCard(
+            name="Test Agent",
+            description="A test agent",
+            url="https://test.example.com",
+            version="1.0.0",
+            skills=[
+                AgentCardSkill(
+                    id="summarize",
+                    name="Summarize",
+                    description="Summarize text",
+                )
+            ],
+            provider="Test Corp",
+        )
+        result = card.to_dict()
+        assert result["name"] == "Test Agent"
+        assert result["description"] == "A test agent"
+        assert result["url"] == "https://test.example.com"
+        assert len(result["skills"]) == 1
+        assert result["skills"][0]["id"] == "summarize"
+        assert result["provider"] == {"organization": "Test Corp"}
+
+    def test_to_dict_minimal(self) -> None:
+        card = AgentCard(name="Simple")
+        result = card.to_dict()
+        assert result["name"] == "Simple"
+        assert "skills" not in result
+        assert "provider" not in result
+
+    def test_roundtrip(self) -> None:
+        original = {
+            "name": "Roundtrip Agent",
+            "description": "Testing roundtrip",
+            "url": "https://rt.example.com",
+            "version": "1.0.0",
+            "skills": [
+                {"id": "test", "name": "Test", "description": "Test skill"}
+            ],
+            "provider": {"organization": "Test"},
+        }
+        card = AgentCard.from_dict(original)
+        result = card.to_dict()
+        assert result["name"] == original["name"]
+        assert result["description"] == original["description"]
+        assert result["url"] == original["url"]
+        assert len(result["skills"]) == len(original["skills"])
+
+
+class TestSanitizeDnsLabel:
+    """Tests for _sanitize_dns_label."""
+
+    def test_simple_name(self) -> None:
+        assert _sanitize_dns_label("my-agent") == "my-agent"
+
+    def test_spaces_to_hyphens(self) -> None:
+        assert _sanitize_dns_label("My Agent") == "my-agent"
+
+    def test_underscores_to_hyphens(self) -> None:
+        assert _sanitize_dns_label("my_agent") == "my-agent"
+
+    def test_removes_special_chars(self) -> None:
+        assert _sanitize_dns_label("my.agent!v2") == "myagentv2"
+
+    def test_strips_hyphens(self) -> None:
+        assert _sanitize_dns_label("-agent-") == "agent"
+
+    def test_lowercase(self) -> None:
+        assert _sanitize_dns_label("MyAgent") == "myagent"
+
+    def test_empty_returns_agent(self) -> None:
+        assert _sanitize_dns_label("") == "agent"
+
+    def test_special_only_returns_agent(self) -> None:
+        assert _sanitize_dns_label("!!!") == "agent"
+
+
+class TestToAgentCard:
+    """Tests for to_agent_card conversion."""
+
+    def test_converts_basic_agent(self) -> None:
+        agent = AgentRecord(
+            name="search-agent",
+            domain="example.com",
+            protocol="a2a",
+            target_host="search.example.com",
+            port=443,
+            capabilities=["search", "summarize"],
+            version="1.0.0",
+            description="A search agent",
+        )
+        card = to_agent_card(agent)
+        assert card.name == "search-agent"
+        assert card.description == "A search agent"
+        assert card.version == "1.0.0"
+        assert len(card.skills) == 2
+        assert card.skills[0].id == "search"
+        assert card.skills[1].id == "summarize"
+
+    def test_converts_agent_without_capabilities(self) -> None:
+        agent = AgentRecord(
+            name="simple",
+            domain="example.com",
+            protocol="a2a",
+            target_host="simple.example.com",
+        )
+        card = to_agent_card(agent)
+        assert card.name == "simple"
+        assert card.skills == []
+
+    def test_includes_endpoint_url(self) -> None:
+        agent = AgentRecord(
+            name="test",
+            domain="example.com",
+            protocol="a2a",
+            target_host="test.example.com",
+            port=8080,
+        )
+        card = to_agent_card(agent)
+        assert "test.example.com" in card.url
+        assert "8080" in card.url
+
+
+class TestDiscoverA2aAgents:
+    """Tests for discover_a2a_agents."""
+
+    @pytest.mark.asyncio
+    async def test_filters_by_a2a_protocol(self) -> None:
+        mock_agent = AgentRecord(
+            name="a2a-agent",
+            domain="example.com",
+            protocol="a2a",
+            target_host="a2a.example.com",
+        )
+        mock_result = DiscoveryResult(
+            query="_agents.example.com",
+            domain="example.com",
+            agents=[mock_agent],
+        )
+
+        with patch(
+            "dns_aid.a2a.bridge.discover", new_callable=AsyncMock
+        ) as mock_discover:
+            mock_discover.return_value = mock_result
+
+            agents = await discover_a2a_agents("example.com")
+
+        assert len(agents) == 1
+        assert agents[0].name == "a2a-agent"
+        mock_discover.assert_awaited_once_with(
+            domain="example.com",
+            protocol="a2a",
+            require_dnssec=False,
+        )
+
+
+class TestFetchAgentCard:
+    """Tests for fetch_agent_card."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_card(self) -> None:
+        card_data = {
+            "name": "Remote Agent",
+            "description": "A remote agent",
+            "url": "https://remote.example.com",
+            "version": "1.0.0",
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = card_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.AsyncClient.return_value = mock_client
+
+            card = await fetch_agent_card("remote.example.com")
+
+        assert card.name == "Remote Agent"
+        assert card.description == "A remote agent"
+        mock_client.get.assert_awaited_once_with(
+            "https://remote.example.com:443/.well-known/agent-card.json"
+        )
+
+    @pytest.mark.asyncio
+    async def test_uses_http_for_non_443(self) -> None:
+        card_data = {"name": "Test"}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = card_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("dns_aid.a2a.bridge.httpx") as mock_httpx:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.AsyncClient.return_value = mock_client
+
+            await fetch_agent_card("test.example.com", port=8080)
+
+        mock_client.get.assert_awaited_once_with(
+            "http://test.example.com:8080/.well-known/agent-card.json"
+        )
+
+
+class TestPublishA2aAgent:
+    """Tests for publish_a2a_agent."""
+
+    @pytest.mark.asyncio
+    async def test_publishes_card(self) -> None:
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {"success": True}
+
+        card = AgentCard(
+            name="My Agent",
+            description="A helpful agent",
+            url="https://agent.example.com",
+            version="1.0.0",
+            skills=[
+                AgentCardSkill(id="search", name="Search"),
+                AgentCardSkill(id="summarize", name="Summarize"),
+            ],
+        )
+
+        with patch(
+            "dns_aid.core.publisher.publish", new_callable=AsyncMock
+        ) as mock_publish:
+            mock_publish.return_value = mock_result
+
+            result = await publish_a2a_agent(
+                card,
+                domain="agents.example.com",
+                endpoint="agent.example.com",
+            )
+
+        assert result["success"] is True
+        call_kwargs = mock_publish.call_args.kwargs
+        assert call_kwargs["name"] == "my-agent"
+        assert call_kwargs["protocol"] == "a2a"
+        assert call_kwargs["capabilities"] == ["search", "summarize"]
+        assert call_kwargs["description"] == "A helpful agent"
+
+    @pytest.mark.asyncio
+    async def test_uses_explicit_name(self) -> None:
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {"success": True}
+
+        card = AgentCard(
+            name="My Agent",
+            url="https://agent.example.com",
+        )
+
+        with patch(
+            "dns_aid.core.publisher.publish", new_callable=AsyncMock
+        ) as mock_publish:
+            mock_publish.return_value = mock_result
+
+            await publish_a2a_agent(
+                card,
+                domain="agents.example.com",
+                name="custom-name",
+                endpoint="agent.example.com",
+            )
+
+        call_kwargs = mock_publish.call_args.kwargs
+        assert call_kwargs["name"] == "custom-name"
+
+    @pytest.mark.asyncio
+    async def test_extracts_endpoint_from_url(self) -> None:
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {"success": True}
+
+        card = AgentCard(
+            name="Test",
+            url="https://agent.example.com:8080/api",
+        )
+
+        with patch(
+            "dns_aid.core.publisher.publish", new_callable=AsyncMock
+        ) as mock_publish:
+            mock_publish.return_value = mock_result
+
+            await publish_a2a_agent(
+                card, domain="agents.example.com"
+            )
+
+        call_kwargs = mock_publish.call_args.kwargs
+        assert call_kwargs["endpoint"] == "agent.example.com"
+        assert call_kwargs["port"] == 8080
+
+    @pytest.mark.asyncio
+    async def test_raises_without_endpoint(self) -> None:
+        card = AgentCard(name="No URL Agent")
+
+        with pytest.raises(ValueError, match="endpoint"):
+            await publish_a2a_agent(
+                card, domain="agents.example.com"
+            )
+
+
+class TestUnpublishA2aAgent:
+    """Tests for unpublish_a2a_agent."""
+
+    @pytest.mark.asyncio
+    async def test_unpublishes(self) -> None:
+        with patch(
+            "dns_aid.core.publisher.unpublish", new_callable=AsyncMock
+        ) as mock_unpublish:
+            mock_unpublish.return_value = True
+
+            result = await unpublish_a2a_agent(
+                name="my-agent",
+                domain="agents.example.com",
+            )
+
+        assert result is True
+        call_kwargs = mock_unpublish.call_args.kwargs
+        assert call_kwargs["name"] == "my-agent"
+        assert call_kwargs["protocol"] == "a2a"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(self) -> None:
+        with patch(
+            "dns_aid.core.publisher.unpublish", new_callable=AsyncMock
+        ) as mock_unpublish:
+            mock_unpublish.return_value = False
+
+            result = await unpublish_a2a_agent(
+                name="missing",
+                domain="agents.example.com",
+            )
+
+        assert result is False

--- a/tests/unit/test_pre_publish_validator.py
+++ b/tests/unit/test_pre_publish_validator.py
@@ -1,0 +1,155 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pre-publish record validator."""
+
+import pytest
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.core.pre_publish_validator import validate_record
+
+
+def _make_agent(**kwargs) -> AgentRecord:
+    """Create an AgentRecord with sensible defaults."""
+    defaults = {
+        "name": "chat",
+        "domain": "example.com",
+        "protocol": Protocol.A2A,
+        "target_host": "api.example.com",
+    }
+    defaults.update(kwargs)
+    return AgentRecord(**defaults)
+
+
+class TestValidateRecord:
+    """Tests for validate_record."""
+
+    def test_valid_record_no_errors(self):
+        agent = _make_agent()
+        errors = validate_record(agent)
+        assert errors == []
+
+    def test_valid_record_with_all_fields(self):
+        agent = _make_agent(
+            capabilities=["search", "summarize"],
+            version="2.0.0",
+            description="A chat agent",
+            cap_uri="https://api.example.com/.well-known/agent-cap.json",
+            bap=["a2a/1"],
+            policy_uri="https://example.com/policy",
+            realm="production",
+        )
+        errors = validate_record(agent)
+        assert errors == []
+
+
+class TestFqdnValidation:
+    """Tests for FQDN length validation."""
+
+    def test_long_fqdn(self):
+        agent = _make_agent(name="a" * 63, domain="b" * 63 + "." + "c" * 63 + "." + "d" * 63)
+        errors = validate_record(agent)
+        fqdn_errors = [e for e in errors if e.field == "fqdn"]
+        assert any("exceeds" in e.message for e in fqdn_errors)
+
+
+class TestTtlValidation:
+    """Tests for TTL bounds checking."""
+
+    def test_ttl_too_low(self):
+        agent = _make_agent(ttl=30)
+        errors = validate_record(agent)
+        assert all(e.field != "ttl" for e in errors)
+
+    def test_ttl_at_minimum(self):
+        agent = _make_agent(ttl=30)
+        errors = validate_record(agent)
+        ttl_errors = [e for e in errors if e.field == "ttl"]
+        assert len(ttl_errors) == 0
+
+    def test_ttl_at_maximum(self):
+        agent = _make_agent(ttl=86400)
+        errors = validate_record(agent)
+        ttl_errors = [e for e in errors if e.field == "ttl"]
+        assert len(ttl_errors) == 0
+
+
+class TestUriValidation:
+    """Tests for URI format validation."""
+
+    def test_valid_https_uri(self):
+        agent = _make_agent(cap_uri="https://example.com/cap.json")
+        errors = validate_record(agent)
+        assert all(e.field != "cap_uri" for e in errors)
+
+    def test_uri_no_scheme(self):
+        agent = _make_agent(cap_uri="example.com/cap.json")
+        errors = validate_record(agent)
+        cap_errors = [e for e in errors if e.field == "cap_uri"]
+        assert len(cap_errors) == 1
+        assert "no scheme" in cap_errors[0].message
+
+    def test_urn_uri_valid(self):
+        agent = _make_agent(cap_uri="urn:dns-aid:cap:example")
+        errors = validate_record(agent)
+        assert all(e.field != "cap_uri" for e in errors)
+
+    def test_unusual_scheme_warns(self):
+        agent = _make_agent(cap_uri="ftp://example.com/cap.json")
+        errors = validate_record(agent)
+        cap_errors = [e for e in errors if e.field == "cap_uri"]
+        assert len(cap_errors) == 1
+        assert cap_errors[0].severity == "warning"
+
+
+class TestCapabilityValidation:
+    """Tests for capability string format."""
+
+    def test_valid_capabilities(self):
+        agent = _make_agent(capabilities=["search", "dns/lookup", "network.ipam"])
+        errors = validate_record(agent)
+        assert all(e.field != "capabilities" for e in errors)
+
+    def test_invalid_capability_chars(self):
+        agent = _make_agent(capabilities=["valid", "has spaces"])
+        errors = validate_record(agent)
+        cap_errors = [e for e in errors if e.field == "capabilities"]
+        assert len(cap_errors) == 1
+        assert "has spaces" in cap_errors[0].message
+
+    def test_empty_capability(self):
+        agent = _make_agent(capabilities=["valid", ""])
+        errors = validate_record(agent)
+        cap_errors = [e for e in errors if e.field == "capabilities"]
+        assert len(cap_errors) == 1
+        assert "Empty" in cap_errors[0].message
+
+
+class TestBapValidation:
+    """Tests for BAP protocol format."""
+
+    def test_valid_bap(self):
+        agent = _make_agent(bap=["a2a/1", "mcp/1"])
+        errors = validate_record(agent)
+        assert all(e.field != "bap" for e in errors)
+
+    def test_bap_without_version(self):
+        agent = _make_agent(bap=["a2a"])
+        errors = validate_record(agent)
+        assert all(e.field != "bap" for e in errors)
+
+    def test_invalid_bap(self):
+        agent = _make_agent(bap=["A2A/1"])  # uppercase
+        errors = validate_record(agent)
+        bap_errors = [e for e in errors if e.field == "bap"]
+        assert len(bap_errors) == 1
+
+
+class TestProtocolValidation:
+    """Tests for protocol/ALPN validation."""
+
+    def test_valid_protocols(self):
+        for proto in [Protocol.A2A, Protocol.MCP, Protocol.HTTPS]:
+            agent = _make_agent(protocol=proto)
+            errors = validate_record(agent)
+            assert all(e.field != "protocol" for e in errors)

--- a/tests/unit/test_pre_publish_validator.py
+++ b/tests/unit/test_pre_publish_validator.py
@@ -56,10 +56,19 @@ class TestFqdnValidation:
 class TestTtlValidation:
     """Tests for TTL bounds checking."""
 
-    def test_ttl_too_low(self):
-        agent = _make_agent(ttl=30)
-        errors = validate_record(agent)
-        assert all(e.field != "ttl" for e in errors)
+    def test_ttl_below_minimum_rejected_by_model(self):
+        """Pydantic model itself rejects ttl < 30."""
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            _make_agent(ttl=29)
+
+    def test_ttl_above_maximum_rejected_by_model(self):
+        """Pydantic model itself rejects ttl > 86400."""
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            _make_agent(ttl=86401)
 
     def test_ttl_at_minimum(self):
         agent = _make_agent(ttl=30)
@@ -100,6 +109,22 @@ class TestUriValidation:
         cap_errors = [e for e in errors if e.field == "cap_uri"]
         assert len(cap_errors) == 1
         assert cap_errors[0].severity == "warning"
+
+    def test_http_cap_uri_warns_cleartext(self):
+        agent = _make_agent(cap_uri="http://example.com/cap.json")
+        errors = validate_record(agent)
+        cap_errors = [e for e in errors if e.field == "cap_uri"]
+        assert len(cap_errors) == 1
+        assert cap_errors[0].severity == "warning"
+        assert "cleartext" in cap_errors[0].message.lower()
+
+    def test_http_policy_uri_warns_cleartext(self):
+        agent = _make_agent(policy_uri="http://example.com/policy")
+        errors = validate_record(agent)
+        policy_errors = [e for e in errors if e.field == "policy_uri"]
+        assert len(policy_errors) == 1
+        assert policy_errors[0].severity == "warning"
+        assert "cleartext" in policy_errors[0].message.lower()
 
 
 class TestCapabilityValidation:

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -240,6 +240,24 @@ class TestPublish:
         assert result.agent.bap == ["a2a/1", "custom/2"]
 
     @pytest.mark.asyncio
+    async def test_publish_a2a_explicit_empty_bap_not_overridden(self, mock_backend: MockBackend):
+        """Test explicit bap=[] is respected (not auto-populated)."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            bap=[],
+            backend=mock_backend,
+        )
+
+        assert result.agent.bap == []
+
+        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        assert svcb is not None
+        assert "key65402" not in svcb["params"]
+
+    @pytest.mark.asyncio
     async def test_publish_a2a_explicit_cap_uri_not_overridden(self, mock_backend: MockBackend):
         """Test explicit cap_uri is not overridden by auto-derivation."""
         result = await publish(

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -152,8 +152,8 @@ class TestPublish:
         assert svcb["params"]["key65404"] == "production"
 
     @pytest.mark.asyncio
-    async def test_publish_without_cap_uri_unchanged(self, mock_backend: MockBackend):
-        """Test publishing without cap_uri doesn't add DNS-AID params (backwards compat)."""
+    async def test_publish_a2a_auto_populates_bap_and_cap(self, mock_backend: MockBackend):
+        """Test A2A publish auto-sets bap=['a2a/1'] and derives cap_uri."""
         result = await publish(
             name="chat",
             domain="example.com",
@@ -163,19 +163,95 @@ class TestPublish:
         )
 
         assert result.success is True
-        assert result.agent.cap_uri is None
+        assert result.agent.bap == ["a2a/1"]
+        assert result.agent.cap_uri == "https://chat.example.com/.well-known/agent-card.json"
         assert result.agent.cap_sha256 is None
-        assert result.agent.bap == []
         assert result.agent.policy_uri is None
         assert result.agent.realm is None
 
         svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
         assert svcb is not None
-        assert "cap" not in svcb["params"]
-        assert "cap-sha256" not in svcb["params"]
-        assert "bap" not in svcb["params"]
-        assert "policy" not in svcb["params"]
-        assert "realm" not in svcb["params"]
+        assert svcb["params"]["key65402"] == "a2a/1"
+        assert svcb["params"]["key65400"] == "https://chat.example.com/.well-known/agent-card.json"
+        assert "key65403" not in svcb["params"]
+        assert "key65404" not in svcb["params"]
+
+    @pytest.mark.asyncio
+    async def test_publish_mcp_auto_populates_bap(self, mock_backend: MockBackend):
+        """Test MCP publish auto-sets bap=['mcp/1']."""
+        result = await publish(
+            name="tools",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="mcp.example.com",
+            backend=mock_backend,
+        )
+
+        assert result.success is True
+        assert result.agent.bap == ["mcp/1"]
+        assert result.agent.cap_uri is None  # No auto cap_uri for MCP
+
+    @pytest.mark.asyncio
+    async def test_publish_https_no_auto_bap(self, mock_backend: MockBackend):
+        """Test HTTPS publish does not auto-populate bap or cap_uri."""
+        result = await publish(
+            name="api",
+            domain="example.com",
+            protocol="https",
+            endpoint="api.example.com",
+            backend=mock_backend,
+        )
+
+        assert result.success is True
+        assert result.agent.bap == []
+        assert result.agent.cap_uri is None
+
+        svcb = mock_backend.get_svcb_record("example.com", "_api._https._agents")
+        assert svcb is not None
+        assert "key65402" not in svcb["params"]
+        assert "key65400" not in svcb["params"]
+
+    @pytest.mark.asyncio
+    async def test_publish_a2a_custom_port_in_cap_uri(self, mock_backend: MockBackend):
+        """Test A2A auto cap_uri includes non-standard port."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            port=8443,
+            backend=mock_backend,
+        )
+
+        assert result.agent.cap_uri == "https://chat.example.com:8443/.well-known/agent-card.json"
+
+    @pytest.mark.asyncio
+    async def test_publish_a2a_explicit_bap_preserved(self, mock_backend: MockBackend):
+        """Test explicit bap is preserved and a2a/1 prepended if missing."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            bap=["custom/2"],
+            backend=mock_backend,
+        )
+
+        assert result.agent.bap == ["a2a/1", "custom/2"]
+
+    @pytest.mark.asyncio
+    async def test_publish_a2a_explicit_cap_uri_not_overridden(self, mock_backend: MockBackend):
+        """Test explicit cap_uri is not overridden by auto-derivation."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            cap_uri="https://custom.example.com/caps.json",
+            backend=mock_backend,
+        )
+
+        assert result.agent.cap_uri == "https://custom.example.com/caps.json"
 
     @pytest.mark.asyncio
     async def test_publish_with_partial_dnsaid_params(self, mock_backend: MockBackend):
@@ -195,7 +271,7 @@ class TestPublish:
         assert svcb is not None
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65404"] == "demo"
-        assert "key65402" not in svcb["params"]
+        assert svcb["params"]["key65402"] == "mcp/1"  # auto-populated for MCP
         assert "key65403" not in svcb["params"]
 
 

--- a/tests/unit/test_schema_registry.py
+++ b/tests/unit/test_schema_registry.py
@@ -1,0 +1,169 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for SvcParam schema registry."""
+
+from dns_aid.core.schema_registry import (
+    REGISTRY,
+    from_a2a_agent_card,
+    from_langserve_route,
+    from_langsmith_project,
+)
+
+
+class TestSchemaRegistry:
+    """Tests for the global schema registry."""
+
+    def test_registry_has_all_svcparams(self):
+        """All DNS-AID SvcParam keys are registered."""
+        expected = {
+            "alpn", "port", "cap_uri", "cap_sha256", "bap",
+            "policy_uri", "realm", "sig", "connect_class",
+            "connect_meta", "enroll_uri",
+        }
+        assert set(REGISTRY.field_names()) == expected
+
+    def test_lookup_by_field_name(self):
+        entry = REGISTRY.lookup("cap_uri")
+        assert entry is not None
+        assert entry.svcparam_name == "cap"
+        assert "langserve" in entry.sources[0]
+
+    def test_lookup_by_svcparam_name(self):
+        entry = REGISTRY.lookup_by_svcparam("bap")
+        assert entry is not None
+        assert entry.field_name == "bap"
+
+    def test_lookup_missing_returns_none(self):
+        assert REGISTRY.lookup("nonexistent") is None
+
+    def test_bap_serializer(self):
+        entry = REGISTRY.lookup("bap")
+        assert entry.serializer(["a2a/1", "mcp/1"]) == "a2a/1,mcp/1"
+        assert entry.serializer("a2a/1") == "a2a/1"
+
+
+class TestFromLangserveRoute:
+    """Tests for LangServe route adapter."""
+
+    def test_basic_conversion(self):
+        result = from_langserve_route(
+            path="/my-agent",
+            protocol="a2a",
+            endpoint="api.example.com",
+        )
+        assert result["name"] == "my-agent"
+        assert result["protocol"].value == "a2a"
+        assert result["endpoint"] == "api.example.com"
+        assert result["port"] == 443
+
+    def test_nested_path(self):
+        result = from_langserve_route(
+            path="/api/v1/chat",
+            protocol="mcp",
+            endpoint="mcp.example.com",
+        )
+        assert result["name"] == "api-v1-chat"
+
+    def test_empty_path(self):
+        result = from_langserve_route(
+            path="",
+            protocol="https",
+            endpoint="api.example.com",
+        )
+        assert result["name"] == "default"
+
+    def test_none_values_excluded(self):
+        result = from_langserve_route(
+            path="/agent",
+            protocol="a2a",
+            endpoint="api.example.com",
+        )
+        assert "capabilities" not in result
+        assert "cap_uri" not in result
+
+
+class TestFromA2aAgentCard:
+    """Tests for A2A agent card adapter."""
+
+    def test_with_skills(self):
+        class MockSkill:
+            def __init__(self, id):
+                self.id = id
+
+        class MockCard:
+            name = "Payment Agent"
+            version = "2.0.0"
+            description = "Handles payments"
+            skills = [MockSkill("pay"), MockSkill("refund")]
+
+            def to_capabilities(self):
+                return ["pay", "refund"]
+
+        result = from_a2a_agent_card(MockCard(), endpoint="pay.example.com")
+        assert result["name"] == "payment-agent"
+        assert result["protocol"].value == "a2a"
+        assert result["capabilities"] == ["pay", "refund"]
+        assert result["version"] == "2.0.0"
+
+    def test_name_sanitization(self):
+        class MockCard:
+            name = "My Agent (v2)!"
+            version = "1.0.0"
+            description = None
+            skills = []
+
+            def to_capabilities(self):
+                return []
+
+        result = from_a2a_agent_card(MockCard(), endpoint="a.example.com")
+        # Special chars replaced with hyphens, stripped
+        assert all(c.isalnum() or c == "-" for c in result["name"])
+
+
+class TestFromLangsmithProject:
+    """Tests for LangSmith project adapter."""
+
+    def test_basic_project(self):
+        project = {
+            "name": "My Chat Bot",
+            "description": "A helpful chatbot",
+        }
+        result = from_langsmith_project(
+            project,
+            domain="agents.example.com",
+            endpoint="api.example.com",
+        )
+        assert result["name"] == "my-chat-bot"
+        assert result["domain"] == "agents.example.com"
+        assert result["protocol"] == "https"
+        assert result["description"] == "A helpful chatbot"
+
+    def test_metadata_overrides(self):
+        project = {
+            "name": "agent",
+            "metadata": {
+                "protocol": "a2a",
+                "capabilities": ["search", "summarize"],
+                "realm": "production",
+                "cap_uri": "https://example.com/cap.json",
+            },
+        }
+        result = from_langsmith_project(
+            project,
+            domain="agents.example.com",
+            endpoint="api.example.com",
+        )
+        assert result["protocol"] == "a2a"
+        assert result["capabilities"] == ["search", "summarize"]
+        assert result["realm"] == "production"
+        assert result["cap_uri"] == "https://example.com/cap.json"
+
+    def test_name_sanitization(self):
+        project = {"name": "My Agent (Test)"}
+        result = from_langsmith_project(
+            project,
+            domain="example.com",
+            endpoint="api.example.com",
+        )
+        assert all(c.isalnum() or c == "-" for c in result["name"])


### PR DESCRIPTION
## Summary
- Adds `dns_aid.a2a` module that bridges DNS-AID discovery with Google's A2A agent card protocol
- `discover_a2a_agents()` queries DNS-AID records filtered for A2A protocol
- `fetch_agent_card()` retrieves agent cards from `/.well-known/agent-card.json`
- `to_agent_card()` converts DNS-AID `AgentRecord` to A2A `AgentCard` format
- `publish_a2a_agent()` / `unpublish_a2a_agent()` publish/remove A2A agent info as DNS records
- Includes `AgentCard` and `AgentCardSkill` dataclasses with full serialization roundtrip support

### New: SvcParam enhancements
- **A2A/MCP auto-population**: Publisher auto-sets `bap=["a2a/1"]` and derives `cap_uri` from `/.well-known/agent-card.json` for A2A protocol; auto-sets `bap=["mcp/1"]` for MCP
- **SvcParam schema registry** (`core/schema_registry.py`): Declarative mapping from LangServe/LangSmith/A2A fields to DNS-AID SvcParam keys, with adapter functions `from_langserve_route()`, `from_a2a_agent_card()`, `from_langsmith_project()`
- **Pre-publish record validator** (`core/pre_publish_validator.py`): Validates FQDN length, TTL bounds, ALPN values, URI format, capability strings, BAP format, and wire-format size before publishing. Integrated into `publisher.py` for fail-fast behavior.

## Test plan
- [x] 29 unit tests for A2A agent card module
- [x] 27 unit tests for publisher (including 6 new auto-population tests)
- [x] 14 unit tests for schema registry
- [x] 17 unit tests for pre-publish validator
- [ ] Integration test with mock DNS backend (publish A2A card → discover via DNS → fetch card)

