### PR TITLE
feat: SDK auth handlers for automatic agent authentication (Phase 5.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ otel = [
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
 ]
+pqc = [
+    # Post-quantum cryptography (ML-DSA-65 for HTTP Message Signatures)
+    "pqcrypto>=0.4.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -92,6 +96,7 @@ dev = [
     "httpx>=0.27.0",
     "cryptography>=41.0.0",
     "cyclonedx-bom>=4.0.0",
+    "pqcrypto>=0.4.0",
 ]
 all = [
     # CLI

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -341,6 +341,20 @@ class AgentRecord(BaseModel):
         "'directory' (from directory API search, Phase 5.7)",
     )
 
+    # Authentication metadata (populated from .well-known/agent.json or directory)
+    auth_type: str | None = Field(
+        default=None,
+        description="Authentication method required to invoke this agent "
+        "(e.g., 'none', 'api_key', 'bearer', 'oauth2', 'http_msg_sig'). "
+        "Sourced from AgentMetadata.auth.type during metadata enrichment.",
+    )
+    auth_config: dict | None = Field(
+        default=None,
+        description="Authentication configuration from the agent's metadata "
+        "(header_name, oauth_discovery, location, etc.). Sourced from "
+        "AgentMetadata.auth during metadata enrichment. Never contains secrets.",
+    )
+
     # A2A Agent Card (populated from .well-known/agent-card.json when available)
     agent_card: Any | None = Field(
         default=None,

--- a/src/dns_aid/sdk/auth/__init__.py
+++ b/src/dns_aid/sdk/auth/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SDK Auth Handlers — automatic authentication for agent invocations.
+
+Phase 5.6: Reads ``auth_type`` + ``auth_config`` from discovery metadata
+and applies credentials to outgoing requests before they reach protocol
+handlers.
+"""
+
+from __future__ import annotations
+
+from dns_aid.sdk.auth.base import AuthHandler
+from dns_aid.sdk.auth.registry import resolve_auth_handler
+
+__all__ = ["AuthHandler", "resolve_auth_handler"]

--- a/src/dns_aid/sdk/auth/base.py
+++ b/src/dns_aid/sdk/auth/base.py
@@ -1,0 +1,29 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AuthHandler abstract base class."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import httpx
+
+
+class AuthHandler(ABC):
+    """Apply authentication to an outgoing HTTP request.
+
+    Implementations modify the request in-place (adding headers, query
+    params, or signatures) before the protocol handler sends it.
+    """
+
+    @abstractmethod
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        """Mutate *request* with authentication credentials and return it."""
+        ...
+
+    @property
+    @abstractmethod
+    def auth_type(self) -> str:
+        """Return the canonical auth type identifier (e.g., 'bearer')."""
+        ...

--- a/src/dns_aid/sdk/auth/http_msg_sig.py
+++ b/src/dns_aid/sdk/auth/http_msg_sig.py
@@ -1,7 +1,10 @@
 # Copyright 2024-2026 The DNS-AID Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""HTTP Message Signatures auth handler (RFC 9421 / Web Bot Auth)."""
+"""HTTP Message Signatures auth handler (RFC 9421 / Web Bot Auth).
+
+Supports Ed25519 (default) and ML-DSA-65 (post-quantum, via ``pqcrypto``).
+"""
 
 from __future__ import annotations
 
@@ -17,9 +20,12 @@ import structlog
 
 from dns_aid.sdk.auth.base import AuthHandler
 
+# Supported signing algorithms
+SUPPORTED_ALGORITHMS = ("ed25519", "ml-dsa-65")
+
 
 class _Signer(TypingProtocol):
-    """Structural type for Ed25519 signing backends."""
+    """Structural type for signing backends (Ed25519, ML-DSA, etc.)."""
 
     def sign(self, data: bytes) -> bytes: ...
 
@@ -30,13 +36,16 @@ logger = structlog.get_logger(__name__)
 class HttpMsgSigAuthHandler(AuthHandler):
     """Sign outgoing requests per RFC 9421 (HTTP Message Signatures).
 
-    This handler produces ``Signature`` and ``Signature-Input`` headers
-    using the caller's Ed25519 private key.  The target agent can verify
-    the signature using the caller's JWKS at ``key_directory_url``.
+    Produces ``Signature`` and ``Signature-Input`` headers using the
+    caller's private key. Supports **Ed25519** (classical) and
+    **ML-DSA-65** (post-quantum, FIPS 204).
 
     Args:
-        private_key_pem: PEM-encoded Ed25519 private key.
+        private_key_pem: PEM-encoded private key (Ed25519) or raw secret
+            key bytes (ML-DSA-65, base64-encoded).
         key_id: Key identifier (``kid``) published in the caller's JWKS.
+        algorithm: Signing algorithm. One of ``"ed25519"`` (default) or
+            ``"ml-dsa-65"`` (post-quantum).
         covered_components: HTTP message components to sign.
             Defaults to ``("@method", "@target-uri", "content-digest")``.
     """
@@ -46,15 +55,22 @@ class HttpMsgSigAuthHandler(AuthHandler):
         private_key_pem: str,
         key_id: str,
         *,
+        algorithm: str = "ed25519",
         covered_components: tuple[str, ...] = (
             "@method",
             "@target-uri",
             "content-digest",
         ),
     ) -> None:
+        if algorithm not in SUPPORTED_ALGORITHMS:
+            raise ValueError(
+                f"Unsupported algorithm: {algorithm!r}. "
+                f"Supported: {', '.join(SUPPORTED_ALGORITHMS)}"
+            )
         self._key_id = key_id
+        self._algorithm = algorithm
         self._covered_components = covered_components
-        self._signing_key: _Signer = _load_ed25519_private_key(private_key_pem)
+        self._signing_key: _Signer = _load_private_key(private_key_pem, algorithm)
 
     @property
     def auth_type(self) -> str:
@@ -74,7 +90,7 @@ class HttpMsgSigAuthHandler(AuthHandler):
         # Build signature base string
         sig_base = _build_signature_base(request, self._covered_components)
 
-        # Sign with Ed25519
+        # Sign
         signature_bytes = self._signing_key.sign(sig_base.encode())
         sig_b64 = base64.b64encode(signature_bytes).decode()
 
@@ -82,7 +98,8 @@ class HttpMsgSigAuthHandler(AuthHandler):
         created = int(time.time())
         components_str = " ".join(f'"{c}"' for c in self._covered_components)
         sig_input = (
-            f'sig1=({components_str});created={created};keyid="{self._key_id}";alg="ed25519"'
+            f"sig1=({components_str});created={created}"
+            f';keyid="{self._key_id}";alg="{self._algorithm}"'
         )
 
         request.headers["signature-input"] = sig_input
@@ -91,7 +108,9 @@ class HttpMsgSigAuthHandler(AuthHandler):
         logger.debug(
             "http_msg_sig.signed",
             key_id=self._key_id,
+            algorithm=self._algorithm,
             components=self._covered_components,
+            signature_bytes=len(signature_bytes),
         )
         return request
 
@@ -118,17 +137,33 @@ def _build_signature_base(
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Key loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_private_key(key_material: str, algorithm: str) -> _Signer:
+    """Load a private key for the given algorithm.
+
+    Args:
+        key_material: PEM-encoded key (Ed25519) or base64-encoded raw
+            secret key (ML-DSA-65).
+        algorithm: ``"ed25519"`` or ``"ml-dsa-65"``.
+    """
+    if algorithm == "ml-dsa-65":
+        return _load_ml_dsa_private_key(key_material)
+    return _load_ed25519_private_key(key_material)
+
+
 def _load_ed25519_private_key(pem: str) -> _Signer:
     """Load an Ed25519 private key from PEM.
 
-    Returns an object with a ``.sign(data)`` method.
     Uses ``cryptography`` if available, falls back to ``nacl``.
     """
     try:
         from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
         key = load_pem_private_key(pem.encode(), password=None)
-        # Wrap to provide a simple .sign() interface
         return _CryptographyEd25519Signer(key)
     except ImportError:
         pass
@@ -139,17 +174,39 @@ def _load_ed25519_private_key(pem: str) -> _Signer:
         from nacl.encoding import RawEncoder
         from nacl.signing import SigningKey
 
-        # Extract raw 32-byte seed from PEM
         lines = [line for line in pem.strip().splitlines() if not line.startswith("-----")]
         raw = b64mod.b64decode("".join(lines))
-        # PKCS#8 Ed25519 private key: last 32 bytes are the seed
         seed = raw[-32:]
         return _NaClEd25519Signer(SigningKey(seed, encoder=RawEncoder))
     except ImportError:
         raise ImportError(
-            "HTTP Message Signatures require either 'cryptography' or 'PyNaCl'. "
+            "Ed25519 signing requires either 'cryptography' or 'PyNaCl'. "
             "Install with: pip install cryptography"
         ) from None
+
+
+def _load_ml_dsa_private_key(key_b64: str) -> _Signer:
+    """Load an ML-DSA-65 secret key from base64-encoded raw bytes.
+
+    Requires the ``pqcrypto`` package (FIPS 204 ML-DSA implementation).
+    """
+    try:
+        from pqcrypto.sign import ml_dsa_65
+    except ImportError:
+        raise ImportError(
+            "ML-DSA-65 signing requires 'pqcrypto'. Install with: pip install pqcrypto"
+        ) from None
+
+    sk = base64.b64decode(key_b64)
+    expected = ml_dsa_65.SECRET_KEY_SIZE
+    if len(sk) != expected:
+        raise ValueError(f"ML-DSA-65 secret key must be {expected} bytes, got {len(sk)}")
+    return _MlDsaSigner(sk)
+
+
+# ---------------------------------------------------------------------------
+# Signer adapters
+# ---------------------------------------------------------------------------
 
 
 class _CryptographyEd25519Signer:
@@ -163,12 +220,7 @@ class _CryptographyEd25519Signer:
 
 
 class _NaClEd25519Signer:
-    """Adapter: PyNaCl SigningKey → .sign(data) → 64-byte signature only.
-
-    PyNaCl's ``SigningKey.sign()`` returns signature+message (96+ bytes).
-    We strip the message suffix to return just the 64-byte Ed25519 signature,
-    matching the behavior of the ``cryptography`` adapter.
-    """
+    """Adapter: PyNaCl SigningKey → .sign(data) → 64-byte signature only."""
 
     def __init__(self, signing_key: Any) -> None:
         self._key = signing_key
@@ -176,3 +228,15 @@ class _NaClEd25519Signer:
     def sign(self, data: bytes) -> bytes:
         signed = self._key.sign(data)
         return signed.signature  # 64 bytes, no message suffix
+
+
+class _MlDsaSigner:
+    """Adapter: pqcrypto ML-DSA-65 → .sign(data) → 3309-byte signature."""
+
+    def __init__(self, secret_key: bytes) -> None:
+        self._sk = secret_key
+
+    def sign(self, data: bytes) -> bytes:
+        from pqcrypto.sign import ml_dsa_65
+
+        return ml_dsa_65.sign(self._sk, data)

--- a/src/dns_aid/sdk/auth/http_msg_sig.py
+++ b/src/dns_aid/sdk/auth/http_msg_sig.py
@@ -9,11 +9,20 @@ import base64
 import hashlib
 import time
 from email.utils import formatdate
+from typing import Any
+from typing import Protocol as TypingProtocol
 
 import httpx
 import structlog
 
 from dns_aid.sdk.auth.base import AuthHandler
+
+
+class _Signer(TypingProtocol):
+    """Structural type for Ed25519 signing backends."""
+
+    def sign(self, data: bytes) -> bytes: ...
+
 
 logger = structlog.get_logger(__name__)
 
@@ -45,7 +54,7 @@ class HttpMsgSigAuthHandler(AuthHandler):
     ) -> None:
         self._key_id = key_id
         self._covered_components = covered_components
-        self._signing_key = _load_ed25519_private_key(private_key_pem)
+        self._signing_key: _Signer = _load_ed25519_private_key(private_key_pem)
 
     @property
     def auth_type(self) -> str:
@@ -72,7 +81,9 @@ class HttpMsgSigAuthHandler(AuthHandler):
         # Build Signature-Input and Signature headers
         created = int(time.time())
         components_str = " ".join(f'"{c}"' for c in self._covered_components)
-        sig_input = f"sig1=({components_str});created={created};keyid=\"{self._key_id}\";alg=\"ed25519\""
+        sig_input = (
+            f'sig1=({components_str});created={created};keyid="{self._key_id}";alg="ed25519"'
+        )
 
         request.headers["signature-input"] = sig_input
         request.headers["signature"] = f"sig1=:{sig_b64}:"
@@ -107,7 +118,7 @@ def _build_signature_base(
     return "\n".join(lines)
 
 
-def _load_ed25519_private_key(pem: str) -> object:
+def _load_ed25519_private_key(pem: str) -> _Signer:
     """Load an Ed25519 private key from PEM.
 
     Returns an object with a ``.sign(data)`` method.
@@ -144,11 +155,11 @@ def _load_ed25519_private_key(pem: str) -> object:
 class _CryptographyEd25519Signer:
     """Adapter: cryptography Ed25519PrivateKey → .sign(data) → 64-byte signature."""
 
-    def __init__(self, private_key: object) -> None:
+    def __init__(self, private_key: Any) -> None:
         self._key = private_key
 
     def sign(self, data: bytes) -> bytes:
-        return self._key.sign(data)  # type: ignore[union-attr]
+        return self._key.sign(data)
 
 
 class _NaClEd25519Signer:
@@ -159,9 +170,9 @@ class _NaClEd25519Signer:
     matching the behavior of the ``cryptography`` adapter.
     """
 
-    def __init__(self, signing_key: object) -> None:
+    def __init__(self, signing_key: Any) -> None:
         self._key = signing_key
 
     def sign(self, data: bytes) -> bytes:
-        signed = self._key.sign(data)  # type: ignore[union-attr]
+        signed = self._key.sign(data)
         return signed.signature  # 64 bytes, no message suffix

--- a/src/dns_aid/sdk/auth/http_msg_sig.py
+++ b/src/dns_aid/sdk/auth/http_msg_sig.py
@@ -1,0 +1,167 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP Message Signatures auth handler (RFC 9421 / Web Bot Auth)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from email.utils import formatdate
+
+import httpx
+import structlog
+
+from dns_aid.sdk.auth.base import AuthHandler
+
+logger = structlog.get_logger(__name__)
+
+
+class HttpMsgSigAuthHandler(AuthHandler):
+    """Sign outgoing requests per RFC 9421 (HTTP Message Signatures).
+
+    This handler produces ``Signature`` and ``Signature-Input`` headers
+    using the caller's Ed25519 private key.  The target agent can verify
+    the signature using the caller's JWKS at ``key_directory_url``.
+
+    Args:
+        private_key_pem: PEM-encoded Ed25519 private key.
+        key_id: Key identifier (``kid``) published in the caller's JWKS.
+        covered_components: HTTP message components to sign.
+            Defaults to ``("@method", "@target-uri", "content-digest")``.
+    """
+
+    def __init__(
+        self,
+        private_key_pem: str,
+        key_id: str,
+        *,
+        covered_components: tuple[str, ...] = (
+            "@method",
+            "@target-uri",
+            "content-digest",
+        ),
+    ) -> None:
+        self._key_id = key_id
+        self._covered_components = covered_components
+        self._signing_key = _load_ed25519_private_key(private_key_pem)
+
+    @property
+    def auth_type(self) -> str:
+        return "http_msg_sig"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        # Ensure Date header is present (required by many signature profiles)
+        if "date" not in request.headers:
+            request.headers["date"] = formatdate(usegmt=True)
+
+        # Add Content-Digest for requests with a body (RFC 9530)
+        if request.content and "content-digest" not in request.headers:
+            digest = hashlib.sha256(request.content).digest()
+            b64 = base64.b64encode(digest).decode()
+            request.headers["content-digest"] = f"sha-256=:{b64}:"
+
+        # Build signature base string
+        sig_base = _build_signature_base(request, self._covered_components)
+
+        # Sign with Ed25519
+        signature_bytes = self._signing_key.sign(sig_base.encode())
+        sig_b64 = base64.b64encode(signature_bytes).decode()
+
+        # Build Signature-Input and Signature headers
+        created = int(time.time())
+        components_str = " ".join(f'"{c}"' for c in self._covered_components)
+        sig_input = f"sig1=({components_str});created={created};keyid=\"{self._key_id}\";alg=\"ed25519\""
+
+        request.headers["signature-input"] = sig_input
+        request.headers["signature"] = f"sig1=:{sig_b64}:"
+
+        logger.debug(
+            "http_msg_sig.signed",
+            key_id=self._key_id,
+            components=self._covered_components,
+        )
+        return request
+
+
+def _build_signature_base(
+    request: httpx.Request,
+    components: tuple[str, ...],
+) -> str:
+    """Build the signature base string per RFC 9421 §2.5."""
+    lines: list[str] = []
+    for component in components:
+        if component == "@method":
+            lines.append(f'"@method": {request.method}')
+        elif component == "@target-uri":
+            lines.append(f'"@target-uri": {request.url}')
+        elif component == "@authority":
+            lines.append(f'"@authority": {request.url.host}')
+        elif component == "@path":
+            lines.append(f'"@path": {request.url.raw_path.decode()}')
+        else:
+            # Regular header
+            value = request.headers.get(component, "")
+            lines.append(f'"{component}": {value}')
+    return "\n".join(lines)
+
+
+def _load_ed25519_private_key(pem: str) -> object:
+    """Load an Ed25519 private key from PEM.
+
+    Returns an object with a ``.sign(data)`` method.
+    Uses ``cryptography`` if available, falls back to ``nacl``.
+    """
+    try:
+        from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+        key = load_pem_private_key(pem.encode(), password=None)
+        # Wrap to provide a simple .sign() interface
+        return _CryptographyEd25519Signer(key)
+    except ImportError:
+        pass
+
+    try:
+        import base64 as b64mod
+
+        from nacl.encoding import RawEncoder
+        from nacl.signing import SigningKey
+
+        # Extract raw 32-byte seed from PEM
+        lines = [line for line in pem.strip().splitlines() if not line.startswith("-----")]
+        raw = b64mod.b64decode("".join(lines))
+        # PKCS#8 Ed25519 private key: last 32 bytes are the seed
+        seed = raw[-32:]
+        return _NaClEd25519Signer(SigningKey(seed, encoder=RawEncoder))
+    except ImportError:
+        raise ImportError(
+            "HTTP Message Signatures require either 'cryptography' or 'PyNaCl'. "
+            "Install with: pip install cryptography"
+        ) from None
+
+
+class _CryptographyEd25519Signer:
+    """Adapter: cryptography Ed25519PrivateKey → .sign(data) → 64-byte signature."""
+
+    def __init__(self, private_key: object) -> None:
+        self._key = private_key
+
+    def sign(self, data: bytes) -> bytes:
+        return self._key.sign(data)  # type: ignore[union-attr]
+
+
+class _NaClEd25519Signer:
+    """Adapter: PyNaCl SigningKey → .sign(data) → 64-byte signature only.
+
+    PyNaCl's ``SigningKey.sign()`` returns signature+message (96+ bytes).
+    We strip the message suffix to return just the 64-byte Ed25519 signature,
+    matching the behavior of the ``cryptography`` adapter.
+    """
+
+    def __init__(self, signing_key: object) -> None:
+        self._key = signing_key
+
+    def sign(self, data: bytes) -> bytes:
+        signed = self._key.sign(data)  # type: ignore[union-attr]
+        return signed.signature  # 64 bytes, no message suffix

--- a/src/dns_aid/sdk/auth/oauth2.py
+++ b/src/dns_aid/sdk/auth/oauth2.py
@@ -1,0 +1,149 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""OAuth 2.0 client-credentials auth handler with token caching."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import structlog
+
+from dns_aid.sdk.auth.base import AuthHandler
+
+logger = structlog.get_logger(__name__)
+
+# Buffer before actual expiry to avoid using nearly-expired tokens.
+_EXPIRY_BUFFER_SECONDS = 30
+
+
+class OAuth2AuthHandler(AuthHandler):
+    """OAuth 2.0 client-credentials flow with in-memory token caching.
+
+    Thread-safe: concurrent ``apply()`` calls will not stampede the
+    token endpoint — an asyncio lock serialises refresh attempts.
+
+    Args:
+        client_id: OAuth client ID.
+        client_secret: OAuth client secret.
+        token_url: Token endpoint URL.  When *None*, the handler
+            attempts OpenID Connect discovery via *discovery_url*.
+        discovery_url: ``/.well-known/openid-configuration`` URL.
+            Used to resolve *token_url* when not provided explicitly.
+        scopes: Space-separated scopes to request (optional).
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        *,
+        token_url: str | None = None,
+        discovery_url: str | None = None,
+        scopes: str | None = None,
+    ) -> None:
+        if not token_url and not discovery_url:
+            raise ValueError("Either token_url or discovery_url must be provided")
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._token_url = token_url
+        self._discovery_url = discovery_url
+        self._scopes = scopes
+
+        # Cached token state
+        self._access_token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    @property
+    def auth_type(self) -> str:
+        return "oauth2"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        token = await self._get_token()
+        request.headers["Authorization"] = f"Bearer {token}"
+        return request
+
+    async def _get_token(self) -> str:
+        """Return a cached token or fetch a new one (lock-protected)."""
+        # Fast path: token is valid
+        if self._access_token and time.monotonic() < self._expires_at:
+            return self._access_token
+
+        async with self._lock:
+            # Double-check after acquiring lock (another coroutine may have refreshed)
+            if self._access_token and time.monotonic() < self._expires_at:
+                return self._access_token
+
+            # Resolve token URL from discovery if needed
+            token_url = self._token_url or await self._discover_token_url()
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                data: dict[str, str] = {
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                }
+                if self._scopes:
+                    data["scope"] = self._scopes
+
+                resp = await client.post(token_url, data=data)
+                if resp.status_code >= 400:
+                    body_preview = resp.text[:200] if resp.text else "(empty)"
+                    logger.warning(
+                        "oauth2.token_request_failed",
+                        token_url=token_url,
+                        status_code=resp.status_code,
+                        body=body_preview,
+                    )
+                    raise OAuth2TokenError(
+                        f"Token request failed: HTTP {resp.status_code}: {body_preview}"
+                    )
+                body = resp.json()
+
+            access_token = body.get("access_token")
+            if not access_token:
+                raise OAuth2TokenError(
+                    "Token response missing 'access_token' field"
+                )
+
+            self._access_token = access_token
+            expires_in = int(body.get("expires_in", 3600))
+            self._expires_at = time.monotonic() + expires_in - _EXPIRY_BUFFER_SECONDS
+
+            logger.debug(
+                "oauth2.token_fetched",
+                token_url=token_url,
+                expires_in=expires_in,
+            )
+            return self._access_token
+
+    async def _discover_token_url(self) -> str:
+        """Fetch token endpoint from OpenID Connect discovery."""
+        if not self._discovery_url:
+            raise ValueError("No token_url or discovery_url configured")
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(self._discovery_url)
+            if resp.status_code >= 400:
+                raise OAuth2TokenError(
+                    f"OIDC discovery failed: HTTP {resp.status_code}"
+                )
+            config = resp.json()
+
+        token_endpoint = config.get("token_endpoint")
+        if not token_endpoint:
+            raise ValueError(
+                f"No token_endpoint found in OIDC discovery at {self._discovery_url}"
+            )
+
+        # Cache the resolved URL for future calls
+        self._token_url = token_endpoint
+        logger.debug("oauth2.discovery_resolved", token_url=token_endpoint)
+        return token_endpoint
+
+
+class OAuth2TokenError(Exception):
+    """Raised when OAuth2 token acquisition fails."""

--- a/src/dns_aid/sdk/auth/oauth2.py
+++ b/src/dns_aid/sdk/auth/oauth2.py
@@ -105,9 +105,7 @@ class OAuth2AuthHandler(AuthHandler):
 
             access_token = body.get("access_token")
             if not access_token:
-                raise OAuth2TokenError(
-                    "Token response missing 'access_token' field"
-                )
+                raise OAuth2TokenError("Token response missing 'access_token' field")
 
             self._access_token = access_token
             expires_in = int(body.get("expires_in", 3600))
@@ -128,16 +126,12 @@ class OAuth2AuthHandler(AuthHandler):
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(self._discovery_url)
             if resp.status_code >= 400:
-                raise OAuth2TokenError(
-                    f"OIDC discovery failed: HTTP {resp.status_code}"
-                )
+                raise OAuth2TokenError(f"OIDC discovery failed: HTTP {resp.status_code}")
             config = resp.json()
 
         token_endpoint = config.get("token_endpoint")
         if not token_endpoint:
-            raise ValueError(
-                f"No token_endpoint found in OIDC discovery at {self._discovery_url}"
-            )
+            raise ValueError(f"No token_endpoint found in OIDC discovery at {self._discovery_url}")
 
         # Cache the resolved URL for future calls
         self._token_url = token_endpoint

--- a/src/dns_aid/sdk/auth/registry.py
+++ b/src/dns_aid/sdk/auth/registry.py
@@ -1,0 +1,130 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auth handler registry and factory function."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import structlog
+
+from dns_aid.sdk.auth.base import AuthHandler
+from dns_aid.sdk.auth.simple import ApiKeyAuthHandler, BearerAuthHandler, NoopAuthHandler
+
+logger = structlog.get_logger(__name__)
+
+
+def resolve_auth_handler(
+    auth_type: str,
+    auth_config: dict | None = None,
+    credentials: dict | None = None,
+) -> AuthHandler:
+    """Resolve an AuthHandler from discovery metadata and caller credentials.
+
+    Args:
+        auth_type: The ``auth_type`` from discovery (e.g., ``"bearer"``,
+            ``"oauth2"``).  Also accepts ZTAIP canonical forms
+            (``"bearer_token"``, ``"oauth2_client_credentials"``).
+        auth_config: Authentication configuration from the agent's
+            ``.well-known/agent.json`` ``AuthSpec`` (header_name,
+            oauth_discovery, etc.).
+        credentials: Caller-supplied secrets (tokens, client_id/secret,
+            private keys).  Never stored in discovery metadata.
+
+    Returns:
+        An AuthHandler ready to ``apply()`` to outgoing requests.
+
+    Raises:
+        ValueError: If *auth_type* is unknown or required credentials
+            are missing.
+    """
+    auth_config = auth_config or {}
+    credentials = credentials or {}
+
+    # Normalize ZTAIP canonical names
+    normalized = _ZTAIP_ALIASES.get(auth_type, auth_type)
+
+    factory = _REGISTRY.get(normalized)
+    if factory is None:
+        raise ValueError(
+            f"Unknown auth_type: {auth_type!r}. "
+            f"Supported: {', '.join(sorted(_REGISTRY.keys()))}"
+        )
+
+    return factory(auth_config, credentials)
+
+
+def _build_noop(config: dict, credentials: dict) -> AuthHandler:
+    return NoopAuthHandler()
+
+
+def _build_api_key(config: dict, credentials: dict) -> AuthHandler:
+    api_key = credentials.get("api_key")
+    if not api_key:
+        raise ValueError("ApiKeyAuthHandler requires 'api_key' in credentials")
+    return ApiKeyAuthHandler(
+        api_key=api_key,
+        header_name=config.get("header_name", "X-API-Key"),
+        location=config.get("location", "header"),
+        query_param=config.get("query_param", "api_key"),
+    )
+
+
+def _build_bearer(config: dict, credentials: dict) -> AuthHandler:
+    token = credentials.get("token")
+    if not token:
+        raise ValueError("BearerAuthHandler requires 'token' in credentials")
+    return BearerAuthHandler(
+        token=token,
+        header_name=config.get("header_name", "Authorization"),
+    )
+
+
+def _build_oauth2(config: dict, credentials: dict) -> AuthHandler:
+    from dns_aid.sdk.auth.oauth2 import OAuth2AuthHandler
+
+    client_id = credentials.get("client_id")
+    client_secret = credentials.get("client_secret")
+    if not client_id or not client_secret:
+        raise ValueError(
+            "OAuth2AuthHandler requires 'client_id' and 'client_secret' in credentials"
+        )
+    return OAuth2AuthHandler(
+        client_id=client_id,
+        client_secret=client_secret,
+        token_url=config.get("token_url") or credentials.get("token_url"),
+        discovery_url=config.get("oauth_discovery"),
+        scopes=config.get("scopes") or credentials.get("scopes"),
+    )
+
+
+def _build_http_msg_sig(config: dict, credentials: dict) -> AuthHandler:
+    from dns_aid.sdk.auth.http_msg_sig import HttpMsgSigAuthHandler
+
+    private_key_pem = credentials.get("private_key_pem")
+    key_id = credentials.get("key_id")
+    if not private_key_pem or not key_id:
+        raise ValueError(
+            "HttpMsgSigAuthHandler requires 'private_key_pem' and 'key_id' in credentials"
+        )
+    return HttpMsgSigAuthHandler(
+        private_key_pem=private_key_pem,
+        key_id=key_id,
+    )
+
+
+# Auth type → factory function
+_REGISTRY: dict[str, Callable[[dict, dict], AuthHandler]] = {
+    "none": _build_noop,
+    "api_key": _build_api_key,
+    "bearer": _build_bearer,
+    "oauth2": _build_oauth2,
+    "http_msg_sig": _build_http_msg_sig,
+}
+
+# ZTAIP canonical names → our enum values
+_ZTAIP_ALIASES: dict[str, str] = {
+    "bearer_token": "bearer",
+    "oauth2_client_credentials": "oauth2",
+}

--- a/src/dns_aid/sdk/auth/registry.py
+++ b/src/dns_aid/sdk/auth/registry.py
@@ -125,6 +125,6 @@ _REGISTRY: dict[str, Callable[[dict, dict], AuthHandler]] = {
 
 # ZTAIP canonical names → our enum values
 _ZTAIP_ALIASES: dict[str, str] = {
-    "bearer_token": "bearer",
+    "bearer_token": "bearer",  # nosec B105 — protocol identifier, not a password
     "oauth2_client_credentials": "oauth2",
 }

--- a/src/dns_aid/sdk/auth/registry.py
+++ b/src/dns_aid/sdk/auth/registry.py
@@ -48,8 +48,7 @@ def resolve_auth_handler(
     factory = _REGISTRY.get(normalized)
     if factory is None:
         raise ValueError(
-            f"Unknown auth_type: {auth_type!r}. "
-            f"Supported: {', '.join(sorted(_REGISTRY.keys()))}"
+            f"Unknown auth_type: {auth_type!r}. Supported: {', '.join(sorted(_REGISTRY.keys()))}"
         )
 
     return factory(auth_config, credentials)

--- a/src/dns_aid/sdk/auth/simple.py
+++ b/src/dns_aid/sdk/auth/simple.py
@@ -1,0 +1,85 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Simple auth handlers: Noop, API key, Bearer token."""
+
+from __future__ import annotations
+
+import httpx
+
+from dns_aid.sdk.auth.base import AuthHandler
+
+
+class NoopAuthHandler(AuthHandler):
+    """Pass-through — no authentication applied."""
+
+    @property
+    def auth_type(self) -> str:
+        return "none"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        return request
+
+
+class ApiKeyAuthHandler(AuthHandler):
+    """Inject an API key into a header or query parameter.
+
+    Args:
+        api_key: The API key value.
+        header_name: Header to inject into (default ``X-API-Key``).
+        location: ``"header"`` (default) or ``"query"``.
+        query_param: Query parameter name when *location* is ``"query"``
+            (default ``api_key``).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        header_name: str = "X-API-Key",
+        location: str = "header",
+        query_param: str = "api_key",
+    ) -> None:
+        self._api_key = api_key
+        self._header_name = header_name
+        self._location = location
+        self._query_param = query_param
+
+    @property
+    def auth_type(self) -> str:
+        return "api_key"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        if self._location == "query":
+            # Append API key as query parameter
+            url = request.url.copy_merge_params({self._query_param: self._api_key})
+            request.url = url
+        else:
+            request.headers[self._header_name] = self._api_key
+        return request
+
+
+class BearerAuthHandler(AuthHandler):
+    """Set ``Authorization: Bearer <token>`` header.
+
+    Args:
+        token: The bearer token value.
+        header_name: Header name (default ``Authorization``).
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        header_name: str = "Authorization",
+    ) -> None:
+        self._token = token
+        self._header_name = header_name
+
+    @property
+    def auth_type(self) -> str:
+        return "bearer"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        request.headers[self._header_name] = f"Bearer {self._token}"
+        return request

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -18,6 +18,8 @@ import structlog
 
 from dns_aid.core.models import AgentRecord
 from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.auth import resolve_auth_handler
+from dns_aid.sdk.auth.base import AuthHandler
 from dns_aid.sdk.models import InvocationResult, InvocationSignal
 from dns_aid.sdk.protocols.a2a import A2AProtocolHandler
 from dns_aid.sdk.protocols.base import ProtocolHandler
@@ -86,6 +88,34 @@ class AgentClient:
             self._handlers[protocol] = handler_cls()
         return self._handlers[protocol]
 
+    def _resolve_auth(
+        self,
+        agent: AgentRecord,
+        credentials: dict | None,
+    ) -> AuthHandler | None:
+        """Resolve an auth handler from agent metadata and credentials.
+
+        Returns *None* when the agent requires no auth or credentials
+        are not supplied.
+        """
+        auth_type = getattr(agent, "auth_type", None)
+        if not auth_type or auth_type == "none":
+            return None
+        if not credentials:
+            logger.debug(
+                "sdk.auth_skipped",
+                agent_fqdn=agent.fqdn,
+                auth_type=auth_type,
+                reason="no credentials provided",
+            )
+            return None
+        auth_config = getattr(agent, "auth_config", None) or {}
+        return resolve_auth_handler(
+            auth_type=str(auth_type),
+            auth_config=auth_config if isinstance(auth_config, dict) else {},
+            credentials=credentials,
+        )
+
     async def invoke(
         self,
         agent: AgentRecord,
@@ -93,6 +123,8 @@ class AgentClient:
         method: str | None = None,
         arguments: dict | None = None,
         timeout: float | None = None,
+        credentials: dict | None = None,
+        auth_handler: AuthHandler | None = None,
     ) -> InvocationResult:
         """
         Invoke an agent and capture a telemetry signal.
@@ -102,6 +134,10 @@ class AgentClient:
             method: Protocol-specific method (e.g., "tools/call" for MCP).
             arguments: Method arguments / payload.
             timeout: Override timeout for this call (seconds).
+            credentials: Caller-supplied secrets (tokens, client_id/secret)
+                for automatic auth resolution from agent metadata.
+            auth_handler: Explicit auth handler override. When provided,
+                *credentials* and agent metadata are ignored.
 
         Returns:
             InvocationResult with the response data and attached signal.
@@ -116,12 +152,16 @@ class AgentClient:
         handler = self._get_handler(protocol)
         effective_timeout = timeout or self._config.timeout_seconds
 
+        # Resolve auth handler from agent metadata or explicit override
+        resolved_auth = auth_handler or self._resolve_auth(agent, credentials)
+
         logger.debug(
             "sdk.invoke",
             agent_fqdn=agent.fqdn,
             endpoint=agent.endpoint_url,
             protocol=protocol,
             method=method,
+            auth_type=resolved_auth.auth_type if resolved_auth else None,
         )
 
         raw = await handler.invoke(
@@ -130,6 +170,7 @@ class AgentClient:
             method=method,
             arguments=arguments,
             timeout=effective_timeout,
+            auth_handler=resolved_auth,
         )
 
         signal = self._collector.record(

--- a/src/dns_aid/sdk/protocols/a2a.py
+++ b/src/dns_aid/sdk/protocols/a2a.py
@@ -31,11 +31,15 @@ from __future__ import annotations
 import json
 import time
 import uuid
+from typing import TYPE_CHECKING
 
 import httpx
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
+
+if TYPE_CHECKING:
+    from dns_aid.sdk.auth.base import AuthHandler
 
 # Standard A2A JSON-RPC methods per the Google A2A specification.
 # These get wrapped in a proper JSON-RPC 2.0 envelope automatically.
@@ -77,6 +81,7 @@ class A2AProtocolHandler(ProtocolHandler):
         method: str | None,
         arguments: dict | None,
         timeout: float,
+        auth_handler: AuthHandler | None = None,
     ) -> RawResponse:
         """
         Send an A2A request to an agent.
@@ -114,12 +119,16 @@ class A2AProtocolHandler(ProtocolHandler):
         start = time.perf_counter()
 
         try:
-            response = await client.post(
+            request = client.build_request(
+                "POST",
                 endpoint,
                 json=payload,
                 headers={"Content-Type": "application/json"},
                 timeout=timeout,
             )
+            if auth_handler:
+                request = await auth_handler.apply(request)
+            response = await client.send(request)
             elapsed = (time.perf_counter() - start) * 1000
 
         except httpx.TimeoutException:

--- a/src/dns_aid/sdk/protocols/base.py
+++ b/src/dns_aid/sdk/protocols/base.py
@@ -12,10 +12,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import httpx
 
 from dns_aid.sdk.models import InvocationStatus
+
+if TYPE_CHECKING:
+    from dns_aid.sdk.auth.base import AuthHandler
 
 
 @dataclass
@@ -59,6 +63,7 @@ class ProtocolHandler(ABC):
         method: str | None,
         arguments: dict | None,
         timeout: float,
+        auth_handler: AuthHandler | None = None,
     ) -> RawResponse:
         """
         Invoke an agent at the given endpoint.
@@ -69,6 +74,8 @@ class ProtocolHandler(ABC):
             method: Protocol-specific method name (e.g., "tools/call" for MCP).
             arguments: Method arguments / request payload.
             timeout: Timeout in seconds.
+            auth_handler: Optional auth handler to apply credentials
+                before sending the request.
 
         Returns:
             RawResponse with timing, status, and payload.

--- a/src/dns_aid/sdk/protocols/https.py
+++ b/src/dns_aid/sdk/protocols/https.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 
 import json
 import time
+from typing import TYPE_CHECKING
 
 import httpx
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
+
+if TYPE_CHECKING:
+    from dns_aid.sdk.auth.base import AuthHandler
 
 
 class HTTPSProtocolHandler(ProtocolHandler):
@@ -33,6 +37,7 @@ class HTTPSProtocolHandler(ProtocolHandler):
         method: str | None,
         arguments: dict | None,
         timeout: float,
+        auth_handler: AuthHandler | None = None,
     ) -> RawResponse:
         """
         Send an HTTPS request to an agent.
@@ -48,12 +53,16 @@ class HTTPSProtocolHandler(ProtocolHandler):
         start = time.perf_counter()
 
         try:
-            response = await client.post(
+            request = client.build_request(
+                "POST",
                 url,
                 json=payload,
                 headers={"Content-Type": "application/json"},
                 timeout=timeout,
             )
+            if auth_handler:
+                request = await auth_handler.apply(request)
+            response = await client.send(request)
             elapsed = (time.perf_counter() - start) * 1000
 
         except httpx.TimeoutException:

--- a/src/dns_aid/sdk/protocols/mcp.py
+++ b/src/dns_aid/sdk/protocols/mcp.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 
 import json
 import time
+from typing import TYPE_CHECKING
 
 import httpx
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
+
+if TYPE_CHECKING:
+    from dns_aid.sdk.auth.base import AuthHandler
 
 
 class MCPProtocolHandler(ProtocolHandler):
@@ -33,6 +37,7 @@ class MCPProtocolHandler(ProtocolHandler):
         method: str | None,
         arguments: dict | None,
         timeout: float,
+        auth_handler: AuthHandler | None = None,
     ) -> RawResponse:
         """
         Send a JSON-RPC 2.0 request to an MCP agent.
@@ -56,12 +61,16 @@ class MCPProtocolHandler(ProtocolHandler):
         ttfb_ms: float | None = None
 
         try:
-            response = await client.post(
+            request = client.build_request(
+                "POST",
                 endpoint,
                 json=rpc_request,
                 headers={"Content-Type": "application/json"},
                 timeout=timeout,
             )
+            if auth_handler:
+                request = await auth_handler.apply(request)
+            response = await client.send(request)
             ttfb_ms = (time.perf_counter() - start) * 1000
             invocation_latency_ms = ttfb_ms  # For simple request/response, TTFB ~ total
 

--- a/tests/integration/test_auth_real.py
+++ b/tests/integration/test_auth_real.py
@@ -1,0 +1,219 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for auth handlers against real HTTP endpoints.
+
+These tests hit real services — they require network access and may
+be slow. Skip with: pytest -m "not integration"
+
+Tests:
+1. Bearer handler → httpbin.org (verifies header arrives)
+2. API key handler → httpbin.org (verifies header arrives)
+3. OIDC discovery → Google's public .well-known endpoint
+4. OAuth2 → real Okta/Cognito endpoint (requires env vars, skipped if absent)
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from dns_aid.sdk.auth.oauth2 import OAuth2AuthHandler
+from dns_aid.sdk.auth.simple import ApiKeyAuthHandler, BearerAuthHandler
+
+pytestmark = pytest.mark.integration
+
+
+class TestBearerRealEndpoint:
+    """Verify Bearer token actually arrives at a real HTTP server."""
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_reaches_httpbin(self) -> None:
+        handler = BearerAuthHandler(token="test-token-abc123")
+
+        async with httpx.AsyncClient() as client:
+            request = client.build_request(
+                "GET",
+                "https://httpbin.org/headers",
+            )
+            request = await handler.apply(request)
+            response = await client.send(request)
+
+        assert response.status_code == 200
+        data = response.json()
+        # httpbin echoes back all headers
+        assert data["headers"]["Authorization"] == "Bearer test-token-abc123"
+
+
+class TestApiKeyRealEndpoint:
+    """Verify API key actually arrives at a real HTTP server."""
+
+    @pytest.mark.asyncio
+    async def test_api_key_header_reaches_httpbin(self) -> None:
+        handler = ApiKeyAuthHandler(api_key="sk-live-test", header_name="X-Api-Key")
+
+        async with httpx.AsyncClient() as client:
+            request = client.build_request(
+                "GET",
+                "https://httpbin.org/headers",
+            )
+            request = await handler.apply(request)
+            response = await client.send(request)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["headers"]["X-Api-Key"] == "sk-live-test"
+
+    @pytest.mark.asyncio
+    async def test_api_key_query_reaches_httpbin(self) -> None:
+        handler = ApiKeyAuthHandler(
+            api_key="qk-test",
+            location="query",
+            query_param="api_key",
+        )
+
+        async with httpx.AsyncClient() as client:
+            request = client.build_request(
+                "GET",
+                "https://httpbin.org/get",
+            )
+            request = await handler.apply(request)
+            response = await client.send(request)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["args"]["api_key"] == "qk-test"
+
+
+class TestOIDCDiscoveryReal:
+    """Test OIDC discovery against Google's public endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_google_oidc_discovery(self) -> None:
+        """Verify we can parse a real OIDC discovery document."""
+        handler = OAuth2AuthHandler(
+            client_id="fake-id",  # Won't actually authenticate
+            client_secret="fake-secret",
+            discovery_url="https://accounts.google.com/.well-known/openid-configuration",
+        )
+
+        # Just test discovery resolution, not actual token fetch
+        token_url = await handler._discover_token_url()
+        assert "token" in token_url
+        assert token_url.startswith("https://")
+        # Google's token endpoint
+        assert "googleapis.com" in token_url or "google.com" in token_url
+
+
+def _get_oauth_creds() -> tuple[str, str, str, str | None] | None:
+    """Return (token_url, client_id, client_secret, scopes) or None."""
+    token_url = os.getenv("DNS_AID_TEST_OAUTH_TOKEN_URL")
+    client_id = os.getenv("DNS_AID_TEST_OAUTH_CLIENT_ID")
+    client_secret = os.getenv("DNS_AID_TEST_OAUTH_CLIENT_SECRET")
+    if not all([token_url, client_id, client_secret]):
+        return None
+    return (token_url, client_id, client_secret, os.getenv("DNS_AID_TEST_OAUTH_SCOPES"))
+
+
+class TestOAuth2RealProvider:
+    """Test OAuth2 against a real provider (AWS Cognito).
+
+    Requires env vars:
+        DNS_AID_TEST_OAUTH_TOKEN_URL — token endpoint
+        DNS_AID_TEST_OAUTH_CLIENT_ID — client ID
+        DNS_AID_TEST_OAUTH_CLIENT_SECRET — client secret
+        DNS_AID_TEST_OAUTH_SCOPES — scopes (optional)
+
+    Skip if not configured.
+    """
+
+    @pytest.mark.asyncio
+    async def test_real_oauth2_token_fetch(self) -> None:
+        creds = _get_oauth_creds()
+        if not creds:
+            pytest.skip("Set DNS_AID_TEST_OAUTH_* env vars to run")
+
+        token_url, client_id, client_secret, scopes = creds
+        handler = OAuth2AuthHandler(
+            client_id=client_id,
+            client_secret=client_secret,
+            token_url=token_url,
+            scopes=scopes,
+        )
+
+        # Fetch real token and apply to request
+        request = httpx.Request("POST", "https://agent.example.com/mcp")
+        result = await handler.apply(request)
+
+        auth_header = result.headers.get("authorization", "")
+        assert auth_header.startswith("Bearer ")
+        token = auth_header.split(" ", 1)[1]
+        assert len(token) > 20  # Real JWTs are substantial
+
+        # Verify caching — second call should NOT hit the token endpoint
+        request2 = httpx.Request("POST", "https://agent.example.com/mcp")
+        result2 = await handler.apply(request2)
+        assert result2.headers["authorization"] == result.headers["authorization"]
+
+    @pytest.mark.asyncio
+    async def test_real_oauth2_token_reaches_httpbin(self) -> None:
+        """Full round-trip: Cognito token → httpbin echoes it back."""
+        creds = _get_oauth_creds()
+        if not creds:
+            pytest.skip("Set DNS_AID_TEST_OAUTH_* env vars to run")
+
+        token_url, client_id, client_secret, scopes = creds
+        handler = OAuth2AuthHandler(
+            client_id=client_id,
+            client_secret=client_secret,
+            token_url=token_url,
+            scopes=scopes,
+        )
+
+        async with httpx.AsyncClient() as client:
+            request = client.build_request("GET", "https://httpbin.org/headers")
+            request = await handler.apply(request)
+            response = await client.send(request)
+
+        assert response.status_code == 200
+        echoed = response.json()["headers"]["Authorization"]
+        assert echoed.startswith("Bearer ")
+        # Verify it's a real JWT (three dot-separated parts)
+        token = echoed.split(" ", 1)[1]
+        parts = token.split(".")
+        assert len(parts) == 3, f"Expected JWT (3 parts), got {len(parts)} parts"
+
+    @pytest.mark.asyncio
+    async def test_real_oidc_discovery_to_token(self) -> None:
+        """Full OIDC flow: discover token_url from Cognito, then fetch token.
+
+        Requires DNS_AID_TEST_OAUTH_DISCOVERY_URL in addition to the
+        standard OAuth env vars. Cognito discovery uses a pool-based URL:
+        https://cognito-idp.{region}.amazonaws.com/{pool-id}/.well-known/openid-configuration
+        """
+        creds = _get_oauth_creds()
+        discovery_url = os.getenv("DNS_AID_TEST_OAUTH_DISCOVERY_URL")
+        if not creds or not discovery_url:
+            pytest.skip(
+                "Set DNS_AID_TEST_OAUTH_* + DNS_AID_TEST_OAUTH_DISCOVERY_URL to run"
+            )
+
+        _, client_id, client_secret, scopes = creds
+
+        handler = OAuth2AuthHandler(
+            client_id=client_id,
+            client_secret=client_secret,
+            discovery_url=discovery_url,
+            scopes=scopes,
+        )
+
+        request = httpx.Request("POST", "https://agent.example.com/mcp")
+        result = await handler.apply(request)
+
+        auth_header = result.headers.get("authorization", "")
+        assert auth_header.startswith("Bearer ")
+        token = auth_header.split(" ", 1)[1]
+        assert len(token.split(".")) == 3  # Real JWT

--- a/tests/unit/sdk/auth/test_client_auth.py
+++ b/tests/unit/sdk/auth/test_client_auth.py
@@ -1,0 +1,153 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests: AgentClient.invoke() with auth handlers."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.auth.simple import BearerAuthHandler
+from dns_aid.sdk.client import AgentClient
+
+
+def _make_agent(
+    auth_type: str | None = None,
+    auth_config: dict | None = None,
+) -> AgentRecord:
+    return AgentRecord(
+        name="test-agent",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="mcp.example.com",
+        port=443,
+        auth_type=auth_type,
+        auth_config=auth_config,
+    )
+
+
+def _mock_transport_capturing_headers():
+    """Return a transport that captures request headers and returns a valid MCP response."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        captured["url"] = str(request.url)
+        body = {"jsonrpc": "2.0", "result": {"tools": []}, "id": 1}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"Content-Type": "application/json"},
+            request=request,
+        )
+
+    return httpx.MockTransport(handler), captured
+
+
+class TestClientAuthIntegration:
+    @pytest.mark.asyncio
+    async def test_invoke_with_bearer_credentials(self) -> None:
+        """invoke() resolves Bearer auth from agent metadata + credentials."""
+        agent = _make_agent(auth_type="bearer")
+        transport, captured = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(
+                agent,
+                method="tools/list",
+                credentials={"token": "my-secret-token"},
+            )
+
+        assert result.success
+        assert captured["headers"]["authorization"] == "Bearer my-secret-token"
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_api_key_credentials(self) -> None:
+        """invoke() resolves API key auth from agent metadata + credentials."""
+        agent = _make_agent(
+            auth_type="api_key",
+            auth_config={"header_name": "X-Custom-Key"},
+        )
+        transport, captured = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(
+                agent,
+                method="tools/list",
+                credentials={"api_key": "sk-test-123"},
+            )
+
+        assert result.success
+        assert captured["headers"]["x-custom-key"] == "sk-test-123"
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_explicit_auth_handler(self) -> None:
+        """Explicit auth_handler overrides agent metadata."""
+        agent = _make_agent(auth_type="api_key")  # metadata says api_key
+        transport, captured = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        # Override with a bearer handler
+        handler = BearerAuthHandler(token="override-token")
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(
+                agent,
+                method="tools/list",
+                auth_handler=handler,
+            )
+
+        assert result.success
+        assert captured["headers"]["authorization"] == "Bearer override-token"
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_auth_when_type_none(self) -> None:
+        """No auth applied when agent auth_type is 'none'."""
+        agent = _make_agent(auth_type="none")
+        transport, captured = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(agent, method="tools/list")
+
+        assert result.success
+        assert "authorization" not in captured["headers"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_auth_when_no_credentials(self) -> None:
+        """Auth skipped when agent requires it but no credentials provided."""
+        agent = _make_agent(auth_type="bearer")
+        transport, captured = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(agent, method="tools/list")
+
+        assert result.success
+        assert "authorization" not in captured["headers"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_auth_when_no_auth_type(self) -> None:
+        """No auth applied when agent has no auth_type field."""
+        agent = _make_agent()  # auth_type=None
+        transport, captured = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(agent, method="tools/list")
+
+        assert result.success
+        assert "authorization" not in captured["headers"]

--- a/tests/unit/sdk/auth/test_client_auth.py
+++ b/tests/unit/sdk/auth/test_client_auth.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import json
-
 import httpx
 import pytest
 

--- a/tests/unit/sdk/auth/test_http_msg_sig.py
+++ b/tests/unit/sdk/auth/test_http_msg_sig.py
@@ -1,0 +1,222 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for HTTP Message Signatures auth handler (Ed25519 + ML-DSA-65)."""
+
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+
+from dns_aid.sdk.auth.http_msg_sig import HttpMsgSigAuthHandler
+
+
+def _generate_ed25519_keypair() -> tuple[str, bytes]:
+    """Generate an Ed25519 keypair, return (PEM private key, public key bytes)."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+    )
+
+    private_key = Ed25519PrivateKey.generate()
+    pem = private_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    public_bytes = private_key.public_key().public_bytes_raw()
+    return pem.decode(), public_bytes
+
+
+def _generate_ml_dsa_keypair() -> tuple[str, bytes]:
+    """Generate an ML-DSA-65 keypair, return (base64 secret key, public key bytes)."""
+    from pqcrypto.sign import ml_dsa_65
+
+    pk, sk = ml_dsa_65.generate_keypair()
+    return base64.b64encode(sk).decode(), pk
+
+
+@pytest.fixture
+def ed25519_handler() -> HttpMsgSigAuthHandler:
+    pem, _ = _generate_ed25519_keypair()
+    return HttpMsgSigAuthHandler(
+        private_key_pem=pem,
+        key_id="test-key-ed25519",
+        algorithm="ed25519",
+    )
+
+
+@pytest.fixture
+def ml_dsa_handler() -> HttpMsgSigAuthHandler:
+    sk_b64, _ = _generate_ml_dsa_keypair()
+    return HttpMsgSigAuthHandler(
+        private_key_pem=sk_b64,
+        key_id="test-key-ml-dsa",
+        algorithm="ml-dsa-65",
+    )
+
+
+@pytest.fixture
+def sample_request() -> httpx.Request:
+    return httpx.Request(
+        "POST",
+        "https://agent.example.com/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        headers={"Content-Type": "application/json"},
+    )
+
+
+class TestEd25519Signing:
+    @pytest.mark.asyncio
+    async def test_produces_signature_headers(
+        self, ed25519_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ed25519_handler.apply(sample_request)
+
+        assert "signature" in result.headers
+        assert "signature-input" in result.headers
+        assert "date" in result.headers
+        assert "content-digest" in result.headers
+
+    @pytest.mark.asyncio
+    async def test_signature_input_contains_algorithm(
+        self, ed25519_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ed25519_handler.apply(sample_request)
+
+        sig_input = result.headers["signature-input"]
+        assert 'alg="ed25519"' in sig_input
+        assert 'keyid="test-key-ed25519"' in sig_input
+
+    @pytest.mark.asyncio
+    async def test_signature_is_valid_base64(
+        self, ed25519_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ed25519_handler.apply(sample_request)
+
+        sig_header = result.headers["signature"]
+        # Format: sig1=:<base64>:
+        assert sig_header.startswith("sig1=:")
+        assert sig_header.endswith(":")
+        b64_part = sig_header[6:-1]
+        sig_bytes = base64.b64decode(b64_part)
+        assert len(sig_bytes) == 64  # Ed25519 signature is always 64 bytes
+
+    @pytest.mark.asyncio
+    async def test_content_digest_sha256(
+        self, ed25519_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ed25519_handler.apply(sample_request)
+
+        digest = result.headers["content-digest"]
+        assert digest.startswith("sha-256=:")
+
+    @pytest.mark.asyncio
+    async def test_verify_ed25519_signature(
+        self, sample_request: httpx.Request
+    ) -> None:
+        """Round-trip: sign with Ed25519, then verify with public key."""
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            NoEncryption,
+            PrivateFormat,
+        )
+
+        private_key = Ed25519PrivateKey.generate()
+        pem = private_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+        public_key = private_key.public_key()
+
+        handler = HttpMsgSigAuthHandler(private_key_pem=pem, key_id="verify-test")
+        result = await handler.apply(sample_request)
+
+        # Extract signature bytes
+        sig_header = result.headers["signature"]
+        sig_bytes = base64.b64decode(sig_header[6:-1])
+
+        # Rebuild signature base (same as handler does internally)
+        from dns_aid.sdk.auth.http_msg_sig import _build_signature_base
+
+        sig_base = _build_signature_base(result, ("@method", "@target-uri", "content-digest"))
+
+        # Verify — raises InvalidSignature if bad
+        public_key.verify(sig_bytes, sig_base.encode())
+
+
+class TestMlDsa65Signing:
+    @pytest.mark.asyncio
+    async def test_produces_signature_headers(
+        self, ml_dsa_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ml_dsa_handler.apply(sample_request)
+
+        assert "signature" in result.headers
+        assert "signature-input" in result.headers
+
+    @pytest.mark.asyncio
+    async def test_signature_input_contains_ml_dsa_algorithm(
+        self, ml_dsa_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ml_dsa_handler.apply(sample_request)
+
+        sig_input = result.headers["signature-input"]
+        assert 'alg="ml-dsa-65"' in sig_input
+        assert 'keyid="test-key-ml-dsa"' in sig_input
+
+    @pytest.mark.asyncio
+    async def test_ml_dsa_signature_size(
+        self, ml_dsa_handler: HttpMsgSigAuthHandler, sample_request: httpx.Request
+    ) -> None:
+        result = await ml_dsa_handler.apply(sample_request)
+
+        sig_header = result.headers["signature"]
+        b64_part = sig_header[6:-1]
+        sig_bytes = base64.b64decode(b64_part)
+        assert len(sig_bytes) == 3309  # ML-DSA-65 signature is 3309 bytes
+
+    @pytest.mark.asyncio
+    async def test_verify_ml_dsa_signature(
+        self, sample_request: httpx.Request
+    ) -> None:
+        """Round-trip: sign with ML-DSA-65, then verify with public key."""
+        from pqcrypto.sign import ml_dsa_65
+
+        pk, sk = ml_dsa_65.generate_keypair()
+        sk_b64 = base64.b64encode(sk).decode()
+
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=sk_b64,
+            key_id="pqc-verify-test",
+            algorithm="ml-dsa-65",
+        )
+        result = await handler.apply(sample_request)
+
+        # Extract signature bytes
+        sig_header = result.headers["signature"]
+        sig_bytes = base64.b64decode(sig_header[6:-1])
+
+        # Rebuild signature base
+        from dns_aid.sdk.auth.http_msg_sig import _build_signature_base
+
+        sig_base = _build_signature_base(result, ("@method", "@target-uri", "content-digest"))
+
+        # Verify with pqcrypto
+        assert ml_dsa_65.verify(pk, sig_base.encode(), sig_bytes)
+
+
+class TestAlgorithmValidation:
+    def test_rejects_unsupported_algorithm(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported algorithm"):
+            HttpMsgSigAuthHandler(
+                private_key_pem="fake",
+                key_id="test",
+                algorithm="rsa-sha256",
+            )
+
+    def test_rejects_invalid_ml_dsa_key_size(self) -> None:
+        with pytest.raises(ValueError, match="ML-DSA-65 secret key must be"):
+            HttpMsgSigAuthHandler(
+                private_key_pem=base64.b64encode(b"too-short").decode(),
+                key_id="test",
+                algorithm="ml-dsa-65",
+            )

--- a/tests/unit/sdk/auth/test_http_msg_sig.py
+++ b/tests/unit/sdk/auth/test_http_msg_sig.py
@@ -30,7 +30,7 @@ def _generate_ed25519_keypair() -> tuple[str, bytes]:
 
 def _generate_ml_dsa_keypair() -> tuple[str, bytes]:
     """Generate an ML-DSA-65 keypair, return (base64 secret key, public key bytes)."""
-    from pqcrypto.sign import ml_dsa_65
+    from pqcrypto.sign import ml_dsa_65  # guarded by requires_pqcrypto
 
     pk, sk = ml_dsa_65.generate_keypair()
     return base64.b64encode(sk).decode(), pk
@@ -112,9 +112,7 @@ class TestEd25519Signing:
         assert digest.startswith("sha-256=:")
 
     @pytest.mark.asyncio
-    async def test_verify_ed25519_signature(
-        self, sample_request: httpx.Request
-    ) -> None:
+    async def test_verify_ed25519_signature(self, sample_request: httpx.Request) -> None:
         """Round-trip: sign with Ed25519, then verify with public key."""
         from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
         from cryptography.hazmat.primitives.serialization import (
@@ -175,9 +173,7 @@ class TestMlDsa65Signing:
         assert len(sig_bytes) == 3309  # ML-DSA-65 signature is 3309 bytes
 
     @pytest.mark.asyncio
-    async def test_verify_ml_dsa_signature(
-        self, sample_request: httpx.Request
-    ) -> None:
+    async def test_verify_ml_dsa_signature(self, sample_request: httpx.Request) -> None:
         """Round-trip: sign with ML-DSA-65, then verify with public key."""
         from pqcrypto.sign import ml_dsa_65
 

--- a/tests/unit/sdk/auth/test_oauth2.py
+++ b/tests/unit/sdk/auth/test_oauth2.py
@@ -1,0 +1,170 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OAuth2 client-credentials auth handler."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from dns_aid.sdk.auth.oauth2 import OAuth2AuthHandler
+
+
+@pytest.fixture
+def request_obj() -> httpx.Request:
+    return httpx.Request(
+        "POST",
+        "https://agent.example.com/mcp",
+        json={"method": "tools/list"},
+    )
+
+
+@pytest.fixture
+def token_response() -> dict:
+    return {
+        "access_token": "eyJ0b2tlbiI6InRlc3QifQ",
+        "token_type": "bearer",
+        "expires_in": 3600,
+    }
+
+
+@pytest.fixture
+def discovery_response() -> dict:
+    return {
+        "token_endpoint": "https://auth.example.com/oauth/token",
+        "issuer": "https://auth.example.com",
+    }
+
+
+class TestOAuth2AuthHandler:
+    def test_requires_token_url_or_discovery(self) -> None:
+        with pytest.raises(ValueError, match="Either token_url or discovery_url"):
+            OAuth2AuthHandler(
+                client_id="id",
+                client_secret="secret",
+            )
+
+    @pytest.mark.asyncio
+    async def test_fetches_and_applies_token(
+        self, request_obj: httpx.Request, token_response: dict
+    ) -> None:
+        mock_resp = httpx.Response(200, json=token_response)
+        transport = httpx.MockTransport(lambda req: mock_resp)
+
+        handler = OAuth2AuthHandler(
+            client_id="my-client",
+            client_secret="my-secret",
+            token_url="https://auth.example.com/oauth/token",
+        )
+
+        with patch("dns_aid.sdk.auth.oauth2.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await handler.apply(request_obj)
+
+        assert result.headers["Authorization"] == "Bearer eyJ0b2tlbiI6InRlc3QifQ"
+
+    @pytest.mark.asyncio
+    async def test_caches_token(
+        self, request_obj: httpx.Request, token_response: dict
+    ) -> None:
+        mock_resp = httpx.Response(200, json=token_response)
+
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.example.com/oauth/token",
+        )
+
+        with patch("dns_aid.sdk.auth.oauth2.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            await handler.apply(request_obj)
+            await handler.apply(request_obj)
+
+            # Token endpoint called only once (cached)
+            assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_refreshes_expired_token(
+        self, request_obj: httpx.Request
+    ) -> None:
+        resp1 = httpx.Response(200, json={
+            "access_token": "token-1",
+            "expires_in": 1,  # Expires almost immediately
+        })
+        resp2 = httpx.Response(200, json={
+            "access_token": "token-2",
+            "expires_in": 3600,
+        })
+
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.example.com/oauth/token",
+        )
+
+        with patch("dns_aid.sdk.auth.oauth2.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=[resp1, resp2])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            r1 = await handler.apply(request_obj)
+            assert r1.headers["Authorization"] == "Bearer token-1"
+
+            # Force expiry (token expires_in=1 minus 30s buffer = already expired)
+            handler._expires_at = time.monotonic() - 1
+
+            r2 = await handler.apply(request_obj)
+            assert r2.headers["Authorization"] == "Bearer token-2"
+            assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_oidc_discovery(
+        self,
+        request_obj: httpx.Request,
+        token_response: dict,
+        discovery_response: dict,
+    ) -> None:
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            discovery_url="https://auth.example.com/.well-known/openid-configuration",
+        )
+
+        mock_disc_resp = httpx.Response(200, json=discovery_response)
+        mock_token_resp = httpx.Response(200, json=token_response)
+
+        with patch("dns_aid.sdk.auth.oauth2.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_disc_resp)
+            mock_client.post = AsyncMock(return_value=mock_token_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await handler.apply(request_obj)
+
+        assert result.headers["Authorization"].startswith("Bearer ")
+
+    def test_auth_type(self) -> None:
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.example.com/token",
+        )
+        assert handler.auth_type == "oauth2"

--- a/tests/unit/sdk/auth/test_oauth2.py
+++ b/tests/unit/sdk/auth/test_oauth2.py
@@ -53,7 +53,6 @@ class TestOAuth2AuthHandler:
         self, request_obj: httpx.Request, token_response: dict
     ) -> None:
         mock_resp = httpx.Response(200, json=token_response)
-        transport = httpx.MockTransport(lambda req: mock_resp)
 
         handler = OAuth2AuthHandler(
             client_id="my-client",
@@ -73,9 +72,7 @@ class TestOAuth2AuthHandler:
         assert result.headers["Authorization"] == "Bearer eyJ0b2tlbiI6InRlc3QifQ"
 
     @pytest.mark.asyncio
-    async def test_caches_token(
-        self, request_obj: httpx.Request, token_response: dict
-    ) -> None:
+    async def test_caches_token(self, request_obj: httpx.Request, token_response: dict) -> None:
         mock_resp = httpx.Response(200, json=token_response)
 
         handler = OAuth2AuthHandler(
@@ -98,17 +95,21 @@ class TestOAuth2AuthHandler:
             assert mock_client.post.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_refreshes_expired_token(
-        self, request_obj: httpx.Request
-    ) -> None:
-        resp1 = httpx.Response(200, json={
-            "access_token": "token-1",
-            "expires_in": 1,  # Expires almost immediately
-        })
-        resp2 = httpx.Response(200, json={
-            "access_token": "token-2",
-            "expires_in": 3600,
-        })
+    async def test_refreshes_expired_token(self, request_obj: httpx.Request) -> None:
+        resp1 = httpx.Response(
+            200,
+            json={
+                "access_token": "token-1",
+                "expires_in": 1,  # Expires almost immediately
+            },
+        )
+        resp2 = httpx.Response(
+            200,
+            json={
+                "access_token": "token-2",
+                "expires_in": 3600,
+            },
+        )
 
         handler = OAuth2AuthHandler(
             client_id="id",

--- a/tests/unit/sdk/auth/test_registry.py
+++ b/tests/unit/sdk/auth/test_registry.py
@@ -1,0 +1,90 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for auth handler registry and factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.sdk.auth.registry import resolve_auth_handler
+from dns_aid.sdk.auth.simple import (
+    ApiKeyAuthHandler,
+    BearerAuthHandler,
+    NoopAuthHandler,
+)
+
+
+class TestResolveAuthHandler:
+    def test_noop(self) -> None:
+        handler = resolve_auth_handler("none")
+        assert isinstance(handler, NoopAuthHandler)
+
+    def test_api_key(self) -> None:
+        handler = resolve_auth_handler(
+            "api_key",
+            credentials={"api_key": "sk-123"},
+        )
+        assert isinstance(handler, ApiKeyAuthHandler)
+
+    def test_api_key_with_config(self) -> None:
+        handler = resolve_auth_handler(
+            "api_key",
+            auth_config={"header_name": "X-Custom", "location": "header"},
+            credentials={"api_key": "sk-123"},
+        )
+        assert isinstance(handler, ApiKeyAuthHandler)
+        assert handler._header_name == "X-Custom"
+
+    def test_bearer(self) -> None:
+        handler = resolve_auth_handler(
+            "bearer",
+            credentials={"token": "my-token"},
+        )
+        assert isinstance(handler, BearerAuthHandler)
+
+    def test_oauth2(self) -> None:
+        handler = resolve_auth_handler(
+            "oauth2",
+            auth_config={"oauth_discovery": "https://auth.example.com/.well-known/openid-configuration"},
+            credentials={
+                "client_id": "id",
+                "client_secret": "secret",
+            },
+        )
+        assert handler.auth_type == "oauth2"
+
+    def test_ztaip_alias_bearer_token(self) -> None:
+        handler = resolve_auth_handler(
+            "bearer_token",
+            credentials={"token": "tok"},
+        )
+        assert isinstance(handler, BearerAuthHandler)
+
+    def test_ztaip_alias_oauth2_client_credentials(self) -> None:
+        handler = resolve_auth_handler(
+            "oauth2_client_credentials",
+            auth_config={"token_url": "https://auth.example.com/token"},
+            credentials={"client_id": "id", "client_secret": "s"},
+        )
+        assert handler.auth_type == "oauth2"
+
+    def test_unknown_auth_type(self) -> None:
+        with pytest.raises(ValueError, match="Unknown auth_type"):
+            resolve_auth_handler("kerberos")
+
+    def test_missing_api_key_credential(self) -> None:
+        with pytest.raises(ValueError, match="requires 'api_key'"):
+            resolve_auth_handler("api_key", credentials={})
+
+    def test_missing_bearer_token(self) -> None:
+        with pytest.raises(ValueError, match="requires 'token'"):
+            resolve_auth_handler("bearer", credentials={})
+
+    def test_missing_oauth2_credentials(self) -> None:
+        with pytest.raises(ValueError, match="requires 'client_id'"):
+            resolve_auth_handler(
+                "oauth2",
+                auth_config={"token_url": "https://auth.example.com/token"},
+                credentials={},
+            )

--- a/tests/unit/sdk/auth/test_simple.py
+++ b/tests/unit/sdk/auth/test_simple.py
@@ -1,0 +1,82 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for simple auth handlers: Noop, ApiKey, Bearer."""
+
+from __future__ import annotations
+
+import pytest
+import httpx
+
+from dns_aid.sdk.auth.simple import (
+    ApiKeyAuthHandler,
+    BearerAuthHandler,
+    NoopAuthHandler,
+)
+
+
+@pytest.fixture
+def _build_request() -> httpx.Request:
+    """Build a sample POST request for testing."""
+    return httpx.Request(
+        "POST",
+        "https://agent.example.com/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        headers={"Content-Type": "application/json"},
+    )
+
+
+class TestNoopAuthHandler:
+    @pytest.mark.asyncio
+    async def test_passthrough(self, _build_request: httpx.Request) -> None:
+        handler = NoopAuthHandler()
+        result = await handler.apply(_build_request)
+        assert result is _build_request
+        assert "Authorization" not in result.headers
+
+    def test_auth_type(self) -> None:
+        assert NoopAuthHandler().auth_type == "none"
+
+
+class TestApiKeyAuthHandler:
+    @pytest.mark.asyncio
+    async def test_header_injection(self, _build_request: httpx.Request) -> None:
+        handler = ApiKeyAuthHandler(api_key="sk-test-123")
+        result = await handler.apply(_build_request)
+        assert result.headers["X-API-Key"] == "sk-test-123"
+
+    @pytest.mark.asyncio
+    async def test_custom_header_name(self, _build_request: httpx.Request) -> None:
+        handler = ApiKeyAuthHandler(api_key="my-key", header_name="X-Custom-Auth")
+        result = await handler.apply(_build_request)
+        assert result.headers["X-Custom-Auth"] == "my-key"
+
+    @pytest.mark.asyncio
+    async def test_query_param_injection(self, _build_request: httpx.Request) -> None:
+        handler = ApiKeyAuthHandler(
+            api_key="qk-456",
+            location="query",
+            query_param="key",
+        )
+        result = await handler.apply(_build_request)
+        assert "key=qk-456" in str(result.url)
+
+    def test_auth_type(self) -> None:
+        assert ApiKeyAuthHandler(api_key="x").auth_type == "api_key"
+
+
+class TestBearerAuthHandler:
+    @pytest.mark.asyncio
+    async def test_authorization_header(self, _build_request: httpx.Request) -> None:
+        handler = BearerAuthHandler(token="eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9")
+        result = await handler.apply(_build_request)
+        assert result.headers["Authorization"] == "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9"
+
+    @pytest.mark.asyncio
+    async def test_custom_header_name(self, _build_request: httpx.Request) -> None:
+        handler = BearerAuthHandler(token="tok", header_name="X-Bearer")
+        result = await handler.apply(_build_request)
+        assert result.headers["X-Bearer"] == "Bearer tok"
+
+    def test_auth_type(self) -> None:
+        assert BearerAuthHandler(token="x").auth_type == "bearer"

--- a/tests/unit/sdk/auth/test_simple.py
+++ b/tests/unit/sdk/auth/test_simple.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-import pytest
 import httpx
+import pytest
 
 from dns_aid.sdk.auth.simple import (
     ApiKeyAuthHandler,


### PR DESCRIPTION
## Summary

- Add `AuthHandler` abstraction with 5 implementations: Noop, ApiKey, Bearer, OAuth2 (client-credentials), HTTP Message Signatures (RFC 9421)
- Wire auth into `AgentClient.invoke()` — resolves handler from agent metadata + caller credentials automatically
- Protocol handlers (MCP, A2A, HTTPS) use `build_request → apply → send` pattern for auth injection
- Add `auth_type` and `auth_config` fields to `AgentRecord` for metadata enrichment pipeline
- OAuth2 handler includes asyncio lock for thread safety, token caching with expiry buffer, OIDC discovery support

## Changes

### New: `src/dns_aid/sdk/auth/`
- `base.py` — `AuthHandler` ABC with `apply(request)` + `auth_type` property
- `simple.py` — `NoopAuthHandler`, `ApiKeyAuthHandler`, `BearerAuthHandler`
- `oauth2.py` — `OAuth2AuthHandler` (client-credentials, token cache, asyncio lock, OIDC discovery, `OAuth2TokenError`)
- `http_msg_sig.py` — `HttpMsgSigAuthHandler` (RFC 9421, Ed25519, Content-Digest, cryptography/PyNaCl dual support)
- `registry.py` — `resolve_auth_handler()` factory with ZTAIP alias mapping

### Modified: Protocol handlers
- `protocols/base.py` — Added `auth_handler` param to `ProtocolHandler.invoke()`
- `protocols/mcp.py` — `build_request → apply → send` pattern
- `protocols/a2a.py` — Same pattern
- `protocols/https.py` — Same pattern

### Modified: Client & Models
- `sdk/client.py` — `invoke()` accepts `credentials` dict and `auth_handler` override; `_resolve_auth()` helper
- `core/models.py` — `AgentRecord` gains `auth_type` (str) and `auth_config` (dict) fields

### Tests
- `tests/unit/sdk/auth/test_simple.py` — 9 tests (Noop, ApiKey header/query, Bearer)
- `tests/unit/sdk/auth/test_oauth2.py` — 6 tests (fetch, cache, refresh, OIDC discovery)
- `tests/unit/sdk/auth/test_registry.py` — 11 tests (all types, ZTAIP aliases, error cases)
- `tests/unit/sdk/auth/test_client_auth.py` — 6 tests (full invoke pipeline with mock transport)
- `tests/integration/test_auth_real.py` — 7 tests against live endpoints

## Test plan

- [x] 826 unit tests pass (32 new + 794 existing, zero regressions)
- [x] Lint clean (`ruff check`)
- [x] Integration tested against real endpoints:
  - [x] Bearer token → httpbin.org (header echoed back)
  - [x] API key header/query → httpbin.org (header + query param verified)
  - [x] OIDC discovery → Google Accounts (resolved `token_endpoint`)
  - [x] OAuth2 client_credentials → AWS Cognito (`dns-aid-sdk-auth-test` pool, real JWT returned)
  - [x] OAuth2 token → httpbin.org round-trip (Cognito JWT echoed, 3-part JWT verified)
  - [x] OIDC discovery → Cognito → token fetch (full discovery-to-token flow)
- [x] Token caching verified (second call reuses cached token, no endpoint hit)

## Integration test env vars (for CI)

```
DNS_AID_TEST_OAUTH_TOKEN_URL=https://dns-aid-auth-test.auth.us-east-1.amazoncognito.com/oauth2/token
DNS_AID_TEST_OAUTH_CLIENT_ID=<from Cognito>
DNS_AID_TEST_OAUTH_CLIENT_SECRET=<from Cognito>
DNS_AID_TEST_OAUTH_SCOPES=dns-aid-api/invoke
DNS_AID_TEST_OAUTH_DISCOVERY_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_NE34GkEdc/.well-known/openid-configuration
```