### PR TITLE
feat: add AppHub and Lattice publisher runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-03-19
+
+### Added
+- **Connection mediation SVCB params** — `connect-class` (`key65406`), `connect-meta` (`key65407`), and `enroll-uri` (`key65408`) are now first-class DNS-AID wire parameters for AppHub PSC and VPC Lattice bootstrap flows.
+- **Cloud DNS support for `connect-*` records** — Google Cloud DNS joins NIOS as an authoritative backend that can publish the new private-use SVCB parameters directly.
+
+### Changed
+- **Internal-first backend support for mediated connections** — The first release of `connect-*` publishing targets backends that natively support private-use SVCB keys. Route 53 and Cloudflare remain out of scope for direct `connect-*` publishing in this release.
+
+### Notes
+- **Republish required for adopters** — Zones adopting connection mediation must republish affected records so `key65406`, `key65407`, and `key65408` appear on the wire.
+- See `docs/adr/0001-connect-mediation-wire-format.md` for the compatibility decision and rollout assumptions.
+
 ## [0.12.1] - 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For advanced usage with telemetry, connection reuse, and ranking, see the [SDK documentation](docs/getting-started.md#sdk-agent-invocation--telemetry).
+For advanced usage with telemetry, connection reuse, and ranking, see the [SDK documentation](docs/getting-started.md#sdk-agent-invocation--telemetry). For provider-managed `_agents` publishing on GCP AppHub and AWS VPC Lattice, see [Provider Publishers](docs/provider-publishers.md).
 
 ### Agent Index Records
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pip install dns-aid[mcp]
 
 # With a specific backend
 pip install dns-aid[route53]      # AWS Route 53
+pip install dns-aid[cloud-dns]    # Google Cloud DNS
 pip install dns-aid[cloudflare]   # Cloudflare DNS
 pip install dns-aid[infoblox]     # Infoblox BloxOne (cloud)
 pip install dns-aid[nios]         # Infoblox NIOS (on-prem)
@@ -675,6 +676,7 @@ DNS-AID supports multiple DNS backends:
 | Backend | Description | Status |
 |---------|-------------|--------|
 | Route 53 | AWS Route 53 | ✅ Production |
+| Cloud DNS | Google Cloud DNS | ✅ Production |
 | Infoblox UDDI | Infoblox Universal DDI (cloud) | ✅ Production |
 | Infoblox NIOS | Infoblox NIOS (on-prem WAPI) | ✅ Production |
 | DDNS | RFC 2136 Dynamic DNS (BIND, etc.) | ✅ Production |
@@ -780,17 +782,19 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
 > The draft requires ServiceMode SVCB records (priority > 0) with mandatory `alpn` and `port`
 > parameters. Infoblox UDDI's limitation is a platform constraint, not a DNS-AID limitation.
 
-| DNS-AID Requirement | Route 53 | Cloudflare | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
-|---------------------|----------|------------|-------------|---------------|---------------|
-| ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `alpn` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `port` parameter | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `mandatory` key | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ✅ Native | ❌ |
+| DNS-AID Requirement | Route 53 | Cloudflare | Cloud DNS | DDNS (BIND) | Infoblox NIOS | Infoblox UDDI |
+|---------------------|----------|------------|-----------|-------------|---------------|---------------|
+| ServiceMode (priority > 0) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `alpn` parameter | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `port` parameter | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `mandatory` key | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Custom SVCB params (`cap`, `realm`, etc.) | ⚠️ TXT | ⚠️ TXT | ✅ Native | ✅ Native | ✅ Native | ❌ |
 
 **⚠️ TXT** = Custom DNS-AID params auto-demoted to TXT records with `dnsaid_` prefix (no data loss).
 
-**For full DNS-AID compliance with native custom SVCB params, use DDNS (BIND/RFC 2136) or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
+**For full DNS-AID compliance with native custom SVCB params, use Cloud DNS, DDNS (BIND/RFC 2136), or Infoblox NIOS. Route 53 and Cloudflare support all standard SVCB params with automatic TXT demotion for custom params.**
+
+The connection-mediation keys `key65406` through `key65408` are a protocol-visible addition. When adopting them, republish affected records so the new SVCB parameters are present on the wire. See [`docs/adr/0001-connect-mediation-wire-format.md`](docs/adr/0001-connect-mediation-wire-format.md) for the compatibility decision and rollout assumptions.
 
 DNS-AID stores `alpn` and `port` in TXT records as a fallback for Infoblox UDDI, but this is
 a workaround and not standard-compliant for agent discovery.

--- a/docs/provider-publishers.md
+++ b/docs/provider-publishers.md
@@ -59,7 +59,10 @@ export APPHUB_CONNECT_META_METADATA_KEY="apphub.googleapis.com/agentConnect"
 export APPHUB_CONNECT_META_METADATA_PATH="serviceName"
 export APPHUB_ENROLLMENT_METADATA_KEY="apphub.googleapis.com/agentConnect"
 export APPHUB_ENROLLMENT_METADATA_PATH="pscBaseUrl"
+export APPHUB_NAME_OVERRIDES_JSON='{"projects/.../discoveredServices/inventory-api":"inventory-api"}'
 ```
+
+`APPHUB_ENROLLMENT_METADATA_PATH` is the only metadata path consulted for enrollment URL discovery. DNS-AID does not scan unrelated AppHub metadata blobs for fallback URLs.
 
 ### Running
 
@@ -95,7 +98,10 @@ export LATTICE_STABLE_TAG_KEY="stable"
 export NIOS_HOST="nios.example.com"
 export NIOS_USERNAME="admin"
 export NIOS_PASSWORD="secret"
+export LATTICE_NAME_OVERRIDES_JSON='{"arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123":"orders-api"}'
 ```
+
+NIOS must expose WAPI `2.13+` for these publisher flows. Earlier WAPI versions do not provide the SVCB support DNS-AID expects.
 
 ### Running
 
@@ -123,5 +129,9 @@ If workloads resolve the private agent zone from Route 53, Route 53 Resolver for
 
 - AppHub path: resolve `_agents.<domain>`, read `connect-class=apphub-psc`, call `enroll-uri`, validate `connect-meta`.
 - Lattice path: resolve `_agents.<domain>`, read `connect-class=lattice`, call `enroll-uri`, and verify the ARN in `connect-meta` via the supplied Lattice lookup callback.
+
+The harness validates `enroll-uri` with DNS-AID's URL-safety checks, requires HTTPS, and keeps redirects disabled. For internal PSC or Lattice hostnames, add the expected hostnames to `DNS_AID_FETCH_ALLOWLIST` before running the harness.
+
+For lattice, the `enroll-uri` hostname must match the published target host. The harness treats that endpoint as overlay-mediated bootstrap only; it does not direct-connect to a discovered link-local target.
 
 This repo includes hermetic tests for both paths using generated zone data and mocks. Real cloud validation remains an environment-specific workflow because it requires enabled AppHub, Cloud DNS, VPC Lattice, and NIOS infrastructure.

--- a/docs/provider-publishers.md
+++ b/docs/provider-publishers.md
@@ -1,0 +1,127 @@
+# Provider Publishers
+
+DNS-AID includes a provider-managed publishing layer for environments where agent endpoints are created by a cloud control plane rather than by the agent process itself.
+
+The publisher APIs live under `dns_aid.sdk.publishers` and revolve around a shared async interface:
+
+```python
+from dns_aid.sdk.publishers import AgentRecordPublisher
+
+await publisher.publish(service)
+await publisher.unpublish(service)
+await publisher.sync()
+```
+
+## Components
+
+- `AppHubPublisher` publishes `_agents` records for AppHub discovered services into Google Cloud DNS.
+- `LatticePublisher` publishes `_agents` records for VPC Lattice services into Infoblox NIOS.
+- `DiscoveryValidationHarness` performs a bootstrap flow using only the published DNS records.
+
+## Installation
+
+Install the optional dependencies needed for the provider you are using:
+
+```bash
+pip install -e ".[cloud-dns,apphub]"
+pip install -e ".[nios,publishers]"
+```
+
+## AppHub Publisher
+
+`AppHubPublisher` reconciles AppHub discovered services with `functionalType=AGENT` into a private `_agents` zone in Cloud DNS.
+
+Published SVCB fields:
+
+- `connect-class=apphub-psc`
+- `connect-meta=<AppHub canonical service name or discovered service fallback>`
+- `enroll-uri=<psc-base-url>/.well-known/agent-connect`
+
+Capabilities are read from AppHub extended metadata when present. Missing capability metadata does not block publishing.
+
+### Environment
+
+```bash
+export GOOGLE_CLOUD_PROJECT="my-project"
+export APPHUB_LOCATION="us-central1"
+export APPHUB_DOMAIN="corp.internal"
+export CLOUD_DNS_MANAGED_ZONE="agents-private"
+```
+
+Optional metadata overrides:
+
+```bash
+export APPHUB_CAPABILITIES_METADATA_KEY="apphub.googleapis.com/agentProperties"
+export APPHUB_CAPABILITIES_METADATA_PATH="a2a.capabilities"
+export APPHUB_SERVICE_NAME_METADATA_KEY="apphub.googleapis.com/agentProperties"
+export APPHUB_SERVICE_NAME_METADATA_PATH="serviceName"
+export APPHUB_CONNECT_META_METADATA_KEY="apphub.googleapis.com/agentConnect"
+export APPHUB_CONNECT_META_METADATA_PATH="serviceName"
+export APPHUB_ENROLLMENT_METADATA_KEY="apphub.googleapis.com/agentConnect"
+export APPHUB_ENROLLMENT_METADATA_PATH="pscBaseUrl"
+```
+
+### Running
+
+Run a single reconciliation cycle:
+
+```bash
+python -m dns_aid.sdk.publishers.apphub
+```
+
+Set `APPHUB_RUN_FOREVER=1` to keep polling with `APPHUB_POLL_INTERVAL_SECONDS`.
+
+## VPC Lattice Publisher
+
+`LatticePublisher` reconciles VPC Lattice services into Infoblox NIOS instead of Route 53. Route 53 does not support the private-use SVCB keys DNS-AID needs for `connect-class`, `connect-meta`, and `enroll-uri`.
+
+Published SVCB fields:
+
+- `connect-class=lattice`
+- `connect-meta=<VPC Lattice service ARN>`
+- `enroll-uri=https://<service-fqdn>/.well-known/agent-connect`
+
+TTL behavior:
+
+- `300` seconds when the service has a truthy stable tag
+- `30` seconds otherwise
+
+### Environment
+
+```bash
+export LATTICE_DOMAIN="corp.internal"
+export LATTICE_PROTOCOL="mcp"
+export LATTICE_STABLE_TAG_KEY="stable"
+export NIOS_HOST="nios.example.com"
+export NIOS_USERNAME="admin"
+export NIOS_PASSWORD="secret"
+```
+
+### Running
+
+Startup reconcile:
+
+```bash
+python -m dns_aid.sdk.publishers.lattice
+```
+
+EventBridge / CloudTrail event handling:
+
+```bash
+cat event.json | python -m dns_aid.sdk.publishers.lattice
+```
+
+The handler accepts `CreateService`, `UpdateService`, `DeleteService`, `TagResource`, and `UntagResource` events. Startup always performs a full reconcile so drift is corrected even if an event was missed.
+
+### DNS Prerequisite
+
+If workloads resolve the private agent zone from Route 53, Route 53 Resolver forwarding must send that zone to the authoritative NIOS infrastructure. Without that forwarding path, the Lattice-published `_agents` records will exist in NIOS but will not resolve inside the VPCs that need them.
+
+## Discovery Harness
+
+`DiscoveryValidationHarness` exercises the bootstrap path using only published DNS records:
+
+- AppHub path: resolve `_agents.<domain>`, read `connect-class=apphub-psc`, call `enroll-uri`, validate `connect-meta`.
+- Lattice path: resolve `_agents.<domain>`, read `connect-class=lattice`, call `enroll-uri`, and verify the ARN in `connect-meta` via the supplied Lattice lookup callback.
+
+This repo includes hermetic tests for both paths using generated zone data and mocks. Real cloud validation remains an environment-specific workflow because it requires enabled AppHub, Cloud DNS, VPC Lattice, and NIOS infrastructure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.12.1"
+version = "0.13.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ route53 = [
 cloud-dns = [
     "google-auth>=2.30.0",
 ]
+apphub = [
+    "google-auth>=2.30.0",
+]
 infoblox = [
     # Uses httpx from core deps
 ]
@@ -80,6 +83,11 @@ otel = [
     # OpenTelemetry integration for SDK telemetry
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
+]
+publishers = [
+    # Shared runtime dependencies for cloud publisher workers
+    "boto3>=1.34.0",
+    "google-auth>=2.30.0",
 ]
 dev = [
     "pytest>=8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ mcp = [
 route53 = [
     "boto3>=1.34.0",
 ]
+cloud-dns = [
+    "google-auth>=2.30.0",
+]
 infoblox = [
     # Uses httpx from core deps
 ]
@@ -98,6 +101,7 @@ all = [
     "uvicorn>=0.30.0",
     # Backends: Route53, Infoblox BloxOne, NIOS, Cloudflare, DDNS (last 4 use core deps)
     "boto3>=1.34.0",
+    "google-auth>=2.30.0",
     # JWS
     "cryptography>=41.0.0",
     # OpenTelemetry

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -31,7 +31,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from dns_aid.core.discoverer import discover
-from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol, PublishResult
+from dns_aid.core.models import (
+    AgentRecord,
+    DiscoveryResult,
+    DNSSECError,
+    Protocol,
+    PublishResult,
+    SvcbRecord,
+)
 from dns_aid.core.publisher import publish, unpublish
 
 # Tier 0: DNS validation
@@ -66,6 +73,7 @@ __all__ = [
     "AgentRecord",
     "DiscoveryResult",
     "PublishResult",
+    "SvcbRecord",
     "Protocol",
     # Exceptions
     "DNSSECError",

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -19,6 +19,7 @@ __all__ = ["DNSBackend", "MockBackend", "create_backend", "VALID_BACKEND_NAMES"]
 _BACKEND_CLASSES: dict[str, tuple[str, str]] = {
     "route53": ("dns_aid.backends.route53", "Route53Backend"),
     "cloudflare": ("dns_aid.backends.cloudflare", "CloudflareBackend"),
+    "cloud-dns": ("dns_aid.backends.cloud_dns", "CloudDNSBackend"),
     "infoblox": ("dns_aid.backends.infoblox", "InfobloxBackend"),
     "nios": ("dns_aid.backends.infoblox.nios", "InfobloxNIOSBackend"),
     "ddns": ("dns_aid.backends.ddns", "DDNSBackend"),
@@ -91,5 +92,13 @@ try:
     from dns_aid.backends.cloudflare import CloudflareBackend  # noqa: F401
 
     __all__.append("CloudflareBackend")
+except ImportError:
+    pass
+
+# Cloud DNS backend - uses httpx + google-auth (optional)
+try:
+    from dns_aid.backends.cloud_dns import CloudDNSBackend  # noqa: F401
+
+    __all__.append("CloudDNSBackend")
 except ImportError:
     pass

--- a/src/dns_aid/backends/cloud_dns.py
+++ b/src/dns_aid/backends/cloud_dns.py
@@ -1,0 +1,318 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google Cloud DNS backend."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import httpx
+import structlog
+
+from dns_aid.backends.base import DNSBackend
+from dns_aid.utils.google_auth import get_google_access_token
+
+logger = structlog.get_logger(__name__)
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class CloudDNSBackend(DNSBackend):
+    """Google Cloud DNS backend using the Cloud DNS REST API."""
+
+    def __init__(
+        self,
+        project_id: str | None = None,
+        managed_zone: str | None = None,
+        token_provider: Callable[[], tuple[str, str | None]] | None = None,
+        base_url: str = "https://dns.googleapis.com/dns/v1",
+    ):
+        self._project_id = (
+            project_id
+            or os.environ.get("GOOGLE_CLOUD_PROJECT")
+            or os.environ.get("GCP_PROJECT")
+            or os.environ.get("CLOUD_DNS_PROJECT")
+        )
+        self._managed_zone = managed_zone or os.environ.get("CLOUD_DNS_MANAGED_ZONE")
+        self._token_provider = token_provider or (lambda: get_google_access_token(_SCOPES))
+        self._base_url = base_url.rstrip("/")
+        self._client: httpx.AsyncClient | None = None
+        self._client_loop_id: int | None = None
+        self._zone_cache: dict[str, str] = {}
+
+    @property
+    def name(self) -> str:
+        return "cloud-dns"
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        current_loop_id = id(asyncio.get_running_loop())
+
+        if self._client is not None and self._client_loop_id != current_loop_id:
+            with contextlib.suppress(Exception):
+                await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+            self._client_loop_id = current_loop_id
+
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = None
+        self._client_loop_id = None
+
+    def _resolve_project_id(self, discovered_project: str | None = None) -> str:
+        project_id = self._project_id or discovered_project
+        if not project_id:
+            raise ValueError(
+                "Google Cloud project id not configured. Set GOOGLE_CLOUD_PROJECT, "
+                "CLOUD_DNS_PROJECT, or pass project_id explicitly."
+            )
+        self._project_id = project_id
+        return project_id
+
+    def _ensure_project_id(self) -> str:
+        if self._project_id:
+            return self._project_id
+        _, discovered_project = self._token_provider()
+        return self._resolve_project_id(discovered_project)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        client = await self._get_client()
+        token, discovered_project = self._token_provider()
+        self._resolve_project_id(discovered_project)
+
+        response = await client.request(
+            method=method,
+            url=path,
+            params=params,
+            json=json,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        if not response.content:
+            return {}
+        return response.json()
+
+    async def _get_managed_zone_name(self, zone: str) -> str:
+        zone_name = zone.rstrip(".")
+        if self._managed_zone:
+            return self._managed_zone
+        if zone_name in self._zone_cache:
+            return self._zone_cache[zone_name]
+
+        zones = await self.list_zones()
+        for candidate in zones:
+            if candidate["dns_name"].rstrip(".") == zone_name:
+                self._zone_cache[zone_name] = candidate["name"]
+                return candidate["name"]
+        raise ValueError(f"No Cloud DNS managed zone found for domain: {zone}")
+
+    @staticmethod
+    def _record_name(name: str, zone: str) -> str:
+        fqdn = f"{name}.{zone}".rstrip(".")
+        return f"{fqdn}."
+
+    @staticmethod
+    def _format_svcb_value(priority: int, target: str, params: dict[str, str]) -> str:
+        normalized_target = target if target.endswith(".") else f"{target}."
+        parts = [f'{key}="{value}"' for key, value in params.items()]
+        joined = " ".join(parts)
+        return f"{priority} {normalized_target} {joined}".strip()
+
+    async def _change_record_set(
+        self,
+        zone: str,
+        name: str,
+        record_type: str,
+        ttl: int,
+        rrdatas: list[str],
+    ) -> str:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        fqdn = self._record_name(name, zone)
+        existing = await self.get_record(zone, name, record_type)
+
+        additions = [{"name": fqdn, "type": record_type, "ttl": ttl, "rrdatas": rrdatas}]
+        payload: dict[str, Any] = {"additions": additions}
+        if existing:
+            payload["deletions"] = [
+                {
+                    "name": f"{existing['fqdn'].rstrip('.')}.",
+                    "type": record_type,
+                    "ttl": existing["ttl"],
+                    "rrdatas": existing["values"],
+                }
+            ]
+
+        await self._request(
+            "POST",
+            f"/projects/{project_id}/managedZones/{managed_zone}/changes",
+            json=payload,
+        )
+        return fqdn.rstrip(".")
+
+    async def create_svcb_record(
+        self,
+        zone: str,
+        name: str,
+        priority: int,
+        target: str,
+        params: dict[str, str],
+        ttl: int = 3600,
+    ) -> str:
+        value = self._format_svcb_value(priority, target, params)
+        return await self._change_record_set(zone, name, "SVCB", ttl, [value])
+
+    async def create_txt_record(
+        self,
+        zone: str,
+        name: str,
+        values: list[str],
+        ttl: int = 3600,
+    ) -> str:
+        quoted_values = [value if value.startswith('"') else f'"{value}"' for value in values]
+        return await self._change_record_set(zone, name, "TXT", ttl, quoted_values)
+
+    async def delete_record(self, zone: str, name: str, record_type: str) -> bool:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        existing = await self.get_record(zone, name, record_type)
+        if not existing:
+            return False
+
+        await self._request(
+            "POST",
+            f"/projects/{project_id}/managedZones/{managed_zone}/changes",
+            json={
+                "deletions": [
+                    {
+                        "name": f"{existing['fqdn'].rstrip('.')}.",
+                        "type": record_type,
+                        "ttl": existing["ttl"],
+                        "rrdatas": existing["values"],
+                    }
+                ]
+            },
+        )
+        return True
+
+    async def list_records(
+        self,
+        zone: str,
+        name_pattern: str | None = None,
+        record_type: str | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        page_token: str | None = None
+        zone_clean = zone.rstrip(".")
+
+        while True:
+            params = {"maxResults": "1000"}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = await self._request(
+                "GET",
+                f"/projects/{project_id}/managedZones/{managed_zone}/rrsets",
+                params=params,
+            )
+
+            for record in response.get("rrsets", []):
+                fqdn = str(record.get("name", "")).rstrip(".")
+                rtype = record.get("type", "")
+                if not fqdn or not rtype:
+                    continue
+                if name_pattern and name_pattern not in fqdn:
+                    continue
+                if record_type and rtype != record_type:
+                    continue
+
+                yield {
+                    "name": fqdn.removesuffix(f".{zone_clean}"),
+                    "fqdn": fqdn,
+                    "type": rtype,
+                    "ttl": int(record.get("ttl", 0)),
+                    "values": list(record.get("rrdatas", [])),
+                }
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+    async def zone_exists(self, zone: str) -> bool:
+        try:
+            await self._get_managed_zone_name(zone)
+            return True
+        except Exception:
+            return False
+
+    async def get_record(self, zone: str, name: str, record_type: str) -> dict[str, Any] | None:
+        project_id = self._ensure_project_id()
+        managed_zone = await self._get_managed_zone_name(zone)
+        fqdn = self._record_name(name, zone)
+
+        response = await self._request(
+            "GET",
+            f"/projects/{project_id}/managedZones/{managed_zone}/rrsets",
+            params={"name": fqdn, "type": record_type, "maxResults": "1"},
+        )
+
+        rrsets = response.get("rrsets", [])
+        if not rrsets:
+            return None
+
+        record = rrsets[0]
+        if record.get("name") != fqdn or record.get("type") != record_type:
+            return None
+
+        return {
+            "name": name,
+            "fqdn": fqdn.rstrip("."),
+            "type": record_type,
+            "ttl": int(record.get("ttl", 0)),
+            "values": list(record.get("rrdatas", [])),
+        }
+
+    async def list_zones(self) -> list[dict[str, str]]:
+        project_id = self._ensure_project_id()
+        page_token: str | None = None
+        zones: list[dict[str, str]] = []
+
+        while True:
+            params = {"maxResults": "1000"}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = await self._request("GET", f"/projects/{project_id}/managedZones", params=params)
+            for zone in response.get("managedZones", []):
+                zones.append(
+                    {
+                        "name": zone["name"],
+                        "dns_name": str(zone.get("dnsName", "")).rstrip("."),
+                        "visibility": str(zone.get("visibility", "")),
+                    }
+                )
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+        return zones

--- a/src/dns_aid/backends/cloud_dns.py
+++ b/src/dns_aid/backends/cloud_dns.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import os
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -15,11 +16,12 @@ import httpx
 import structlog
 
 from dns_aid.backends.base import DNSBackend
-from dns_aid.utils.google_auth import get_google_access_token
+from dns_aid.utils.google_auth import GoogleAccessTokenProvider
 
 logger = structlog.get_logger(__name__)
 
 _SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 
 class CloudDNSBackend(DNSBackend):
@@ -29,7 +31,7 @@ class CloudDNSBackend(DNSBackend):
         self,
         project_id: str | None = None,
         managed_zone: str | None = None,
-        token_provider: Callable[[], tuple[str, str | None]] | None = None,
+        token_provider: Callable[[], tuple[str, str | None] | Any] | None = None,
         base_url: str = "https://dns.googleapis.com/dns/v1",
     ):
         self._project_id = (
@@ -39,11 +41,13 @@ class CloudDNSBackend(DNSBackend):
             or os.environ.get("CLOUD_DNS_PROJECT")
         )
         self._managed_zone = managed_zone or os.environ.get("CLOUD_DNS_MANAGED_ZONE")
-        self._token_provider = token_provider or (lambda: get_google_access_token(_SCOPES))
+        default_provider = GoogleAccessTokenProvider(_SCOPES)
+        self._token_provider = token_provider or default_provider.get_token
         self._base_url = base_url.rstrip("/")
         self._client: httpx.AsyncClient | None = None
         self._client_loop_id: int | None = None
         self._zone_cache: dict[str, str] = {}
+        self._zone_cache_lock = asyncio.Lock()
 
     @property
     def name(self) -> str:
@@ -59,7 +63,11 @@ class CloudDNSBackend(DNSBackend):
             self._client_loop_id = None
 
         if self._client is None:
-            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=30.0,
+                follow_redirects=False,
+            )
             self._client_loop_id = current_loop_id
 
         return self._client
@@ -80,11 +88,25 @@ class CloudDNSBackend(DNSBackend):
         self._project_id = project_id
         return project_id
 
-    def _ensure_project_id(self) -> str:
+    async def _get_access_token(self) -> tuple[str, str | None]:
+        result = self._token_provider()
+        if inspect.isawaitable(result):
+            token, discovered_project = await result
+        else:
+            token, discovered_project = result
+        return str(token), discovered_project
+
+    async def _ensure_project_id(self) -> str:
         if self._project_id:
             return self._project_id
-        _, discovered_project = self._token_provider()
+        _, discovered_project = await self._get_access_token()
         return self._resolve_project_id(discovered_project)
+
+    @staticmethod
+    def _is_retryable_http_error(exc: httpx.HTTPError) -> bool:
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code in _RETRYABLE_STATUS_CODES
+        return isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError))
 
     async def _request(
         self,
@@ -95,20 +117,32 @@ class CloudDNSBackend(DNSBackend):
         json: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         client = await self._get_client()
-        token, discovered_project = self._token_provider()
-        self._resolve_project_id(discovered_project)
+        last_error: httpx.HTTPError | None = None
 
-        response = await client.request(
-            method=method,
-            url=path,
-            params=params,
-            json=json,
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        response.raise_for_status()
-        if not response.content:
-            return {}
-        return response.json()
+        for attempt in range(3):
+            try:
+                token, discovered_project = await self._get_access_token()
+                self._resolve_project_id(discovered_project)
+                response = await client.request(
+                    method=method,
+                    url=path,
+                    params=params,
+                    json=json,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                response.raise_for_status()
+                if not response.content:
+                    return {}
+                return response.json()
+            except httpx.HTTPError as exc:
+                last_error = exc
+                if attempt == 2 or not self._is_retryable_http_error(exc):
+                    raise
+                await asyncio.sleep(0.5 * (2**attempt))
+
+        if last_error is not None:  # pragma: no cover - defensive fallback
+            raise last_error
+        return {}
 
     async def _get_managed_zone_name(self, zone: str) -> str:
         zone_name = zone.rstrip(".")
@@ -117,11 +151,16 @@ class CloudDNSBackend(DNSBackend):
         if zone_name in self._zone_cache:
             return self._zone_cache[zone_name]
 
-        zones = await self.list_zones()
-        for candidate in zones:
-            if candidate["dns_name"].rstrip(".") == zone_name:
-                self._zone_cache[zone_name] = candidate["name"]
-                return candidate["name"]
+        async with self._zone_cache_lock:
+            cached = self._zone_cache.get(zone_name)
+            if cached:
+                return cached
+
+            zones = await self.list_zones()
+            for candidate in zones:
+                if candidate["dns_name"].rstrip(".") == zone_name:
+                    self._zone_cache[zone_name] = candidate["name"]
+                    return candidate["name"]
         raise ValueError(f"No Cloud DNS managed zone found for domain: {zone}")
 
     @staticmethod
@@ -144,7 +183,7 @@ class CloudDNSBackend(DNSBackend):
         ttl: int,
         rrdatas: list[str],
     ) -> str:
-        project_id = self._ensure_project_id()
+        project_id = await self._ensure_project_id()
         managed_zone = await self._get_managed_zone_name(zone)
         fqdn = self._record_name(name, zone)
         existing = await self.get_record(zone, name, record_type)
@@ -191,7 +230,7 @@ class CloudDNSBackend(DNSBackend):
         return await self._change_record_set(zone, name, "TXT", ttl, quoted_values)
 
     async def delete_record(self, zone: str, name: str, record_type: str) -> bool:
-        project_id = self._ensure_project_id()
+        project_id = await self._ensure_project_id()
         managed_zone = await self._get_managed_zone_name(zone)
         existing = await self.get_record(zone, name, record_type)
         if not existing:
@@ -219,7 +258,7 @@ class CloudDNSBackend(DNSBackend):
         name_pattern: str | None = None,
         record_type: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
-        project_id = self._ensure_project_id()
+        project_id = await self._ensure_project_id()
         managed_zone = await self._get_managed_zone_name(zone)
         page_token: str | None = None
         zone_clean = zone.rstrip(".")
@@ -261,11 +300,11 @@ class CloudDNSBackend(DNSBackend):
         try:
             await self._get_managed_zone_name(zone)
             return True
-        except Exception:
+        except (ValueError, RuntimeError, httpx.HTTPError):
             return False
 
     async def get_record(self, zone: str, name: str, record_type: str) -> dict[str, Any] | None:
-        project_id = self._ensure_project_id()
+        project_id = await self._ensure_project_id()
         managed_zone = await self._get_managed_zone_name(zone)
         fqdn = self._record_name(name, zone)
 
@@ -292,7 +331,7 @@ class CloudDNSBackend(DNSBackend):
         }
 
     async def list_zones(self) -> list[dict[str, str]]:
-        project_id = self._ensure_project_id()
+        project_id = await self._ensure_project_id()
         page_token: str | None = None
         zones: list[dict[str, str]] = []
 

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -56,6 +56,9 @@ class InfobloxNIOSBackend(DNSBackend):
         "policy": "key65403",
         "realm": "key65404",
         "sig": "key65405",
+        "connect-class": "key65406",
+        "connect-meta": "key65407",
+        "enroll-uri": "key65408",
     }
     _NUMERIC_KEY_TO_CUSTOM_PARAM = {
         value: key for key, value in _CUSTOM_PARAM_TO_NUMERIC_KEY.items()

--- a/src/dns_aid/cli/backends.py
+++ b/src/dns_aid/cli/backends.py
@@ -79,6 +79,25 @@ BACKEND_REGISTRY: dict[str, BackendInfo] = {
             "Set CLOUDFLARE_API_TOKEN",
         ],
     ),
+    "cloud-dns": BackendInfo(
+        name="cloud-dns",
+        display_name="Google Cloud DNS",
+        required_env={
+            "GOOGLE_CLOUD_PROJECT": "Google Cloud project id that owns the managed zone",
+        },
+        optional_env={
+            "CLOUD_DNS_MANAGED_ZONE": "Managed zone name (auto-discovered by dnsName if omitted)",
+            "GOOGLE_APPLICATION_CREDENTIALS": "ADC service account JSON path",
+            "CLOUD_DNS_PROJECT": "Alternate project id variable",
+        },
+        optional_dep="cloud-dns",
+        setup_url="https://cloud.google.com/dns/docs",
+        setup_steps=[
+            "Enable Cloud DNS in the target Google Cloud project",
+            "Configure Application Default Credentials for the runtime",
+            "Set GOOGLE_CLOUD_PROJECT and optionally CLOUD_DNS_MANAGED_ZONE",
+        ],
+    ),
     "infoblox": BackendInfo(
         name="infoblox",
         display_name="Infoblox BloxOne DDI",

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -11,6 +11,7 @@ records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 from __future__ import annotations
 
 import asyncio
+import shlex
 import time
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -278,6 +279,9 @@ async def _query_single_agent(
             bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
             policy_uri = custom_params.get("policy")
             realm = custom_params.get("realm")
+            connect_class = custom_params.get("connect-class")
+            connect_meta = custom_params.get("connect-meta")
+            enroll_uri = custom_params.get("enroll-uri")
 
             # Discovery priority: cap URI first, then TXT fallback
             capabilities: list[str] = []
@@ -342,6 +346,9 @@ async def _query_single_agent(
                 bap=bap,
                 policy_uri=policy_uri,
                 realm=realm,
+                connect_class=connect_class,
+                connect_meta=connect_meta,
+                enroll_uri=enroll_uri,
                 capability_source=capability_source,
                 endpoint_source="dns_svcb",  # Endpoint resolved via DNS SVCB lookup
                 agent_card=agent_card,
@@ -370,10 +377,23 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
     from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
 
     custom_params: dict[str, str] = {}
-    dnsaid_keys = {"cap", "cap-sha256", "bap", "policy", "realm", "sig"}
+    dnsaid_keys = {
+        "cap",
+        "cap-sha256",
+        "bap",
+        "policy",
+        "realm",
+        "sig",
+        "connect-class",
+        "connect-meta",
+        "enroll-uri",
+    }
 
-    # Split on spaces, then look for key="value" or key=value patterns
-    parts = svcb_text.split()
+    try:
+        parts = shlex.split(svcb_text)
+    except ValueError:
+        return custom_params
+
     for part in parts:
         if "=" not in part:
             continue
@@ -385,8 +405,6 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
             key = DNS_AID_KEY_MAP_REVERSE[key]
 
         if key in dnsaid_keys:
-            # Remove surrounding quotes if present
-            value = value.strip('"').strip("'")
             custom_params[key] = value
 
     return custom_params

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -16,6 +16,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from dns_aid.utils.validation import validate_connect_class
+
 # DNS-AID custom SVCB param key mapping (IETF draft-01, Section 4.4.3)
 # These use the RFC 9460 Private Use range (65280-65534).
 # Once IANA assigns official SvcParamKey numbers, update these values.
@@ -26,6 +28,9 @@ DNS_AID_KEY_MAP: dict[str, str] = {
     "policy": "key65403",
     "realm": "key65404",
     "sig": "key65405",
+    "connect-class": "key65406",
+    "connect-meta": "key65407",
+    "enroll-uri": "key65408",
 }
 
 DNS_AID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in DNS_AID_KEY_MAP.items()}
@@ -39,6 +44,16 @@ def _use_string_keys() -> bool:
     Default is keyNNNNN format per RFC 9460 requirements.
     """
     return os.environ.get("DNS_AID_SVCB_STRING_KEYS", "").lower() in ("1", "true", "yes")
+
+
+def _svcb_param_key(name: str) -> str:
+    """Map a logical DNS-AID SvcParamKey name to its emitted wire key."""
+    return name if _use_string_keys() else DNS_AID_KEY_MAP.get(name, name)
+
+
+def _normalize_connect_class(value: str | None) -> str | None:
+    """Normalize optional connect-class values consistently across models."""
+    return validate_connect_class(value)
 
 
 class DNSSECError(Exception):
@@ -74,6 +89,94 @@ class Protocol(StrEnum):
     A2A = "a2a"  # Agent-to-Agent (Google's protocol)
     MCP = "mcp"  # Model Context Protocol (Anthropic's protocol)
     HTTPS = "https"  # Standard HTTPS
+
+
+class SvcbRecord(BaseModel):
+    """Shared SVCB presentation model used by publishers and AgentRecord serialization."""
+
+    priority: int = Field(default=1, ge=0, le=65535)
+    target: str = Field(..., min_length=1, description="SVCB target host with or without trailing dot")
+    alpn: str = Field(..., min_length=1, description="ALPN protocol identifier")
+    port: int = Field(default=443, ge=1, le=65535, description="Port number")
+    mandatory: list[str] = Field(
+        default_factory=lambda: ["alpn", "port"],
+        description="SvcParamKeys that clients must understand",
+    )
+    ipv4_hint: str | None = Field(default=None, description="IPv4 address hint")
+    ipv6_hint: str | None = Field(default=None, description="IPv6 address hint")
+    uri: str | None = Field(
+        default=None,
+        description="Capability document URI mapped to the DNS-AID 'cap' SVCB parameter",
+    )
+    cap_sha256: str | None = Field(default=None, description="SHA-256 digest for the cap URI")
+    bap: list[str] = Field(default_factory=list, description="Bulk application protocols")
+    policy_uri: str | None = Field(default=None, description="Agent policy URI")
+    realm: str | None = Field(default=None, description="Opaque authz realm identifier")
+    sig: str | None = Field(default=None, description="JWS signature for the record")
+    connect_class: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Connection mediation mode such as 'direct', 'lattice', or 'apphub-psc'",
+    )
+    connect_meta: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Provider-specific metadata that qualifies the connection path",
+    )
+    enroll_uri: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Managed enrollment URI required before direct connection",
+    )
+
+    @field_validator("connect_class", mode="before")
+    @classmethod
+    def normalize_connect_class(cls, v: str | None) -> str | None:
+        return _normalize_connect_class(v)
+
+    @property
+    def normalized_target(self) -> str:
+        """SVCB targets are emitted with a trailing dot."""
+        return self.target if self.target.endswith(".") else f"{self.target}."
+
+    def to_params(self) -> dict[str, str]:
+        """Serialize this record into RFC 9460 presentation parameters."""
+        mandatory = []
+        seen_mandatory = set()
+        for key in self.mandatory:
+            normalized = key.strip()
+            if normalized and normalized not in seen_mandatory:
+                mandatory.append(normalized)
+                seen_mandatory.add(normalized)
+
+        params = {
+            "alpn": self.alpn,
+            "port": str(self.port),
+            "mandatory": ",".join(mandatory or ["alpn", "port"]),
+        }
+        if self.ipv4_hint:
+            params["ipv4hint"] = self.ipv4_hint
+        if self.ipv6_hint:
+            params["ipv6hint"] = self.ipv6_hint
+        if self.uri:
+            params[_svcb_param_key("cap")] = self.uri
+        if self.cap_sha256:
+            params[_svcb_param_key("cap-sha256")] = self.cap_sha256
+        if self.bap:
+            params[_svcb_param_key("bap")] = ",".join(self.bap)
+        if self.policy_uri:
+            params[_svcb_param_key("policy")] = self.policy_uri
+        if self.realm:
+            params[_svcb_param_key("realm")] = self.realm
+        if self.sig:
+            params[_svcb_param_key("sig")] = self.sig
+        if self.connect_class:
+            params[_svcb_param_key("connect-class")] = self.connect_class
+        if self.connect_meta:
+            params[_svcb_param_key("connect-meta")] = self.connect_meta
+        if self.enroll_uri:
+            params[_svcb_param_key("enroll-uri")] = self.enroll_uri
+        return params
 
 
 class AgentRecord(BaseModel):
@@ -174,6 +277,21 @@ class AgentRecord(BaseModel):
         description="Opaque token for multi-tenant scoping or authz realm selection "
         "(e.g., 'production', 'staging')",
     )
+    connect_class: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Connection mediation class such as 'direct', 'lattice', or 'apphub-psc'",
+    )
+    connect_meta: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Provider-specific connection metadata such as a service ARN",
+    )
+    enroll_uri: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Enrollment endpoint required before direct overlay access",
+    )
 
     # JWS signature for application-layer verification (alternative to DNSSEC)
     sig: str | None = Field(
@@ -194,7 +312,7 @@ class AgentRecord(BaseModel):
     )
 
     # DNS settings
-    ttl: int = Field(default=3600, ge=60, le=86400, description="Time-to-live in seconds")
+    ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
 
     # Optional direct endpoint (overrides target_host:port for HTTP index agents)
     endpoint_override: str | None = Field(
@@ -245,6 +363,11 @@ class AgentRecord(BaseModel):
         """Normalize domain to lowercase without trailing dot."""
         return v.lower().rstrip(".")
 
+    @field_validator("connect_class", mode="before")
+    @classmethod
+    def validate_connect_class(cls, v: str | None) -> str | None:
+        return _normalize_connect_class(v)
+
     @property
     def fqdn(self) -> str:
         """
@@ -267,6 +390,27 @@ class AgentRecord(BaseModel):
         """Target for SVCB record (with trailing dot)."""
         return f"{self.target_host}."
 
+    def to_svcb_record(self) -> SvcbRecord:
+        """Convert this agent into the shared SVCB presentation model."""
+        return SvcbRecord(
+            priority=1,
+            target=self.svcb_target,
+            alpn=self.protocol.value,
+            port=self.port,
+            mandatory=["alpn", "port"],
+            ipv4_hint=self.ipv4_hint,
+            ipv6_hint=self.ipv6_hint,
+            uri=self.cap_uri,
+            cap_sha256=self.cap_sha256,
+            bap=self.bap,
+            policy_uri=self.policy_uri,
+            realm=self.realm,
+            sig=self.sig,
+            connect_class=self.connect_class,
+            connect_meta=self.connect_meta,
+            enroll_uri=self.enroll_uri,
+        )
+
     def to_svcb_params(self) -> dict[str, str]:
         """
         Generate SVCB parameters for DNS record.
@@ -276,38 +420,7 @@ class AgentRecord(BaseModel):
         required params for agent discovery, plus custom DNS-AID params
         (cap, bap, policy, realm) when present.
         """
-        params = {
-            "alpn": self.protocol.value,
-            "port": str(self.port),
-            # DNS-AID compliance: indicate alpn and port are mandatory
-            "mandatory": "alpn,port",
-        }
-        if self.ipv4_hint:
-            params["ipv4hint"] = self.ipv4_hint
-        if self.ipv6_hint:
-            params["ipv6hint"] = self.ipv6_hint
-        # DNS-AID custom SVCB params (IETF draft-01, Section 4.4.3)
-        # Emit keyNNNNN format by default (RFC 9460 compliant for unregistered keys).
-        # Set DNS_AID_SVCB_STRING_KEYS=1 for human-readable string names.
-        use_strings = _use_string_keys()
-
-        def _key(name: str) -> str:
-            return name if use_strings else DNS_AID_KEY_MAP.get(name, name)
-
-        if self.cap_uri:
-            params[_key("cap")] = self.cap_uri
-        if self.cap_sha256:
-            params[_key("cap-sha256")] = self.cap_sha256
-        if self.bap:
-            params[_key("bap")] = ",".join(self.bap)
-        if self.policy_uri:
-            params[_key("policy")] = self.policy_uri
-        if self.realm:
-            params[_key("realm")] = self.realm
-        # JWS signature for application-layer verification
-        if self.sig:
-            params[_key("sig")] = self.sig
-        return params
+        return self.to_svcb_record().to_params()
 
     def to_txt_values(self) -> list[str]:
         """

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -82,6 +82,9 @@ async def publish(
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
+    connect_class: str | None = None,
+    connect_meta: str | None = None,
+    enroll_uri: str | None = None,
     ipv4_hint: str | None = None,
     ipv6_hint: str | None = None,
     sign: bool = False,
@@ -111,6 +114,9 @@ async def publish(
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
+        connect_class: Connection mediation class (e.g., "direct", "lattice", "apphub-psc")
+        connect_meta: Provider-specific connection metadata (e.g., service ARN)
+        enroll_uri: Managed enrollment endpoint required before direct connection
         ipv4_hint: IPv4 address hints for SVCB record (RFC 9460 key 4)
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6)
         sign: If True, sign the record with JWS (requires private_key_path)
@@ -179,6 +185,9 @@ async def publish(
         bap=bap or [],
         policy_uri=policy_uri,
         realm=realm,
+        connect_class=connect_class,
+        connect_meta=connect_meta,
+        enroll_uri=enroll_uri,
         ipv4_hint=ipv4_hint,
         ipv6_hint=ipv6_hint,
         sig=sig,

--- a/src/dns_aid/sdk/__init__.py
+++ b/src/dns_aid/sdk/__init__.py
@@ -22,6 +22,16 @@ from dns_aid.sdk.models import (
     InvocationSignal,
     InvocationStatus,
 )
+from dns_aid.sdk.publishers import (
+    AgentRecordPublisher,
+    AppHubPublisher,
+    AppHubPublisherConfig,
+    DiscoveryBootstrapResult,
+    DiscoveryValidationHarness,
+    LatticePublisher,
+    LatticePublisherConfig,
+    SyncResult,
+)
 
 __all__ = [
     "AgentClient",
@@ -30,4 +40,12 @@ __all__ = [
     "InvocationResult",
     "InvocationStatus",
     "AgentScorecard",
+    "AgentRecordPublisher",
+    "AppHubPublisher",
+    "AppHubPublisherConfig",
+    "LatticePublisher",
+    "LatticePublisherConfig",
+    "SyncResult",
+    "DiscoveryValidationHarness",
+    "DiscoveryBootstrapResult",
 ]

--- a/src/dns_aid/sdk/publishers/__init__.py
+++ b/src/dns_aid/sdk/publishers/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-managed DNS-AID record publishers."""
+
+from dns_aid.sdk.publishers.apphub import AppHubPublisher, run_polling_sync
+from dns_aid.sdk.publishers.base import AgentRecordPublisher
+from dns_aid.sdk.publishers.harness import DiscoveryBootstrapResult, DiscoveryValidationHarness
+from dns_aid.sdk.publishers.lattice import LatticePublisher, run_startup_sync
+from dns_aid.sdk.publishers.models import (
+    AppHubPublisherConfig,
+    AppHubServiceRef,
+    AppHubServiceSnapshot,
+    LatticePublisherConfig,
+    LatticeServiceRef,
+    LatticeServiceSnapshot,
+    PublishedAgentState,
+    SyncResult,
+)
+
+__all__ = [
+    "AgentRecordPublisher",
+    "SyncResult",
+    "PublishedAgentState",
+    "AppHubPublisher",
+    "AppHubPublisherConfig",
+    "AppHubServiceRef",
+    "AppHubServiceSnapshot",
+    "LatticePublisher",
+    "LatticePublisherConfig",
+    "LatticeServiceRef",
+    "LatticeServiceSnapshot",
+    "DiscoveryValidationHarness",
+    "DiscoveryBootstrapResult",
+    "run_polling_sync",
+    "run_startup_sync",
+]

--- a/src/dns_aid/sdk/publishers/_helpers.py
+++ b/src/dns_aid/sdk/publishers/_helpers.py
@@ -6,14 +6,26 @@
 from __future__ import annotations
 
 import re
+import shlex
 from typing import Any
 
-from dns_aid.core.discoverer import _parse_fqdn, _parse_svcb_custom_params
+from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
 from dns_aid.sdk.publishers.models import PublishedAgentState
 from dns_aid.utils.validation import validate_agent_name
 
 _INVALID_AGENT_CHARS = re.compile(r"[^a-z0-9-]+")
 _DASH_RUN = re.compile(r"-{2,}")
+_DNS_AID_SVCB_KEYS = {
+    "cap",
+    "cap-sha256",
+    "bap",
+    "policy",
+    "realm",
+    "sig",
+    "connect-class",
+    "connect-meta",
+    "enroll-uri",
+}
 
 
 def normalize_agent_name(raw_name: str) -> str:
@@ -22,6 +34,45 @@ def normalize_agent_name(raw_name: str) -> str:
     candidate = _INVALID_AGENT_CHARS.sub("-", candidate)
     candidate = _DASH_RUN.sub("-", candidate).strip("-")
     return validate_agent_name(candidate)
+
+
+def parse_agent_fqdn(fqdn: str) -> tuple[str | None, str | None]:
+    """Parse a DNS-AID agent FQDN into agent name and protocol."""
+    if not fqdn or not fqdn.startswith("_"):
+        return None, None
+
+    parts = fqdn.split(".")
+    if len(parts) < 3:
+        return None, None
+
+    name_part = parts[0]
+    protocol_part = parts[1]
+    if not name_part.startswith("_") or not protocol_part.startswith("_"):
+        return None, None
+
+    return name_part[1:], protocol_part[1:]
+
+
+def parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
+    """Parse DNS-AID SVCB params without importing private discoverer helpers."""
+    custom_params: dict[str, str] = {}
+
+    try:
+        parts = shlex.split(svcb_text)
+    except ValueError:
+        return custom_params
+
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, _, value = part.partition("=")
+        key = key.strip().lower()
+        if key in DNS_AID_KEY_MAP_REVERSE:
+            key = DNS_AID_KEY_MAP_REVERSE[key]
+        if key in _DNS_AID_SVCB_KEYS:
+            custom_params[key] = value
+
+    return custom_params
 
 
 def get_nested_value(data: Any, path: str) -> Any | None:
@@ -91,7 +142,7 @@ def parse_capabilities_txt(values: list[str]) -> list[str]:
 def parse_published_state(record: dict[str, Any], txt_values: list[str] | None = None) -> PublishedAgentState | None:
     """Convert backend SVCB record data into a comparable publisher state."""
     fqdn = record.get("fqdn") or ""
-    name, protocol = _parse_fqdn(str(fqdn))
+    name, protocol = parse_agent_fqdn(str(fqdn))
     if not name or not protocol:
         return None
 
@@ -105,7 +156,7 @@ def parse_published_state(record: dict[str, Any], txt_values: list[str] | None =
         return None
 
     target_host = parts[1].rstrip(".")
-    custom_params = _parse_svcb_custom_params(first_value)
+    custom_params = parse_svcb_custom_params(first_value)
     return PublishedAgentState(
         name=name,
         protocol=protocol,

--- a/src/dns_aid/sdk/publishers/_helpers.py
+++ b/src/dns_aid/sdk/publishers/_helpers.py
@@ -1,0 +1,118 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal helpers for provider-managed publishers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dns_aid.core.discoverer import _parse_fqdn, _parse_svcb_custom_params
+from dns_aid.sdk.publishers.models import PublishedAgentState
+from dns_aid.utils.validation import validate_agent_name
+
+_INVALID_AGENT_CHARS = re.compile(r"[^a-z0-9-]+")
+_DASH_RUN = re.compile(r"-{2,}")
+
+
+def normalize_agent_name(raw_name: str) -> str:
+    """Normalize provider-native service names into DNS-AID-safe agent names."""
+    candidate = raw_name.strip().lower()
+    candidate = _INVALID_AGENT_CHARS.sub("-", candidate)
+    candidate = _DASH_RUN.sub("-", candidate).strip("-")
+    return validate_agent_name(candidate)
+
+
+def get_nested_value(data: Any, path: str) -> Any | None:
+    """Traverse a dotted path through nested dict/list structures."""
+    if not path:
+        return data
+
+    current = data
+    for segment in path.split("."):
+        if isinstance(current, dict):
+            current = current.get(segment)
+        elif isinstance(current, list):
+            try:
+                current = current[int(segment)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+
+        if current is None:
+            return None
+
+    return current
+
+
+def coerce_capabilities(value: Any) -> list[str]:
+    """Normalize provider metadata into a deduplicated capability list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_caps = [part.strip() for part in value.split(",")]
+    elif isinstance(value, list):
+        raw_caps = [str(part).strip() for part in value]
+    else:
+        return []
+
+    deduped: list[str] = []
+    seen = set()
+    for cap in raw_caps:
+        normalized = cap.lower()
+        if normalized and normalized not in seen:
+            deduped.append(normalized)
+            seen.add(normalized)
+    return deduped
+
+
+def is_truthy_tag(value: str | None, truthy_values: list[str]) -> bool:
+    """Interpret common stable-tag values."""
+    if value is None:
+        return False
+    return value.strip().lower() in {item.strip().lower() for item in truthy_values}
+
+
+def parse_capabilities_txt(values: list[str]) -> list[str]:
+    """Extract the existing DNS-AID TXT capability wire format."""
+    for value in values:
+        normalized = value.strip().strip('"')
+        if normalized.startswith("capabilities="):
+            return [
+                part.strip()
+                for part in normalized[len("capabilities=") :].split(",")
+                if part.strip()
+            ]
+    return []
+
+
+def parse_published_state(record: dict[str, Any], txt_values: list[str] | None = None) -> PublishedAgentState | None:
+    """Convert backend SVCB record data into a comparable publisher state."""
+    fqdn = record.get("fqdn") or ""
+    name, protocol = _parse_fqdn(str(fqdn))
+    if not name or not protocol:
+        return None
+
+    values = record.get("values") or []
+    if not values:
+        return None
+
+    first_value = str(values[0]).strip()
+    parts = first_value.split()
+    if len(parts) < 2:
+        return None
+
+    target_host = parts[1].rstrip(".")
+    custom_params = _parse_svcb_custom_params(first_value)
+    return PublishedAgentState(
+        name=name,
+        protocol=protocol,
+        target_host=target_host,
+        ttl=int(record.get("ttl", 0)),
+        capabilities=parse_capabilities_txt(txt_values or []),
+        connect_class=custom_params.get("connect-class"),
+        connect_meta=custom_params.get("connect-meta"),
+        enroll_uri=custom_params.get("enroll-uri"),
+    )

--- a/src/dns_aid/sdk/publishers/apphub.py
+++ b/src/dns_aid/sdk/publishers/apphub.py
@@ -1,0 +1,461 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GCP AppHub-backed DNS-AID record publisher."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from dns_aid.backends.base import DNSBackend
+from dns_aid.backends.cloud_dns import CloudDNSBackend
+from dns_aid.core.models import AgentRecord, PublishResult
+from dns_aid.sdk.publishers._helpers import (
+    coerce_capabilities,
+    get_nested_value,
+    normalize_agent_name,
+)
+from dns_aid.sdk.publishers.base import BaseAgentRecordPublisher
+from dns_aid.sdk.publishers.models import (
+    AppHubPublisherConfig,
+    AppHubServiceRef,
+    AppHubServiceSnapshot,
+    PublishedAgentState,
+    SyncResult,
+)
+from dns_aid.utils.google_auth import get_google_access_token
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceSnapshot | str]):
+    """Publisher that reconciles AppHub discovered services into Cloud DNS."""
+
+    def __init__(
+        self,
+        config: AppHubPublisherConfig,
+        *,
+        backend: DNSBackend | None = None,
+        token_provider: Callable[[], tuple[str, str | None]] | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.config = config
+        self._token_provider = token_provider or (lambda: get_google_access_token(_SCOPES))
+        self._http_client = http_client
+        self._client_loop_id: int | None = None
+
+        dns_backend = backend or CloudDNSBackend(
+            project_id=config.project_id,
+            managed_zone=config.managed_zone,
+            token_provider=self._token_provider,
+        )
+        super().__init__(dns_backend, config.domain, config.protocol)
+
+    @classmethod
+    def from_env(cls, *, backend: DNSBackend | None = None) -> AppHubPublisher:
+        return cls(
+            AppHubPublisherConfig(
+                project_id=os.environ["GOOGLE_CLOUD_PROJECT"],
+                location=os.environ["APPHUB_LOCATION"],
+                domain=os.environ["APPHUB_DOMAIN"],
+                protocol=os.environ.get("APPHUB_PROTOCOL", "mcp"),
+                managed_zone=os.environ.get("CLOUD_DNS_MANAGED_ZONE"),
+                capabilities_metadata_key=os.environ.get(
+                    "APPHUB_CAPABILITIES_METADATA_KEY",
+                    "apphub.googleapis.com/agentProperties",
+                ),
+                capabilities_metadata_path=os.environ.get(
+                    "APPHUB_CAPABILITIES_METADATA_PATH",
+                    "a2a.capabilities",
+                ),
+                service_name_metadata_key=os.environ.get(
+                    "APPHUB_SERVICE_NAME_METADATA_KEY",
+                    "apphub.googleapis.com/agentProperties",
+                ),
+                service_name_metadata_path=os.environ.get(
+                    "APPHUB_SERVICE_NAME_METADATA_PATH",
+                    "serviceName",
+                ),
+                connect_meta_metadata_key=os.environ.get(
+                    "APPHUB_CONNECT_META_METADATA_KEY",
+                    "apphub.googleapis.com/agentConnect",
+                ),
+                connect_meta_metadata_path=os.environ.get(
+                    "APPHUB_CONNECT_META_METADATA_PATH",
+                    "serviceName",
+                ),
+                enrollment_metadata_key=os.environ.get(
+                    "APPHUB_ENROLLMENT_METADATA_KEY",
+                    "apphub.googleapis.com/agentConnect",
+                ),
+                enrollment_metadata_path=os.environ.get(
+                    "APPHUB_ENROLLMENT_METADATA_PATH",
+                    "pscBaseUrl",
+                ),
+                poll_interval_seconds=int(os.environ.get("APPHUB_POLL_INTERVAL_SECONDS", "300")),
+            ),
+            backend=backend,
+        )
+
+    async def _get_http_client(self) -> httpx.AsyncClient:
+        current_loop_id = id(asyncio.get_running_loop())
+
+        if self._http_client is not None and self._client_loop_id not in (None, current_loop_id):
+            with contextlib.suppress(Exception):
+                await self._http_client.aclose()
+            self._http_client = None
+            self._client_loop_id = None
+
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                base_url="https://apphub.googleapis.com",
+                timeout=30.0,
+            )
+            self._client_loop_id = current_loop_id
+
+        return self._http_client
+
+    async def close(self) -> None:
+        if self._http_client and not self._http_client.is_closed:
+            await self._http_client.aclose()
+        self._http_client = None
+        self._client_loop_id = None
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        client = await self._get_http_client()
+        token, _ = self._token_provider()
+        response = await client.request(
+            method=method,
+            url=path,
+            params=params,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _unwrap_extended_metadata_entry(entry: Any) -> Any:
+        if isinstance(entry, dict):
+            for key in ("metadata", "details", "value", "json", "data"):
+                if key in entry:
+                    return entry[key]
+        return entry
+
+    def _extract_extended_metadata_value(
+        self,
+        extended_metadata: dict[str, Any],
+        metadata_key: str,
+        path: str,
+    ) -> Any | None:
+        entry = self._unwrap_extended_metadata_entry(extended_metadata.get(metadata_key))
+        return get_nested_value(entry, path)
+
+    def _derive_enrollment_base_url(
+        self,
+        service_uri: str | None,
+        extended_metadata: dict[str, Any],
+    ) -> str | None:
+        configured = self._extract_extended_metadata_value(
+            extended_metadata,
+            self.config.enrollment_metadata_key,
+            self.config.enrollment_metadata_path,
+        )
+        if isinstance(configured, str) and configured.strip():
+            return configured.rstrip("/")
+
+        if service_uri:
+            parsed = urlparse(service_uri)
+            if parsed.scheme in {"http", "https"} and parsed.netloc:
+                return f"{parsed.scheme}://{parsed.netloc}"
+
+        for entry in extended_metadata.values():
+            unwrapped = self._unwrap_extended_metadata_entry(entry)
+            for path in ("pscBaseUrl", "pscEndpointUri", "baseUrl", "uri"):
+                candidate = get_nested_value(unwrapped, path)
+                if isinstance(candidate, str) and candidate.startswith(("http://", "https://")):
+                    parsed = urlparse(candidate)
+                    if parsed.netloc:
+                        return f"{parsed.scheme}://{parsed.netloc}"
+        return None
+
+    def _derive_agent_name(
+        self,
+        discovered_service_name: str,
+        service_uri: str | None,
+        canonical_service_name: str | None,
+        extended_metadata: dict[str, Any],
+    ) -> str:
+        configured = self._extract_extended_metadata_value(
+            extended_metadata,
+            self.config.service_name_metadata_key,
+            self.config.service_name_metadata_path,
+        )
+        candidates = [
+            configured,
+            canonical_service_name,
+            service_uri,
+            discovered_service_name,
+        ]
+        for candidate in candidates:
+            if not isinstance(candidate, str) or not candidate.strip():
+                continue
+            value = candidate.rstrip("/").split("/")[-1]
+            try:
+                return normalize_agent_name(value)
+            except Exception:
+                continue
+        return normalize_agent_name(discovered_service_name.split("/")[-1])
+
+    def _snapshot_from_api(self, data: dict[str, Any]) -> AppHubServiceSnapshot:
+        discovered_service_name = str(data["name"])
+        service_uri = get_nested_value(data, "serviceReference.uri")
+        properties = (
+            data.get("serviceProperties", {})
+            if isinstance(data.get("serviceProperties"), dict)
+            else {}
+        )
+        extended_metadata = (
+            properties.get("extendedMetadata", {})
+            if isinstance(properties.get("extendedMetadata"), dict)
+            else {}
+        )
+        functional_type = get_nested_value(properties, "functionalType.type")
+        canonical_service_name = self._extract_extended_metadata_value(
+            extended_metadata,
+            self.config.connect_meta_metadata_key,
+            self.config.connect_meta_metadata_path,
+        )
+        enrollment_base_url = self._derive_enrollment_base_url(service_uri, extended_metadata)
+        capabilities = coerce_capabilities(
+            self._extract_extended_metadata_value(
+                extended_metadata,
+                self.config.capabilities_metadata_key,
+                self.config.capabilities_metadata_path,
+            )
+        )
+        agent_name = self._derive_agent_name(
+            discovered_service_name,
+            service_uri,
+            canonical_service_name if isinstance(canonical_service_name, str) else None,
+            extended_metadata,
+        )
+
+        return AppHubServiceSnapshot(
+            discovered_service_name=discovered_service_name,
+            agent_name=agent_name,
+            service_uri=service_uri if isinstance(service_uri, str) else None,
+            canonical_service_name=(
+                canonical_service_name if isinstance(canonical_service_name, str) else None
+            ),
+            functional_type=functional_type if isinstance(functional_type, str) else None,
+            capabilities=capabilities,
+            enrollment_base_url=enrollment_base_url,
+            metadata=extended_metadata,
+        )
+
+    async def _resolve_ref(self, service: AppHubServiceRef | str) -> AppHubServiceSnapshot:
+        ref = service if isinstance(service, AppHubServiceRef) else AppHubServiceRef(name=service)
+
+        if ref.uri:
+            response = await self._request(
+                "GET",
+                f"/v1/projects/{self.config.project_id}/locations/{self.config.location}/discoveredServices:lookup",
+                params={"uri": ref.uri},
+            )
+            if response:
+                return self._snapshot_from_api(response)
+
+        if ref.name:
+            name = ref.name.lstrip("/")
+            if not name.startswith("projects/"):
+                name = (
+                    f"projects/{self.config.project_id}/locations/{self.config.location}/"
+                    f"discoveredServices/{name}"
+                )
+            response = await self._request("GET", f"/v1/{name}")
+            return self._snapshot_from_api(response)
+
+        raise ValueError("AppHub service reference must include either name or uri")
+
+    async def _resolve_service(
+        self,
+        service: AppHubServiceRef | AppHubServiceSnapshot | str,
+    ) -> AppHubServiceSnapshot:
+        if isinstance(service, AppHubServiceSnapshot):
+            return service
+        return await self._resolve_ref(service)
+
+    async def _list_discovered_services(self) -> list[AppHubServiceSnapshot]:
+        snapshots: list[AppHubServiceSnapshot] = []
+        page_token: str | None = None
+
+        while True:
+            params = {"pageSize": "100"}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = await self._request(
+                "GET",
+                f"/v1/projects/{self.config.project_id}/locations/{self.config.location}/discoveredServices",
+                params=params,
+            )
+            snapshots.extend(
+                self._snapshot_from_api(item)
+                for item in response.get("discoveredServices", [])
+            )
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+        return snapshots
+
+    def _build_agent(self, snapshot: AppHubServiceSnapshot, *, strict: bool = True) -> AgentRecord:
+        target_host = snapshot.target_host or f"{snapshot.agent_name}.{self.domain}"
+        if strict and not snapshot.target_host:
+            raise ValueError(
+                f"AppHub service '{snapshot.discovered_service_name}' is missing an addressable endpoint"
+            )
+        if strict and not snapshot.enrollment_base_url:
+            raise ValueError(
+                f"AppHub service '{snapshot.discovered_service_name}' is missing an enrollment base URL"
+            )
+
+        return AgentRecord(
+            name=snapshot.agent_name,
+            domain=self.domain,
+            protocol=self.protocol,
+            target_host=target_host,
+            capabilities=snapshot.capabilities,
+            connect_class="apphub-psc",
+            connect_meta=snapshot.connect_meta,
+            enroll_uri=(
+                urljoin(
+                    snapshot.enrollment_base_url.rstrip("/") + "/",
+                    ".well-known/agent-connect",
+                )
+                if snapshot.enrollment_base_url
+                else None
+            ),
+        )
+
+    @staticmethod
+    def _matches_state(state: PublishedAgentState, agent: AgentRecord) -> bool:
+        return (
+            state.protocol == agent.protocol.value
+            and state.target_host == agent.target_host
+            and state.ttl == agent.ttl
+            and sorted(state.capabilities) == sorted(agent.capabilities)
+            and state.connect_class == agent.connect_class
+            and state.connect_meta == agent.connect_meta
+            and state.enroll_uri == agent.enroll_uri
+        )
+
+    async def publish(self, service: AppHubServiceRef | AppHubServiceSnapshot | str):
+        snapshot = await self._resolve_service(service)
+        if (snapshot.functional_type or "").upper() != "AGENT":
+            agent = self._build_agent(snapshot, strict=False)
+            return PublishResult(
+                agent=agent,
+                records_created=[],
+                zone=agent.domain,
+                backend=self.backend.name,
+                success=False,
+                message="AppHub service is not eligible for AGENT publishing",
+            )
+        agent = self._build_agent(snapshot)
+        return await self._publish_agent_record(agent)
+
+    async def unpublish(self, service: AppHubServiceRef | AppHubServiceSnapshot | str) -> bool:
+        try:
+            snapshot = await self._resolve_service(service)
+            return await self._unpublish_agent_name(snapshot.agent_name)
+        except Exception:
+            ref = (
+                service
+                if isinstance(service, AppHubServiceRef)
+                else AppHubServiceRef(name=str(service))
+            )
+            current_states = await self._list_published_states(connect_class="apphub-psc")
+            for state in current_states.values():
+                if state.connect_meta in {ref.name, ref.uri}:
+                    return await self._unpublish_agent_name(state.name)
+            return False
+
+    async def sync(self) -> SyncResult:
+        result = SyncResult()
+        current_states = await self._list_published_states(connect_class="apphub-psc")
+        desired_snapshots = await self._list_discovered_services()
+
+        for snapshot in desired_snapshots:
+            if (snapshot.functional_type or "").upper() != "AGENT":
+                continue
+
+            try:
+                agent = self._build_agent(snapshot)
+            except Exception as exc:
+                result.errors.append(str(exc))
+                continue
+
+            key = f"{agent.name}:{agent.protocol.value}"
+            current = current_states.pop(key, None)
+
+            if current and self._matches_state(current, agent):
+                result.unchanged += 1
+                continue
+
+            publish_result = await self._publish_agent_record(agent)
+            if not publish_result.success:
+                result.errors.append(publish_result.message or f"Failed to publish {agent.name}")
+            elif current:
+                result.updated += 1
+            else:
+                result.published += 1
+
+        for stale in current_states.values():
+            deleted = await self._unpublish_agent_name(stale.name)
+            if deleted:
+                result.unpublished += 1
+            else:
+                result.errors.append(f"Failed to unpublish stale AppHub record {stale.name}")
+
+        return result
+
+
+async def run_polling_sync(publisher: AppHubPublisher, *, once: bool = False) -> SyncResult:
+    """Run one or more AppHub reconciliation cycles."""
+    last_result = SyncResult()
+    while True:
+        last_result = await publisher.sync()
+        if once:
+            return last_result
+        await asyncio.sleep(publisher.config.poll_interval_seconds)
+
+
+async def main_async() -> SyncResult:
+    publisher = AppHubPublisher.from_env()
+    try:
+        once = os.environ.get("APPHUB_RUN_FOREVER", "").lower() not in {"1", "true", "yes"}
+        return await run_polling_sync(publisher, once=once)
+    finally:
+        await publisher.close()
+
+
+def main() -> None:
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/dns_aid/sdk/publishers/apphub.py
+++ b/src/dns_aid/sdk/publishers/apphub.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
+import json
 import os
 from collections.abc import Callable
 from typing import Any
@@ -30,9 +32,11 @@ from dns_aid.sdk.publishers.models import (
     PublishedAgentState,
     SyncResult,
 )
-from dns_aid.utils.google_auth import get_google_access_token
+from dns_aid.utils.google_auth import GoogleAccessTokenProvider
 
 _SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+_APPHUB_RUNTIME_ERRORS = (ValueError, RuntimeError, httpx.HTTPError)
 
 
 class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceSnapshot | str]):
@@ -43,13 +47,15 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
         config: AppHubPublisherConfig,
         *,
         backend: DNSBackend | None = None,
-        token_provider: Callable[[], tuple[str, str | None]] | None = None,
+        token_provider: Callable[[], tuple[str, str | None] | Any] | None = None,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self.config = config
-        self._token_provider = token_provider or (lambda: get_google_access_token(_SCOPES))
+        default_provider = GoogleAccessTokenProvider(_SCOPES)
+        self._token_provider = token_provider or default_provider.get_token
         self._http_client = http_client
         self._client_loop_id: int | None = None
+        self._sync_lock = asyncio.Lock()
 
         dns_backend = backend or CloudDNSBackend(
             project_id=config.project_id,
@@ -60,6 +66,7 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
 
     @classmethod
     def from_env(cls, *, backend: DNSBackend | None = None) -> AppHubPublisher:
+        raw_name_overrides = os.environ.get("APPHUB_NAME_OVERRIDES_JSON", "{}")
         return cls(
             AppHubPublisherConfig(
                 project_id=os.environ["GOOGLE_CLOUD_PROJECT"],
@@ -100,6 +107,11 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
                     "pscBaseUrl",
                 ),
                 poll_interval_seconds=int(os.environ.get("APPHUB_POLL_INTERVAL_SECONDS", "300")),
+                name_overrides=(
+                    json.loads(raw_name_overrides)
+                    if raw_name_overrides.strip()
+                    else {}
+                ),
             ),
             backend=backend,
         )
@@ -117,6 +129,7 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
             self._http_client = httpx.AsyncClient(
                 base_url="https://apphub.googleapis.com",
                 timeout=30.0,
+                follow_redirects=False,
             )
             self._client_loop_id = current_loop_id
 
@@ -136,15 +149,38 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
         params: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         client = await self._get_http_client()
-        token, _ = self._token_provider()
-        response = await client.request(
-            method=method,
-            url=path,
-            params=params,
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        response.raise_for_status()
-        return response.json()
+        last_error: httpx.HTTPError | None = None
+
+        for attempt in range(3):
+            try:
+                result = self._token_provider()
+                if inspect.isawaitable(result):
+                    token, _ = await result
+                else:
+                    token, _ = result
+                response = await client.request(
+                    method=method,
+                    url=path,
+                    params=params,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError as exc:
+                last_error = exc
+                if attempt == 2 or not self._is_retryable_http_error(exc):
+                    raise
+                await asyncio.sleep(0.5 * (2**attempt))
+
+        if last_error is not None:  # pragma: no cover - defensive fallback
+            raise last_error
+        return {}
+
+    @staticmethod
+    def _is_retryable_http_error(exc: httpx.HTTPError) -> bool:
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code in _RETRYABLE_STATUS_CODES
+        return isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError))
 
     @staticmethod
     def _unwrap_extended_metadata_entry(entry: Any) -> Any:
@@ -180,15 +216,15 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
             parsed = urlparse(service_uri)
             if parsed.scheme in {"http", "https"} and parsed.netloc:
                 return f"{parsed.scheme}://{parsed.netloc}"
+        return None
 
-        for entry in extended_metadata.values():
-            unwrapped = self._unwrap_extended_metadata_entry(entry)
-            for path in ("pscBaseUrl", "pscEndpointUri", "baseUrl", "uri"):
-                candidate = get_nested_value(unwrapped, path)
-                if isinstance(candidate, str) and candidate.startswith(("http://", "https://")):
-                    parsed = urlparse(candidate)
-                    if parsed.netloc:
-                        return f"{parsed.scheme}://{parsed.netloc}"
+    def _configured_name_override(self, *identifiers: str | None) -> str | None:
+        for identifier in identifiers:
+            if not identifier:
+                continue
+            override = self.config.name_overrides.get(identifier)
+            if override:
+                return normalize_agent_name(override)
         return None
 
     def _derive_agent_name(
@@ -198,6 +234,14 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
         canonical_service_name: str | None,
         extended_metadata: dict[str, Any],
     ) -> str:
+        override = self._configured_name_override(
+            canonical_service_name,
+            discovered_service_name,
+            service_uri,
+        )
+        if override:
+            return override
+
         configured = self._extract_extended_metadata_value(
             extended_metadata,
             self.config.service_name_metadata_key,
@@ -215,12 +259,16 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
             value = candidate.rstrip("/").split("/")[-1]
             try:
                 return normalize_agent_name(value)
-            except Exception:
+            except ValueError:
                 continue
         return normalize_agent_name(discovered_service_name.split("/")[-1])
 
     def _snapshot_from_api(self, data: dict[str, Any]) -> AppHubServiceSnapshot:
-        discovered_service_name = str(data["name"])
+        raw_name = data.get("name")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise ValueError("AppHub discovered service response is missing a name")
+
+        discovered_service_name = raw_name
         service_uri = get_nested_value(data, "serviceReference.uri")
         properties = (
             data.get("serviceProperties", {})
@@ -375,14 +423,35 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
                 success=False,
                 message="AppHub service is not eligible for AGENT publishing",
             )
-        agent = self._build_agent(snapshot)
-        return await self._publish_agent_record(agent)
+        try:
+            agent = self._build_agent(snapshot)
+        except _APPHUB_RUNTIME_ERRORS as exc:
+            fallback_agent = self._build_agent(snapshot, strict=False)
+            return PublishResult(
+                agent=fallback_agent,
+                records_created=[],
+                zone=fallback_agent.domain,
+                backend=self.backend.name,
+                success=False,
+                message=str(exc),
+            )
+        async with self._sync_lock:
+            if not await self._ensure_name_is_unique(agent.name, snapshot.connect_meta):
+                return PublishResult(
+                    agent=agent,
+                    records_created=[],
+                    zone=agent.domain,
+                    backend=self.backend.name,
+                    success=False,
+                    message=f"Agent name collision for {agent.name}; add an explicit name override",
+                )
+            return await self._publish_agent_record(agent)
 
     async def unpublish(self, service: AppHubServiceRef | AppHubServiceSnapshot | str) -> bool:
         try:
             snapshot = await self._resolve_service(service)
             return await self._unpublish_agent_name(snapshot.agent_name)
-        except Exception:
+        except _APPHUB_RUNTIME_ERRORS:
             ref = (
                 service
                 if isinstance(service, AppHubServiceRef)
@@ -394,44 +463,77 @@ class AppHubPublisher(BaseAgentRecordPublisher[AppHubServiceRef | AppHubServiceS
                     return await self._unpublish_agent_name(state.name)
             return False
 
-    async def sync(self) -> SyncResult:
-        result = SyncResult()
+    async def _ensure_name_is_unique(self, agent_name: str, connect_meta: str) -> bool:
         current_states = await self._list_published_states(connect_class="apphub-psc")
-        desired_snapshots = await self._list_discovered_services()
+        state = current_states.get(f"{agent_name}:{self.protocol.value}")
+        return state is None or state.connect_meta == connect_meta
 
-        for snapshot in desired_snapshots:
-            if (snapshot.functional_type or "").upper() != "AGENT":
-                continue
+    async def sync(self) -> SyncResult:
+        async with self._sync_lock:
+            result = SyncResult()
+            current_states = await self._list_published_states(connect_class="apphub-psc")
+            desired_snapshots = await self._list_discovered_services()
 
-            try:
-                agent = self._build_agent(snapshot)
-            except Exception as exc:
-                result.errors.append(str(exc))
-                continue
+            desired_agents: list[tuple[AppHubServiceSnapshot, AgentRecord]] = []
+            collisions: set[str] = set()
+            seen_connect_meta: dict[str, str] = {}
 
-            key = f"{agent.name}:{agent.protocol.value}"
-            current = current_states.pop(key, None)
+            for snapshot in desired_snapshots:
+                if (snapshot.functional_type or "").upper() != "AGENT":
+                    continue
 
-            if current and self._matches_state(current, agent):
-                result.unchanged += 1
-                continue
+                try:
+                    agent = self._build_agent(snapshot)
+                except _APPHUB_RUNTIME_ERRORS as exc:
+                    result.errors.append(str(exc))
+                    continue
 
-            publish_result = await self._publish_agent_record(agent)
-            if not publish_result.success:
-                result.errors.append(publish_result.message or f"Failed to publish {agent.name}")
-            elif current:
-                result.updated += 1
-            else:
-                result.published += 1
+                key = f"{agent.name}:{agent.protocol.value}"
+                previous_connect_meta = seen_connect_meta.get(key)
+                if previous_connect_meta and previous_connect_meta != snapshot.connect_meta:
+                    collisions.add(key)
+                    result.errors.append(
+                        f"Agent name collision for {agent.name}; add an explicit name override"
+                    )
+                    continue
 
-        for stale in current_states.values():
-            deleted = await self._unpublish_agent_name(stale.name)
-            if deleted:
-                result.unpublished += 1
-            else:
-                result.errors.append(f"Failed to unpublish stale AppHub record {stale.name}")
+                seen_connect_meta[key] = snapshot.connect_meta
+                desired_agents.append((snapshot, agent))
 
-        return result
+            for snapshot, agent in desired_agents:
+                key = f"{agent.name}:{agent.protocol.value}"
+                if key in collisions:
+                    continue
+
+                current = current_states.get(key)
+                if current and current.connect_meta not in {snapshot.connect_meta, None}:
+                    result.errors.append(
+                        f"Existing AppHub record for {agent.name} belongs to {current.connect_meta}; add an explicit name override"
+                    )
+                    current_states.pop(key, None)
+                    continue
+
+                current = current_states.pop(key, None)
+                if current and self._matches_state(current, agent):
+                    result.unchanged += 1
+                    continue
+
+                publish_result = await self._publish_agent_record(agent)
+                if not publish_result.success:
+                    result.errors.append(publish_result.message or f"Failed to publish {agent.name}")
+                elif current:
+                    result.updated += 1
+                else:
+                    result.published += 1
+
+            for stale in current_states.values():
+                deleted = await self._unpublish_agent_name(stale.name)
+                if deleted:
+                    result.unpublished += 1
+                else:
+                    result.errors.append(f"Failed to unpublish stale AppHub record {stale.name}")
+
+            return result
 
 
 async def run_polling_sync(publisher: AppHubPublisher, *, once: bool = False) -> SyncResult:

--- a/src/dns_aid/sdk/publishers/base.py
+++ b/src/dns_aid/sdk/publishers/base.py
@@ -1,0 +1,103 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Base abstractions for provider-managed record publishers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from dns_aid.backends.base import DNSBackend
+from dns_aid.core.models import AgentRecord, Protocol, PublishResult
+from dns_aid.core.publisher import unpublish
+from dns_aid.sdk.publishers._helpers import parse_published_state
+from dns_aid.sdk.publishers.models import PublishedAgentState, SyncResult
+
+TService = TypeVar("TService")
+
+
+class AgentRecordPublisher(ABC, Generic[TService]):
+    """Abstract interface for provider-managed agent record publishing."""
+
+    @abstractmethod
+    async def publish(self, service: TService) -> PublishResult:
+        """Publish or update DNS-AID records for the given provider service."""
+
+    @abstractmethod
+    async def unpublish(self, service: TService) -> bool:
+        """Remove DNS-AID records for the given provider service."""
+
+    @abstractmethod
+    async def sync(self) -> SyncResult:
+        """Reconcile provider state against authoritative DNS."""
+
+
+class BaseAgentRecordPublisher(AgentRecordPublisher[TService], Generic[TService]):
+    """Shared DNS mutation helpers for provider-backed publishers."""
+
+    def __init__(self, backend: DNSBackend, domain: str, protocol: str | Protocol) -> None:
+        self.backend = backend
+        self.domain = domain.rstrip(".")
+        self.protocol = protocol if isinstance(protocol, Protocol) else Protocol(protocol.lower())
+
+    async def _publish_agent_record(self, agent: AgentRecord) -> PublishResult:
+        if not await self.backend.zone_exists(agent.domain):
+            return PublishResult(
+                agent=agent,
+                records_created=[],
+                zone=agent.domain,
+                backend=self.backend.name,
+                success=False,
+                message=f"Zone '{agent.domain}' does not exist or is not accessible",
+            )
+
+        try:
+            records = await self.backend.publish_agent(agent)
+        except Exception as exc:
+            return PublishResult(
+                agent=agent,
+                records_created=[],
+                zone=agent.domain,
+                backend=self.backend.name,
+                success=False,
+                message=f"Failed to publish: {exc}",
+            )
+
+        return PublishResult(
+            agent=agent,
+            records_created=records,
+            zone=agent.domain,
+            backend=self.backend.name,
+            success=True,
+            message="Agent published successfully",
+        )
+
+    async def _unpublish_agent_name(self, agent_name: str) -> bool:
+        return await unpublish(
+            name=agent_name,
+            domain=self.domain,
+            protocol=self.protocol,
+            backend=self.backend,
+        )
+
+    async def _list_published_states(
+        self,
+        *,
+        connect_class: str | None = None,
+    ) -> dict[str, PublishedAgentState]:
+        states: dict[str, PublishedAgentState] = {}
+
+        async for record in self.backend.list_records(self.domain, name_pattern="._agents", record_type="SVCB"):
+            svcb_record = record
+            if not record.get("values"):
+                svcb_record = await self.backend.get_record(self.domain, record["name"], "SVCB") or record
+            txt_record = await self.backend.get_record(self.domain, record["name"], "TXT")
+            txt_values = txt_record["values"] if txt_record else []
+            state = parse_published_state(svcb_record, txt_values)
+            if state is None:
+                continue
+            if connect_class and state.connect_class != connect_class:
+                continue
+            states[f"{state.name}:{state.protocol}"] = state
+        return states

--- a/src/dns_aid/sdk/publishers/harness.py
+++ b/src/dns_aid/sdk/publishers/harness.py
@@ -1,0 +1,142 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermetic discovery validation harness for provider-managed connection flows."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+import dns_aid
+from dns_aid.core.models import AgentRecord
+
+
+class DiscoveryBootstrapResult(BaseModel):
+    """Outcome of a full discovery and provider-specific bootstrap attempt."""
+
+    agent_name: str
+    domain: str
+    connect_class: str | None = None
+    connect_meta: str | None = None
+    enroll_uri: str | None = None
+    success: bool = False
+    direct_connect_attempted: bool = False
+    details: dict[str, Any] = Field(default_factory=dict)
+    message: str | None = None
+
+
+class DiscoveryValidationHarness:
+    """Bootstrap discovered DNS-AID agents using only the published records."""
+
+    def __init__(
+        self,
+        *,
+        lattice_lookup: Callable[[str], Awaitable[dict[str, Any] | None]] | None = None,
+        apphub_connect_meta_validator: Callable[[str], bool] | None = None,
+    ) -> None:
+        self._lattice_lookup = lattice_lookup
+        self._apphub_connect_meta_validator = apphub_connect_meta_validator
+
+    async def bootstrap(
+        self,
+        domain: str,
+        *,
+        protocol: str | None = None,
+        name: str | None = None,
+    ) -> list[DiscoveryBootstrapResult]:
+        discovery = await dns_aid.discover(
+            domain,
+            protocol=protocol,
+            name=name,
+            enrich_endpoints=False,
+        )
+        results = []
+        for agent in discovery.agents:
+            results.append(await self._bootstrap_agent(domain, agent))
+        return results
+
+    async def _bootstrap_agent(self, domain: str, agent: AgentRecord) -> DiscoveryBootstrapResult:
+        if agent.connect_class == "apphub-psc":
+            return await self._bootstrap_apphub(domain, agent)
+        if agent.connect_class == "lattice":
+            return await self._bootstrap_lattice(domain, agent)
+        return DiscoveryBootstrapResult(
+            agent_name=agent.name,
+            domain=domain,
+            connect_class=agent.connect_class,
+            connect_meta=agent.connect_meta,
+            enroll_uri=agent.enroll_uri,
+            success=True,
+            direct_connect_attempted=True,
+            details={"endpoint_url": agent.endpoint_url},
+            message="Direct agent bootstrap path",
+        )
+
+    async def _bootstrap_apphub(self, domain: str, agent: AgentRecord) -> DiscoveryBootstrapResult:
+        if not agent.enroll_uri:
+            return DiscoveryBootstrapResult(
+                agent_name=agent.name,
+                domain=domain,
+                connect_class=agent.connect_class,
+                connect_meta=agent.connect_meta,
+                success=False,
+                message="Missing enroll_uri for AppHub bootstrap",
+            )
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(agent.enroll_uri)
+            response.raise_for_status()
+            payload = response.json()
+
+        meta_valid = True
+        if self._apphub_connect_meta_validator and agent.connect_meta:
+            meta_valid = self._apphub_connect_meta_validator(agent.connect_meta)
+
+        return DiscoveryBootstrapResult(
+            agent_name=agent.name,
+            domain=domain,
+            connect_class=agent.connect_class,
+            connect_meta=agent.connect_meta,
+            enroll_uri=agent.enroll_uri,
+            success=meta_valid,
+            direct_connect_attempted=False,
+            details={"enrollment": payload},
+            message="AppHub enrollment bootstrap completed" if meta_valid else "AppHub connect_meta validation failed",
+        )
+
+    async def _bootstrap_lattice(self, domain: str, agent: AgentRecord) -> DiscoveryBootstrapResult:
+        if not agent.enroll_uri:
+            return DiscoveryBootstrapResult(
+                agent_name=agent.name,
+                domain=domain,
+                connect_class=agent.connect_class,
+                connect_meta=agent.connect_meta,
+                success=False,
+                message="Missing enroll_uri for lattice bootstrap",
+            )
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(agent.enroll_uri)
+            response.raise_for_status()
+            payload = response.json()
+
+        lattice_record = None
+        if self._lattice_lookup and agent.connect_meta:
+            lattice_record = await self._lattice_lookup(agent.connect_meta)
+
+        success = lattice_record is not None or self._lattice_lookup is None
+        return DiscoveryBootstrapResult(
+            agent_name=agent.name,
+            domain=domain,
+            connect_class=agent.connect_class,
+            connect_meta=agent.connect_meta,
+            enroll_uri=agent.enroll_uri,
+            success=success,
+            direct_connect_attempted=False,
+            details={"enrollment": payload, "lattice_record": lattice_record},
+            message="Lattice overlay bootstrap completed" if success else "Lattice ARN lookup failed",
+        )

--- a/src/dns_aid/sdk/publishers/harness.py
+++ b/src/dns_aid/sdk/publishers/harness.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, Field
@@ -40,6 +41,12 @@ class DiscoveryValidationHarness:
     ) -> None:
         self._lattice_lookup = lattice_lookup
         self._apphub_connect_meta_validator = apphub_connect_meta_validator
+
+    @staticmethod
+    def _validate_enroll_uri(enroll_uri: str) -> str:
+        from dns_aid.utils.url_safety import validate_fetch_url
+
+        return validate_fetch_url(enroll_uri)
 
     async def bootstrap(
         self,
@@ -87,8 +94,10 @@ class DiscoveryValidationHarness:
                 message="Missing enroll_uri for AppHub bootstrap",
             )
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(agent.enroll_uri)
+        enroll_uri = self._validate_enroll_uri(agent.enroll_uri)
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            response = await client.get(enroll_uri)
             response.raise_for_status()
             payload = response.json()
 
@@ -101,7 +110,7 @@ class DiscoveryValidationHarness:
             domain=domain,
             connect_class=agent.connect_class,
             connect_meta=agent.connect_meta,
-            enroll_uri=agent.enroll_uri,
+            enroll_uri=enroll_uri,
             success=meta_valid,
             direct_connect_attempted=False,
             details={"enrollment": payload},
@@ -119,8 +128,22 @@ class DiscoveryValidationHarness:
                 message="Missing enroll_uri for lattice bootstrap",
             )
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(agent.enroll_uri)
+        enroll_uri = self._validate_enroll_uri(agent.enroll_uri)
+        parsed_enroll = urlparse(enroll_uri)
+        if parsed_enroll.hostname and parsed_enroll.hostname.rstrip(".") != agent.target_host.rstrip("."):
+            return DiscoveryBootstrapResult(
+                agent_name=agent.name,
+                domain=domain,
+                connect_class=agent.connect_class,
+                connect_meta=agent.connect_meta,
+                enroll_uri=enroll_uri,
+                success=False,
+                direct_connect_attempted=False,
+                message="Lattice enroll_uri host does not match the published target host",
+            )
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            response = await client.get(enroll_uri)
             response.raise_for_status()
             payload = response.json()
 
@@ -134,9 +157,14 @@ class DiscoveryValidationHarness:
             domain=domain,
             connect_class=agent.connect_class,
             connect_meta=agent.connect_meta,
-            enroll_uri=agent.enroll_uri,
+            enroll_uri=enroll_uri,
             success=success,
             direct_connect_attempted=False,
-            details={"enrollment": payload, "lattice_record": lattice_record},
+            details={
+                "enrollment": payload,
+                "lattice_record": lattice_record,
+                "overlay_required": True,
+                "target_host": agent.target_host,
+            },
             message="Lattice overlay bootstrap completed" if success else "Lattice ARN lookup failed",
         )

--- a/src/dns_aid/sdk/publishers/lattice.py
+++ b/src/dns_aid/sdk/publishers/lattice.py
@@ -1,0 +1,274 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AWS VPC Lattice-backed DNS-AID record publisher."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+from dns_aid.backends.base import DNSBackend
+from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+from dns_aid.core.models import AgentRecord
+from dns_aid.sdk.publishers._helpers import is_truthy_tag, normalize_agent_name
+from dns_aid.sdk.publishers.base import BaseAgentRecordPublisher
+from dns_aid.sdk.publishers.models import (
+    LatticePublisherConfig,
+    LatticeServiceRef,
+    LatticeServiceSnapshot,
+    PublishedAgentState,
+    SyncResult,
+)
+
+
+class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServiceSnapshot | str]):
+    """Publisher that reconciles VPC Lattice services into authoritative DNS."""
+
+    def __init__(
+        self,
+        config: LatticePublisherConfig,
+        *,
+        backend: DNSBackend | None = None,
+        client: Any | None = None,
+    ) -> None:
+        self.config = config
+        self._client = client
+        dns_backend = backend or InfobloxNIOSBackend()
+        super().__init__(dns_backend, config.domain, config.protocol)
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        backend: DNSBackend | None = None,
+        client: Any | None = None,
+    ) -> LatticePublisher:
+        return cls(
+            LatticePublisherConfig(
+                domain=os.environ["LATTICE_DOMAIN"],
+                protocol=os.environ.get("LATTICE_PROTOCOL", "mcp"),
+                stable_tag_key=os.environ.get("LATTICE_STABLE_TAG_KEY", "stable"),
+                stable_tag_values=[
+                    item.strip()
+                    for item in os.environ.get("LATTICE_STABLE_TAG_VALUES", "1,true,yes,stable").split(",")
+                    if item.strip()
+                ],
+                dynamic_ttl=int(os.environ.get("LATTICE_DYNAMIC_TTL", "30")),
+                stable_ttl=int(os.environ.get("LATTICE_STABLE_TTL", "300")),
+            ),
+            backend=backend,
+            client=client,
+        )
+
+    def _get_client(self):
+        if self._client is None:
+            import boto3
+
+            self._client = boto3.client("vpc-lattice")
+        return self._client
+
+    async def _resolve_ref(self, service: LatticeServiceRef | str) -> LatticeServiceSnapshot:
+        ref = service if isinstance(service, LatticeServiceRef) else LatticeServiceRef(service_id=service)
+        identifier = ref.service_arn or ref.service_id or ref.service_name
+        if not identifier:
+            raise ValueError("Lattice service reference must include a service identifier")
+
+        client = self._get_client()
+        data = client.get_service(serviceIdentifier=identifier)
+        tags = {}
+        service_arn = data.get("arn")
+        if service_arn:
+            tags_response = client.list_tags_for_resource(resourceArn=service_arn)
+            tags = dict(tags_response.get("tags", {}))
+        return self._snapshot_from_api(data, tags)
+
+    def _snapshot_from_api(self, data: dict[str, Any], tags: dict[str, str]) -> LatticeServiceSnapshot:
+        dns_name = (
+            data.get("dnsEntry", {}).get("domainName")
+            or data.get("customDomainName")
+            or ""
+        )
+        if not dns_name:
+            raise ValueError("VPC Lattice service is missing a DNS name")
+
+        return LatticeServiceSnapshot(
+            service_id=data["id"],
+            service_name=normalize_agent_name(data["name"]),
+            service_arn=data["arn"],
+            dns_name=dns_name,
+            tags=tags,
+            status=data.get("status"),
+        )
+
+    async def _resolve_service(self, service: LatticeServiceRef | LatticeServiceSnapshot | str) -> LatticeServiceSnapshot:
+        if isinstance(service, LatticeServiceSnapshot):
+            return service
+        return await self._resolve_ref(service)
+
+    def _ttl_for_snapshot(self, snapshot: LatticeServiceSnapshot) -> int:
+        value = snapshot.tags.get(self.config.stable_tag_key)
+        if is_truthy_tag(value, self.config.stable_tag_values):
+            return self.config.stable_ttl
+        return self.config.dynamic_ttl
+
+    def _build_agent(self, snapshot: LatticeServiceSnapshot) -> AgentRecord:
+        return AgentRecord(
+            name=snapshot.service_name,
+            domain=self.domain,
+            protocol=self.protocol,
+            target_host=snapshot.target_host,
+            ttl=self._ttl_for_snapshot(snapshot),
+            connect_class="lattice",
+            connect_meta=snapshot.service_arn,
+            enroll_uri=f"https://{snapshot.target_host}/.well-known/agent-connect",
+        )
+
+    @staticmethod
+    def _matches_state(state: PublishedAgentState, agent: AgentRecord) -> bool:
+        return (
+            state.protocol == agent.protocol.value
+            and state.target_host == agent.target_host
+            and state.ttl == agent.ttl
+            and state.connect_class == agent.connect_class
+            and state.connect_meta == agent.connect_meta
+            and state.enroll_uri == agent.enroll_uri
+        )
+
+    async def _list_services(self) -> list[LatticeServiceSnapshot]:
+        client = self._get_client()
+        next_token: str | None = None
+        snapshots: list[LatticeServiceSnapshot] = []
+
+        while True:
+            params: dict[str, Any] = {"maxResults": 100}
+            if next_token:
+                params["nextToken"] = next_token
+
+            response = client.list_services(**params)
+            for summary in response.get("items", []):
+                snapshot = await self._resolve_ref(LatticeServiceRef(service_id=summary["id"]))
+                snapshots.append(snapshot)
+
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+
+        return snapshots
+
+    async def publish(self, service: LatticeServiceRef | LatticeServiceSnapshot | str):
+        snapshot = await self._resolve_service(service)
+        return await self._publish_agent_record(self._build_agent(snapshot))
+
+    async def unpublish(self, service: LatticeServiceRef | LatticeServiceSnapshot | str) -> bool:
+        try:
+            snapshot = await self._resolve_service(service)
+            return await self._unpublish_agent_name(snapshot.service_name)
+        except Exception:
+            candidates: set[str] = set()
+            if isinstance(service, LatticeServiceRef):
+                candidates.update(filter(None, [service.service_id, service.service_arn, service.service_name]))
+            else:
+                candidates.add(str(service))
+
+            current_states = await self._list_published_states(connect_class="lattice")
+            for state in current_states.values():
+                if state.connect_meta in candidates or state.name in candidates:
+                    return await self._unpublish_agent_name(state.name)
+            return False
+
+    async def sync(self) -> SyncResult:
+        result = SyncResult()
+        current_states = await self._list_published_states(connect_class="lattice")
+        desired_snapshots = await self._list_services()
+
+        for snapshot in desired_snapshots:
+            agent = self._build_agent(snapshot)
+            key = f"{agent.name}:{agent.protocol.value}"
+            current = current_states.pop(key, None)
+
+            if current and self._matches_state(current, agent):
+                result.unchanged += 1
+                continue
+
+            publish_result = await self._publish_agent_record(agent)
+            if not publish_result.success:
+                result.errors.append(publish_result.message or f"Failed to publish {agent.name}")
+            elif current:
+                result.updated += 1
+            else:
+                result.published += 1
+
+        for stale in current_states.values():
+            deleted = await self._unpublish_agent_name(stale.name)
+            if deleted:
+                result.unpublished += 1
+            else:
+                result.errors.append(f"Failed to unpublish stale lattice record {stale.name}")
+
+        return result
+
+    @staticmethod
+    def _extract_service_identifier(event: dict[str, Any]) -> LatticeServiceRef | None:
+        detail = event.get("detail", {})
+        request_parameters = detail.get("requestParameters", {}) if isinstance(detail, dict) else {}
+        response_elements = detail.get("responseElements", {}) if isinstance(detail, dict) else {}
+
+        service_arn = (
+            response_elements.get("arn")
+            or request_parameters.get("resourceArn")
+            or request_parameters.get("serviceArn")
+        )
+        service_id = (
+            response_elements.get("id")
+            or request_parameters.get("serviceIdentifier")
+            or request_parameters.get("serviceId")
+        )
+        service_name = (
+            response_elements.get("name")
+            or request_parameters.get("name")
+            or request_parameters.get("serviceName")
+        )
+
+        if not any((service_id, service_arn, service_name)):
+            return None
+        return LatticeServiceRef(service_id=service_id, service_arn=service_arn, service_name=service_name)
+
+    async def handle_eventbridge_event(self, event: dict[str, Any]):
+        detail = event.get("detail", {})
+        event_name = detail.get("eventName", "") if isinstance(detail, dict) else ""
+
+        if event_name == "DeleteService":
+            return await self.sync()
+
+        if event_name in {"CreateService", "UpdateService", "TagResource", "UntagResource"}:
+            ref = self._extract_service_identifier(event)
+            if ref is not None:
+                return await self.publish(ref)
+
+        return await self.sync()
+
+
+async def run_startup_sync(publisher: LatticePublisher) -> SyncResult:
+    """Run a single startup reconciliation cycle."""
+    return await publisher.sync()
+
+
+async def main_async() -> SyncResult | Any:
+    publisher = LatticePublisher.from_env()
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read().strip()
+        if raw:
+            return await publisher.handle_eventbridge_event(json.loads(raw))
+    return await run_startup_sync(publisher)
+
+
+def main() -> None:
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/dns_aid/sdk/publishers/lattice.py
+++ b/src/dns_aid/sdk/publishers/lattice.py
@@ -9,11 +9,12 @@ import asyncio
 import json
 import os
 import sys
+from collections.abc import Callable
 from typing import Any
 
 from dns_aid.backends.base import DNSBackend
 from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
-from dns_aid.core.models import AgentRecord
+from dns_aid.core.models import AgentRecord, PublishResult
 from dns_aid.sdk.publishers._helpers import is_truthy_tag, normalize_agent_name
 from dns_aid.sdk.publishers.base import BaseAgentRecordPublisher
 from dns_aid.sdk.publishers.models import (
@@ -22,6 +23,26 @@ from dns_aid.sdk.publishers.models import (
     LatticeServiceSnapshot,
     PublishedAgentState,
     SyncResult,
+)
+
+_BotocoreBotoCoreError: type[Exception] = Exception
+_BotocoreClientError: type[Exception] = Exception
+
+try:  # pragma: no cover - optional dependency
+    from botocore.exceptions import BotoCoreError as ImportedBotocoreBotoCoreError
+    from botocore.exceptions import ClientError as ImportedBotocoreClientError
+except ImportError:  # pragma: no cover - exercised when boto3 extra is absent
+    pass
+else:  # pragma: no cover - trivial assignment
+    _BotocoreBotoCoreError = ImportedBotocoreBotoCoreError
+    _BotocoreClientError = ImportedBotocoreClientError
+
+
+_LATTICE_RUNTIME_ERRORS = (
+    ValueError,
+    RuntimeError,
+    _BotocoreBotoCoreError,
+    _BotocoreClientError,
 )
 
 
@@ -37,6 +58,7 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
     ) -> None:
         self.config = config
         self._client = client
+        self._sync_lock = asyncio.Lock()
         dns_backend = backend or InfobloxNIOSBackend()
         super().__init__(dns_backend, config.domain, config.protocol)
 
@@ -47,6 +69,7 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
         backend: DNSBackend | None = None,
         client: Any | None = None,
     ) -> LatticePublisher:
+        raw_name_overrides = os.environ.get("LATTICE_NAME_OVERRIDES_JSON", "{}")
         return cls(
             LatticePublisherConfig(
                 domain=os.environ["LATTICE_DOMAIN"],
@@ -59,17 +82,43 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
                 ],
                 dynamic_ttl=int(os.environ.get("LATTICE_DYNAMIC_TTL", "30")),
                 stable_ttl=int(os.environ.get("LATTICE_STABLE_TTL", "300")),
+                name_overrides=json.loads(raw_name_overrides) if raw_name_overrides.strip() else {},
             ),
             backend=backend,
             client=client,
         )
 
-    def _get_client(self):
+    def _get_client(self) -> Any:
         if self._client is None:
             import boto3
 
             self._client = boto3.client("vpc-lattice")
         return self._client
+
+    async def _call_client(self, method_name: str, **kwargs: Any) -> Any:
+        client = self._get_client()
+        method: Callable[..., Any] = getattr(client, method_name)
+        return await asyncio.to_thread(method, **kwargs)
+
+    async def _list_tags(self, service_arn: str | None) -> dict[str, str]:
+        if not service_arn:
+            return {}
+        tags_response = await self._call_client("list_tags_for_resource", resourceArn=service_arn)
+        tags = tags_response.get("tags", {})
+        return {
+            str(key): str(value)
+            for key, value in tags.items()
+            if isinstance(key, str) and isinstance(value, str)
+        }
+
+    def _configured_name_override(self, *identifiers: str | None) -> str | None:
+        for identifier in identifiers:
+            if not identifier:
+                continue
+            override = self.config.name_overrides.get(identifier)
+            if override:
+                return normalize_agent_name(override)
+        return None
 
     async def _resolve_ref(self, service: LatticeServiceRef | str) -> LatticeServiceSnapshot:
         ref = service if isinstance(service, LatticeServiceRef) else LatticeServiceRef(service_id=service)
@@ -77,40 +126,51 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
         if not identifier:
             raise ValueError("Lattice service reference must include a service identifier")
 
-        client = self._get_client()
-        data = client.get_service(serviceIdentifier=identifier)
-        tags = {}
-        service_arn = data.get("arn")
-        if service_arn:
-            tags_response = client.list_tags_for_resource(resourceArn=service_arn)
-            tags = dict(tags_response.get("tags", {}))
+        data = await self._call_client("get_service", serviceIdentifier=identifier)
+        tags = await self._list_tags(data.get("arn"))
         return self._snapshot_from_api(data, tags)
 
     def _snapshot_from_api(self, data: dict[str, Any], tags: dict[str, str]) -> LatticeServiceSnapshot:
-        dns_name = (
-            data.get("dnsEntry", {}).get("domainName")
-            or data.get("customDomainName")
-            or ""
-        )
+        dns_entry = data.get("dnsEntry", {})
+        dns_name = (dns_entry.get("domainName") if isinstance(dns_entry, dict) else None) or data.get(
+            "customDomainName"
+        ) or ""
         if not dns_name:
             raise ValueError("VPC Lattice service is missing a DNS name")
 
+        service_id = data.get("id")
+        service_arn = data.get("arn")
+        raw_name = data.get("name")
+        if not isinstance(service_id, str) or not service_id:
+            raise ValueError("VPC Lattice service is missing an id")
+        if not isinstance(service_arn, str) or not service_arn:
+            raise ValueError("VPC Lattice service is missing an ARN")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise ValueError("VPC Lattice service is missing a name")
+
+        service_name = self._configured_name_override(service_arn, service_id, raw_name)
+        if service_name is None:
+            service_name = normalize_agent_name(raw_name)
+
         return LatticeServiceSnapshot(
-            service_id=data["id"],
-            service_name=normalize_agent_name(data["name"]),
-            service_arn=data["arn"],
+            service_id=service_id,
+            service_name=service_name,
+            service_arn=service_arn,
             dns_name=dns_name,
-            tags=tags,
+            tags=tuple(sorted(tags.items())),
             status=data.get("status"),
         )
 
-    async def _resolve_service(self, service: LatticeServiceRef | LatticeServiceSnapshot | str) -> LatticeServiceSnapshot:
+    async def _resolve_service(
+        self,
+        service: LatticeServiceRef | LatticeServiceSnapshot | str,
+    ) -> LatticeServiceSnapshot:
         if isinstance(service, LatticeServiceSnapshot):
             return service
         return await self._resolve_ref(service)
 
     def _ttl_for_snapshot(self, snapshot: LatticeServiceSnapshot) -> int:
-        value = snapshot.tags.get(self.config.stable_tag_key)
+        value = snapshot.tag_map.get(self.config.stable_tag_key)
         if is_truthy_tag(value, self.config.stable_tag_values):
             return self.config.stable_ttl
         return self.config.dynamic_ttl
@@ -139,7 +199,6 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
         )
 
     async def _list_services(self) -> list[LatticeServiceSnapshot]:
-        client = self._get_client()
         next_token: str | None = None
         snapshots: list[LatticeServiceSnapshot] = []
 
@@ -148,9 +207,19 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
             if next_token:
                 params["nextToken"] = next_token
 
-            response = client.list_services(**params)
+            response = await self._call_client("list_services", **params)
             for summary in response.get("items", []):
-                snapshot = await self._resolve_ref(LatticeServiceRef(service_id=summary["id"]))
+                if not isinstance(summary, dict):
+                    continue
+                service_id = summary.get("id")
+                if not isinstance(service_id, str) or not service_id:
+                    continue
+
+                tags = await self._list_tags(summary.get("arn"))
+                try:
+                    snapshot = self._snapshot_from_api(summary, tags)
+                except ValueError:
+                    snapshot = await self._resolve_ref(LatticeServiceRef(service_id=service_id))
                 snapshots.append(snapshot)
 
             next_token = response.get("nextToken")
@@ -159,15 +228,34 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
 
         return snapshots
 
+    async def _ensure_name_is_unique(self, agent_name: str, connect_meta: str) -> bool:
+        current_states = await self._list_published_states(connect_class="lattice")
+        state = current_states.get(f"{agent_name}:{self.protocol.value}")
+        return state is None or state.connect_meta == connect_meta
+
+    def _publish_collision_result(self, agent: AgentRecord) -> PublishResult:
+        return PublishResult(
+            agent=agent,
+            records_created=[],
+            zone=agent.domain,
+            backend=self.backend.name,
+            success=False,
+            message=f"Agent name collision for {agent.name}; add an explicit name override",
+        )
+
     async def publish(self, service: LatticeServiceRef | LatticeServiceSnapshot | str):
         snapshot = await self._resolve_service(service)
-        return await self._publish_agent_record(self._build_agent(snapshot))
+        agent = self._build_agent(snapshot)
+        async with self._sync_lock:
+            if not await self._ensure_name_is_unique(agent.name, snapshot.service_arn):
+                return self._publish_collision_result(agent)
+            return await self._publish_agent_record(agent)
 
     async def unpublish(self, service: LatticeServiceRef | LatticeServiceSnapshot | str) -> bool:
         try:
             snapshot = await self._resolve_service(service)
             return await self._unpublish_agent_name(snapshot.service_name)
-        except Exception:
+        except _LATTICE_RUNTIME_ERRORS:
             candidates: set[str] = set()
             if isinstance(service, LatticeServiceRef):
                 candidates.update(filter(None, [service.service_id, service.service_arn, service.service_name]))
@@ -181,35 +269,62 @@ class LatticePublisher(BaseAgentRecordPublisher[LatticeServiceRef | LatticeServi
             return False
 
     async def sync(self) -> SyncResult:
-        result = SyncResult()
-        current_states = await self._list_published_states(connect_class="lattice")
-        desired_snapshots = await self._list_services()
+        async with self._sync_lock:
+            result = SyncResult()
+            current_states = await self._list_published_states(connect_class="lattice")
+            desired_snapshots = await self._list_services()
 
-        for snapshot in desired_snapshots:
-            agent = self._build_agent(snapshot)
-            key = f"{agent.name}:{agent.protocol.value}"
-            current = current_states.pop(key, None)
+            desired_agents: list[tuple[LatticeServiceSnapshot, AgentRecord]] = []
+            collisions: set[str] = set()
+            seen_connect_meta: dict[str, str] = {}
 
-            if current and self._matches_state(current, agent):
-                result.unchanged += 1
-                continue
+            for snapshot in desired_snapshots:
+                agent = self._build_agent(snapshot)
+                key = f"{agent.name}:{agent.protocol.value}"
+                previous_connect_meta = seen_connect_meta.get(key)
+                if previous_connect_meta and previous_connect_meta != snapshot.service_arn:
+                    collisions.add(key)
+                    result.errors.append(
+                        f"Agent name collision for {agent.name}; add an explicit name override"
+                    )
+                    continue
+                seen_connect_meta[key] = snapshot.service_arn
+                desired_agents.append((snapshot, agent))
 
-            publish_result = await self._publish_agent_record(agent)
-            if not publish_result.success:
-                result.errors.append(publish_result.message or f"Failed to publish {agent.name}")
-            elif current:
-                result.updated += 1
-            else:
-                result.published += 1
+            for snapshot, agent in desired_agents:
+                key = f"{agent.name}:{agent.protocol.value}"
+                if key in collisions:
+                    continue
 
-        for stale in current_states.values():
-            deleted = await self._unpublish_agent_name(stale.name)
-            if deleted:
-                result.unpublished += 1
-            else:
-                result.errors.append(f"Failed to unpublish stale lattice record {stale.name}")
+                current = current_states.get(key)
+                if current and current.connect_meta not in {snapshot.service_arn, None}:
+                    result.errors.append(
+                        f"Existing lattice record for {agent.name} belongs to {current.connect_meta}; add an explicit name override"
+                    )
+                    current_states.pop(key, None)
+                    continue
 
-        return result
+                current = current_states.pop(key, None)
+                if current and self._matches_state(current, agent):
+                    result.unchanged += 1
+                    continue
+
+                publish_result = await self._publish_agent_record(agent)
+                if not publish_result.success:
+                    result.errors.append(publish_result.message or f"Failed to publish {agent.name}")
+                elif current:
+                    result.updated += 1
+                else:
+                    result.published += 1
+
+            for stale in current_states.values():
+                deleted = await self._unpublish_agent_name(stale.name)
+                if deleted:
+                    result.unpublished += 1
+                else:
+                    result.errors.append(f"Failed to unpublish stale lattice record {stale.name}")
+
+            return result
 
     @staticmethod
     def _extract_service_identifier(event: dict[str, Any]) -> LatticeServiceRef | None:
@@ -260,7 +375,11 @@ async def run_startup_sync(publisher: LatticePublisher) -> SyncResult:
 async def main_async() -> SyncResult | Any:
     publisher = LatticePublisher.from_env()
     if not sys.stdin.isatty():
-        raw = sys.stdin.read().strip()
+        try:
+            raw = await asyncio.wait_for(asyncio.to_thread(sys.stdin.read), timeout=5.0)
+        except TimeoutError:
+            raw = ""
+        raw = raw.strip()
         if raw:
             return await publisher.handle_eventbridge_event(json.loads(raw))
     return await run_startup_sync(publisher)

--- a/src/dns_aid/sdk/publishers/models.py
+++ b/src/dns_aid/sdk/publishers/models.py
@@ -1,0 +1,129 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared models for provider-managed agent record publishers."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SyncResult(BaseModel):
+    """Outcome summary for a reconciliation cycle."""
+
+    published: int = 0
+    updated: int = 0
+    unpublished: int = 0
+    unchanged: int = 0
+    errors: list[str] = Field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return not self.errors
+
+
+class PublishedAgentState(BaseModel):
+    """Parsed view of an already-published agent record."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    protocol: str
+    target_host: str
+    ttl: int
+    capabilities: list[str] = Field(default_factory=list)
+    connect_class: str | None = None
+    connect_meta: str | None = None
+    enroll_uri: str | None = None
+
+
+class AppHubPublisherConfig(BaseModel):
+    """Configuration for AppHub-backed publishing."""
+
+    project_id: str
+    location: str
+    domain: str
+    protocol: str = "mcp"
+    managed_zone: str | None = None
+    capabilities_metadata_key: str = "apphub.googleapis.com/agentProperties"
+    capabilities_metadata_path: str = "a2a.capabilities"
+    service_name_metadata_key: str = "apphub.googleapis.com/agentProperties"
+    service_name_metadata_path: str = "serviceName"
+    connect_meta_metadata_key: str = "apphub.googleapis.com/agentConnect"
+    connect_meta_metadata_path: str = "serviceName"
+    enrollment_metadata_key: str = "apphub.googleapis.com/agentConnect"
+    enrollment_metadata_path: str = "pscBaseUrl"
+    poll_interval_seconds: int = 300
+
+
+class AppHubServiceRef(BaseModel):
+    """Reference used to resolve an AppHub discovered service."""
+
+    name: str | None = None
+    uri: str | None = None
+
+
+class AppHubServiceSnapshot(BaseModel):
+    """Resolved AppHub service data used by the publisher."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    discovered_service_name: str
+    agent_name: str
+    service_uri: str | None = None
+    canonical_service_name: str | None = None
+    functional_type: str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+    enrollment_base_url: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def connect_meta(self) -> str:
+        return self.canonical_service_name or self.discovered_service_name
+
+    @property
+    def target_host(self) -> str:
+        candidate = self.enrollment_base_url or self.service_uri or ""
+        parsed = urlparse(candidate)
+        if parsed.hostname:
+            return parsed.hostname.rstrip(".")
+        return candidate.rstrip(".")
+
+
+class LatticePublisherConfig(BaseModel):
+    """Configuration for VPC Lattice-backed publishing."""
+
+    domain: str
+    protocol: str = "mcp"
+    stable_tag_key: str = "stable"
+    stable_tag_values: list[str] = Field(default_factory=lambda: ["1", "true", "yes", "stable"])
+    dynamic_ttl: int = 30
+    stable_ttl: int = 300
+
+
+class LatticeServiceRef(BaseModel):
+    """Reference used to resolve a VPC Lattice service."""
+
+    service_id: str | None = None
+    service_arn: str | None = None
+    service_name: str | None = None
+
+
+class LatticeServiceSnapshot(BaseModel):
+    """Resolved VPC Lattice service data used by the publisher."""
+
+    model_config = ConfigDict(frozen=True)
+
+    service_id: str
+    service_name: str
+    service_arn: str
+    dns_name: str
+    tags: dict[str, str] = Field(default_factory=dict)
+    status: str | None = None
+
+    @property
+    def target_host(self) -> str:
+        return self.dns_name.rstrip(".")

--- a/src/dns_aid/sdk/publishers/models.py
+++ b/src/dns_aid/sdk/publishers/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SyncResult(BaseModel):
@@ -57,6 +57,7 @@ class AppHubPublisherConfig(BaseModel):
     enrollment_metadata_key: str = "apphub.googleapis.com/agentConnect"
     enrollment_metadata_path: str = "pscBaseUrl"
     poll_interval_seconds: int = 300
+    name_overrides: dict[str, str] = Field(default_factory=dict)
 
 
 class AppHubServiceRef(BaseModel):
@@ -102,6 +103,7 @@ class LatticePublisherConfig(BaseModel):
     stable_tag_values: list[str] = Field(default_factory=lambda: ["1", "true", "yes", "stable"])
     dynamic_ttl: int = 30
     stable_ttl: int = 300
+    name_overrides: dict[str, str] = Field(default_factory=dict)
 
 
 class LatticeServiceRef(BaseModel):
@@ -121,9 +123,31 @@ class LatticeServiceSnapshot(BaseModel):
     service_name: str
     service_arn: str
     dns_name: str
-    tags: dict[str, str] = Field(default_factory=dict)
+    tags: tuple[tuple[str, str], ...] = Field(default_factory=tuple)
     status: str | None = None
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _normalize_tags(cls, value: Any) -> tuple[tuple[str, str], ...]:
+        if value is None:
+            return ()
+        if isinstance(value, dict):
+            return tuple(sorted((str(key), str(item)) for key, item in value.items()))
+        if isinstance(value, (list, tuple)):
+            normalized: list[tuple[str, str]] = []
+            for entry in value:
+                if (
+                    isinstance(entry, (list, tuple))
+                    and len(entry) == 2
+                ):
+                    normalized.append((str(entry[0]), str(entry[1])))
+            return tuple(sorted(normalized))
+        raise TypeError("tags must be a dict or sequence of key/value pairs")
 
     @property
     def target_host(self) -> str:
         return self.dns_name.rstrip(".")
+
+    @property
+    def tag_map(self) -> dict[str, str]:
+        return dict(self.tags)

--- a/src/dns_aid/utils/google_auth.py
+++ b/src/dns_aid/utils/google_auth.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
 
 
-def get_google_auth_state(scopes: list[str]) -> tuple[Credentials, str | None]:
-    """Return refreshed ADC credentials and the discovered project id."""
+_DEFAULT_REFRESH_MARGIN = timedelta(minutes=5)
+
+
+def _load_google_auth_modules():
     try:
         from google.auth import default
         from google.auth.transport.requests import Request
@@ -21,10 +25,37 @@ def get_google_auth_state(scopes: list[str]) -> tuple[Credentials, str | None]:
             "Google Cloud support requires the 'google-auth' package. "
             "Install the dns-aid[apphub] or dns-aid[cloud-dns] extra."
         ) from exc
+    return default, Request
 
-    credentials, project_id = default(scopes=scopes)
+
+def _needs_refresh(credentials: Credentials, refresh_margin: timedelta) -> bool:
     if not credentials.valid or not credentials.token:
-        credentials.refresh(Request())
+        return True
+    expiry = getattr(credentials, "expiry", None)
+    if expiry is None:
+        return False
+    if expiry.tzinfo is None:
+        expiry = expiry.replace(tzinfo=UTC)
+    return expiry <= datetime.now(UTC) + refresh_margin
+
+
+def get_google_auth_state(
+    scopes: list[str],
+    *,
+    refresh_margin: timedelta = _DEFAULT_REFRESH_MARGIN,
+    credentials: Credentials | None = None,
+    project_id: str | None = None,
+) -> tuple[Credentials, str | None]:
+    """Return refreshed ADC credentials and the discovered project id."""
+    default, request_cls = _load_google_auth_modules()
+
+    if credentials is None:
+        credentials, discovered_project = default(scopes=scopes)
+        if project_id is None:
+            project_id = discovered_project
+
+    if _needs_refresh(credentials, refresh_margin):
+        credentials.refresh(request_cls())
     if not credentials.token:
         raise RuntimeError("Failed to acquire a Google Cloud access token from ADC")
     return credentials, project_id
@@ -34,3 +65,34 @@ def get_google_access_token(scopes: list[str]) -> tuple[str, str | None]:
     """Return a Google Cloud bearer token and the discovered project id."""
     credentials, project_id = get_google_auth_state(scopes)
     return credentials.token, project_id
+
+
+class GoogleAccessTokenProvider:
+    """Async, cached Google ADC token provider with refresh-window handling."""
+
+    def __init__(
+        self,
+        scopes: list[str],
+        *,
+        refresh_margin: timedelta = _DEFAULT_REFRESH_MARGIN,
+    ) -> None:
+        self._scopes = list(scopes)
+        self._refresh_margin = refresh_margin
+        self._credentials: Credentials | None = None
+        self._project_id: str | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_token(self) -> tuple[str, str | None]:
+        async with self._lock:
+            credentials, project_id = await asyncio.to_thread(
+                get_google_auth_state,
+                self._scopes,
+                refresh_margin=self._refresh_margin,
+                credentials=self._credentials,
+                project_id=self._project_id,
+            )
+            self._credentials = credentials
+            self._project_id = project_id
+            if not credentials.token:
+                raise RuntimeError("Failed to acquire a Google Cloud access token from ADC")
+            return credentials.token, project_id

--- a/src/dns_aid/utils/google_auth.py
+++ b/src/dns_aid/utils/google_auth.py
@@ -1,0 +1,36 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for lazily acquiring Google Cloud auth state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
+
+
+def get_google_auth_state(scopes: list[str]) -> tuple[Credentials, str | None]:
+    """Return refreshed ADC credentials and the discovered project id."""
+    try:
+        from google.auth import default
+        from google.auth.transport.requests import Request
+    except ImportError as exc:  # pragma: no cover - exercised by optional-dep paths
+        raise ImportError(
+            "Google Cloud support requires the 'google-auth' package. "
+            "Install the dns-aid[cloud-dns] extra."
+        ) from exc
+
+    credentials, project_id = default(scopes=scopes)
+    if not credentials.valid or not credentials.token:
+        credentials.refresh(Request())
+    if not credentials.token:
+        raise RuntimeError("Failed to acquire a Google Cloud access token from ADC")
+    return credentials, project_id
+
+
+def get_google_access_token(scopes: list[str]) -> tuple[str, str | None]:
+    """Return a Google Cloud bearer token and the discovered project id."""
+    credentials, project_id = get_google_auth_state(scopes)
+    return credentials.token, project_id

--- a/src/dns_aid/utils/google_auth.py
+++ b/src/dns_aid/utils/google_auth.py
@@ -19,7 +19,7 @@ def get_google_auth_state(scopes: list[str]) -> tuple[Credentials, str | None]:
     except ImportError as exc:  # pragma: no cover - exercised by optional-dep paths
         raise ImportError(
             "Google Cloud support requires the 'google-auth' package. "
-            "Install the dns-aid[cloud-dns] extra."
+            "Install the dns-aid[apphub] or dns-aid[cloud-dns] extra."
         ) from exc
 
     credentials, project_id = default(scopes=scopes)

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -32,6 +32,10 @@ DOMAIN_LABEL_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
 # Safe characters for capabilities
 CAPABILITY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
+# Supported provider mediation classes and their token grammar
+CONNECT_CLASS_PATTERN = re.compile(r"^[a-z0-9-]{1,64}$")
+KNOWN_CONNECT_CLASSES = frozenset({"direct", "lattice", "apphub-psc"})
+
 # Version pattern (semver-like, supports pre-release and build metadata)
 VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9._+-]*)?$")
 
@@ -183,6 +187,43 @@ def validate_protocol(protocol: str) -> Literal["mcp", "a2a"]:
     return protocol  # type: ignore
 
 
+def validate_connect_class(connect_class: str | None) -> str | None:
+    """
+    Validate and normalize the DNS-AID connect-class token.
+
+    Args:
+        connect_class: Connection mediation class or ``None``
+
+    Returns:
+        Normalized mediation class or ``None``
+
+    Raises:
+        ValidationError: If the token is malformed or unsupported
+    """
+    if connect_class is None:
+        return None
+
+    normalized = connect_class.strip().lower()
+    if not normalized:
+        return None
+
+    if not CONNECT_CLASS_PATTERN.match(normalized):
+        raise ValidationError(
+            "connect_class",
+            "connect_class must contain only lowercase letters, digits, and hyphens",
+            connect_class,
+        )
+
+    if normalized not in KNOWN_CONNECT_CLASSES:
+        raise ValidationError(
+            "connect_class",
+            f"connect_class must be one of: {', '.join(sorted(KNOWN_CONNECT_CLASSES))}",
+            connect_class,
+        )
+
+    return normalized
+
+
 def validate_endpoint(endpoint: str) -> str:
     """
     Validate endpoint hostname.
@@ -274,9 +315,9 @@ def validate_ttl(ttl: int) -> int:
     if not isinstance(ttl, int):
         raise ValidationError("ttl", "TTL must be an integer", str(ttl))
 
-    # Minimum 60 seconds, maximum 1 week
-    if ttl < 60:
-        raise ValidationError("ttl", "TTL must be at least 60 seconds", str(ttl))
+    # Minimum 30 seconds, maximum 1 week
+    if ttl < 30:
+        raise ValidationError("ttl", "TTL must be at least 30 seconds", str(ttl))
 
     if ttl > 604800:  # 7 days
         raise ValidationError("ttl", "TTL cannot exceed 604800 seconds (7 days)", str(ttl))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -59,9 +59,18 @@ class MockDNSBridge:
             "mtype": mtype,
         }
 
-    def set_endpoint_reachable(self, host: str, port: int = 443) -> None:
+    def set_endpoint_reachable(
+        self,
+        host: str,
+        port: int = 443,
+        *,
+        json_data: dict[str, Any] | None = None,
+    ) -> None:
         """Register an endpoint as reachable (returns HTTP 200)."""
-        self._endpoint_responses[f"{host}:{port}"] = {"status_code": 200}
+        self._endpoint_responses[f"{host}:{port}"] = {
+            "status_code": 200,
+            "json": json_data or {},
+        }
 
     def set_cap_document(self, uri: str, data: dict) -> None:
         """Register a capability document at the given URI."""
@@ -265,7 +274,7 @@ class MockDNSBridge:
                 resp_data = bridge._endpoint_responses[key]
                 resp = MagicMock()
                 resp.status_code = resp_data.get("status_code", 200)
-                resp.json.return_value = {}
+                resp.json.return_value = resp_data.get("json", {})
                 resp.content = b""
                 resp.raise_for_status = MagicMock()
                 return resp
@@ -303,6 +312,7 @@ class MockDNSBridge:
                 "dns_aid.core.a2a_card",
                 "dns_aid.core.validator",
                 "dns_aid.core.http_index",
+                "dns_aid.sdk.publishers.harness",
             ):
                 stack.enter_context(patch(f"{mod}.httpx.AsyncClient", return_value=http_mock))
             # SSRF bypass — validate_fetch_url is lazy-imported inside

--- a/tests/integration/test_provider_harness.py
+++ b/tests/integration/test_provider_harness.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from dns_aid.backends.mock import MockBackend
 from dns_aid.core.models import AgentRecord, Protocol
 from dns_aid.sdk.publishers.harness import DiscoveryValidationHarness
+from dns_aid.utils.url_safety import UnsafeURLError
 
 
 @pytest.mark.asyncio
@@ -80,3 +83,41 @@ async def test_lattice_harness_bootstraps_overlay_path(dns_bridge):
     assert results[0].direct_connect_attempted is False
     assert results[0].connect_class == "lattice"
     assert results[0].details["lattice_record"]["overlay_required"] is True
+    assert results[0].details["overlay_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_apphub_harness_rejects_unsafe_enroll_uri():
+    harness = DiscoveryValidationHarness()
+    agent = AgentRecord(
+        name="inventory-api",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="psc.inventory.internal",
+        connect_class="apphub-psc",
+        connect_meta="apphub.googleapis.com/projects/test/services/inventory-api",
+        enroll_uri="http://psc.inventory.internal/.well-known/agent-connect",
+    )
+
+    with pytest.raises(UnsafeURLError):
+        await harness._bootstrap_apphub("example.com", agent)
+
+
+@pytest.mark.asyncio
+async def test_lattice_harness_rejects_hostname_mismatch():
+    harness = DiscoveryValidationHarness()
+    agent = AgentRecord(
+        name="orders-api",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="orders.service.internal",
+        connect_class="lattice",
+        connect_meta="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+        enroll_uri="https://different.service.internal/.well-known/agent-connect",
+    )
+
+    with patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda value: value):
+        result = await harness._bootstrap_lattice("example.com", agent)
+
+    assert result.success is False
+    assert "host does not match" in (result.message or "")

--- a/tests/integration/test_provider_harness.py
+++ b/tests/integration/test_provider_harness.py
@@ -1,0 +1,82 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermetic end-to-end tests for provider discovery bootstrap flows."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.backends.mock import MockBackend
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk.publishers.harness import DiscoveryValidationHarness
+
+
+@pytest.mark.asyncio
+async def test_apphub_harness_bootstraps_from_published_records(dns_bridge):
+    backend = MockBackend(zones=["example.com"])
+    dns_bridge.backend = backend
+
+    agent = AgentRecord(
+        name="inventory-api",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="psc.inventory.internal",
+        connect_class="apphub-psc",
+        connect_meta=(
+            "apphub.googleapis.com/projects/test-project/locations/global/services/inventory-api"
+        ),
+        enroll_uri="https://psc.inventory.internal/.well-known/agent-connect",
+    )
+    await backend.publish_agent(agent)
+    dns_bridge.set_endpoint_reachable(
+        "psc.inventory.internal",
+        json_data={"enrollment": "ok", "service": "inventory-api"},
+    )
+
+    harness = DiscoveryValidationHarness(
+        apphub_connect_meta_validator=lambda value: value.endswith("/inventory-api")
+    )
+
+    with dns_bridge.patch_all():
+        results = await harness.bootstrap("example.com", protocol="mcp", name="inventory-api")
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert results[0].connect_class == "apphub-psc"
+    assert results[0].details["enrollment"]["service"] == "inventory-api"
+
+
+@pytest.mark.asyncio
+async def test_lattice_harness_bootstraps_overlay_path(dns_bridge):
+    backend = MockBackend(zones=["example.com"])
+    dns_bridge.backend = backend
+
+    agent = AgentRecord(
+        name="orders-api",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="orders.service.internal",
+        connect_class="lattice",
+        connect_meta="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+        enroll_uri="https://orders.service.internal/.well-known/agent-connect",
+    )
+    await backend.publish_agent(agent)
+    dns_bridge.set_endpoint_reachable(
+        "orders.service.internal",
+        json_data={"overlay": "required"},
+    )
+
+    async def lattice_lookup(arn: str):
+        return {"arn": arn, "overlay_required": True}
+
+    harness = DiscoveryValidationHarness(lattice_lookup=lattice_lookup)
+
+    with dns_bridge.patch_all():
+        results = await harness.bootstrap("example.com", protocol="mcp", name="orders-api")
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert results[0].direct_connect_attempted is False
+    assert results[0].connect_class == "lattice"
+    assert results[0].details["lattice_record"]["overlay_required"] is True

--- a/tests/unit/sdk/test_apphub_publisher.py
+++ b/tests/unit/sdk/test_apphub_publisher.py
@@ -1,0 +1,187 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AppHub publisher."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.backends.mock import MockBackend
+from dns_aid.sdk.publishers.apphub import AppHubPublisher
+from dns_aid.sdk.publishers.models import (
+    AppHubPublisherConfig,
+    AppHubServiceRef,
+    AppHubServiceSnapshot,
+)
+
+
+def _config() -> AppHubPublisherConfig:
+    return AppHubPublisherConfig(
+        project_id="test-project",
+        location="us-central1",
+        domain="example.com",
+        protocol="mcp",
+    )
+
+
+def _publisher(backend: MockBackend | None = None) -> AppHubPublisher:
+    return AppHubPublisher(
+        _config(),
+        backend=backend or MockBackend(zones=["example.com"]),
+        token_provider=lambda: ("token", None),
+    )
+
+
+def _apphub_snapshot(
+    *,
+    agent_name: str = "inventory-api",
+    capabilities: list[str] | None = None,
+    enrollment_base_url: str = "https://psc.inventory.internal",
+    functional_type: str = "AGENT",
+) -> AppHubServiceSnapshot:
+    return AppHubServiceSnapshot(
+        discovered_service_name=(
+            "projects/test-project/locations/us-central1/discoveredServices/inventory-api"
+        ),
+        agent_name=agent_name,
+        service_uri="https://psc.inventory.internal",
+        canonical_service_name=(
+            "apphub.googleapis.com/projects/test-project/locations/global/services/inventory-api"
+        ),
+        functional_type=functional_type,
+        capabilities=capabilities or [],
+        enrollment_base_url=enrollment_base_url,
+        metadata={},
+    )
+
+
+class TestAppHubPublisher:
+    """AppHub publisher behavior with mock DNS and API responses."""
+
+    @pytest.mark.asyncio
+    async def test_publish_resolves_service_and_populates_connect_fields(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend)
+
+        api_response = {
+            "name": "projects/test-project/locations/us-central1/discoveredServices/inventory-api",
+            "serviceReference": {"uri": "https://psc.inventory.internal"},
+            "serviceProperties": {
+                "functionalType": {"type": "AGENT"},
+                "extendedMetadata": {
+                    "apphub.googleapis.com/agentProperties": {
+                        "metadata": {
+                            "a2a": {"capabilities": ["search", "invoke"]},
+                            "serviceName": "Inventory API",
+                        }
+                    },
+                    "apphub.googleapis.com/agentConnect": {
+                        "metadata": {
+                            "serviceName": (
+                                "apphub.googleapis.com/projects/test-project/locations/global/"
+                                "services/inventory-api"
+                            ),
+                            "pscBaseUrl": "https://psc.inventory.internal",
+                        }
+                    },
+                },
+            },
+        }
+
+        with patch.object(publisher, "_request", AsyncMock(return_value=api_response)) as mock_request:
+            result = await publisher.publish(AppHubServiceRef(name="inventory-api"))
+
+        assert result.success is True
+        mock_request.assert_awaited_once_with(
+            "GET",
+            "/v1/projects/test-project/locations/us-central1/discoveredServices/inventory-api",
+        )
+
+        record_name = "_inventory-api._mcp._agents"
+        svcb = backend.get_svcb_record("example.com", record_name)
+        txt_values = backend.get_txt_record("example.com", record_name)
+
+        assert svcb is not None
+        assert svcb["target"] == "psc.inventory.internal."
+        assert svcb["params"]["key65406"] == "apphub-psc"
+        assert (
+            svcb["params"]["key65407"]
+            == "apphub.googleapis.com/projects/test-project/locations/global/services/inventory-api"
+        )
+        assert (
+            svcb["params"]["key65408"]
+            == "https://psc.inventory.internal/.well-known/agent-connect"
+        )
+        assert txt_values is not None
+        assert "capabilities=search,invoke" in txt_values
+
+    @pytest.mark.asyncio
+    async def test_publish_without_capabilities_metadata_keeps_record_valid(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend)
+
+        result = await publisher.publish(_apphub_snapshot(capabilities=[]))
+
+        assert result.success is True
+        txt_values = backend.get_txt_record("example.com", "_inventory-api._mcp._agents")
+        assert txt_values is not None
+        assert not any(value.startswith("capabilities=") for value in txt_values)
+        assert "version=1.0.0" in txt_values
+
+    @pytest.mark.asyncio
+    async def test_sync_updates_endpoint_on_next_cycle(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend)
+
+        first = _apphub_snapshot(
+            capabilities=["search"],
+            enrollment_base_url="https://psc-v1.inventory.internal",
+        )
+        second = _apphub_snapshot(
+            capabilities=["search"],
+            enrollment_base_url="https://psc-v2.inventory.internal",
+        )
+
+        with patch.object(
+            publisher,
+            "_list_discovered_services",
+            AsyncMock(side_effect=[[first], [second]]),
+        ):
+            first_result = await publisher.sync()
+            second_result = await publisher.sync()
+
+        assert first_result.published == 1
+        assert second_result.updated == 1
+
+        svcb = backend.get_svcb_record("example.com", "_inventory-api._mcp._agents")
+        assert svcb is not None
+        assert svcb["target"] == "psc-v2.inventory.internal."
+        assert (
+            svcb["params"]["key65408"]
+            == "https://psc-v2.inventory.internal/.well-known/agent-connect"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_removes_deleted_or_detached_services(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend)
+
+        active = _apphub_snapshot(capabilities=["search"])
+        detached = _apphub_snapshot(functional_type="APPLICATION")
+
+        with patch.object(
+            publisher,
+            "_list_discovered_services",
+            AsyncMock(side_effect=[[active], [detached], []]),
+        ):
+            published = await publisher.sync()
+            detached_result = await publisher.sync()
+            deleted_result = await publisher.sync()
+
+        assert published.published == 1
+        assert detached_result.unpublished == 1
+        assert deleted_result.unpublished == 0
+        assert backend.get_svcb_record("example.com", "_inventory-api._mcp._agents") is None

--- a/tests/unit/sdk/test_apphub_publisher.py
+++ b/tests/unit/sdk/test_apphub_publisher.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from dns_aid.backends.mock import MockBackend
@@ -185,3 +186,52 @@ class TestAppHubPublisher:
         assert detached_result.unpublished == 1
         assert deleted_result.unpublished == 0
         assert backend.get_svcb_record("example.com", "_inventory-api._mcp._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_publish_does_not_scan_unrelated_metadata_for_enrollment_url(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend)
+
+        api_response = {
+            "name": "projects/test-project/locations/us-central1/discoveredServices/inventory-api",
+            "serviceProperties": {
+                "functionalType": {"type": "AGENT"},
+                "extendedMetadata": {
+                    "unrelated": {
+                        "metadata": {
+                            "pscBaseUrl": "https://should-not-be-used.internal",
+                        }
+                    }
+                },
+            },
+        }
+
+        with patch.object(publisher, "_request", AsyncMock(return_value=api_response)):
+            result = await publisher.publish(AppHubServiceRef(name="inventory-api"))
+
+        assert result.success is False
+        assert "missing an addressable endpoint" in (result.message or "")
+        assert backend.get_svcb_record("example.com", "_inventory-api._mcp._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_request_retries_on_transient_http_errors(self):
+        publisher = _publisher()
+        request = httpx.Request("GET", "https://apphub.googleapis.com/v1/example")
+        retry_response = httpx.Response(status_code=503, request=request)
+        success_response = MagicMock()
+        success_response.raise_for_status.return_value = None
+        success_response.json.return_value = {"ok": True}
+
+        client = MagicMock()
+        client.request = AsyncMock(
+            side_effect=[
+                httpx.HTTPStatusError("retry", request=request, response=retry_response),
+                success_response,
+            ]
+        )
+
+        with patch.object(publisher, "_get_http_client", AsyncMock(return_value=client)):
+            result = await publisher._request("GET", "/v1/example")
+
+        assert result == {"ok": True}
+        assert client.request.await_count == 2

--- a/tests/unit/sdk/test_lattice_publisher.py
+++ b/tests/unit/sdk/test_lattice_publisher.py
@@ -20,19 +20,25 @@ from dns_aid.sdk.publishers.models import (
 )
 
 
-def _config() -> LatticePublisherConfig:
+def _config(*, name_overrides: dict[str, str] | None = None) -> LatticePublisherConfig:
     return LatticePublisherConfig(
         domain="example.com",
         protocol="mcp",
         stable_tag_key="stable",
         dynamic_ttl=30,
         stable_ttl=300,
+        name_overrides=name_overrides or {},
     )
 
 
-def _publisher(*, backend: MockBackend | None = None, client: MagicMock | None = None) -> LatticePublisher:
+def _publisher(
+    *,
+    backend: MockBackend | None = None,
+    client: MagicMock | None = None,
+    name_overrides: dict[str, str] | None = None,
+) -> LatticePublisher:
     return LatticePublisher(
-        _config(),
+        _config(name_overrides=name_overrides),
         backend=backend or MockBackend(zones=["example.com"]),
         client=client,
     )
@@ -174,6 +180,78 @@ class TestLatticePublisher:
         assert len(backend.records["example.com"]["_orders-api._mcp._agents"]["SVCB"]) == 1
 
     @pytest.mark.asyncio
+    async def test_list_services_uses_summary_without_get_service_when_dns_present(self):
+        client = MagicMock()
+        client.list_services.return_value = {"items": [_service_response()]}
+        client.list_tags_for_resource.return_value = {"tags": {}}
+        publisher = _publisher(client=client)
+
+        snapshots = await publisher._list_services()
+
+        assert len(snapshots) == 1
+        client.get_service.assert_not_called()
+        client.list_tags_for_resource.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_reports_name_collisions_without_override(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend=backend)
+
+        first = LatticeServiceSnapshot(
+            service_id="svc-123",
+            service_name="orders-api",
+            service_arn="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+            dns_name="orders-a.service.internal",
+            tags=(),
+            status="ACTIVE",
+        )
+        second = LatticeServiceSnapshot(
+            service_id="svc-456",
+            service_name="orders-api",
+            service_arn="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-456",
+            dns_name="orders-b.service.internal",
+            tags=(),
+            status="ACTIVE",
+        )
+
+        with patch.object(publisher, "_list_services", AsyncMock(return_value=[first, second])):
+            result = await publisher.sync()
+
+        assert result.published == 0
+        assert result.errors
+        assert "name collision" in result.errors[0]
+        assert backend.get_svcb_record("example.com", "_orders-api._mcp._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_name_override_allows_colliding_services_to_publish(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(
+            backend=backend,
+            name_overrides={
+                "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-456": "orders-api-west"
+            },
+        )
+
+        first = publisher._snapshot_from_api(_service_response("orders-a.service.internal"), {})
+        second = publisher._snapshot_from_api(
+            {
+                "id": "svc-456",
+                "name": "Orders API",
+                "arn": "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-456",
+                "dnsEntry": {"domainName": "orders-b.service.internal"},
+                "status": "ACTIVE",
+            },
+            {},
+        )
+
+        with patch.object(publisher, "_list_services", AsyncMock(return_value=[first, second])):
+            result = await publisher.sync()
+
+        assert result.published == 2
+        assert backend.get_svcb_record("example.com", "_orders-api._mcp._agents") is not None
+        assert backend.get_svcb_record("example.com", "_orders-api-west._mcp._agents") is not None
+
+    @pytest.mark.asyncio
     async def test_handle_eventbridge_event_routes_tag_updates_to_publish(self):
         publisher = _publisher()
 
@@ -214,3 +292,27 @@ class TestLatticePublisher:
 
         assert result.unpublished == 1
         mock_sync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_main_async_times_out_on_stdin_and_falls_back_to_startup_sync(self):
+        publisher = _publisher()
+
+        async def _timeout_read(coro, timeout):
+            coro.close()
+            raise TimeoutError
+
+        with (
+            patch("dns_aid.sdk.publishers.lattice.LatticePublisher.from_env", return_value=publisher),
+            patch("dns_aid.sdk.publishers.lattice.sys.stdin.isatty", return_value=False),
+            patch("dns_aid.sdk.publishers.lattice.asyncio.wait_for", side_effect=_timeout_read),
+            patch(
+                "dns_aid.sdk.publishers.lattice.run_startup_sync",
+                AsyncMock(return_value=SyncResult(unchanged=1)),
+            ) as mock_startup_sync,
+        ):
+            from dns_aid.sdk.publishers.lattice import main_async
+
+            result = await main_async()
+
+        assert result.unchanged == 1
+        mock_startup_sync.assert_awaited_once_with(publisher)

--- a/tests/unit/sdk/test_lattice_publisher.py
+++ b/tests/unit/sdk/test_lattice_publisher.py
@@ -1,0 +1,216 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the VPC Lattice publisher."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dns_aid.backends.mock import MockBackend
+from dns_aid.sdk.publishers.lattice import LatticePublisher
+from dns_aid.sdk.publishers.models import (
+    LatticePublisherConfig,
+    LatticeServiceRef,
+    LatticeServiceSnapshot,
+    SyncResult,
+)
+
+
+def _config() -> LatticePublisherConfig:
+    return LatticePublisherConfig(
+        domain="example.com",
+        protocol="mcp",
+        stable_tag_key="stable",
+        dynamic_ttl=30,
+        stable_ttl=300,
+    )
+
+
+def _publisher(*, backend: MockBackend | None = None, client: MagicMock | None = None) -> LatticePublisher:
+    return LatticePublisher(
+        _config(),
+        backend=backend or MockBackend(zones=["example.com"]),
+        client=client,
+    )
+
+
+def _service_response(dns_name: str = "orders.service.internal") -> dict[str, str | dict[str, str]]:
+    return {
+        "id": "svc-123",
+        "name": "Orders API",
+        "arn": "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+        "dnsEntry": {"domainName": dns_name},
+        "status": "ACTIVE",
+    }
+
+
+def _snapshot(dns_name: str = "orders.service.internal") -> LatticeServiceSnapshot:
+    return LatticeServiceSnapshot(
+        service_id="svc-123",
+        service_name="orders-api",
+        service_arn="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+        dns_name=dns_name,
+        tags={},
+        status="ACTIVE",
+    )
+
+
+class TestLatticePublisher:
+    """VPC Lattice publisher behavior with mock DNS and boto3 stubs."""
+
+    @pytest.mark.asyncio
+    async def test_publish_uses_stable_tag_ttl(self):
+        backend = MockBackend(zones=["example.com"])
+        client = MagicMock()
+        client.get_service.return_value = _service_response()
+        client.list_tags_for_resource.return_value = {"tags": {"stable": "true"}}
+        publisher = _publisher(backend=backend, client=client)
+
+        result = await publisher.publish(LatticeServiceRef(service_id="svc-123"))
+
+        assert result.success is True
+        client.get_service.assert_called_once_with(serviceIdentifier="svc-123")
+        svcb = backend.get_svcb_record("example.com", "_orders-api._mcp._agents")
+        assert svcb is not None
+        assert svcb["ttl"] == 300
+        assert svcb["params"]["key65406"] == "lattice"
+        assert (
+            svcb["params"]["key65407"]
+            == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_without_stable_tag_uses_dynamic_ttl(self):
+        backend = MockBackend(zones=["example.com"])
+        client = MagicMock()
+        client.get_service.return_value = _service_response()
+        client.list_tags_for_resource.return_value = {"tags": {}}
+        publisher = _publisher(backend=backend, client=client)
+
+        result = await publisher.publish(LatticeServiceRef(service_id="svc-123"))
+
+        assert result.success is True
+        svcb = backend.get_svcb_record("example.com", "_orders-api._mcp._agents")
+        assert svcb is not None
+        assert svcb["ttl"] == 30
+
+    @pytest.mark.asyncio
+    async def test_sync_replaces_changed_fqdn_atomically(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend=backend)
+
+        first = _snapshot("orders-v1.service.internal")
+        second = _snapshot("orders-v2.service.internal")
+
+        with patch.object(
+            publisher,
+            "_list_services",
+            AsyncMock(side_effect=[[first], [second]]),
+        ):
+            first_result = await publisher.sync()
+            second_result = await publisher.sync()
+
+        assert first_result.published == 1
+        assert second_result.updated == 1
+
+        svcb = backend.get_svcb_record("example.com", "_orders-api._mcp._agents")
+        assert svcb is not None
+        assert svcb["target"] == "orders-v2.service.internal."
+        assert len(backend.records["example.com"]["_orders-api._mcp._agents"]["SVCB"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_removes_deleted_services(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend=backend)
+
+        with patch.object(
+            publisher,
+            "_list_services",
+            AsyncMock(side_effect=[[_snapshot()], []]),
+        ):
+            published = await publisher.sync()
+            deleted = await publisher.sync()
+
+        assert published.published == 1
+        assert deleted.unpublished == 1
+        assert backend.get_svcb_record("example.com", "_orders-api._mcp._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_publish_is_idempotent(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend=backend)
+
+        snapshot = _snapshot()
+        results = await asyncio.gather(
+            publisher.publish(snapshot),
+            publisher.publish(snapshot),
+        )
+
+        assert all(result.success for result in results)
+        assert len(backend.records["example.com"]["_orders-api._mcp._agents"]["SVCB"]) == 1
+        assert len(backend.records["example.com"]["_orders-api._mcp._agents"]["TXT"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_republishes_after_zone_records_are_deleted(self):
+        backend = MockBackend(zones=["example.com"])
+        publisher = _publisher(backend=backend)
+        snapshot = _snapshot()
+
+        with patch.object(
+            publisher,
+            "_list_services",
+            AsyncMock(side_effect=[[snapshot], [snapshot]]),
+        ):
+            first_result = await publisher.sync()
+            backend.clear()
+            second_result = await publisher.sync()
+
+        assert first_result.published == 1
+        assert second_result.published == 1
+        assert len(backend.records["example.com"]["_orders-api._mcp._agents"]["SVCB"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_eventbridge_event_routes_tag_updates_to_publish(self):
+        publisher = _publisher()
+
+        with patch.object(
+            publisher,
+            "publish",
+            AsyncMock(return_value=MagicMock(success=True)),
+        ) as mock_publish:
+            await publisher.handle_eventbridge_event(
+                {
+                    "detail": {
+                        "eventName": "TagResource",
+                        "requestParameters": {
+                            "serviceArn": (
+                                "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+                            )
+                        },
+                    }
+                }
+            )
+
+        ref = mock_publish.await_args.args[0]
+        assert isinstance(ref, LatticeServiceRef)
+        assert ref.service_arn == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+
+    @pytest.mark.asyncio
+    async def test_handle_eventbridge_delete_falls_back_to_sync(self):
+        publisher = _publisher()
+
+        with patch.object(
+            publisher,
+            "sync",
+            AsyncMock(return_value=SyncResult(unpublished=1)),
+        ) as mock_sync:
+            result = await publisher.handle_eventbridge_event(
+                {"detail": {"eventName": "DeleteService"}}
+            )
+
+        assert result.unpublished == 1
+        mock_sync.assert_awaited_once()

--- a/tests/unit/test_backend_factory.py
+++ b/tests/unit/test_backend_factory.py
@@ -12,7 +12,6 @@ import pytest
 from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
 from dns_aid.backends.base import DNSBackend
 
-
 # ---------------------------------------------------------------------------
 # Basic contract
 # ---------------------------------------------------------------------------
@@ -25,8 +24,8 @@ class TestValidBackendNames:
         assert isinstance(VALID_BACKEND_NAMES, frozenset)
 
     def test_contains_all_backends(self):
-        expected = {"route53", "cloudflare", "infoblox", "nios", "ddns", "mock"}
-        assert VALID_BACKEND_NAMES == expected
+        expected = {"route53", "cloudflare", "cloud-dns", "infoblox", "nios", "ddns", "mock"}
+        assert expected == VALID_BACKEND_NAMES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_onboarding.py
+++ b/tests/unit/test_cli_onboarding.py
@@ -24,6 +24,7 @@ class TestBackendRegistry:
     def test_all_backends_present(self):
         assert set(ALL_BACKEND_NAMES) == {
             "route53",
+            "cloud-dns",
             "cloudflare",
             "infoblox",
             "nios",
@@ -188,7 +189,7 @@ class TestDoctorAPI:
         from dns_aid.doctor import run_checks
 
         report = run_checks()
-        for section, checks in report.sections.items():
+        for _section, checks in report.sections.items():
             for check in checks:
                 assert check.status in ("pass", "fail", "warn")
                 assert check.label

--- a/tests/unit/test_cloud_dns_backend.py
+++ b/tests/unit/test_cloud_dns_backend.py
@@ -1,0 +1,167 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dns_aid.backends.cloud_dns."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.backends.cloud_dns import CloudDNSBackend
+
+
+def _backend() -> CloudDNSBackend:
+    return CloudDNSBackend(
+        project_id="test-project",
+        managed_zone="agents-zone",
+        token_provider=lambda: ("test-token", None),
+    )
+
+
+class TestCloudDNSBackend:
+    """Unit coverage for Cloud DNS request shaping."""
+
+    def test_name_property(self):
+        backend = _backend()
+        assert backend.name == "cloud-dns"
+
+    @pytest.mark.asyncio
+    async def test_create_svcb_record_builds_change_payload(self):
+        backend = _backend()
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=None)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._mcp._agents",
+                priority=1,
+                target="service.example.internal",
+                params={"alpn": "mcp", "port": "443", "key65406": "lattice"},
+                ttl=30,
+            )
+
+        assert result == "_chat._mcp._agents.example.com"
+        assert mock_request.await_count == 1
+        call = mock_request.await_args
+        assert call.args == (
+            "POST",
+            "/projects/test-project/managedZones/agents-zone/changes",
+        )
+        payload = call.kwargs["json"]
+        assert payload["additions"] == [
+            {
+                "name": "_chat._mcp._agents.example.com.",
+                "type": "SVCB",
+                "ttl": 30,
+                "rrdatas": [
+                    '1 service.example.internal. alpn="mcp" port="443" key65406="lattice"'
+                ],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_txt_record_quotes_values(self):
+        backend = _backend()
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=None)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            await backend.create_txt_record(
+                zone="example.com",
+                name="_chat._mcp._agents",
+                values=["capabilities=chat,search", '"version=1.0.0"'],
+                ttl=300,
+            )
+
+        payload = mock_request.await_args.kwargs["json"]
+        assert payload["additions"] == [
+            {
+                "name": "_chat._mcp._agents.example.com.",
+                "type": "TXT",
+                "ttl": 300,
+                "rrdatas": ['"capabilities=chat,search"', '"version=1.0.0"'],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_records_filters_and_normalizes_rrsets(self):
+        backend = _backend()
+
+        responses = [
+            {
+                "rrsets": [
+                    {
+                        "name": "_chat._mcp._agents.example.com.",
+                        "type": "SVCB",
+                        "ttl": 30,
+                        "rrdatas": ['1 service.example.internal. alpn="mcp"'],
+                    },
+                    {
+                        "name": "_chat._mcp._agents.example.com.",
+                        "type": "TXT",
+                        "ttl": 30,
+                        "rrdatas": ['"version=1.0.0"'],
+                    },
+                ]
+            }
+        ]
+
+        with patch.object(backend, "_request", AsyncMock(side_effect=responses)):
+            records = [
+                record
+                async for record in backend.list_records(
+                    "example.com",
+                    name_pattern="_chat._mcp._agents",
+                    record_type="SVCB",
+                )
+            ]
+
+        assert records == [
+            {
+                "name": "_chat._mcp._agents",
+                "fqdn": "_chat._mcp._agents.example.com",
+                "type": "SVCB",
+                "ttl": 30,
+                "values": ['1 service.example.internal. alpn="mcp"'],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_record_returns_none_for_mismatched_rrset(self):
+        backend = _backend()
+
+        with patch.object(
+            backend,
+            "_request",
+            AsyncMock(
+                return_value={
+                    "rrsets": [
+                        {
+                            "name": "_other._mcp._agents.example.com.",
+                            "type": "TXT",
+                            "ttl": 30,
+                            "rrdatas": ['"version=1.0.0"'],
+                        }
+                    ]
+                }
+            ),
+        ):
+            record = await backend.get_record("example.com", "_chat._mcp._agents", "TXT")
+
+        assert record is None
+
+    @pytest.mark.asyncio
+    async def test_zone_exists_returns_false_on_lookup_failure(self):
+        backend = _backend()
+
+        with patch.object(
+            backend,
+            "_get_managed_zone_name",
+            AsyncMock(side_effect=ValueError("zone missing")),
+        ):
+            assert await backend.zone_exists("example.com") is False

--- a/tests/unit/test_cloud_dns_backend.py
+++ b/tests/unit/test_cloud_dns_backend.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from dns_aid.backends.cloud_dns import CloudDNSBackend
@@ -165,3 +167,49 @@ class TestCloudDNSBackend:
             AsyncMock(side_effect=ValueError("zone missing")),
         ):
             assert await backend.zone_exists("example.com") is False
+
+    @pytest.mark.asyncio
+    async def test_request_retries_on_transient_http_errors(self):
+        backend = _backend()
+        request = httpx.Request("GET", "https://dns.googleapis.com/dns/v1/example")
+        retry_response = httpx.Response(status_code=503, request=request)
+        success_response = MagicMock()
+        success_response.raise_for_status.return_value = None
+        success_response.content = b'{"ok": true}'
+        success_response.json.return_value = {"ok": True}
+
+        client = MagicMock()
+        client.request = AsyncMock(
+            side_effect=[
+                httpx.HTTPStatusError("retry", request=request, response=retry_response),
+                success_response,
+            ]
+        )
+
+        with patch.object(backend, "_get_client", AsyncMock(return_value=client)):
+            result = await backend._request("GET", "/example")
+
+        assert result == {"ok": True}
+        assert client.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_managed_zone_name_serializes_cache_population(self):
+        backend = CloudDNSBackend(
+            project_id="test-project",
+            managed_zone=None,
+            token_provider=lambda: ("test-token", "test-project"),
+        )
+
+        with patch.object(
+            backend,
+            "list_zones",
+            AsyncMock(return_value=[{"name": "agents-zone", "dns_name": "example.com"}]),
+        ) as mock_list_zones:
+            first, second = await asyncio.gather(
+                backend._get_managed_zone_name("example.com"),
+                backend._get_managed_zone_name("example.com"),
+            )
+
+        assert first == "agents-zone"
+        assert second == "agents-zone"
+        mock_list_zones.assert_awaited_once()

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -511,7 +511,9 @@ class TestParseSvcbCustomParams:
             '1 mcp.example.com. alpn="mcp" port="443" '
             'cap="https://mcp.example.com/.well-known/agent-cap.json" '
             'cap-sha256="dGVzdGhhc2g" '
-            'bap="mcp/1,a2a/1" policy="https://example.com/policy" realm="production"'
+            'bap="mcp/1,a2a/1" policy="https://example.com/policy" realm="production" '
+            'connect-class="lattice" connect-meta="arn:aws:vpc-lattice:::service/svc-123" '
+            'enroll-uri="https://service.example.com/.well-known/agent-connect"'
         )
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
@@ -519,6 +521,9 @@ class TestParseSvcbCustomParams:
         assert params["bap"] == "mcp/1,a2a/1"
         assert params["policy"] == "https://example.com/policy"
         assert params["realm"] == "production"
+        assert params["connect-class"] == "lattice"
+        assert params["connect-meta"] == "arn:aws:vpc-lattice:::service/svc-123"
+        assert params["enroll-uri"] == "https://service.example.com/.well-known/agent-connect"
 
     def test_ignores_non_dnsaid_params(self):
         svcb_text = '1 mcp.example.com. alpn="mcp" port="443" ipv4hint="192.0.2.1"'
@@ -559,6 +564,18 @@ class TestParseSvcbCustomParams:
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://example.com/cap.json"
         assert params["realm"] == "prod"
+
+    def test_preserves_quoted_values_with_spaces(self):
+        svcb_text = (
+            '1 mcp.example.com. connect-meta="apphub.googleapis.com/projects/test/services/My Service" '
+            'enroll-uri="https://example.com/.well-known/agent-connect?label=My Service"'
+        )
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["connect-meta"] == "apphub.googleapis.com/projects/test/services/My Service"
+        assert (
+            params["enroll-uri"]
+            == "https://example.com/.well-known/agent-connect?label=My Service"
+        )
 
 
 class TestDiscoveryWithCapUri:
@@ -740,6 +757,47 @@ class TestDiscoveryWithCapUri:
         assert agent.bap == ["mcp", "a2a"]
         assert agent.policy_uri == "https://example.com/policy"
         assert agent.realm == "staging"
+
+    @pytest.mark.asyncio
+    async def test_discovery_extracts_connect_fields(self):
+        """Test that provider-specific connection params round-trip through discovery."""
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("service.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: (
+            '1 service.example.com. alpn="mcp" port="443" '
+            'connect-class="apphub-psc" '
+            'connect-meta="projects/test/locations/us/discoveredServices/123" '
+            'enroll-uri="https://psc.example.com/.well-known/agent-connect"'
+        )
+
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=mock_answers)
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer._query_capabilities",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            from dns_aid.core.discoverer import _query_single_agent
+
+            agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.connect_class == "apphub-psc"
+        assert agent.connect_meta == "projects/test/locations/us/discoveredServices/123"
+        assert agent.enroll_uri == "https://psc.example.com/.well-known/agent-connect"
 
 
 # =============================================================================

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -1,0 +1,60 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dns_aid.utils.google_auth."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dns_aid.utils.google_auth import GoogleAccessTokenProvider
+
+
+class _FakeCredentials:
+    def __init__(self, *, token: str, expiry: datetime, valid: bool = True) -> None:
+        self.token = token
+        self.expiry = expiry
+        self.valid = valid
+        self.refresh_count = 0
+
+    def refresh(self, _request: object) -> None:
+        self.refresh_count += 1
+        self.token = "fresh-token"
+        self.valid = True
+        self.expiry = datetime.now(UTC) + timedelta(hours=1)
+
+
+class _FakeRequest:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_google_access_token_provider_refreshes_and_caches(monkeypatch):
+    credentials = _FakeCredentials(
+        token="stale-token",
+        expiry=datetime.now(UTC) + timedelta(minutes=1),
+        valid=True,
+    )
+    default_calls = 0
+
+    def fake_default(*, scopes: list[str]):
+        nonlocal default_calls
+        default_calls += 1
+        assert scopes == ["scope"]
+        return credentials, "test-project"
+
+    monkeypatch.setattr(
+        "dns_aid.utils.google_auth._load_google_auth_modules",
+        lambda: (fake_default, _FakeRequest),
+    )
+
+    provider = GoogleAccessTokenProvider(["scope"])
+    first, second = await asyncio.gather(provider.get_token(), provider.get_token())
+
+    assert first == ("fresh-token", "test-project")
+    assert second == ("fresh-token", "test-project")
+    assert default_calls == 1
+    assert credentials.refresh_count == 1

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -154,12 +154,13 @@ class TestInfobloxNIOSSvcParameters:
 
     def test_svc_parameters_conversion(self) -> None:
         params = {
-            "mandatory": "alpn,port,cap",
+            "mandatory": "alpn,port,cap,connect-class",
             "alpn": "h2,h3",
             "port": "443",
             "bap": "mcp/1,a2a/1",
             "cap": "https://example.com/.well-known/agent-cap.json",
             "sig": "abc123",
+            "connect-class": "lattice",
         }
 
         converted = InfobloxNIOSBackend._svc_parameters_from_params(params)
@@ -171,6 +172,8 @@ class TestInfobloxNIOSSvcParameters:
         assert as_map["port"]["svc_value"] == ["443"]
         assert as_map["key65400"]["mandatory"] is True
         assert as_map["key65405"]["svc_value"] == ["abc123"]
+        assert as_map["key65406"]["mandatory"] is True
+        assert as_map["key65406"]["svc_value"] == ["lattice"]
 
     def test_svc_parameters_preserves_numeric_keys(self) -> None:
         converted = InfobloxNIOSBackend._svc_parameters_from_params(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -6,7 +6,7 @@
 import pytest
 from pydantic import ValidationError
 
-from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol, VerifyResult
+from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol, SvcbRecord, VerifyResult
 
 
 class TestAgentRecord:
@@ -220,6 +220,46 @@ class TestAgentRecord:
         assert params["key65401"] == "dGVzdGhhc2g"
         assert "key65400" not in params
 
+    def test_svcb_params_with_connect_fields(self):
+        """Test provider-managed connection params are serialized as SVCB custom keys."""
+        agent = AgentRecord(
+            name="lattice-agent",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="service.internal",
+            connect_class="lattice",
+            connect_meta="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+            enroll_uri="https://service.internal/.well-known/agent-connect",
+        )
+
+        params = agent.to_svcb_params()
+
+        assert params["key65406"] == "lattice"
+        assert params["key65407"] == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert params["key65408"] == "https://service.internal/.well-known/agent-connect"
+
+    def test_ttl_allows_30_seconds(self):
+        """Dynamic publishers need a 30 second TTL floor."""
+        agent = AgentRecord(
+            name="fast-agent",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="fast.example.com",
+            ttl=30,
+        )
+        assert agent.ttl == 30
+
+    def test_connect_fields_have_length_bounds(self):
+        """Connection metadata is bounded to avoid oversized records."""
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="bounded-agent",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="mcp.example.com",
+                connect_meta="x" * 2049,
+            )
+
     def test_txt_values(self):
         """Test TXT record values generation."""
         agent = AgentRecord(
@@ -295,6 +335,46 @@ class TestProtocol:
         """Test creating protocol from string."""
         assert Protocol("a2a") == Protocol.A2A
         assert Protocol("mcp") == Protocol.MCP
+
+
+class TestSvcbRecord:
+    """Tests for the shared SvcbRecord helper."""
+
+    def test_to_params_with_connect_class_variants(self):
+        direct = SvcbRecord(target="direct.example.com", alpn="mcp", connect_class="direct")
+        lattice = SvcbRecord(target="lattice.example.com", alpn="mcp", connect_class="lattice")
+        apphub = SvcbRecord(target="psc.example.com", alpn="mcp", connect_class="apphub-psc")
+
+        assert direct.to_params()["key65406"] == "direct"
+        assert lattice.to_params()["key65406"] == "lattice"
+        assert apphub.to_params()["key65406"] == "apphub-psc"
+
+    def test_to_params_with_string_keys(self):
+        import os
+        from unittest.mock import patch
+
+        record = SvcbRecord(
+            target="psc.example.com",
+            alpn="mcp",
+            connect_class="apphub-psc",
+            connect_meta="projects/test/locations/us/discoveredServices/123",
+            enroll_uri="https://psc.example.com/.well-known/agent-connect",
+        )
+
+        with patch.dict(os.environ, {"DNS_AID_SVCB_STRING_KEYS": "1"}):
+            params = record.to_params()
+
+        assert params["connect-class"] == "apphub-psc"
+        assert params["connect-meta"] == "projects/test/locations/us/discoveredServices/123"
+        assert params["enroll-uri"] == "https://psc.example.com/.well-known/agent-connect"
+
+    def test_connect_class_uses_shared_normalization(self):
+        record = SvcbRecord(target="svc.example.com", alpn="mcp", connect_class=" LATTICE ")
+        assert record.connect_class == "lattice"
+
+    def test_normalized_target_adds_trailing_dot(self):
+        record = SvcbRecord(target="svc.example.com", alpn="mcp")
+        assert record.normalized_target == "svc.example.com."
 
 
 class TestDiscoveryResult:

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -198,6 +198,31 @@ class TestPublish:
         assert "key65402" not in svcb["params"]
         assert "key65403" not in svcb["params"]
 
+    @pytest.mark.asyncio
+    async def test_publish_with_connect_params(self, mock_backend: MockBackend):
+        """Test publishing with provider-managed connection metadata."""
+        result = await publish(
+            name="overlay",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="overlay.example.com",
+            connect_class="lattice",
+            connect_meta="arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123",
+            enroll_uri="https://overlay.example.com/.well-known/agent-connect",
+            backend=mock_backend,
+        )
+
+        assert result.success is True
+        assert result.agent.connect_class == "lattice"
+        assert result.agent.connect_meta == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert result.agent.enroll_uri == "https://overlay.example.com/.well-known/agent-connect"
+
+        svcb = mock_backend.get_svcb_record("example.com", "_overlay._mcp._agents")
+        assert svcb is not None
+        assert svcb["params"]["key65406"] == "lattice"
+        assert svcb["params"]["key65407"] == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert svcb["params"]["key65408"] == "https://overlay.example.com/.well-known/agent-connect"
+
 
 class TestUnpublish:
     """Tests for unpublish function."""

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -10,6 +10,7 @@ from dns_aid.utils.validation import (
     validate_agent_name,
     validate_backend,
     validate_capabilities,
+    validate_connect_class,
     validate_domain,
     validate_endpoint,
     validate_fqdn,
@@ -128,6 +129,32 @@ class TestValidateProtocol:
         assert exc.value.field == "protocol"
 
 
+class TestValidateConnectClass:
+    """Tests for validate_connect_class."""
+
+    def test_valid_known_class(self):
+        assert validate_connect_class("lattice") == "lattice"
+
+    def test_normalizes_whitespace_and_case(self):
+        assert validate_connect_class(" AppHub-PSC ") == "apphub-psc"
+
+    def test_none_returns_none(self):
+        assert validate_connect_class(None) is None
+
+    def test_empty_returns_none(self):
+        assert validate_connect_class("   ") is None
+
+    def test_rejects_invalid_characters(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_connect_class("bad class")
+        assert exc.value.field == "connect_class"
+
+    def test_rejects_unknown_class(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_connect_class("overlay")
+        assert exc.value.field == "connect_class"
+
+
 class TestValidateEndpoint:
     """Tests for validate_endpoint."""
 
@@ -181,15 +208,15 @@ class TestValidateTtl:
         assert validate_ttl(3600) == 3600
 
     def test_valid_min_ttl(self):
-        assert validate_ttl(60) == 60
+        assert validate_ttl(30) == 30
 
     def test_valid_max_ttl(self):
         assert validate_ttl(604800) == 604800
 
     def test_ttl_too_low_raises(self):
         with pytest.raises(ValidationError) as exc:
-            validate_ttl(59)
-        assert "at least 60" in exc.value.message
+            validate_ttl(29)
+        assert "at least 30" in exc.value.message
 
     def test_ttl_too_high_raises(self):
         with pytest.raises(ValidationError) as exc:
@@ -284,6 +311,9 @@ class TestValidateBackend:
 
     def test_valid_cloudflare(self):
         assert validate_backend("cloudflare") == "cloudflare"
+
+    def test_valid_cloud_dns(self):
+        assert validate_backend("cloud-dns") == "cloud-dns"
 
     def test_valid_infoblox(self):
         assert validate_backend("infoblox") == "infoblox"

--- a/uv.lock
+++ b/uv.lock
@@ -473,6 +473,9 @@ all = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
+apphub = [
+    { name = "google-auth" },
+]
 cli = [
     { name = "rich" },
     { name = "typer" },
@@ -502,6 +505,10 @@ otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
 ]
+publishers = [
+    { name = "boto3" },
+    { name = "google-auth" },
+]
 route53 = [
     { name = "boto3" },
 ]
@@ -509,6 +516,7 @@ route53 = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.34.0" },
+    { name = "boto3", marker = "extra == 'publishers'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'route53'", specifier = ">=1.34.0" },
     { name = "boto3-stubs", extras = ["route53"], marker = "extra == 'all'", specifier = ">=1.34.0" },
     { name = "boto3-stubs", extras = ["route53"], marker = "extra == 'dev'", specifier = ">=1.34.0" },
@@ -518,7 +526,9 @@ requires-dist = [
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "dnspython", specifier = ">=2.6.0" },
     { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.30.0" },
+    { name = "google-auth", marker = "extra == 'apphub'", specifier = ">=2.30.0" },
     { name = "google-auth", marker = "extra == 'cloud-dns'", specifier = ">=2.30.0" },
+    { name = "google-auth", marker = "extra == 'publishers'", specifier = ">=2.30.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.0.0" },
@@ -547,7 +557,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "cloud-dns", "apphub", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "publishers", "dev", "all"]
 
 [[package]]
 name = "dnspython"

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -460,6 +460,7 @@ all = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["route53"] },
     { name = "cryptography" },
+    { name = "google-auth" },
     { name = "mcp" },
     { name = "mypy" },
     { name = "opentelemetry-api" },
@@ -475,6 +476,9 @@ all = [
 cli = [
     { name = "rich" },
     { name = "typer" },
+]
+cloud-dns = [
+    { name = "google-auth" },
 ]
 dev = [
     { name = "boto3-stubs", extra = ["route53"] },
@@ -513,6 +517,8 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'jws'", specifier = ">=41.0.0" },
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "dnspython", specifier = ">=2.6.0" },
+    { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.30.0" },
+    { name = "google-auth", marker = "extra == 'cloud-dns'", specifier = ">=2.30.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.0.0" },
@@ -541,7 +547,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
 
 [[package]]
 name = "dnspython"
@@ -559,6 +565,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
 ]
 
 [[package]]
@@ -1098,6 +1117,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- split the provider runtime portion of the old `#47` stack into its own branch
- add the AppHub and VPC Lattice publisher implementations, runtime worker package, and discovery harness
- keep this track separate from the protocol/backend work in `#50`

## Important dependency note
This draft branch intentionally stacks on top of `#50`. Until `#50` lands, the diff against `main` includes the protocol/backend base it depends on. Review the runtime-specific files on top of that base.

## Included in this PR
- `src/dns_aid/sdk/publishers/*`
- `docs/provider-publishers.md`
- SDK exports for the publisher surface
- runtime extras in `pyproject.toml`
- hermetic publisher/harness tests

## Validation
- `PYTHONPATH=src uv run --with '.[dev,cli,mcp,route53,cloud-dns,apphub,publishers]' pytest tests/unit/sdk/test_apphub_publisher.py tests/unit/sdk/test_lattice_publisher.py tests/integration/test_provider_harness.py -q`
- `PYTHONPATH=src uv run --with '.[dev,cli,mcp,route53,cloud-dns,apphub,publishers]' mypy src/dns_aid/sdk/publishers src/dns_aid/sdk/__init__.py src/dns_aid/utils/google_auth.py`
- `PYTHONPATH=src uv run --with '.[dev,cli,mcp,route53,cloud-dns,apphub,publishers]' ruff check README.md docs/provider-publishers.md pyproject.toml src/dns_aid/sdk/__init__.py src/dns_aid/sdk/publishers src/dns_aid/utils/google_auth.py tests/integration/conftest.py tests/integration/test_provider_harness.py tests/unit/sdk/test_apphub_publisher.py tests/unit/sdk/test_lattice_publisher.py`

## Still pending on this branch
- the deeper hardening items called out in review: async-safe cloud auth, retry/backoff, sync serialization, collision handling, and the remaining harness security tightening