### PR TITLE
feat: add A2A card conversion helpers

### DIFF
--- a/src/dns_aid/core/__init__.py
+++ b/src/dns_aid/core/__init__.py
@@ -10,6 +10,7 @@ from dns_aid.core.a2a_card import (
     A2ASkill,
     fetch_agent_card,
     fetch_agent_card_from_domain,
+    publish_agent_card,
 )
 from dns_aid.core.agent_metadata import AgentMetadata, AuthType, TransportType
 from dns_aid.core.capability_model import Action, ActionIntent, ActionSemantics, CapabilitySpec
@@ -33,4 +34,5 @@ __all__ = [
     "TransportType",
     "fetch_agent_card",
     "fetch_agent_card_from_domain",
+    "publish_agent_card",
 ]

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -13,8 +13,8 @@ Reference: https://google.github.io/A2A/
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
-from urllib.parse import urljoin
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin, urlparse
 
 import httpx
 import structlog
@@ -23,6 +23,11 @@ logger = structlog.get_logger(__name__)
 
 # Well-known path for A2A Agent Cards
 A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
+_MAX_DNS_LABEL_LENGTH = 63
+
+if TYPE_CHECKING:
+    from dns_aid.backends.base import DNSBackend
+    from dns_aid.core.models import AgentRecord, PublishResult
 
 
 @dataclass
@@ -152,6 +157,25 @@ class A2AAgentCard:
             metadata=metadata,
         )
 
+    @classmethod
+    def from_agent_record(cls, agent: AgentRecord) -> A2AAgentCard:
+        """Convert a discovered DNS-AID A2A record into a public agent card model."""
+        skills = [
+            A2ASkill(
+                id=capability,
+                name=capability.replace("-", " ").replace("_", " ").title(),
+                description=f"Capability: {capability}",
+            )
+            for capability in agent.capabilities
+        ]
+        return cls(
+            name=agent.name,
+            url=_origin_for_endpoint(agent.target_host, agent.port),
+            version=agent.version,
+            description=agent.description,
+            skills=skills,
+        )
+
     @property
     def skill_ids(self) -> list[str]:
         """Get list of skill IDs (convenience for capability matching)."""
@@ -165,6 +189,35 @@ class A2AAgentCard:
     def to_capabilities(self) -> list[str]:
         """Convert skills to DNS-AID capability format (skill IDs)."""
         return self.skill_ids
+
+    def to_publish_params(
+        self,
+        domain: str,
+        *,
+        name: str | None = None,
+        endpoint: str | None = None,
+        port: int | None = None,
+        ttl: int = 3600,
+    ) -> dict[str, Any]:
+        """Build keyword arguments for ``dns_aid.publish()`` from this card."""
+        resolved_endpoint, resolved_port, cap_uri = _resolve_publish_endpoint(
+            card_url=self.url,
+            endpoint=endpoint,
+            port=port,
+        )
+        return {
+            "name": name or _sanitize_dns_label(self.name),
+            "domain": domain,
+            "protocol": "a2a",
+            "endpoint": resolved_endpoint,
+            "port": resolved_port,
+            "capabilities": self.to_capabilities() or None,
+            "version": self.version or "1.0.0",
+            "description": self.description,
+            "ttl": ttl,
+            "cap_uri": cap_uri,
+            "bap": ["a2a/1"],
+        }
 
 
 async def fetch_agent_card(
@@ -265,3 +318,77 @@ async def fetch_agent_card_from_domain(
         >>> card = await fetch_agent_card_from_domain("example.com")
     """
     return await fetch_agent_card(f"https://{domain}", timeout=timeout)
+
+
+async def publish_agent_card(
+    card: A2AAgentCard,
+    *,
+    domain: str,
+    name: str | None = None,
+    endpoint: str | None = None,
+    port: int | None = None,
+    ttl: int = 3600,
+    backend: DNSBackend | None = None,
+) -> PublishResult:
+    """Publish an A2A agent card through the existing DNS-AID publish entrypoint."""
+    from dns_aid.core.publisher import publish
+
+    publish_kwargs = card.to_publish_params(
+        domain,
+        name=name,
+        endpoint=endpoint,
+        port=port,
+        ttl=ttl,
+    )
+    publish_kwargs["backend"] = backend
+    return await publish(**publish_kwargs)
+
+
+def _sanitize_dns_label(name: str) -> str:
+    """Convert a human-readable name into a DNS-safe label."""
+    label = name.lower().strip().replace(" ", "-").replace("_", "-")
+    label = "".join(char for char in label if char.isalnum() or char == "-")
+    label = label.strip("-")
+    label = label[:_MAX_DNS_LABEL_LENGTH].rstrip("-")
+    return label or "agent"
+
+
+def _resolve_publish_endpoint(
+    *,
+    card_url: str,
+    endpoint: str | None,
+    port: int | None,
+) -> tuple[str, int, str]:
+    parsed = _parse_endpoint_url(card_url) if card_url else None
+    resolved_port = port or 443
+    resolved_endpoint = endpoint
+    if resolved_endpoint is None and card_url:
+        resolved_endpoint = parsed.hostname if parsed else ""
+    if parsed and parsed.port and port is None:
+        resolved_port = parsed.port
+
+    if not resolved_endpoint:
+        raise ValueError("endpoint must be provided or derivable from card.url")
+
+    if endpoint is not None or port is not None:
+        origin_source = resolved_endpoint
+    else:
+        origin_source = parsed.geturl() if parsed else resolved_endpoint
+
+    origin = _origin_for_endpoint(origin_source, resolved_port)
+    return resolved_endpoint, resolved_port, urljoin(origin.rstrip("/") + "/", A2A_AGENT_CARD_PATH.lstrip("/"))
+
+
+def _parse_endpoint_url(url: str):
+    candidate = url if "://" in url else f"https://{url}"
+    return urlparse(candidate)
+
+
+def _origin_for_endpoint(url_or_host: str, port: int) -> str:
+    parsed = _parse_endpoint_url(url_or_host)
+    hostname = parsed.hostname or url_or_host
+    scheme = parsed.scheme or "https"
+    default_port = 443 if scheme == "https" else 80
+    effective_port = parsed.port or port
+    port_suffix = "" if effective_port == default_port else f":{effective_port}"
+    return f"{scheme}://{hostname}{port_suffix}"

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -15,7 +15,9 @@ from dns_aid.core.a2a_card import (
     A2ASkill,
     fetch_agent_card,
     fetch_agent_card_from_domain,
+    publish_agent_card,
 )
+from dns_aid.core.models import AgentRecord, Protocol
 
 
 class TestA2ASkill:
@@ -168,6 +170,110 @@ class TestA2AAgentCard:
             ],
         )
         assert card.to_capabilities() == ["payment", "refund"]
+
+    def test_from_agent_record(self) -> None:
+        """Test converting an AgentRecord into an A2A agent card."""
+        agent = AgentRecord(
+            name="payments",
+            domain="example.com",
+            protocol=Protocol.A2A,
+            target_host="a2a.example.com",
+            capabilities=["pay", "refund"],
+            version="2.0.0",
+            description="Payment workflows",
+        )
+
+        card = A2AAgentCard.from_agent_record(agent)
+
+        assert card.name == "payments"
+        assert card.url == "https://a2a.example.com"
+        assert card.version == "2.0.0"
+        assert card.description == "Payment workflows"
+        assert [skill.id for skill in card.skills] == ["pay", "refund"]
+
+    def test_to_publish_params_derives_defaults(self) -> None:
+        """Test publish helper derives endpoint, cap_uri, and DNS-safe name from card url."""
+        card = A2AAgentCard(
+            name="Payments Agent",
+            url="https://a2a.example.com/tasks",
+            version="2.0.0",
+            description="Payment workflows",
+            skills=[A2ASkill(id="pay", name="Pay"), A2ASkill(id="refund", name="Refund")],
+        )
+
+        params = card.to_publish_params("example.com")
+
+        assert params == {
+            "name": "payments-agent",
+            "domain": "example.com",
+            "protocol": "a2a",
+            "endpoint": "a2a.example.com",
+            "port": 443,
+            "capabilities": ["pay", "refund"],
+            "version": "2.0.0",
+            "description": "Payment workflows",
+            "ttl": 3600,
+            "cap_uri": "https://a2a.example.com/.well-known/agent-card.json",
+            "bap": ["a2a/1"],
+        }
+
+    def test_to_publish_params_respects_overrides(self) -> None:
+        """Test publish helper respects explicit name, endpoint, and port overrides."""
+        card = A2AAgentCard(name="Payments Agent", url="https://a2a.example.com")
+
+        params = card.to_publish_params(
+            "example.com",
+            name="payments-v2",
+            endpoint="overlay.internal",
+            port=8443,
+            ttl=30,
+        )
+
+        assert params["name"] == "payments-v2"
+        assert params["endpoint"] == "overlay.internal"
+        assert params["port"] == 8443
+        assert params["ttl"] == 30
+        assert params["cap_uri"] == "https://overlay.internal:8443/.well-known/agent-card.json"
+
+    def test_to_publish_params_requires_endpoint_source(self) -> None:
+        """Test publish helper rejects cards with no usable endpoint source."""
+        card = A2AAgentCard(name="No Endpoint", url="")
+
+        with pytest.raises(ValueError, match="endpoint must be provided or derivable"):
+            card.to_publish_params("example.com")
+
+
+class TestPublishAgentCard:
+    """Tests for publish_agent_card helper."""
+
+    @pytest.mark.asyncio
+    async def test_publish_agent_card_calls_publish(self) -> None:
+        card = A2AAgentCard(
+            name="Payments Agent",
+            url="https://a2a.example.com/api",
+            skills=[A2ASkill(id="pay", name="Pay")],
+        )
+
+        publish_result = MagicMock()
+
+        with patch("dns_aid.core.publisher.publish", AsyncMock(return_value=publish_result)) as mock_publish:
+            result = await publish_agent_card(card, domain="example.com", ttl=30)
+
+        assert result is publish_result
+        mock_publish.assert_awaited_once_with(
+            name="payments-agent",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="a2a.example.com",
+            port=443,
+            capabilities=["pay"],
+            version="1.0.0",
+            description=None,
+            ttl=30,
+            cap_uri="https://a2a.example.com/.well-known/agent-card.json",
+            bap=["a2a/1"],
+            backend=None,
+        )
 
 
 class TestFetchAgentCard:


### PR DESCRIPTION
## Summary
- salvage the net-new value from the old `#48` stack without reviving the duplicate `dns_aid.a2a` package
- add DNS-AID record -> `A2AAgentCard` conversion on the existing core card model
- add `A2AAgentCard` -> `dns_aid.publish()` helper using the current core publish surface

## Included in this PR
- `A2AAgentCard.from_agent_record(...)`
- `A2AAgentCard.to_publish_params(...)`
- `publish_agent_card(...)` in `src/dns_aid/core/a2a_card.py`
- unit coverage for conversion defaults, override behavior, and publish helper wiring

## Explicitly not included
- duplicate `dns_aid.a2a` wrappers for discover or unpublish
- schema registry work
- pre-publish validator changes
- shared integrations layer changes

## Validation
- `PYTHONPATH=src uv run --with '.[dev,cli]' mypy src/dns_aid/core/a2a_card.py src/dns_aid/core/__init__.py`
- `PYTHONPATH=src uv run --with '.[dev,cli]' ruff check src/dns_aid/core/a2a_card.py src/dns_aid/core/__init__.py tests/unit/test_a2a_card.py`
- `PYTHONPATH=src uv run --with '.[dev,cli,mcp,route53]' pytest tests/unit -q`