### PR TITLE
feat: split connect core and Cloud DNS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-03-19
+
+### Added
+- **Connection mediation SVCB params** — `connect-class` (`key65406`), `connect-meta` (`key65407`), and `enroll-uri` (`key65408`) are now first-class DNS-AID wire parameters for AppHub PSC and VPC Lattice bootstrap flows.
+- **Cloud DNS support for `connect-*` records** — Google Cloud DNS joins NIOS as an authoritative backend that can publish the new private-use SVCB parameters directly.
+
+### Changed
+- **Internal-first backend support for mediated connections** — The first release of `connect-*` publishing targets backends that natively support private-use SVCB keys. Route 53 and Cloudflare remain out of scope for direct `connect-*` publishing in this release.
+
+### Notes
+- **Republish required for adopters** — Zones adopting connection mediation must republish affected records so `key65406`, `key65407`, and `key65408` appear on the wire.
+- See `docs/adr/0001-connect-mediation-wire-format.md` for the compatibility decision and rollout assumptions.
+
 ## [0.12.1] - 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pip install dns-aid[mcp]
 
 # With a specific backend
 pip install dns-aid[route53]      # AWS Route 53
+pip install dns-aid[cloud-dns]    # Google Cloud DNS
 pip install dns-aid[cloudflare]   # Cloudflare DNS
 pip install dns-aid[infoblox]     # Infoblox BloxOne (cloud)
 pip install dns-aid[nios]         # Infoblox NIOS (on-prem)
@@ -675,6 +676,7 @@ DNS-AID supports multiple DNS backends:
 | Backend | Description | Status |
 |---------|-------------|--------|
 | Route 53 | AWS Route 53 | ✅ Production |
+| Cloud DNS | Google Cloud DNS | ✅ Production |
 | Infoblox UDDI | Infoblox Universal DDI (cloud) | ✅ Production |
 | Infoblox NIOS | Infoblox NIOS (on-prem WAPI) | ✅ Production |
 | DDNS | RFC 2136 Dynamic DNS (BIND, etc.) | ✅ Production |
@@ -780,17 +782,19 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
 > The draft requires ServiceMode SVCB records (priority > 0) with mandatory `alpn` and `port`
 > parameters. Infoblox UDDI's limitation is a platform constraint, not a DNS-AID limitation.
 
-| DNS-AID Requirement | Route 53 | Cloudflare | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
-|---------------------|----------|------------|-------------|---------------|---------------|
-| ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `alpn` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `port` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `mandatory` key | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ✅ Native | ❌ |
+| DNS-AID Requirement | Route 53 | Cloudflare | Cloud DNS | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
+|---------------------|----------|------------|-----------|-------------|---------------|---------------|
+| ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `alpn` parameter | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `port` parameter | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `mandatory` key | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ✅ Native | ✅ Native | ❌ |
 
 **⚠️ TXT** = Custom DNS-AID params auto-demoted to TXT records with `dnsaid_` prefix (no data loss).
 
-**For full DNS-AID compliance with native custom SVCB params, use DDNS (BIND/RFC 2136) or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
+**For full DNS-AID compliance with native custom SVCB params, use Cloud DNS, DDNS (BIND/RFC 2136), or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
+
+The connection-mediation keys `key65406` through `key65408` are a protocol-visible addition. When adopting them, republish affected records so the new SVCB parameters are present on the wire. See [`docs/adr/0001-connect-mediation-wire-format.md`](docs/adr/0001-connect-mediation-wire-format.md) for the compatibility decision and rollout assumptions.
 
 DNS-AID stores `alpn` and `port` in TXT records as a fallback for Infoblox UDDI, but this is
 a workaround and not standard-compliant for agent discovery.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.12.1"
+version = "0.13.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ mcp = [
 route53 = [
     "boto3>=1.34.0",
 ]
+cloud-dns = [
+    "google-auth>=2.30.0",
+]
 infoblox = [
     # Uses httpx from core deps
 ]
@@ -98,6 +101,7 @@ all = [
     "uvicorn>=0.30.0",
     # Backends: Route53, Infoblox BloxOne, NIOS, Cloudflare, DDNS (last 4 use core deps)
     "boto3>=1.34.0",
+    "google-auth>=2.30.0",
     # JWS
     "cryptography>=41.0.0",
     # OpenTelemetry

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -31,7 +31,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from dns_aid.core.discoverer import discover
-from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol, PublishResult
+from dns_aid.core.models import (
+    AgentRecord,
+    DiscoveryResult,
+    DNSSECError,
+    Protocol,
+    PublishResult,
+    SvcbRecord,
+)
 from dns_aid.core.publisher import publish, unpublish
 
 # Tier 0: DNS validation
@@ -66,6 +73,7 @@ __all__ = [
     "AgentRecord",
     "DiscoveryResult",
     "PublishResult",
+    "SvcbRecord",
     "Protocol",
     # Exceptions
     "DNSSECError",

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -19,6 +19,7 @@ __all__ = ["DNSBackend", "MockBackend", "create_backend", "VALID_BACKEND_NAMES"]
 _BACKEND_CLASSES: dict[str, tuple[str, str]] = {
     "route53": ("dns_aid.backends.route53", "Route53Backend"),
     "cloudflare": ("dns_aid.backends.cloudflare", "CloudflareBackend"),
+    "cloud-dns": ("dns_aid.backends.cloud_dns", "CloudDNSBackend"),
     "infoblox": ("dns_aid.backends.infoblox", "InfobloxBackend"),
     "nios": ("dns_aid.backends.infoblox.nios", "InfobloxNIOSBackend"),
     "ddns": ("dns_aid.backends.ddns", "DDNSBackend"),
@@ -91,5 +92,13 @@ try:
     from dns_aid.backends.cloudflare import CloudflareBackend  # noqa: F401
 
     __all__.append("CloudflareBackend")
+except ImportError:
+    pass
+
+# Cloud DNS backend - uses httpx + google-auth (optional)
+try:
+    from dns_aid.backends.cloud_dns import CloudDNSBackend  # noqa: F401
+
+    __all__.append("CloudDNSBackend")
 except ImportError:
     pass

--- a/src/dns_aid/backends/cloud_dns.py
+++ b/src/dns_aid/backends/cloud_dns.py
@@ -1,0 +1,318 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google Cloud DNS backend."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import httpx
+import structlog
+
+from dns_aid.backends.base import DNSBackend
+from dns_aid.utils.google_auth import get_google_access_token
+
+logger = structlog.get_logger(__name__)
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class CloudDNSBackend(DNSBackend):
+    """Google Cloud DNS backend using the Cloud DNS REST API."""
+
+    def __init__(
+        self,
+        project_id: str | None = None,
+        managed_zone: str | None = None,
+        token_provider: Callable[[], tuple[str, str | None]] | None = None,
+        base_url: str = "https://dns.googleapis.com/dns/v1",
+    ):
+        self._project_id = (
+            project_id
+            or os.environ.get("GOOGLE_CLOUD_PROJECT")
+            or os.environ.get("GCP_PROJECT")
+            or os.environ.get("CLOUD_DNS_PROJECT")
+        )
+        self._managed_zone = managed_zone or os.environ.get("CLOUD_DNS_MANAGED_ZONE")
+        self._token_provider = token_provider or (lambda: get_google_access_token(_SCOPES))
+        self._base_url = base_url.rstrip("/")
+        self._client: httpx.AsyncClient | None = None
+        self._client_loop_id: int | None = None
+        self._zone_cache: dict[str, str] = {}
+
+    @property
+    def name(self) -> str:
+        return "cloud-dns"
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        current_loop_id = id(asyncio.get_running_loop())
+
+        if self._client is not None and self._client_loop_id != current_loop_id:
+            with contextlib.suppress(Exception):
+                await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+            self._client_loop_id = current_loop_id
+
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = None
+        self._client_loop_id = None
+
+    def _resolve_project_id(self, discovered_project: str | None = None) -> str:
+        project_id = self._project_id or discovered_project
+        if not project_id:
+            raise ValueError(
+                "Google Cloud project id not configured. Set GOOGLE_CLOUD_PROJECT, "
+                "CLOUD_DNS_PROJECT, or pass project_id explicitly."
+            )
+        self._project_id = project_id
+        return project_id
+
+    def _ensure_project_id(self) -> str:
+        if self._project_id:
+            return self._project_id
+        _, discovered_project = self._token_provider()
+        return self._resolve_project_id(discovered_project)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        client = await self._get_client()
+        token, discovered_project = self._token_provider()
+        self._resolve_project_id(discovered_project)
+
+        response = await client.request(
+            method=method,
+            url=path,
+            params=params,
+            json=json,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        if not response.content:
+            return {}
+        return response.json()
+
+    async def _get_managed_zone_name(self, zone: str) -> str:
+        zone_name = zone.rstrip(".")
+        if self._managed_zone:
+            return self._managed_zone
+        if zone_name in self._zone_cache:
+            return self._zone_cache[zone_name]
+
+        zones = await self.list_zones()
+        for candidate in zones:
+            if candidate["dns_name"].rstrip(".") == zone_name:
+                self._zone_cache[zone_name] = candidate["name"]
+                return candidate["name"]
+        raise ValueError(f"No Cloud DNS managed zone found for domain: {zone}")
+
+    @staticmethod
+    def _record_name(name: str, zone: str) -> str:
+        fqdn = f"{name}.{zone}".rstrip(".")
+        return f"{fqdn}."
+
+    @staticmethod
+    def _format_svcb_value(priority: int, target: str, params: dict[str, str]) -> str:
+        normalized_target = target if target.endswith(".") else f"{target}."
+        parts = [f'{key}="{value}"' for key, value in params.items()]
+        joined = " ".join(parts)
+        return f"{priority} {normalized_target} {joined}".strip()
+
+    async def _change_record_set(
+        self,
+        zone: str,
+        name: str,
+        record_type: str,
+        ttl: int,
+        rrdatas: list[str],
+    ) -> str:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        fqdn = self._record_name(name, zone)
+        existing = await self.get_record(zone, name, record_type)
+
+        additions = [{"name": fqdn, "type": record_type, "ttl": ttl, "rrdatas": rrdatas}]
+        payload: dict[str, Any] = {"additions": additions}
+        if existing:
+            payload["deletions"] = [
+                {
+                    "name": f"{existing['fqdn'].rstrip('.')}.",
+                    "type": record_type,
+                    "ttl": existing["ttl"],
+                    "rrdatas": existing["values"],
+                }
+            ]
+
+        await self._request(
+            "POST",
+            f"/projects/{project_id}/managedZones/{managed_zone}/changes",
+            json=payload,
+        )
+        return fqdn.rstrip(".")
+
+    async def create_svcb_record(
+        self,
+        zone: str,
+        name: str,
+        priority: int,
+        target: str,
+        params: dict[str, str],
+        ttl: int = 3600,
+    ) -> str:
+        value = self._format_svcb_value(priority, target, params)
+        return await self._change_record_set(zone, name, "SVCB", ttl, [value])
+
+    async def create_txt_record(
+        self,
+        zone: str,
+        name: str,
+        values: list[str],
+        ttl: int = 3600,
+    ) -> str:
+        quoted_values = [value if value.startswith('"') else f'"{value}"' for value in values]
+        return await self._change_record_set(zone, name, "TXT", ttl, quoted_values)
+
+    async def delete_record(self, zone: str, name: str, record_type: str) -> bool:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        existing = await self.get_record(zone, name, record_type)
+        if not existing:
+            return False
+
+        await self._request(
+            "POST",
+            f"/projects/{project_id}/managedZones/{managed_zone}/changes",
+            json={
+                "deletions": [
+                    {
+                        "name": f"{existing['fqdn'].rstrip('.')}.",
+                        "type": record_type,
+                        "ttl": existing["ttl"],
+                        "rrdatas": existing["values"],
+                    }
+                ]
+            },
+        )
+        return True
+
+    async def list_records(
+        self,
+        zone: str,
+        name_pattern: str | None = None,
+        record_type: str | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        page_token: str | None = None
+        zone_clean = zone.rstrip(".")
+
+        while True:
+            params = {"maxResults": "1000"}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = await self._request(
+                "GET",
+                f"/projects/{project_id}/managedZones/{managed_zone}/rrsets",
+                params=params,
+            )
+
+            for record in response.get("rrsets", []):
+                fqdn = str(record.get("name", "")).rstrip(".")
+                rtype = record.get("type", "")
+                if not fqdn or not rtype:
+                    continue
+                if name_pattern and name_pattern not in fqdn:
+                    continue
+                if record_type and rtype != record_type:
+                    continue
+
+                yield {
+                    "name": fqdn.removesuffix(f".{zone_clean}"),
+                    "fqdn": fqdn,
+                    "type": rtype,
+                    "ttl": int(record.get("ttl", 0)),
+                    "values": list(record.get("rrdatas", [])),
+                }
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+    async def zone_exists(self, zone: str) -> bool:
+        try:
+            await self._get_managed_zone_name(zone)
+            return True
+        except Exception:
+            return False
+
+    async def get_record(self, zone: str, name: str, record_type: str) -> dict[str, Any] | None:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        fqdn = self._record_name(name, zone)
+
+        response = await self._request(
+            "GET",
+            f"/projects/{project_id}/managedZones/{managed_zone}/rrsets",
+            params={"name": fqdn, "type": record_type, "maxResults": "1"},
+        )
+
+        rrsets = response.get("rrsets", [])
+        if not rrsets:
+            return None
+
+        record = rrsets[0]
+        if record.get("name") != fqdn or record.get("type") != record_type:
+            return None
+
+        return {
+            "name": name,
+            "fqdn": fqdn.rstrip("."),
+            "type": record_type,
+            "ttl": int(record.get("ttl", 0)),
+            "values": list(record.get("rrdatas", [])),
+        }
+
+    async def list_zones(self) -> list[dict[str, str]]:
+        project_id = self._ensure_project_id()
+        page_token: str | None = None
+        zones: list[dict[str, str]] = []
+
+        while True:
+            params = {"maxResults": "1000"}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = await self._request("GET", f"/projects/{project_id}/managedZones", params=params)
+            for zone in response.get("managedZones", []):
+                zones.append(
+                    {
+                        "name": zone["name"],
+                        "dns_name": str(zone.get("dnsName", "")).rstrip("."),
+                        "visibility": str(zone.get("visibility", "")),
+                    }
+                )
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+        return zones

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -56,6 +56,9 @@ class InfobloxNIOSBackend(DNSBackend):
         "policy": "key65403",
         "realm": "key65404",
         "sig": "key65405",
+        "connect-class": "key65406",
+        "connect-meta": "key65407",
+        "enroll-uri": "key65408",
     }
     _NUMERIC_KEY_TO_CUSTOM_PARAM = {
         value: key for key, value in _CUSTOM_PARAM_TO_NUMERIC_KEY.items()

--- a/src/dns_aid/cli/backends.py
+++ b/src/dns_aid/cli/backends.py
@@ -79,6 +79,25 @@ BACKEND_REGISTRY: dict[str, BackendInfo] = {
             "Set CLOUDFLARE_API_TOKEN",
         ],
     ),
+    "cloud-dns": BackendInfo(
+        name="cloud-dns",
+        display_name="Google Cloud DNS",
+        required_env={
+            "GOOGLE_CLOUD_PROJECT": "Google Cloud project id that owns the managed zone",
+        },
+        optional_env={
+            "CLOUD_DNS_MANAGED_ZONE": "Managed zone name (auto-discovered by dnsName if omitted)",
+            "GOOGLE_APPLICATION_CREDENTIALS": "ADC service account JSON path",
+            "CLOUD_DNS_PROJECT": "Alternate project id variable",
+        },
+        optional_dep="cloud-dns",
+        setup_url="https://cloud.google.com/dns/docs",
+        setup_steps=[
+            "Enable Cloud DNS in the target Google Cloud project",
+            "Configure Application Default Credentials for the runtime",
+            "Set GOOGLE_CLOUD_PROJECT and optionally CLOUD_DNS_MANAGED_ZONE",
+        ],
+    ),
     "infoblox": BackendInfo(
         name="infoblox",
         display_name="Infoblox BloxOne DDI",

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -11,6 +11,7 @@ records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 from __future__ import annotations
 
 import asyncio
+import shlex
 import time
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -278,6 +279,9 @@ async def _query_single_agent(
             bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
             policy_uri = custom_params.get("policy")
             realm = custom_params.get("realm")
+            connect_class = custom_params.get("connect-class")
+            connect_meta = custom_params.get("connect-meta")
+            enroll_uri = custom_params.get("enroll-uri")
 
             # Discovery priority: cap URI first, then TXT fallback
             capabilities: list[str] = []
@@ -342,6 +346,9 @@ async def _query_single_agent(
                 bap=bap,
                 policy_uri=policy_uri,
                 realm=realm,
+                connect_class=connect_class,
+                connect_meta=connect_meta,
+                enroll_uri=enroll_uri,
                 capability_source=capability_source,
                 endpoint_source="dns_svcb",  # Endpoint resolved via DNS SVCB lookup
                 agent_card=agent_card,
@@ -370,10 +377,23 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
     from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
 
     custom_params: dict[str, str] = {}
-    dnsaid_keys = {"cap", "cap-sha256", "bap", "policy", "realm", "sig"}
+    dnsaid_keys = {
+        "cap",
+        "cap-sha256",
+        "bap",
+        "policy",
+        "realm",
+        "sig",
+        "connect-class",
+        "connect-meta",
+        "enroll-uri",
+    }
 
-    # Split on spaces, then look for key="value" or key=value patterns
-    parts = svcb_text.split()
+    try:
+        parts = shlex.split(svcb_text)
+    except ValueError:
+        return custom_params
+
     for part in parts:
         if "=" not in part:
             continue
@@ -385,8 +405,6 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
             key = DNS_AID_KEY_MAP_REVERSE[key]
 
         if key in dnsaid_keys:
-            # Remove surrounding quotes if present
-            value = value.strip('"').strip("'")
             custom_params[key] = value
 
     return custom_params

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -16,6 +16,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from dns_aid.utils.validation import validate_connect_class
+
 # DNS-AID custom SVCB param key mapping (IETF draft-01, Section 4.4.3)
 # These use the RFC 9460 Private Use range (65280-65534).
 # Once IANA assigns official SvcParamKey numbers, update these values.
@@ -26,6 +28,9 @@ DNS_AID_KEY_MAP: dict[str, str] = {
     "policy": "key65403",
     "realm": "key65404",
     "sig": "key65405",
+    "connect-class": "key65406",
+    "connect-meta": "key65407",
+    "enroll-uri": "key65408",
 }
 
 DNS_AID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in DNS_AID_KEY_MAP.items()}
@@ -39,6 +44,16 @@ def _use_string_keys() -> bool:
     Default is keyNNNNN format per RFC 9460 requirements.
     """
     return os.environ.get("DNS_AID_SVCB_STRING_KEYS", "").lower() in ("1", "true", "yes")
+
+
+def _svcb_param_key(name: str) -> str:
+    """Map a logical DNS-AID SvcParamKey name to its emitted wire key."""
+    return name if _use_string_keys() else DNS_AID_KEY_MAP.get(name, name)
+
+
+def _normalize_connect_class(value: str | None) -> str | None:
+    """Normalize optional connect-class values consistently across models."""
+    return validate_connect_class(value)
 
 
 class DNSSECError(Exception):
@@ -74,6 +89,94 @@ class Protocol(StrEnum):
     A2A = "a2a"  # Agent-to-Agent (Google's protocol)
     MCP = "mcp"  # Model Context Protocol (Anthropic's protocol)
     HTTPS = "https"  # Standard HTTPS
+
+
+class SvcbRecord(BaseModel):
+    """Shared SVCB presentation model used by publishers and AgentRecord serialization."""
+
+    priority: int = Field(default=1, ge=0, le=65535)
+    target: str = Field(..., min_length=1, description="SVCB target host with or without trailing dot")
+    alpn: str = Field(..., min_length=1, description="ALPN protocol identifier")
+    port: int = Field(default=443, ge=1, le=65535, description="Port number")
+    mandatory: list[str] = Field(
+        default_factory=lambda: ["alpn", "port"],
+        description="SvcParamKeys that clients must understand",
+    )
+    ipv4_hint: str | None = Field(default=None, description="IPv4 address hint")
+    ipv6_hint: str | None = Field(default=None, description="IPv6 address hint")
+    uri: str | None = Field(
+        default=None,
+        description="Capability document URI mapped to the DNS-AID 'cap' SVCB parameter",
+    )
+    cap_sha256: str | None = Field(default=None, description="SHA-256 digest for the cap URI")
+    bap: list[str] = Field(default_factory=list, description="Bulk application protocols")
+    policy_uri: str | None = Field(default=None, description="Agent policy URI")
+    realm: str | None = Field(default=None, description="Opaque authz realm identifier")
+    sig: str | None = Field(default=None, description="JWS signature for the record")
+    connect_class: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Connection mediation mode such as 'direct', 'lattice', or 'apphub-psc'",
+    )
+    connect_meta: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Provider-specific metadata that qualifies the connection path",
+    )
+    enroll_uri: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Managed enrollment URI required before direct connection",
+    )
+
+    @field_validator("connect_class", mode="before")
+    @classmethod
+    def normalize_connect_class(cls, v: str | None) -> str | None:
+        return _normalize_connect_class(v)
+
+    @property
+    def normalized_target(self) -> str:
+        """SVCB targets are emitted with a trailing dot."""
+        return self.target if self.target.endswith(".") else f"{self.target}."
+
+    def to_params(self) -> dict[str, str]:
+        """Serialize this record into RFC 9460 presentation parameters."""
+        mandatory = []
+        seen_mandatory = set()
+        for key in self.mandatory:
+            normalized = key.strip()
+            if normalized and normalized not in seen_mandatory:
+                mandatory.append(normalized)
+                seen_mandatory.add(normalized)
+
+        params = {
+            "alpn": self.alpn,
+            "port": str(self.port),
+            "mandatory": ",".join(mandatory or ["alpn", "port"]),
+        }
+        if self.ipv4_hint:
+            params["ipv4hint"] = self.ipv4_hint
+        if self.ipv6_hint:
+            params["ipv6hint"] = self.ipv6_hint
+        if self.uri:
+            params[_svcb_param_key("cap")] = self.uri
+        if self.cap_sha256:
+            params[_svcb_param_key("cap-sha256")] = self.cap_sha256
+        if self.bap:
+            params[_svcb_param_key("bap")] = ",".join(self.bap)
+        if self.policy_uri:
+            params[_svcb_param_key("policy")] = self.policy_uri
+        if self.realm:
+            params[_svcb_param_key("realm")] = self.realm
+        if self.sig:
+            params[_svcb_param_key("sig")] = self.sig
+        if self.connect_class:
+            params[_svcb_param_key("connect-class")] = self.connect_class
+        if self.connect_meta:
+            params[_svcb_param_key("connect-meta")] = self.connect_meta
+        if self.enroll_uri:
+            params[_svcb_param_key("enroll-uri")] = self.enroll_uri
+        return params
 
 
 class AgentRecord(BaseModel):
@@ -174,6 +277,21 @@ class AgentRecord(BaseModel):
         description="Opaque token for multi-tenant scoping or authz realm selection "
         "(e.g., 'production', 'staging')",
     )
+    connect_class: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Connection mediation class such as 'direct', 'lattice', or 'apphub-psc'",
+    )
+    connect_meta: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Provider-specific connection metadata such as a service ARN",
+    )
+    enroll_uri: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Enrollment endpoint required before direct overlay access",
+    )
 
     # JWS signature for application-layer verification (alternative to DNSSEC)
     sig: str | None = Field(
@@ -194,7 +312,7 @@ class AgentRecord(BaseModel):
     )
 
     # DNS settings
-    ttl: int = Field(default=3600, ge=60, le=86400, description="Time-to-live in seconds")
+    ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
 
     # Optional direct endpoint (overrides target_host:port for HTTP index agents)
     endpoint_override: str | None = Field(
@@ -245,6 +363,11 @@ class AgentRecord(BaseModel):
         """Normalize domain to lowercase without trailing dot."""
         return v.lower().rstrip(".")
 
+    @field_validator("connect_class", mode="before")
+    @classmethod
+    def validate_connect_class(cls, v: str | None) -> str | None:
+        return _normalize_connect_class(v)
+
     @property
     def fqdn(self) -> str:
         """
@@ -267,6 +390,27 @@ class AgentRecord(BaseModel):
         """Target for SVCB record (with trailing dot)."""
         return f"{self.target_host}."
 
+    def to_svcb_record(self) -> SvcbRecord:
+        """Convert this agent into the shared SVCB presentation model."""
+        return SvcbRecord(
+            priority=1,
+            target=self.svcb_target,
+            alpn=self.protocol.value,
+            port=self.port,
+            mandatory=["alpn", "port"],
+            ipv4_hint=self.ipv4_hint,
+            ipv6_hint=self.ipv6_hint,
+            uri=self.cap_uri,
+            cap_sha256=self.cap_sha256,
+            bap=self.bap,
+            policy_uri=self.policy_uri,
+            realm=self.realm,
+            sig=self.sig,
+            connect_class=self.connect_class,
+            connect_meta=self.connect_meta,
+            enroll_uri=self.enroll_uri,
+        )
+
     def to_svcb_params(self) -> dict[str, str]:
         """
         Generate SVCB parameters for DNS record.
@@ -276,38 +420,7 @@ class AgentRecord(BaseModel):
         required params for agent discovery, plus custom DNS-AID params
         (cap, bap, policy, realm) when present.
         """
-        params = {
-            "alpn": self.protocol.value,
-            "port": str(self.port),
-            # DNS-AID compliance: indicate alpn and port are mandatory
-            "mandatory": "alpn,port",
-        }
-        if self.ipv4_hint:
-            params["ipv4hint"] = self.ipv4_hint
-        if self.ipv6_hint:
-            params["ipv6hint"] = self.ipv6_hint
-        # DNS-AID custom SVCB params (IETF draft-01, Section 4.4.3)
-        # Emit keyNNNNN format by default (RFC 9460 compliant for unregistered keys).
-        # Set DNS_AID_SVCB_STRING_KEYS=1 for human-readable string names.
-        use_strings = _use_string_keys()
-
-        def _key(name: str) -> str:
-            return name if use_strings else DNS_AID_KEY_MAP.get(name, name)
-
-        if self.cap_uri:
-            params[_key("cap")] = self.cap_uri
-        if self.cap_sha256:
-            params[_key("cap-sha256")] = self.cap_sha256
-        if self.bap:
-            params[_key("bap")] = ",".join(self.bap)
-        if self.policy_uri:
-            params[_key("policy")] = self.policy_uri
-        if self.realm:
-            params[_key("realm")] = self.realm
-        # JWS signature for application-layer verification
-        if self.sig:
-            params[_key("sig")] = self.sig
-        return params
+        return self.to_svcb_record().to_params()
 
     def to_txt_values(self) -> list[str]:
         """

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -82,6 +82,9 @@ async def publish(
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
+    connect_class: str | None = None,
+    connect_meta: str | None = None,
+    enroll_uri: str | None = None,
     ipv4_hint: str | None = None,
     ipv6_hint: str | None = None,
     sign: bool = False,
@@ -111,6 +114,9 @@ async def publish(
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
+        connect_class: Connection mediation class (e.g., "direct", "lattice", "apphub-psc")
+        connect_meta: Provider-specific connection metadata (e.g., service ARN)
+        enroll_uri: Managed enrollment endpoint required before direct connection
         ipv4_hint: IPv4 address hints for SVCB record (RFC 9460 key 4)
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6)
         sign: If True, sign the record with JWS (requires private_key_path)
@@ -179,6 +185,9 @@ async def publish(
         bap=bap or [],
         policy_uri=policy_uri,
         realm=realm,
+        connect_class=connect_class,
+        connect_meta=connect_meta,
+        enroll_uri=enroll_uri,
         ipv4_hint=ipv4_hint,
         ipv6_hint=ipv6_hint,
         sig=sig,

--- a/src/dns_aid/utils/google_auth.py
+++ b/src/dns_aid/utils/google_auth.py
@@ -1,0 +1,36 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for lazily acquiring Google Cloud auth state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
+
+
+def get_google_auth_state(scopes: list[str]) -> tuple[Credentials, str | None]:
+    """Return refreshed ADC credentials and the discovered project id."""
+    try:
+        from google.auth import default
+        from google.auth.transport.requests import Request
+    except ImportError as exc:  # pragma: no cover - exercised by optional-dep paths
+        raise ImportError(
+            "Google Cloud support requires the 'google-auth' package. "
+            "Install the dns-aid[cloud-dns] extra."
+        ) from exc
+
+    credentials, project_id = default(scopes=scopes)
+    if not credentials.valid or not credentials.token:
+        credentials.refresh(Request())
+    if not credentials.token:
+        raise RuntimeError("Failed to acquire a Google Cloud access token from ADC")
+    return credentials, project_id
+
+
+def get_google_access_token(scopes: list[str]) -> tuple[str, str | None]:
+    """Return a Google Cloud bearer token and the discovered project id."""
+    credentials, project_id = get_google_auth_state(scopes)
+    return credentials.token, project_id

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -32,6 +32,10 @@ DOMAIN_LABEL_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
 # Safe characters for capabilities
 CAPABILITY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
+# Supported provider mediation classes and their token grammar
+CONNECT_CLASS_PATTERN = re.compile(r"^[a-z0-9-]{1,64}$")
+KNOWN_CONNECT_CLASSES = frozenset({"direct", "lattice", "apphub-psc"})
+
 # Version pattern (semver-like, supports pre-release and build metadata)
 VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9._+-]*)?$")
 
@@ -183,6 +187,43 @@ def validate_protocol(protocol: str) -> Literal["mcp", "a2a"]:
     return protocol  # type: ignore
 
 
+def validate_connect_class(connect_class: str | None) -> str | None:
+    """
+    Validate and normalize the DNS-AID connect-class token.
+
+    Args:
+        connect_class: Connection mediation class or ``None``
+
+    Returns:
+        Normalized mediation class or ``None``
+
+    Raises:
+        ValidationError: If the token is malformed or unsupported
+    """
+    if connect_class is None:
+        return None
+
+    normalized = connect_class.strip().lower()
+    if not normalized:
+        return None
+
+    if not CONNECT_CLASS_PATTERN.match(normalized):
+        raise ValidationError(
+            "connect_class",
+            "connect_class must contain only lowercase letters, digits, and hyphens",
+            connect_class,
+        )
+
+    if normalized not in KNOWN_CONNECT_CLASSES:
+        raise ValidationError(
+            "connect_class",
+            f"connect_class must be one of: {', '.join(sorted(KNOWN_CONNECT_CLASSES))}",
+            connect_class,
+        )
+
+    return normalized
+
+
 def validate_endpoint(endpoint: str) -> str:
     """
     Validate endpoint hostname.
@@ -274,9 +315,9 @@ def validate_ttl(ttl: int) -> int:
     if not isinstance(ttl, int):
         raise ValidationError("ttl", "TTL must be an integer", str(ttl))
 
-    # Minimum 60 seconds, maximum 1 week
-    if ttl < 60:
-        raise ValidationError("ttl", "TTL must be at least 60 seconds", str(ttl))
+    # Minimum 30 seconds, maximum 1 week
+    if ttl < 30:
+        raise ValidationError("ttl", "TTL must be at least 30 seconds", str(ttl))
 
     if ttl > 604800:  # 7 days
         raise ValidationError("ttl", "TTL cannot exceed 604800 seconds (7 days)", str(ttl))

--- a/tests/unit/test_backend_factory.py
+++ b/tests/unit/test_backend_factory.py
@@ -12,7 +12,6 @@ import pytest
 from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
 from dns_aid.backends.base import DNSBackend
 
-
 # ---------------------------------------------------------------------------
 # Basic contract
 # ---------------------------------------------------------------------------
@@ -25,8 +24,8 @@ class TestValidBackendNames:
         assert isinstance(VALID_BACKEND_NAMES, frozenset)
 
     def test_contains_all_backends(self):
-        expected = {"route53", "cloudflare", "infoblox", "nios", "ddns", "mock"}
-        assert VALID_BACKEND_NAMES == expected
+        expected = {"route53", "cloudflare", "cloud-dns", "infoblox", "nios", "ddns", "mock"}
+        assert expected == VALID_BACKEND_NAMES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_onboarding.py
+++ b/tests/unit/test_cli_onboarding.py
@@ -24,6 +24,7 @@ class TestBackendRegistry:
     def test_all_backends_present(self):
         assert set(ALL_BACKEND_NAMES) == {
             "route53",
+            "cloud-dns",
             "cloudflare",
             "infoblox",
             "nios",
@@ -188,7 +189,7 @@ class TestDoctorAPI:
         from dns_aid.doctor import run_checks
 
         report = run_checks()
-        for section, checks in report.sections.items():
+        for _section, checks in report.sections.items():
             for check in checks:
                 assert check.status in ("pass", "fail", "warn")
                 assert check.label

--- a/tests/unit/test_cloud_dns_backend.py
+++ b/tests/unit/test_cloud_dns_backend.py
@@ -1,0 +1,167 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dns_aid.backends.cloud_dns."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.backends.cloud_dns import CloudDNSBackend
+
+
+def _backend() -> CloudDNSBackend:
+    return CloudDNSBackend(
+        project_id="test-project",
+        managed_zone="agents-zone",
+        token_provider=lambda: ("test-token", None),
+    )
+
+
+class TestCloudDNSBackend:
+    """Unit coverage for Cloud DNS request shaping."""
+
+    def test_name_property(self):
+        backend = _backend()
+        assert backend.name == "cloud-dns"
+
+    @pytest.mark.asyncio
+    async def test_create_svcb_record_builds_change_payload(self):
+        backend = _backend()
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=None)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._mcp._agents",
+                priority=1,
+                target="service.example.internal",
+                params={"alpn": "mcp", "port": "443", "key65406": "lattice"},
+                ttl=30,
+            )
+
+        assert result == "_chat._mcp._agents.example.com"
+        assert mock_request.await_count == 1
+        call = mock_request.await_args
+        assert call.args == (
+            "POST",
+            "/projects/test-project/managedZones/agents-zone/changes",
+        )
+        payload = call.kwargs["json"]
+        assert payload["additions"] == [
+            {
+                "name": "_chat._mcp._agents.example.com.",
+                "type": "SVCB",
+                "ttl": 30,
+                "rrdatas": [
+                    '1 service.example.internal. alpn="mcp" port="443" key65406="lattice"'
+                ],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_txt_record_quotes_values(self):
+        backend = _backend()
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=None)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            await backend.create_txt_record(
+                zone="example.com",
+                name="_chat._mcp._agents",
+                values=["capabilities=chat,search", '"version=1.0.0"'],
+                ttl=300,
+            )
+
+        payload = mock_request.await_args.kwargs["json"]
+        assert payload["additions"] == [
+            {
+                "name": "_chat._mcp._agents.example.com.",
+                "type": "TXT",
+                "ttl": 300,
+                "rrdatas": ['"capabilities=chat,search"', '"version=1.0.0"'],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_records_filters_and_normalizes_rrsets(self):
+        backend = _backend()
+
+        responses = [
+            {
+                "rrsets": [
+                    {
+                        "name": "_chat._mcp._agents.example.com.",
+                        "type": "SVCB",
+                        "ttl": 30,
+                        "rrdatas": ['1 service.example.internal. alpn="mcp"'],
+                    },
+                    {
+                        "name": "_chat._mcp._agents.example.com.",
+                        "type": "TXT",
+                        "ttl": 30,
+                        "rrdatas": ['"version=1.0.0"'],
+                    },
+                ]
+            }
+        ]
+
+        with patch.object(backend, "_request", AsyncMock(side_effect=responses)):
+            records = [
+                record
+                async for record in backend.list_records(
+                    "example.com",
+                    name_pattern="_chat._mcp._agents",
+                    record_type="SVCB",
+                )
+            ]
+
+        assert records == [
+            {
+                "name": "_chat._mcp._agents",
+                "fqdn": "_chat._mcp._agents.example.com",
+                "type": "SVCB",
+                "ttl": 30,
+                "values": ['1 service.example.internal. alpn="mcp"'],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_record_returns_none_for_mismatched_rrset(self):
+        backend = _backend()
+
+        with patch.object(
+            backend,
+            "_request",
+            AsyncMock(
+                return_value={
+                    "rrsets": [
+                        {
+                            "name": "_other._mcp._agents.example.com.",
+                            "type": "TXT",
+                            "ttl": 30,
+                            "rrdatas": ['"version=1.0.0"'],
+                        }
+                    ]
+                }
+            ),
+        ):
+            record = await backend.get_record("example.com", "_chat._mcp._agents", "TXT")
+
+        assert record is None
+
+    @pytest.mark.asyncio
+    async def test_zone_exists_returns_false_on_lookup_failure(self):
+        backend = _backend()
+
+        with patch.object(
+            backend,
+            "_get_managed_zone_name",
+            AsyncMock(side_effect=ValueError("zone missing")),
+        ):
+            assert await backend.zone_exists("example.com") is False

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -511,7 +511,9 @@ class TestParseSvcbCustomParams:
             '1 mcp.example.com. alpn="mcp" port="443" '
             'cap="https://mcp.example.com/.well-known/agent-cap.json" '
             'cap-sha256="dGVzdGhhc2g" '
-            'bap="mcp/1,a2a/1" policy="https://example.com/policy" realm="production"'
+            'bap="mcp/1,a2a/1" policy="https://example.com/policy" realm="production" '
+            'connect-class="lattice" connect-meta="arn:aws:vpc-lattice:::service/svc-123" '
+            'enroll-uri="https://service.example.com/.well-known/agent-connect"'
         )
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
@@ -519,6 +521,9 @@ class TestParseSvcbCustomParams:
         assert params["bap"] == "mcp/1,a2a/1"
         assert params["policy"] == "https://example.com/policy"
         assert params["realm"] == "production"
+        assert params["connect-class"] == "lattice"
+        assert params["connect-meta"] == "arn:aws:vpc-lattice:::service/svc-123"
+        assert params["enroll-uri"] == "https://service.example.com/.well-known/agent-connect"
 
     def test_ignores_non_dnsaid_params(self):
         svcb_text = '1 mcp.example.com. alpn="mcp" port="443" ipv4hint="192.0.2.1"'
@@ -559,6 +564,18 @@ class TestParseSvcbCustomParams:
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://example.com/cap.json"
         assert params["realm"] == "prod"
+
+    def test_preserves_quoted_values_with_spaces(self):
+        svcb_text = (
+            '1 mcp.example.com. connect-meta="apphub.googleapis.com/projects/test/services/My Service" '
+            'enroll-uri="https://example.com/.well-known/agent-connect?label=My Service"'
+        )
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["connect-meta"] == "apphub.googleapis.com/projects/test/services/My Service"
+        assert (
+            params["enroll-uri"]
+            == "https://example.com/.well-known/agent-connect?label=My Service"
+        )
 
 
 class TestDiscoveryWithCapUri:
@@ -740,6 +757,47 @@ class TestDiscoveryWithCapUri:
         assert agent.bap == ["mcp", "a2a"]
         assert agent.policy_uri == "https://example.com/policy"
         assert agent.realm == "staging"
+
+    @pytest.mark.asyncio
+    async def test_discovery_extracts_connect_fields(self):
+        """Test that provider-specific connection params round-trip through discovery."""
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("service.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: (
+            '1 service.example.com. alpn="mcp" port="443" '
+            'connect-class="apphub-psc" '
+            'connect-meta="projects/test/locations/us/discoveredServices/123" '
+            'enroll-uri="https://psc.example.com/.well-known/agent-connect"'
+        )
+
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=mock_answers)
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer._query_capabilities",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            from dns_aid.core.discoverer import _query_single_agent
+
+            agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.connect_class == "apphub-psc"
+        assert agent.connect_meta == "projects/test/locations/us/discoveredServices/123"
+        assert agent.enroll_uri == "https://psc.example.com/.well-known/agent-connect"
 
 
 # =============================================================================

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -154,12 +154,13 @@ class TestInfobloxNIOSSvcParameters:
 
     def test_svc_parameters_conversion(self) -> None:
         params = {
-            "mandatory": "alpn,port,cap",
+            "mandatory": "alpn,port,cap,connect-class",
             "alpn": "h2,h3",
             "port": "443",
             "bap": "mcp/1,a2a/1",
             "cap": "https://example.com/.well-known/agent-cap.json",
             "sig": "abc123",
+            "connect-class": "lattice",
         }
 
         converted = InfobloxNIOSBackend._svc_parameters_from_params(params)
@@ -171,6 +172,8 @@ class TestInfobloxNIOSSvcParameters:
         assert as_map["port"]["svc_value"] == ["443"]
         assert as_map["key65400"]["mandatory"] is True
         assert as_map["key65405"]["svc_value"] == ["abc123"]
+        assert as_map["key65406"]["mandatory"] is True
+        assert as_map["key65406"]["svc_value"] == ["lattice"]
 
     def test_svc_parameters_preserves_numeric_keys(self) -> None:
         converted = InfobloxNIOSBackend._svc_parameters_from_params(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -6,7 +6,7 @@
 import pytest
 from pydantic import ValidationError
 
-from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol, VerifyResult
+from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol, SvcbRecord, VerifyResult
 
 
 class TestAgentRecord:
@@ -220,6 +220,46 @@ class TestAgentRecord:
         assert params["key65401"] == "dGVzdGhhc2g"
         assert "key65400" not in params
 
+    def test_svcb_params_with_connect_fields(self):
+        """Test provider-managed connection params are serialized as SVCB custom keys."""
+        agent = AgentRecord(
+            name="lattice-agent",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="service.internal",
+            connect_class="lattice",
+            connect_meta="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+            enroll_uri="https://service.internal/.well-known/agent-connect",
+        )
+
+        params = agent.to_svcb_params()
+
+        assert params["key65406"] == "lattice"
+        assert params["key65407"] == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert params["key65408"] == "https://service.internal/.well-known/agent-connect"
+
+    def test_ttl_allows_30_seconds(self):
+        """Dynamic publishers need a 30 second TTL floor."""
+        agent = AgentRecord(
+            name="fast-agent",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="fast.example.com",
+            ttl=30,
+        )
+        assert agent.ttl == 30
+
+    def test_connect_fields_have_length_bounds(self):
+        """Connection metadata is bounded to avoid oversized records."""
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="bounded-agent",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="mcp.example.com",
+                connect_meta="x" * 2049,
+            )
+
     def test_txt_values(self):
         """Test TXT record values generation."""
         agent = AgentRecord(
@@ -295,6 +335,46 @@ class TestProtocol:
         """Test creating protocol from string."""
         assert Protocol("a2a") == Protocol.A2A
         assert Protocol("mcp") == Protocol.MCP
+
+
+class TestSvcbRecord:
+    """Tests for the shared SvcbRecord helper."""
+
+    def test_to_params_with_connect_class_variants(self):
+        direct = SvcbRecord(target="direct.example.com", alpn="mcp", connect_class="direct")
+        lattice = SvcbRecord(target="lattice.example.com", alpn="mcp", connect_class="lattice")
+        apphub = SvcbRecord(target="psc.example.com", alpn="mcp", connect_class="apphub-psc")
+
+        assert direct.to_params()["key65406"] == "direct"
+        assert lattice.to_params()["key65406"] == "lattice"
+        assert apphub.to_params()["key65406"] == "apphub-psc"
+
+    def test_to_params_with_string_keys(self):
+        import os
+        from unittest.mock import patch
+
+        record = SvcbRecord(
+            target="psc.example.com",
+            alpn="mcp",
+            connect_class="apphub-psc",
+            connect_meta="projects/test/locations/us/discoveredServices/123",
+            enroll_uri="https://psc.example.com/.well-known/agent-connect",
+        )
+
+        with patch.dict(os.environ, {"DNS_AID_SVCB_STRING_KEYS": "1"}):
+            params = record.to_params()
+
+        assert params["connect-class"] == "apphub-psc"
+        assert params["connect-meta"] == "projects/test/locations/us/discoveredServices/123"
+        assert params["enroll-uri"] == "https://psc.example.com/.well-known/agent-connect"
+
+    def test_connect_class_uses_shared_normalization(self):
+        record = SvcbRecord(target="svc.example.com", alpn="mcp", connect_class=" LATTICE ")
+        assert record.connect_class == "lattice"
+
+    def test_normalized_target_adds_trailing_dot(self):
+        record = SvcbRecord(target="svc.example.com", alpn="mcp")
+        assert record.normalized_target == "svc.example.com."
 
 
 class TestDiscoveryResult:

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -198,6 +198,31 @@ class TestPublish:
         assert "key65402" not in svcb["params"]
         assert "key65403" not in svcb["params"]
 
+    @pytest.mark.asyncio
+    async def test_publish_with_connect_params(self, mock_backend: MockBackend):
+        """Test publishing with provider-managed connection metadata."""
+        result = await publish(
+            name="overlay",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="overlay.example.com",
+            connect_class="lattice",
+            connect_meta="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+            enroll_uri="https://overlay.example.com/.well-known/agent-connect",
+            backend=mock_backend,
+        )
+
+        assert result.success is True
+        assert result.agent.connect_class == "lattice"
+        assert result.agent.connect_meta == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert result.agent.enroll_uri == "https://overlay.example.com/.well-known/agent-connect"
+
+        svcb = mock_backend.get_svcb_record("example.com", "_overlay._mcp._agents")
+        assert svcb is not None
+        assert svcb["params"]["key65406"] == "lattice"
+        assert svcb["params"]["key65407"] == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert svcb["params"]["key65408"] == "https://overlay.example.com/.well-known/agent-connect"
+
 
 class TestUnpublish:
     """Tests for unpublish function."""

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -10,6 +10,7 @@ from dns_aid.utils.validation import (
     validate_agent_name,
     validate_backend,
     validate_capabilities,
+    validate_connect_class,
     validate_domain,
     validate_endpoint,
     validate_fqdn,
@@ -128,6 +129,32 @@ class TestValidateProtocol:
         assert exc.value.field == "protocol"
 
 
+class TestValidateConnectClass:
+    """Tests for validate_connect_class."""
+
+    def test_valid_known_class(self):
+        assert validate_connect_class("lattice") == "lattice"
+
+    def test_normalizes_whitespace_and_case(self):
+        assert validate_connect_class(" AppHub-PSC ") == "apphub-psc"
+
+    def test_none_returns_none(self):
+        assert validate_connect_class(None) is None
+
+    def test_empty_returns_none(self):
+        assert validate_connect_class("   ") is None
+
+    def test_rejects_invalid_characters(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_connect_class("bad class")
+        assert exc.value.field == "connect_class"
+
+    def test_rejects_unknown_class(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_connect_class("overlay")
+        assert exc.value.field == "connect_class"
+
+
 class TestValidateEndpoint:
     """Tests for validate_endpoint."""
 
@@ -181,15 +208,15 @@ class TestValidateTtl:
         assert validate_ttl(3600) == 3600
 
     def test_valid_min_ttl(self):
-        assert validate_ttl(60) == 60
+        assert validate_ttl(30) == 30
 
     def test_valid_max_ttl(self):
         assert validate_ttl(604800) == 604800
 
     def test_ttl_too_low_raises(self):
         with pytest.raises(ValidationError) as exc:
-            validate_ttl(59)
-        assert "at least 60" in exc.value.message
+            validate_ttl(29)
+        assert "at least 30" in exc.value.message
 
     def test_ttl_too_high_raises(self):
         with pytest.raises(ValidationError) as exc:
@@ -284,6 +311,9 @@ class TestValidateBackend:
 
     def test_valid_cloudflare(self):
         assert validate_backend("cloudflare") == "cloudflare"
+
+    def test_valid_cloud_dns(self):
+        assert validate_backend("cloud-dns") == "cloud-dns"
 
     def test_valid_infoblox(self):
         assert validate_backend("infoblox") == "infoblox"

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -460,6 +460,7 @@ all = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["route53"] },
     { name = "cryptography" },
+    { name = "google-auth" },
     { name = "mcp" },
     { name = "mypy" },
     { name = "opentelemetry-api" },
@@ -475,6 +476,9 @@ all = [
 cli = [
     { name = "rich" },
     { name = "typer" },
+]
+cloud-dns = [
+    { name = "google-auth" },
 ]
 dev = [
     { name = "boto3-stubs", extra = ["route53"] },
@@ -513,6 +517,8 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'jws'", specifier = ">=41.0.0" },
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "dnspython", specifier = ">=2.6.0" },
+    { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.30.0" },
+    { name = "google-auth", marker = "extra == 'cloud-dns'", specifier = ">=2.30.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.0.0" },
@@ -541,7 +547,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
 
 [[package]]
 name = "dnspython"
@@ -559,6 +565,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
 ]
 
 [[package]]
@@ -1098,6 +1117,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- split the protocol/backend portion of the old `#47` stack into its own reviewable PR
- add the new connection-mediation SVCB fields and round-trip discovery support
- add the Cloud DNS backend plus CLI/backend registry wiring

## Included in this PR
- shared `SvcbRecord` model and additive `AgentRecord` fields for `connect_class`, `connect_meta`, and `enroll_uri`
- DNS-AID private-use key mapping for `key65406` through `key65408`
- quoted-string-aware custom SVCB param parsing during discovery
- Cloud DNS backend, backend factory wiring, CLI onboarding coverage, and README support-matrix updates
- shared validation for `connect_class` and tighter bounds on the new connect fields
- TTL floor adjustment to `30s`

## Explicitly not included
- AppHub and VPC Lattice publisher runtimes
- provider workers / harness code
- A2A bridge or shared integrations work

## Validation
- `PYTHONPATH=src uv run --with '.[dev,cli,cloud-dns]' mypy src/dns_aid/core/models.py src/dns_aid/core/discoverer.py src/dns_aid/core/publisher.py src/dns_aid/backends/cloud_dns.py src/dns_aid/cli/backends.py src/dns_aid/utils/validation.py src/dns_aid/utils/google_auth.py`
- `PYTHONPATH=src uv run --with '.[dev,cli,cloud-dns]' ruff check README.md pyproject.toml src/dns_aid/__init__.py src/dns_aid/backends/__init__.py src/dns_aid/backends/cloud_dns.py src/dns_aid/backends/infoblox/nios.py src/dns_aid/cli/backends.py src/dns_aid/core/discoverer.py src/dns_aid/core/models.py src/dns_aid/core/publisher.py src/dns_aid/utils/google_auth.py src/dns_aid/utils/validation.py tests/unit/test_backend_factory.py tests/unit/test_cli_onboarding.py tests/unit/test_cloud_dns_backend.py tests/unit/test_discoverer.py tests/unit/test_infoblox_nios_backend.py tests/unit/test_models.py tests/unit/test_publisher.py tests/unit/test_validation.py`
- `PYTHONPATH=src uv run --with '.[dev,cli,mcp,route53,cloud-dns]' pytest tests/unit -q`

## Dependency note
This PR follows the ADR in the separate wire-format decision PR. It intentionally leaves the cloud provider runtimes for a follow-up restack branch.
