### PR TITLE
feat: auth metadata enrichment from discovery + AWS SigV4 handler

### DIFF
--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 import dns.asyncresolver
 import dns.rdatatype
 import dns.resolver
+import httpx
 import structlog
 
 from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
@@ -742,7 +743,8 @@ def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
     """Apply A2A Agent Card data to an agent record.
 
     Stores the card, wires skills → capabilities (if not already set),
-    and extracts endpoint paths from card metadata.
+    extracts endpoint paths from card metadata, and populates auth
+    metadata from the card's authentication field.
     """
     agent.agent_card = card
 
@@ -773,11 +775,56 @@ def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
                 path=path,
             )
 
+    # Extract auth metadata from card (A2A format)
+    # Only populate if not already set (DNS-AID native AuthSpec takes precedence)
+    if not agent.auth_type and card.authentication and card.authentication.schemes:
+        agent.auth_type = card.authentication.schemes[0]
+        agent.auth_config = {"schemes": card.authentication.schemes}
+        logger.debug(
+            "Auth metadata from A2A Agent Card",
+            agent=agent.name,
+            auth_type=agent.auth_type,
+        )
+
+    # Check if card metadata contains DNS-AID native auth (aid_version present)
+    # Some agents serve DNS-AID native format at agent-card.json
+    if not agent.auth_type:
+        _apply_auth_from_metadata(agent, card.metadata)
+
     logger.debug(
         "Applied A2A Agent Card to agent",
         agent=agent.name,
         card_name=card.name,
         skills_count=len(card.skills),
+    )
+
+
+def _apply_auth_from_metadata(agent: AgentRecord, metadata: dict) -> None:
+    """Extract auth from DNS-AID native metadata (``aid_version`` discriminator).
+
+    DNS-AID native documents embed a full ``auth`` object with ``type``,
+    ``location``, ``header_name``, ``oauth_discovery``, etc.  This is
+    richer than A2A's ``authentication.schemes`` list and always takes
+    precedence when present.
+    """
+    auth_data = metadata.get("auth")
+    if not isinstance(auth_data, dict):
+        return
+
+    auth_type = auth_data.get("type")
+    if not auth_type or auth_type == "none":
+        return
+
+    # Build auth_config from all non-type fields, excluding None values
+    auth_config = {k: v for k, v in auth_data.items() if k != "type" and v is not None}
+
+    agent.auth_type = str(auth_type)
+    agent.auth_config = auth_config if auth_config else None
+    logger.debug(
+        "Auth metadata from DNS-AID native format",
+        agent=agent.name,
+        auth_type=agent.auth_type,
+        config_keys=list(auth_config.keys()) if auth_config else [],
     )
 
 
@@ -817,16 +864,58 @@ async def _enrich_agents_with_endpoint_paths(agents: list[AgentRecord]) -> None:
     async def _fetch_and_enrich(host: str, host_agents: list[AgentRecord]) -> None:
         # Use typed A2AAgentCard fetcher
         card = await fetch_agent_card(f"https://{host}")
-        if not card:
-            return
+        if card:
+            for agent in host_agents:
+                _apply_agent_card(agent, card)
 
-        for agent in host_agents:
-            _apply_agent_card(agent, card)
+        # If auth still not populated, try DNS-AID native .well-known/agent.json
+        agents_missing_auth = [a for a in host_agents if not a.auth_type]
+        if agents_missing_auth:
+            auth_data = await _fetch_agent_json_auth(host)
+            if auth_data:
+                for agent in agents_missing_auth:
+                    _apply_auth_from_metadata(agent, {"auth": auth_data})
 
     await asyncio.gather(
         *[_fetch_and_enrich(host, host_agents) for host, host_agents in hosts_to_agents.items()],
         return_exceptions=True,
     )
+
+
+async def _fetch_agent_json_auth(host: str, timeout: float = 5.0) -> dict | None:
+    """Fetch auth section from ``/.well-known/agent.json`` (DNS-AID native).
+
+    Returns the ``auth`` dict if the document has ``aid_version`` (DNS-AID
+    discriminator), *None* otherwise.  Does NOT parse the full document —
+    only extracts the auth section to minimize coupling.
+    """
+    url = f"https://{host}/.well-known/agent.json"
+
+    try:
+        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+
+        validate_fetch_url(url)
+    except UnsafeURLError:
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+            resp = await client.get(url)
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            if not isinstance(data, dict):
+                return None
+            # Discriminator: DNS-AID native documents have aid_version
+            if "aid_version" not in data:
+                return None
+            auth = data.get("auth")
+            if isinstance(auth, dict) and auth.get("type", "none") != "none":
+                logger.debug("Fetched auth from agent.json", host=host, auth_type=auth.get("type"))
+                return auth
+    except Exception:
+        pass
+    return None
 
 
 async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:

--- a/src/dns_aid/sdk/auth/registry.py
+++ b/src/dns_aid/sdk/auth/registry.py
@@ -110,6 +110,20 @@ def _build_http_msg_sig(config: dict, credentials: dict) -> AuthHandler:
     return HttpMsgSigAuthHandler(
         private_key_pem=private_key_pem,
         key_id=key_id,
+        algorithm=credentials.get("algorithm", "ed25519"),
+    )
+
+
+def _build_sigv4(config: dict, credentials: dict) -> AuthHandler:
+    from dns_aid.sdk.auth.sigv4 import SigV4AuthHandler
+
+    region = config.get("region") or credentials.get("region")
+    if not region:
+        raise ValueError("SigV4AuthHandler requires 'region' in auth_config or credentials")
+    return SigV4AuthHandler(
+        region=region,
+        service=config.get("service", "vpc-lattice-svcs"),
+        profile_name=credentials.get("profile_name"),
     )
 
 
@@ -120,6 +134,7 @@ _REGISTRY: dict[str, Callable[[dict, dict], AuthHandler]] = {
     "bearer": _build_bearer,
     "oauth2": _build_oauth2,
     "http_msg_sig": _build_http_msg_sig,
+    "sigv4": _build_sigv4,
 }
 
 # ZTAIP canonical names → our enum values

--- a/src/dns_aid/sdk/auth/sigv4.py
+++ b/src/dns_aid/sdk/auth/sigv4.py
@@ -1,0 +1,123 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AWS SigV4 auth handler for VPC Lattice and API Gateway IAM auth."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+
+from dns_aid.sdk.auth.base import AuthHandler
+
+logger = structlog.get_logger(__name__)
+
+# Headers that SigV4 produces and we copy back to the httpx request.
+_SIGV4_HEADERS = ("authorization", "x-amz-date", "x-amz-security-token", "x-amz-content-sha256")
+
+
+class SigV4AuthHandler(AuthHandler):
+    """Sign requests with AWS Signature Version 4.
+
+    Used for agents behind **VPC Lattice** (``connect-class=lattice``)
+    or **API Gateway with IAM auth**.
+
+    Credentials are resolved via the standard boto3 credential chain
+    (env vars → config files → IAM role → instance metadata).
+
+    Args:
+        region: AWS region (e.g., ``"us-east-1"``).
+        service: AWS service name for signing scope.  Defaults to
+            ``"vpc-lattice-svcs"`` for VPC Lattice.  Use
+            ``"execute-api"`` for API Gateway.
+        profile_name: Optional AWS profile name for credential resolution.
+    """
+
+    def __init__(
+        self,
+        region: str,
+        *,
+        service: str = "vpc-lattice-svcs",
+        profile_name: str | None = None,
+    ) -> None:
+        self._region = region
+        self._service = service
+        self._signer, self._credentials = _create_signer(region, service, profile_name)
+
+    @property
+    def auth_type(self) -> str:
+        return "sigv4"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        # Refresh credentials if they're from an assumed role / instance profile
+        frozen = self._credentials.get_frozen_credentials()
+        self._signer, _ = _create_signer_from_frozen(frozen, self._region, self._service)
+
+        aws_request = _httpx_to_aws_request(request)
+        self._signer.add_auth(aws_request)
+
+        # Copy SigV4 headers back to httpx request
+        for header in _SIGV4_HEADERS:
+            value = aws_request.headers.get(header)
+            if value:
+                request.headers[header] = value
+
+        logger.debug(
+            "sigv4.signed",
+            service=self._service,
+            region=self._region,
+            method=request.method,
+        )
+        return request
+
+
+def _create_signer(region: str, service: str, profile_name: str | None) -> tuple[Any, Any]:
+    """Create a SigV4Auth signer from boto3 session credentials."""
+    try:
+        import boto3
+        from botocore.auth import SigV4Auth
+    except ImportError:
+        raise ImportError(
+            "SigV4 signing requires 'boto3'. Install with: pip install dns-aid[route53]"
+        ) from None
+
+    session = boto3.Session(profile_name=profile_name)
+    credentials = session.get_credentials()
+    if not credentials:
+        raise ValueError(
+            "No AWS credentials found. Configure via environment variables, "
+            "AWS config files, or IAM role."
+        )
+    frozen = credentials.get_frozen_credentials()
+    signer = SigV4Auth(frozen, service, region)
+    return signer, credentials
+
+
+def _create_signer_from_frozen(frozen: Any, region: str, service: str) -> tuple[Any, Any]:
+    """Create a SigV4Auth signer from already-frozen credentials."""
+    from botocore.auth import SigV4Auth
+
+    return SigV4Auth(frozen, service, region), frozen
+
+
+def _httpx_to_aws_request(request: httpx.Request) -> Any:
+    """Convert an httpx Request to a botocore AWSRequest for signing."""
+    from botocore.awsrequest import AWSRequest
+
+    parsed = urlparse(str(request.url))
+    url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    if parsed.query:
+        url = f"{url}?{parsed.query}"
+
+    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+
+    return AWSRequest(
+        method=request.method,
+        url=url,
+        headers=headers,
+        data=BytesIO(request.content) if request.content else None,
+    )

--- a/tests/unit/sdk/auth/test_sigv4.py
+++ b/tests/unit/sdk/auth/test_sigv4.py
@@ -1,0 +1,119 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AWS SigV4 auth handler."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from botocore.credentials import Credentials
+
+from dns_aid.sdk.auth.sigv4 import SigV4AuthHandler, _httpx_to_aws_request
+
+# Test credentials (not real — AWS example keys from docs)
+_TEST_CREDS = Credentials(
+    access_key="AKIAIOSFODNN7EXAMPLE",
+    secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",  # noqa: S106
+)
+
+
+@pytest.fixture
+def sigv4_handler() -> SigV4AuthHandler:
+    """Create a SigV4 handler with test credentials."""
+    with patch("boto3.Session") as mock_session_cls:
+        mock_session = mock_session_cls.return_value
+        mock_creds = mock_session.get_credentials.return_value
+        mock_creds.get_frozen_credentials.return_value = _TEST_CREDS
+        return SigV4AuthHandler(region="us-east-1", service="vpc-lattice-svcs")
+
+
+class TestSigV4AuthHandler:
+    @pytest.mark.asyncio
+    async def test_signs_request_with_authorization_header(
+        self, sigv4_handler: SigV4AuthHandler
+    ) -> None:
+        request = httpx.Request(
+            "POST",
+            "https://agent.lattice.example.com/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        )
+        result = await sigv4_handler.apply(request)
+
+        assert "authorization" in result.headers
+        auth_header = result.headers["authorization"]
+        assert auth_header.startswith("AWS4-HMAC-SHA256")
+        assert "Credential=AKIAIOSFODNN7EXAMPLE" in auth_header
+        assert "vpc-lattice-svcs" in auth_header
+
+    @pytest.mark.asyncio
+    async def test_adds_amz_date_header(self, sigv4_handler: SigV4AuthHandler) -> None:
+        request = httpx.Request("GET", "https://agent.lattice.example.com/health")
+        result = await sigv4_handler.apply(request)
+
+        assert "x-amz-date" in result.headers
+
+    @pytest.mark.asyncio
+    async def test_signs_with_api_gateway_service(self) -> None:
+        with patch("boto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_creds = mock_session.get_credentials.return_value
+            mock_creds.get_frozen_credentials.return_value = _TEST_CREDS
+
+            handler = SigV4AuthHandler(region="us-west-2", service="execute-api")
+
+        request = httpx.Request("POST", "https://api.example.com/invoke")
+        result = await handler.apply(request)
+
+        assert "execute-api" in result.headers["authorization"]
+        assert "us-west-2" in result.headers["authorization"]
+
+    def test_auth_type(self, sigv4_handler: SigV4AuthHandler) -> None:
+        assert sigv4_handler.auth_type == "sigv4"
+
+
+class TestHttpxToAWSRequest:
+    def test_converts_post_request(self) -> None:
+        request = httpx.Request(
+            "POST",
+            "https://agent.example.com/mcp?foo=bar",
+            json={"method": "tools/list"},
+            headers={"Content-Type": "application/json"},
+        )
+        aws_req = _httpx_to_aws_request(request)
+
+        assert aws_req.method == "POST"
+        assert "agent.example.com" in aws_req.url
+        assert "foo=bar" in aws_req.url
+        assert aws_req.headers.get("Content-Type") == "application/json"
+
+    def test_converts_get_request_without_body(self) -> None:
+        request = httpx.Request("GET", "https://agent.example.com/health")
+        aws_req = _httpx_to_aws_request(request)
+
+        assert aws_req.method == "GET"
+        assert aws_req.data is None
+
+
+class TestSigV4Registry:
+    def test_registry_resolves_sigv4(self) -> None:
+        from dns_aid.sdk.auth.registry import resolve_auth_handler
+
+        with patch("boto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_creds = mock_session.get_credentials.return_value
+            mock_creds.get_frozen_credentials.return_value = _TEST_CREDS
+
+            handler = resolve_auth_handler(
+                "sigv4",
+                auth_config={"region": "us-east-1", "service": "vpc-lattice-svcs"},
+            )
+        assert handler.auth_type == "sigv4"
+
+    def test_registry_requires_region(self) -> None:
+        from dns_aid.sdk.auth.registry import resolve_auth_handler
+
+        with pytest.raises(ValueError, match="requires 'region'"):
+            resolve_auth_handler("sigv4", auth_config={})

--- a/tests/unit/test_auth_enrichment.py
+++ b/tests/unit/test_auth_enrichment.py
@@ -1,0 +1,185 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for auth metadata enrichment during discovery."""
+
+from __future__ import annotations
+
+from dns_aid.core.a2a_card import A2AAgentCard, A2AAuthentication
+from dns_aid.core.discoverer import _apply_agent_card, _apply_auth_from_metadata
+from dns_aid.core.models import AgentRecord, Protocol
+
+
+def _make_agent(**kwargs: object) -> AgentRecord:
+    defaults = {
+        "name": "test-agent",
+        "domain": "example.com",
+        "protocol": Protocol.MCP,
+        "target_host": "mcp.example.com",
+        "port": 443,
+    }
+    defaults.update(kwargs)
+    return AgentRecord(**defaults)
+
+
+def _make_card(
+    auth: A2AAuthentication | None = None,
+    metadata: dict | None = None,
+) -> A2AAgentCard:
+    return A2AAgentCard(
+        name="test-agent",
+        url="https://mcp.example.com",
+        authentication=auth,
+        metadata=metadata or {},
+    )
+
+
+class TestApplyAgentCardAuth:
+    def test_extracts_auth_from_a2a_schemes(self) -> None:
+        agent = _make_agent()
+        card = _make_card(auth=A2AAuthentication(schemes=["oauth2", "api_key"]))
+
+        _apply_agent_card(agent, card)
+
+        assert agent.auth_type == "oauth2"
+        assert agent.auth_config == {"schemes": ["oauth2", "api_key"]}
+
+    def test_no_auth_when_no_schemes(self) -> None:
+        agent = _make_agent()
+        card = _make_card(auth=A2AAuthentication(schemes=[]))
+
+        _apply_agent_card(agent, card)
+
+        assert agent.auth_type is None
+        assert agent.auth_config is None
+
+    def test_no_auth_when_no_authentication(self) -> None:
+        agent = _make_agent()
+        card = _make_card(auth=None)
+
+        _apply_agent_card(agent, card)
+
+        assert agent.auth_type is None
+
+    def test_does_not_overwrite_existing_auth(self) -> None:
+        agent = _make_agent(auth_type="bearer", auth_config={"header_name": "Authorization"})
+        card = _make_card(auth=A2AAuthentication(schemes=["oauth2"]))
+
+        _apply_agent_card(agent, card)
+
+        # Existing auth preserved — card auth does NOT override
+        assert agent.auth_type == "bearer"
+        assert agent.auth_config == {"header_name": "Authorization"}
+
+    def test_extracts_dns_aid_native_auth_from_metadata(self) -> None:
+        """Card metadata may contain DNS-AID native auth (aid_version present)."""
+        agent = _make_agent()
+        card = _make_card(
+            metadata={
+                "auth": {
+                    "type": "oauth2",
+                    "oauth_discovery": "https://auth.example.com/.well-known/openid-configuration",
+                    "location": "header",
+                }
+            }
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.auth_type == "oauth2"
+        assert agent.auth_config == {
+            "oauth_discovery": "https://auth.example.com/.well-known/openid-configuration",
+            "location": "header",
+        }
+
+
+class TestApplyAuthFromMetadata:
+    def test_extracts_full_auth_spec(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(
+            agent,
+            {
+                "auth": {
+                    "type": "bearer",
+                    "header_name": "Authorization",
+                    "location": "header",
+                }
+            },
+        )
+
+        assert agent.auth_type == "bearer"
+        assert agent.auth_config == {
+            "header_name": "Authorization",
+            "location": "header",
+        }
+
+    def test_skips_none_type(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(agent, {"auth": {"type": "none"}})
+
+        assert agent.auth_type is None
+
+    def test_skips_missing_auth(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(agent, {})
+
+        assert agent.auth_type is None
+
+    def test_skips_non_dict_auth(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(agent, {"auth": "invalid"})
+
+        assert agent.auth_type is None
+
+    def test_excludes_none_values_from_config(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(
+            agent,
+            {
+                "auth": {
+                    "type": "api_key",
+                    "header_name": "X-API-Key",
+                    "oauth_discovery": None,
+                    "location": None,
+                }
+            },
+        )
+
+        assert agent.auth_type == "api_key"
+        assert agent.auth_config == {"header_name": "X-API-Key"}
+
+    def test_oauth2_with_discovery_url(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(
+            agent,
+            {
+                "auth": {
+                    "type": "oauth2",
+                    "oauth_discovery": "https://auth.example.com/.well-known/openid-configuration",
+                }
+            },
+        )
+
+        assert agent.auth_type == "oauth2"
+        assert agent.auth_config == {
+            "oauth_discovery": "https://auth.example.com/.well-known/openid-configuration",
+        }
+
+    def test_http_msg_sig_with_algorithms(self) -> None:
+        agent = _make_agent()
+        _apply_auth_from_metadata(
+            agent,
+            {
+                "auth": {
+                    "type": "http_msg_sig",
+                    "key_directory_url": "https://example.com/.well-known/jwks.json",
+                    "supported_algorithms": ["ed25519", "ml-dsa-65"],
+                }
+            },
+        )
+
+        assert agent.auth_type == "http_msg_sig"
+        assert agent.auth_config == {
+            "key_directory_url": "https://example.com/.well-known/jwks.json",
+            "supported_algorithms": ["ed25519", "ml-dsa-65"],
+        }


### PR DESCRIPTION
## Summary

- Wire `auth_type` and `auth_config` population during agent discovery — both A2A (`agent-card.json`) and DNS-AID native (`agent.json`) formats
- Add `SigV4AuthHandler` for VPC Lattice (`connect-class=lattice`) and API Gateway IAM auth
- Completes the Phase 5.6 auth pipeline: discover → enrich auth metadata → invoke with credentials

## Changes

### Auth metadata enrichment (`discoverer.py`)
- `_apply_agent_card()` — now extracts auth from `A2AAuthentication.schemes` (first scheme → `auth_type`)
- `_apply_auth_from_metadata()` — NEW: extracts DNS-AID native `AuthSpec` from metadata (richer than A2A — includes `oauth_discovery`, `header_name`, etc.)
- `_fetch_agent_json_auth()` — NEW: fetches `/.well-known/agent.json`, discriminates via `aid_version`, extracts auth section (SSRF-protected)
- `_enrich_agents_with_endpoint_paths()` — falls back to `agent.json` when `agent-card.json` doesn't provide auth
- Priority: existing auth > DNS-AID native > A2A schemes (never overwrites)

### AWS SigV4 handler (`sdk/auth/sigv4.py`)
- `SigV4AuthHandler` — signs requests with AWS Signature Version 4
- Converts `httpx.Request` → `botocore.AWSRequest` → sign → copy headers back
- Default service: `vpc-lattice-svcs` (VPC Lattice), also supports `execute-api` (API Gateway)
- Credentials via standard boto3 chain (env vars → config → IAM role → instance metadata)
- Registered in factory as `auth_type="sigv4"`

### Registry updates (`registry.py`)
- Added `_build_sigv4()` factory with region/service/profile_name config
- `HttpMsgSigAuthHandler` now passes `algorithm` from credentials

## Test plan

- [x] 857 tests pass (20 new + 837 existing)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] Type clean (`mypy`)
- [x] Auth enrichment: 12 tests (A2A schemes, DNS-AID native, precedence, edge cases)
- [x] SigV4: 8 tests (signing, service config, registry, request conversion)
- [x] SigV4 signs with real botocore `SigV4Auth` (mock credentials, real signing logic)