### PR TITLE
feat: add shared integration layer for framework integrations

### DIFF
--- a/src/dns_aid/integrations/__init__.py
+++ b/src/dns_aid/integrations/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared integration layer for DNS-AID framework integrations.
+
+Provides framework-agnostic operations, input schemas, and async/sync
+bridging that any framework integration can build upon.
+"""
+
+from dns_aid.integrations._async_bridge import run_async
+from dns_aid.integrations._base import DnsAidOperations
+from dns_aid.integrations._schemas import (
+    DiscoverInput,
+    PublishInput,
+    UnpublishInput,
+)
+
+__all__ = [
+    "DnsAidOperations",
+    "DiscoverInput",
+    "PublishInput",
+    "UnpublishInput",
+    "run_async",
+]

--- a/src/dns_aid/integrations/_async_bridge.py
+++ b/src/dns_aid/integrations/_async_bridge.py
@@ -1,0 +1,29 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async/sync bridge for framework integrations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine
+
+
+def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Run an async coroutine from a sync context.
+
+    Handles the case where an event loop is already running
+    (e.g., Jupyter, FastAPI) by running in a separate thread.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, coro).result()
+    else:
+        return asyncio.run(coro)

--- a/src/dns_aid/integrations/_async_bridge.py
+++ b/src/dns_aid/integrations/_async_bridge.py
@@ -1,19 +1,33 @@
 # Copyright 2024-2026 The DNS-AID Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Async/sync bridge for framework integrations."""
+"""Async/sync bridge for framework integrations.
+
+This module provides a safe way to call async coroutines from synchronous
+contexts, handling edge cases like nested event loops in Jupyter, FastAPI,
+and ASGI frameworks.
+"""
 
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Coroutine
+import contextvars
+import threading
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
 
 
-def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
+def run_async(coro: Coroutine[Any, Any, T]) -> T:
     """Run an async coroutine from a sync context.
 
     Handles the case where an event loop is already running
-    (e.g., Jupyter, FastAPI) by running in a separate thread.
+    (e.g., Jupyter, FastAPI, ASGI) by running in a dedicated thread
+    with its own event loop that propagates context variables.
+
+    This avoids the deadlock that occurs with ``asyncio.run()`` inside
+    a ``ThreadPoolExecutor`` when ``uvloop`` is installed, and properly
+    copies ``contextvars`` so ASGI middleware context is preserved.
     """
     try:
         loop = asyncio.get_running_loop()
@@ -21,9 +35,25 @@ def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
         loop = None
 
     if loop and loop.is_running():
-        import concurrent.futures
+        # We're inside an existing event loop (Jupyter, FastAPI, etc.).
+        # Spawn a dedicated thread with a fresh loop to avoid deadlocks.
+        ctx = contextvars.copy_context()
+        result: Any = None
+        exception: BaseException | None = None
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(asyncio.run, coro).result()
+        def _run_in_thread() -> None:
+            nonlocal result, exception
+            try:
+                result = ctx.run(asyncio.run, coro)
+            except BaseException as exc:
+                exception = exc
+
+        thread = threading.Thread(target=_run_in_thread, daemon=True)
+        thread.start()
+        thread.join()
+
+        if exception is not None:
+            raise exception
+        return result  # type: ignore[return-value]
     else:
         return asyncio.run(coro)

--- a/src/dns_aid/integrations/_base.py
+++ b/src/dns_aid/integrations/_base.py
@@ -1,0 +1,167 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework-agnostic DNS-AID operations for integrations."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from dns_aid.integrations._async_bridge import run_async
+
+
+class DnsAidOperations:
+    """Shared DNS-AID operations that any framework integration can delegate to.
+
+    Handles backend resolution, async execution, and JSON serialization
+    so framework-specific wrappers only need to adapt to their tool interface.
+
+    Args:
+        backend_name: DNS backend name (e.g. 'route53', 'cloudflare', 'mock').
+        backend: Pre-configured DNSBackend instance. Takes priority over backend_name.
+    """
+
+    def __init__(
+        self,
+        backend_name: Optional[str] = None,
+        backend: Any = None,
+    ) -> None:
+        self.backend_name = backend_name
+        self.backend = backend
+
+    def _get_backend(self) -> Any:
+        """Resolve the DNS backend instance."""
+        if self.backend is not None:
+            return self.backend
+        if self.backend_name:
+            from dns_aid.backends import create_backend
+
+            return create_backend(self.backend_name)
+        return None
+
+    # -- Async operations --
+
+    async def discover_async(
+        self,
+        domain: str,
+        protocol: Optional[str] = None,
+        name: Optional[str] = None,
+        require_dnssec: bool = False,
+    ) -> str:
+        """Discover agents at a domain. Returns JSON string."""
+        import dns_aid
+
+        result = await dns_aid.discover(
+            domain=domain,
+            protocol=protocol,
+            name=name,
+            require_dnssec=require_dnssec,
+        )
+        return json.dumps(result.model_dump(), default=str)
+
+    async def publish_async(
+        self,
+        name: str,
+        domain: str,
+        protocol: str = "mcp",
+        endpoint: str = "",
+        port: int = 443,
+        capabilities: Optional[list[str]] = None,
+        version: str = "1.0.0",
+        description: Optional[str] = None,
+        ttl: int = 3600,
+    ) -> str:
+        """Publish an agent to DNS. Returns JSON string."""
+        import dns_aid
+
+        result = await dns_aid.publish(
+            name=name,
+            domain=domain,
+            protocol=protocol,
+            endpoint=endpoint,
+            port=port,
+            capabilities=capabilities,
+            version=version,
+            description=description,
+            ttl=ttl,
+            backend=self._get_backend(),
+        )
+        return json.dumps(result.model_dump(), default=str)
+
+    async def unpublish_async(
+        self,
+        name: str,
+        domain: str,
+        protocol: str = "mcp",
+    ) -> str:
+        """Remove an agent from DNS. Returns JSON string."""
+        import dns_aid
+
+        deleted = await dns_aid.unpublish(
+            name=name,
+            domain=domain,
+            protocol=protocol,
+            backend=self._get_backend(),
+        )
+        if deleted:
+            return json.dumps(
+                {"success": True, "message": f"Agent '{name}' unpublished from {domain}"}
+            )
+        return json.dumps(
+            {"success": False, "message": f"Agent '{name}' not found at {domain}"}
+        )
+
+    # -- Sync wrappers --
+
+    def discover_sync(
+        self,
+        domain: str,
+        protocol: Optional[str] = None,
+        name: Optional[str] = None,
+        require_dnssec: bool = False,
+    ) -> str:
+        """Discover agents (sync wrapper). Returns JSON string."""
+        return run_async(
+            self.discover_async(
+                domain=domain, protocol=protocol, name=name, require_dnssec=require_dnssec
+            )
+        )
+
+    def publish_sync(
+        self,
+        name: str,
+        domain: str,
+        protocol: str = "mcp",
+        endpoint: str = "",
+        port: int = 443,
+        capabilities: Optional[list[str]] = None,
+        version: str = "1.0.0",
+        description: Optional[str] = None,
+        ttl: int = 3600,
+    ) -> str:
+        """Publish an agent (sync wrapper). Returns JSON string."""
+        return run_async(
+            self.publish_async(
+                name=name,
+                domain=domain,
+                protocol=protocol,
+                endpoint=endpoint,
+                port=port,
+                capabilities=capabilities,
+                version=version,
+                description=description,
+                ttl=ttl,
+            )
+        )
+
+    def unpublish_sync(
+        self,
+        name: str,
+        domain: str,
+        protocol: str = "mcp",
+    ) -> str:
+        """Remove an agent (sync wrapper). Returns JSON string."""
+        return run_async(
+            self.unpublish_async(name=name, domain=domain, protocol=protocol)
+        )

--- a/src/dns_aid/integrations/_base.py
+++ b/src/dns_aid/integrations/_base.py
@@ -27,6 +27,10 @@ class DnsAidOperations:
         backend_name: Optional[str] = None,
         backend: Any = None,
     ) -> None:
+        if backend is not None and backend_name is not None:
+            raise ValueError(
+                "Specify either 'backend' or 'backend_name', not both."
+            )
         self.backend_name = backend_name
         self.backend = backend
 
@@ -70,9 +74,25 @@ class DnsAidOperations:
         capabilities: Optional[list[str]] = None,
         version: str = "1.0.0",
         description: Optional[str] = None,
+        use_cases: Optional[list[str]] = None,
+        category: Optional[str] = None,
         ttl: int = 3600,
+        cap_uri: Optional[str] = None,
+        cap_sha256: Optional[str] = None,
+        bap: Optional[list[str]] = None,
+        policy_uri: Optional[str] = None,
+        realm: Optional[str] = None,
+        connect_class: Optional[str] = None,
+        connect_meta: Optional[str] = None,
+        enroll_uri: Optional[str] = None,
+        ipv4_hint: Optional[str] = None,
+        ipv6_hint: Optional[str] = None,
     ) -> str:
-        """Publish an agent to DNS. Returns JSON string."""
+        """Publish an agent to DNS. Returns JSON string.
+
+        Supports the full parameter set of ``dns_aid.publish()``. See
+        :func:`dns_aid.core.publisher.publish` for detailed parameter docs.
+        """
         import dns_aid
 
         result = await dns_aid.publish(
@@ -84,8 +104,20 @@ class DnsAidOperations:
             capabilities=capabilities,
             version=version,
             description=description,
+            use_cases=use_cases,
+            category=category,
             ttl=ttl,
             backend=self._get_backend(),
+            cap_uri=cap_uri,
+            cap_sha256=cap_sha256,
+            bap=bap,
+            policy_uri=policy_uri,
+            realm=realm,
+            connect_class=connect_class,
+            connect_meta=connect_meta,
+            enroll_uri=enroll_uri,
+            ipv4_hint=ipv4_hint,
+            ipv6_hint=ipv6_hint,
         )
         return json.dumps(result.model_dump(), default=str)
 
@@ -138,7 +170,19 @@ class DnsAidOperations:
         capabilities: Optional[list[str]] = None,
         version: str = "1.0.0",
         description: Optional[str] = None,
+        use_cases: Optional[list[str]] = None,
+        category: Optional[str] = None,
         ttl: int = 3600,
+        cap_uri: Optional[str] = None,
+        cap_sha256: Optional[str] = None,
+        bap: Optional[list[str]] = None,
+        policy_uri: Optional[str] = None,
+        realm: Optional[str] = None,
+        connect_class: Optional[str] = None,
+        connect_meta: Optional[str] = None,
+        enroll_uri: Optional[str] = None,
+        ipv4_hint: Optional[str] = None,
+        ipv6_hint: Optional[str] = None,
     ) -> str:
         """Publish an agent (sync wrapper). Returns JSON string."""
         return run_async(
@@ -151,7 +195,19 @@ class DnsAidOperations:
                 capabilities=capabilities,
                 version=version,
                 description=description,
+                use_cases=use_cases,
+                category=category,
                 ttl=ttl,
+                cap_uri=cap_uri,
+                cap_sha256=cap_sha256,
+                bap=bap,
+                policy_uri=policy_uri,
+                realm=realm,
+                connect_class=connect_class,
+                connect_meta=connect_meta,
+                enroll_uri=enroll_uri,
+                ipv4_hint=ipv4_hint,
+                ipv6_hint=ipv6_hint,
             )
         )
 

--- a/src/dns_aid/integrations/_schemas.py
+++ b/src/dns_aid/integrations/_schemas.py
@@ -1,7 +1,12 @@
 # Copyright 2024-2026 The DNS-AID Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Framework-agnostic Pydantic input schemas for DNS-AID operations."""
+"""Framework-agnostic Pydantic input schemas for DNS-AID operations.
+
+These schemas match the full parameter set of ``dns_aid.publish()`` and
+``dns_aid.discover()`` so that framework integrations expose all features
+without needing to bypass the shared layer.
+"""
 
 from __future__ import annotations
 
@@ -33,7 +38,52 @@ class PublishInput(BaseModel):
     description: Optional[str] = Field(
         default=None, description="Human-readable description of the agent"
     )
+    use_cases: Optional[list[str]] = Field(
+        default=None, description="List of use cases for this agent"
+    )
+    category: Optional[str] = Field(
+        default=None, description="Agent category (e.g. 'network', 'security')"
+    )
     ttl: int = Field(default=3600, description="DNS time-to-live in seconds")
+    cap_uri: Optional[str] = Field(
+        default=None,
+        description="URI to capability document (DNS-AID draft-compliant)",
+    )
+    cap_sha256: Optional[str] = Field(
+        default=None,
+        description="Base64url-encoded SHA-256 digest of the capability descriptor",
+    )
+    bap: Optional[list[str]] = Field(
+        default=None,
+        description="Supported bulk agent protocols (e.g. ['mcp', 'a2a'])",
+    )
+    policy_uri: Optional[str] = Field(
+        default=None, description="URI to agent policy document"
+    )
+    realm: Optional[str] = Field(
+        default=None,
+        description="Multi-tenant scope identifier (e.g. 'production')",
+    )
+    connect_class: Optional[str] = Field(
+        default=None,
+        description="Connection mediation class (e.g. 'direct', 'lattice')",
+    )
+    connect_meta: Optional[str] = Field(
+        default=None,
+        description="Provider-specific connection metadata (e.g. service ARN)",
+    )
+    enroll_uri: Optional[str] = Field(
+        default=None,
+        description="Managed enrollment endpoint required before direct connection",
+    )
+    ipv4_hint: Optional[str] = Field(
+        default=None,
+        description="IPv4 address hint for SVCB record (RFC 9460 key 4)",
+    )
+    ipv6_hint: Optional[str] = Field(
+        default=None,
+        description="IPv6 address hint for SVCB record (RFC 9460 key 6)",
+    )
 
 
 class DiscoverInput(BaseModel):

--- a/src/dns_aid/integrations/_schemas.py
+++ b/src/dns_aid/integrations/_schemas.py
@@ -1,0 +1,64 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework-agnostic Pydantic input schemas for DNS-AID operations."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PublishInput(BaseModel):
+    """Input schema for publishing an agent to DNS."""
+
+    name: str = Field(
+        ..., description="Agent identifier in DNS label format (e.g. 'my-agent')"
+    )
+    domain: str = Field(
+        ..., description="Domain to publish under (e.g. 'agents.example.com')"
+    )
+    protocol: str = Field(
+        default="mcp", description="Protocol: 'a2a', 'mcp', or 'https'"
+    )
+    endpoint: str = Field(
+        ..., description="Hostname where the agent is reachable"
+    )
+    port: int = Field(default=443, description="Port number")
+    capabilities: Optional[list[str]] = Field(
+        default=None, description="List of agent capabilities"
+    )
+    version: str = Field(default="1.0.0", description="Agent version")
+    description: Optional[str] = Field(
+        default=None, description="Human-readable description of the agent"
+    )
+    ttl: int = Field(default=3600, description="DNS time-to-live in seconds")
+
+
+class DiscoverInput(BaseModel):
+    """Input schema for discovering agents via DNS."""
+
+    domain: str = Field(
+        ..., description="Domain to search for agents (e.g. 'agents.example.com')"
+    )
+    protocol: Optional[str] = Field(
+        default=None,
+        description="Filter by protocol: 'a2a', 'mcp', 'https', or None for all",
+    )
+    name: Optional[str] = Field(
+        default=None, description="Filter by specific agent name"
+    )
+    require_dnssec: bool = Field(
+        default=False, description="Require DNSSEC-validated responses"
+    )
+
+
+class UnpublishInput(BaseModel):
+    """Input schema for removing an agent from DNS."""
+
+    name: str = Field(..., description="Agent identifier to remove")
+    domain: str = Field(..., description="Domain the agent is published under")
+    protocol: str = Field(
+        default="mcp", description="Protocol: 'a2a', 'mcp', or 'https'"
+    )


### PR DESCRIPTION
## Summary
- Adds `dns_aid.integrations` module with framework-agnostic operations, input schemas, and async/sync bridge
- `DnsAidOperations` class provides discover/publish/unpublish methods (both async and sync) that any framework integration can delegate to
- Shared Pydantic schemas (`PublishInput`, `DiscoverInput`, `UnpublishInput`) eliminate schema duplication across framework packages
- Extracted from the existing LangChain integration pattern to serve as the foundation for CrewAI, OpenAI Agents SDK, Google ADK, Agno, AutoGen, Semantic Kernel, LlamaIndex, and Haystack integrations

## Test plan
- [ ] Verify existing LangChain integration tests still pass
- [ ] Import `dns_aid.integrations` and call `DnsAidOperations` methods with mock backend
- [ ] Validate Pydantic schema serialization matches existing tool schemas
