### PR TITLE
fix: harden Phase 5.6 auth infrastructure for production readiness

### DIFF
--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -47,6 +47,9 @@ from dns_aid.core.validator import verify
 # Tier 1: Execution Telemetry SDK
 from dns_aid.sdk import AgentClient, InvocationResult, InvocationSignal, SDKConfig
 
+# Auth handlers
+from dns_aid.sdk.auth import AuthHandler, resolve_auth_handler
+
 if TYPE_CHECKING:
     from dns_aid.sdk.ranking.ranker import RankedAgent
 
@@ -69,6 +72,9 @@ __all__ = [
     "SDKConfig",
     "InvocationResult",
     "InvocationSignal",
+    # Auth
+    "AuthHandler",
+    "resolve_auth_handler",
     # Models
     "AgentRecord",
     "DiscoveryResult",
@@ -89,6 +95,8 @@ async def invoke(
     arguments: dict | None = None,
     timeout: float | None = None,
     config: SDKConfig | None = None,
+    credentials: dict | None = None,
+    auth_handler: AuthHandler | None = None,
 ) -> InvocationResult:
     """
     Invoke an agent and capture telemetry — convenience wrapper.
@@ -103,6 +111,10 @@ async def invoke(
         arguments: Method arguments / payload.
         timeout: Request timeout in seconds (default: 30).
         config: Optional SDKConfig. Defaults to ``SDKConfig.from_env()``.
+        credentials: Caller-supplied secrets (tokens, client_id/secret)
+            for automatic auth resolution from agent metadata.
+        auth_handler: Explicit auth handler override. When provided,
+            *credentials* and agent metadata are ignored.
 
     Returns:
         InvocationResult with the response data and telemetry signal.
@@ -125,6 +137,8 @@ async def invoke(
             method=method,
             arguments=arguments,
             timeout=timeout,
+            credentials=credentials,
+            auth_handler=auth_handler,
         )
 
 

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
     from dns_aid.backends.base import DNSBackend
     from dns_aid.core.models import AgentRecord, PublishResult
 
+# Maximum response size for agent-card.json fetches (1MB).
+# A2A cards with many skills and OpenAPI-style schemas can reach 200-300KB.
+_MAX_AGENT_CARD_RESPONSE_BYTES = 1_000_000
+
 
 @dataclass
 class A2AProvider:
@@ -268,6 +272,15 @@ async def fetch_agent_card(
                     "Agent Card fetch failed",
                     url=card_url,
                     status_code=response.status_code,
+                )
+                return None
+
+            if len(response.content) > _MAX_AGENT_CARD_RESPONSE_BYTES:
+                logger.warning(
+                    "Agent Card response too large — skipping",
+                    url=card_url,
+                    size_bytes=len(response.content),
+                    limit=_MAX_AGENT_CARD_RESPONSE_BYTES,
                 )
                 return None
 

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -31,6 +31,10 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
+# Maximum response size for capability document fetches (256KB).
+# Cap documents are structured metadata — 256KB is very generous.
+_MAX_CAP_RESPONSE_BYTES = 256_000
+
 
 @dataclass
 class CapabilityDocument:
@@ -155,6 +159,15 @@ async def fetch_cap_document(
                     "Cap document fetch failed",
                     cap_uri=cap_uri,
                     status_code=response.status_code,
+                )
+                return None
+
+            if len(response.content) > _MAX_CAP_RESPONSE_BYTES:
+                logger.warning(
+                    "Cap document response too large — skipping",
+                    cap_uri=cap_uri,
+                    size_bytes=len(response.content),
+                    limit=_MAX_CAP_RESPONSE_BYTES,
                 )
                 return None
 

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -815,6 +815,21 @@ def _apply_auth_from_metadata(agent: AgentRecord, metadata: dict) -> None:
     if not auth_type or auth_type == "none":
         return
 
+    # Validate against known auth types to prevent malicious metadata
+    # from injecting arbitrary auth_type values that would only fail
+    # at invocation time with a confusing error.
+    from dns_aid.sdk.auth.registry import _REGISTRY, _ZTAIP_ALIASES
+
+    normalized = _ZTAIP_ALIASES.get(str(auth_type), str(auth_type))
+    if normalized not in _REGISTRY:
+        logger.warning(
+            "Unknown auth_type in metadata — skipping",
+            agent=agent.name,
+            auth_type=auth_type,
+            supported=sorted(_REGISTRY.keys()),
+        )
+        return
+
     # Build auth_config from all non-type fields, excluding None values
     auth_config = {k: v for k, v in auth_data.items() if k != "type" and v is not None}
 
@@ -902,6 +917,15 @@ async def _fetch_agent_json_auth(host: str, timeout: float = 5.0) -> dict | None
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
             resp = await client.get(url)
             if resp.status_code != 200:
+                return None
+            # Guard against oversized responses from malicious servers
+            if len(resp.content) > 100_000:
+                logger.warning(
+                    "agent.json response too large — skipping",
+                    host=host,
+                    size_bytes=len(resp.content),
+                    limit=100_000,
+                )
                 return None
             data = resp.json()
             if not isinstance(data, dict):

--- a/src/dns_aid/sdk/auth/http_msg_sig.py
+++ b/src/dns_aid/sdk/auth/http_msg_sig.py
@@ -76,6 +76,9 @@ class HttpMsgSigAuthHandler(AuthHandler):
     def auth_type(self) -> str:
         return "http_msg_sig"
 
+    def __repr__(self) -> str:
+        return f"HttpMsgSigAuthHandler(key_id={self._key_id!r}, algorithm={self._algorithm!r})"
+
     async def apply(self, request: httpx.Request) -> httpx.Request:
         # Ensure Date header is present (required by many signature profiles)
         if "date" not in request.headers:
@@ -131,8 +134,17 @@ def _build_signature_base(
         elif component == "@path":
             lines.append(f'"@path": {request.url.raw_path.decode()}')
         else:
-            # Regular header
-            value = request.headers.get(component, "")
+            # Regular header — MUST be present on the request.
+            # Signing an empty value for a missing header lets an attacker
+            # forge a request without that header and still pass verification.
+            value = request.headers.get(component)
+            if value is None:
+                raise ValueError(
+                    f"Covered component {component!r} is not present on the "
+                    f"request. Cannot sign a missing header — this would allow "
+                    f"signature bypass. Either add the header to the request or "
+                    f"remove it from covered_components."
+                )
             lines.append(f'"{component}": {value}')
     return "\n".join(lines)
 

--- a/src/dns_aid/sdk/auth/oauth2.py
+++ b/src/dns_aid/sdk/auth/oauth2.py
@@ -61,6 +61,9 @@ class OAuth2AuthHandler(AuthHandler):
     def auth_type(self) -> str:
         return "oauth2"
 
+    def __repr__(self) -> str:
+        return f"OAuth2AuthHandler(client_id={self._client_id!r}, token_url={self._token_url!r})"
+
     async def apply(self, request: httpx.Request) -> httpx.Request:
         token = await self._get_token()
         request.headers["Authorization"] = f"Bearer {token}"
@@ -79,6 +82,15 @@ class OAuth2AuthHandler(AuthHandler):
 
             # Resolve token URL from discovery if needed
             token_url = self._token_url or await self._discover_token_url()
+
+            # SSRF protection: validate token URL before sending credentials.
+            # token_url may come from untrusted agent metadata (oauth_discovery).
+            try:
+                from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+
+                validate_fetch_url(token_url)
+            except UnsafeURLError as e:
+                raise OAuth2TokenError(f"Token URL blocked by SSRF protection: {e}") from e
 
             async with httpx.AsyncClient(timeout=10.0) as client:
                 data: dict[str, str] = {
@@ -123,6 +135,14 @@ class OAuth2AuthHandler(AuthHandler):
         if not self._discovery_url:
             raise ValueError("No token_url or discovery_url configured")
 
+        # SSRF protection: discovery_url may come from untrusted agent metadata.
+        try:
+            from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+
+            validate_fetch_url(self._discovery_url)
+        except UnsafeURLError as e:
+            raise OAuth2TokenError(f"Discovery URL blocked by SSRF protection: {e}") from e
+
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(self._discovery_url)
             if resp.status_code >= 400:
@@ -132,6 +152,16 @@ class OAuth2AuthHandler(AuthHandler):
         token_endpoint = config.get("token_endpoint")
         if not token_endpoint:
             raise ValueError(f"No token_endpoint found in OIDC discovery at {self._discovery_url}")
+
+        # SSRF protection: the token_endpoint comes from an untrusted OIDC
+        # response — a malicious discovery server could redirect credentials
+        # to an internal host (e.g., cloud metadata at 169.254.169.254).
+        try:
+            validate_fetch_url(token_endpoint)
+        except UnsafeURLError as e:
+            raise OAuth2TokenError(
+                f"Discovered token_endpoint blocked by SSRF protection: {e}"
+            ) from e
 
         # Cache the resolved URL for future calls
         self._token_url = token_endpoint

--- a/src/dns_aid/sdk/auth/sigv4.py
+++ b/src/dns_aid/sdk/auth/sigv4.py
@@ -52,6 +52,9 @@ class SigV4AuthHandler(AuthHandler):
     def auth_type(self) -> str:
         return "sigv4"
 
+    def __repr__(self) -> str:
+        return f"SigV4AuthHandler(region={self._region!r}, service={self._service!r})"
+
     async def apply(self, request: httpx.Request) -> httpx.Request:
         # Refresh credentials if they're from an assumed role / instance profile
         frozen = self._credentials.get_frozen_credentials()

--- a/src/dns_aid/sdk/auth/simple.py
+++ b/src/dns_aid/sdk/auth/simple.py
@@ -17,6 +17,9 @@ class NoopAuthHandler(AuthHandler):
     def auth_type(self) -> str:
         return "none"
 
+    def __repr__(self) -> str:
+        return "NoopAuthHandler()"
+
     async def apply(self, request: httpx.Request) -> httpx.Request:
         return request
 
@@ -49,6 +52,9 @@ class ApiKeyAuthHandler(AuthHandler):
     def auth_type(self) -> str:
         return "api_key"
 
+    def __repr__(self) -> str:
+        return f"ApiKeyAuthHandler(header={self._header_name!r}, location={self._location!r})"
+
     async def apply(self, request: httpx.Request) -> httpx.Request:
         if self._location == "query":
             # Append API key as query parameter
@@ -79,6 +85,9 @@ class BearerAuthHandler(AuthHandler):
     @property
     def auth_type(self) -> str:
         return "bearer"
+
+    def __repr__(self) -> str:
+        return f"BearerAuthHandler(header={self._header_name!r})"
 
     async def apply(self, request: httpx.Request) -> httpx.Request:
         request.headers[self._header_name] = f"Bearer {self._token}"

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -110,11 +110,16 @@ class AgentClient:
             )
             return None
         auth_config = getattr(agent, "auth_config", None) or {}
-        return resolve_auth_handler(
-            auth_type=str(auth_type),
-            auth_config=auth_config if isinstance(auth_config, dict) else {},
-            credentials=credentials,
-        )
+        try:
+            return resolve_auth_handler(
+                auth_type=str(auth_type),
+                auth_config=auth_config if isinstance(auth_config, dict) else {},
+                credentials=credentials,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Auth resolution failed for agent {agent.fqdn!r} (auth_type={auth_type!r}): {exc}"
+            ) from exc
 
     async def invoke(
         self,
@@ -179,6 +184,8 @@ class AgentClient:
             protocol=protocol,
             method=method,
             raw=raw,
+            auth_type=resolved_auth.auth_type if resolved_auth else None,
+            auth_applied=resolved_auth is not None,
         )
 
         # HTTP push to telemetry API if configured (true fire-and-forget via thread)
@@ -214,8 +221,14 @@ class AgentClient:
                     status_code=resp.status_code,
                     body=resp.text[:200],
                 )
-        except Exception:
-            logger.debug("sdk.http_push_failed", signal_id=str(signal.id), url=push_url)
+        except Exception as e:
+            logger.warning(
+                "sdk.http_push_failed",
+                signal_id=str(signal.id),
+                url=push_url,
+                error=str(e),
+                exc_info=True,
+            )
 
     def rank(
         self,

--- a/src/dns_aid/sdk/models.py
+++ b/src/dns_aid/sdk/models.py
@@ -62,6 +62,10 @@ class InvocationSignal(BaseModel):
     dnssec_validated: bool = False
     tls_version: str | None = None
 
+    # Auth
+    auth_type: str | None = None
+    auth_applied: bool = False
+
     # Caller context
     caller_id: str | None = None
 

--- a/src/dns_aid/sdk/signals/collector.py
+++ b/src/dns_aid/sdk/signals/collector.py
@@ -43,6 +43,8 @@ class SignalCollector:
         raw: RawResponse,
         discovery_latency_ms: float = 0.0,
         dnssec_validated: bool = False,
+        auth_type: str | None = None,
+        auth_applied: bool = False,
     ) -> InvocationSignal:
         """
         Enrich a RawResponse into a full InvocationSignal and store it.
@@ -69,6 +71,8 @@ class SignalCollector:
             response_size_bytes=raw.response_size_bytes,
             dnssec_validated=dnssec_validated,
             tls_version=raw.tls_version,
+            auth_type=auth_type,
+            auth_applied=auth_applied,
             caller_id=self._caller_id,
         )
 

--- a/tests/integration/test_sdk_auth_live.py
+++ b/tests/integration/test_sdk_auth_live.py
@@ -376,3 +376,322 @@ class TestMultiAgent:
         assert "[PUBLIC] Echo:" in str(results["public"].data)
         assert results["bearer-agent"].data["headers"]["Authorization"] == "Bearer multi-test-token"
         assert "Auth verified!" in str(results["sigv4-agent"].data)
+
+
+# ─────────────────────────────────────────────────────────
+# 9. HARDENING — signal auth fields (Enhancement 2)
+# ─────────────────────────────────────────────────────────
+
+
+class TestSignalAuthFields:
+    @pytest.mark.asyncio
+    async def test_signal_records_auth_type_on_bearer(self) -> None:
+        """Signal captures auth_type='bearer' and auth_applied=True."""
+        agent = _agent(
+            "httpbin.org",
+            "signal-bearer",
+            auth_type="bearer",
+            endpoint_override="https://httpbin.org/post",
+        )
+
+        async with AgentClient(SDKConfig(timeout_seconds=15.0)) as client:
+            result = await client.invoke(
+                agent,
+                method=None,
+                arguments={"test": "signal"},
+                credentials={"token": "signal-test-token"},
+            )
+
+        assert result.signal.auth_type == "bearer"
+        assert result.signal.auth_applied is True
+
+    @pytest.mark.asyncio
+    async def test_signal_records_no_auth_on_public(self) -> None:
+        """Signal has auth_applied=False for public agents."""
+        agent = _agent(PUBLIC_HOST, "signal-public")
+
+        async with AgentClient(SDKConfig(timeout_seconds=15.0)) as client:
+            result = await client.invoke(
+                agent,
+                method="message/send",
+                arguments=_a2a_payload("signal test"),
+            )
+
+        assert result.signal.auth_type is None
+        assert result.signal.auth_applied is False
+
+    @pytest.mark.asyncio
+    async def test_signal_records_sigv4_auth(self) -> None:
+        """Signal captures auth_type='sigv4' for IAM-authed requests."""
+        agent = _agent(
+            SIGV4_HOST,
+            "signal-sigv4",
+            auth_type="sigv4",
+            auth_config={"region": "us-east-1", "service": "execute-api"},
+        )
+
+        async with AgentClient(SDKConfig(timeout_seconds=15.0)) as client:
+            result = await client.invoke(
+                agent,
+                method="message/send",
+                arguments=_a2a_payload("signal sigv4"),
+                credentials={"profile_name": "okta-sso"},
+            )
+
+        assert result.success
+        assert result.signal.auth_type == "sigv4"
+        assert result.signal.auth_applied is True
+
+
+# ─────────────────────────────────────────────────────────
+# 10. ADVERSARIAL — bad actors & developer mistakes
+# ─────────────────────────────────────────────────────────
+
+
+class TestAdversarialAuthType:
+    """Simulate malicious agent-card.json with unknown auth_type."""
+
+    def test_malicious_auth_type_rejected(self) -> None:
+        """A malicious agent.json with auth_type='evil_handler' is rejected."""
+        agent = _agent(PUBLIC_HOST, "evil-agent")
+
+        _apply_auth_from_metadata(
+            agent, {"auth": {"type": "evil_handler", "location": "header"}}
+        )
+
+        # Must NOT be set — unknown type rejected at discovery time
+        assert agent.auth_type is None
+        assert agent.auth_config is None
+
+    def test_sql_injection_auth_type_rejected(self) -> None:
+        """SQL injection attempt in auth_type is rejected."""
+        agent = _agent(PUBLIC_HOST, "sqli-agent")
+
+        _apply_auth_from_metadata(
+            agent, {"auth": {"type": "'; DROP TABLE agents; --"}}
+        )
+
+        assert agent.auth_type is None
+
+    def test_empty_string_auth_type_rejected(self) -> None:
+        """Empty string auth_type is rejected (falsy)."""
+        agent = _agent(PUBLIC_HOST, "empty-auth")
+
+        _apply_auth_from_metadata(agent, {"auth": {"type": ""}})
+
+        assert agent.auth_type is None
+
+    def test_ztaip_alias_accepted(self) -> None:
+        """ZTAIP canonical names (bearer_token) are accepted."""
+        agent = _agent(PUBLIC_HOST, "ztaip-agent")
+
+        _apply_auth_from_metadata(
+            agent, {"auth": {"type": "bearer_token", "header_name": "Authorization"}}
+        )
+
+        assert agent.auth_type == "bearer_token"
+
+
+class TestAdversarialMissingCredentials:
+    """Simulate developer mistakes with wrong/missing credentials."""
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_agent_fqdn(self) -> None:
+        """ValueError from missing credentials includes agent FQDN for debugging."""
+        agent = _agent(
+            "httpbin.org",
+            "debug-agent",
+            auth_type="bearer",
+            endpoint_override="https://httpbin.org/post",
+        )
+
+        async with AgentClient(SDKConfig(timeout_seconds=15.0)) as client:
+            with pytest.raises(ValueError) as exc_info:
+                await client.invoke(
+                    agent,
+                    method=None,
+                    arguments={"test": "bad-creds"},
+                    credentials={"wrong_key": "value"},  # missing 'token'
+                )
+
+        # Error must contain agent context for debugging
+        error_msg = str(exc_info.value)
+        assert "debug-agent" in error_msg or "a2a" in error_msg
+        assert "bearer" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_wrong_oauth2_credentials_clear_error(self) -> None:
+        """OAuth2 with bad client_secret gives clear error, not silent failure."""
+        agent = _agent(
+            "httpbin.org",
+            "bad-oauth",
+            auth_type="oauth2",
+            auth_config={
+                "oauth_discovery": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_NE34GkEdc/.well-known/openid-configuration",
+            },
+            endpoint_override="https://httpbin.org/post",
+        )
+
+        from dns_aid.sdk.auth.oauth2 import OAuth2TokenError
+
+        async with AgentClient(SDKConfig(timeout_seconds=15.0)) as client:
+            with pytest.raises(OAuth2TokenError, match="Token request failed"):
+                await client.invoke(
+                    agent,
+                    method=None,
+                    arguments={"test": "bad-oauth"},
+                    credentials={
+                        "client_id": "17gid5tgiv7634o57kvo9ph6mm",
+                        "client_secret": "WRONG_SECRET_intentionally_bad",
+                        "scopes": "dns-aid-api/invoke",
+                    },
+                )
+
+
+class TestAdversarialSignature:
+    """Simulate attacks on HTTP Message Signatures (Fix 2)."""
+
+    @pytest.mark.asyncio
+    async def test_signing_missing_header_raises(self) -> None:
+        """Signing a covered component that's not on the request must raise."""
+        from dns_aid.sdk.auth.http_msg_sig import HttpMsgSigAuthHandler
+
+        from tests.unit.sdk.auth.test_http_msg_sig import _generate_ed25519_keypair
+
+        pem, _ = _generate_ed25519_keypair()
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=pem,
+            key_id="adversarial-test",
+            covered_components=("@method", "@target-uri", "authorization"),
+        )
+
+        import httpx
+
+        request = httpx.Request("POST", "https://evil.example.com/api")
+        # "authorization" header is NOT present — attacker scenario
+        with pytest.raises(ValueError, match="not present on the request"):
+            await handler.apply(request)
+
+    @pytest.mark.asyncio
+    async def test_signing_with_present_header_succeeds(self) -> None:
+        """Signing a header that IS present should work normally."""
+        from dns_aid.sdk.auth.http_msg_sig import HttpMsgSigAuthHandler
+
+        from tests.unit.sdk.auth.test_http_msg_sig import _generate_ed25519_keypair
+
+        pem, _ = _generate_ed25519_keypair()
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=pem,
+            key_id="good-test",
+            covered_components=("@method", "x-custom"),
+        )
+
+        import httpx
+
+        request = httpx.Request(
+            "POST",
+            "https://good.example.com/api",
+            headers={"X-Custom": "present"},
+        )
+        result = await handler.apply(request)
+        assert "signature" in result.headers
+
+
+class TestAdversarialAgentJson:
+    """Simulate malicious .well-known/agent.json responses (Fix 6)."""
+
+    @pytest.mark.asyncio
+    async def test_size_limit_on_agent_json(self) -> None:
+        """Verify the size limit is enforced on agent.json responses."""
+        import httpx
+
+        # Simulate a response > 100KB
+        oversized_body = b'{"aid_version": "1.0", "auth": {"type": "bearer"}, "pad": "' + b"x" * 110_000 + b'"}'
+
+        async def oversized_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=oversized_body)
+
+        transport = httpx.MockTransport(oversized_handler)
+
+        # Patch httpx to use our mock transport
+        from unittest.mock import patch
+
+        mock_client = httpx.AsyncClient(transport=transport)
+
+        with patch("dns_aid.core.discoverer.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__ = lambda self: mock_client.__aenter__()
+            mock_cls.return_value.__aexit__ = mock_client.__aexit__
+
+            result = await _fetch_agent_json_auth("evil-server.example.com")
+
+        assert result is None  # Oversized response should be rejected
+
+
+class TestHandlerRepr:
+    """Verify __repr__ methods (Enhancement 4) — never leak secrets."""
+
+    def test_bearer_repr_no_token(self) -> None:
+        from dns_aid.sdk.auth.simple import BearerAuthHandler
+
+        handler = BearerAuthHandler(token="super-secret-token")
+        repr_str = repr(handler)
+
+        assert "super-secret-token" not in repr_str
+        assert "BearerAuthHandler" in repr_str
+        assert "Authorization" in repr_str
+
+    def test_api_key_repr_no_key(self) -> None:
+        from dns_aid.sdk.auth.simple import ApiKeyAuthHandler
+
+        handler = ApiKeyAuthHandler(api_key="sk-secret-key-123")
+        repr_str = repr(handler)
+
+        assert "sk-secret-key-123" not in repr_str
+        assert "ApiKeyAuthHandler" in repr_str
+
+    def test_oauth2_repr_no_secret(self) -> None:
+        from dns_aid.sdk.auth.oauth2 import OAuth2AuthHandler
+
+        handler = OAuth2AuthHandler(
+            client_id="my-client",
+            client_secret="ultra-secret",
+            token_url="https://auth.example.com/token",
+        )
+        repr_str = repr(handler)
+
+        assert "ultra-secret" not in repr_str
+        assert "my-client" in repr_str
+        assert "OAuth2AuthHandler" in repr_str
+
+    def test_sigv4_repr(self) -> None:
+        from unittest.mock import patch
+
+        from botocore.credentials import Credentials
+
+        test_creds = Credentials("AKID", "secret")
+        with patch("boto3.Session") as mock:
+            mock.return_value.get_credentials.return_value.get_frozen_credentials.return_value = test_creds
+            from dns_aid.sdk.auth.sigv4 import SigV4AuthHandler
+
+            handler = SigV4AuthHandler(region="us-east-1")
+
+        repr_str = repr(handler)
+        assert "secret" not in repr_str
+        assert "us-east-1" in repr_str
+        assert "SigV4AuthHandler" in repr_str
+
+    def test_http_msg_sig_repr_no_key(self) -> None:
+        from tests.unit.sdk.auth.test_http_msg_sig import _generate_ed25519_keypair
+
+        pem, _ = _generate_ed25519_keypair()
+        from dns_aid.sdk.auth.http_msg_sig import HttpMsgSigAuthHandler
+
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=pem,
+            key_id="my-key-id",
+        )
+        repr_str = repr(handler)
+
+        assert pem not in repr_str  # private key never in repr
+        assert "my-key-id" in repr_str
+        assert "ed25519" in repr_str

--- a/tests/unit/sdk/auth/test_client_auth.py
+++ b/tests/unit/sdk/auth/test_client_auth.py
@@ -149,3 +149,52 @@ class TestClientAuthIntegration:
 
         assert result.success
         assert "authorization" not in captured["headers"]
+
+    @pytest.mark.asyncio
+    async def test_auth_error_includes_agent_context(self) -> None:
+        """ValueError from resolve_auth_handler includes agent FQDN."""
+        agent = _make_agent(auth_type="bearer")
+        config = SDKConfig(timeout_seconds=5.0)
+        transport, _ = _mock_transport_capturing_headers()
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            with pytest.raises(ValueError, match="test-agent.*mcp.*example.com"):
+                # Missing 'token' in credentials triggers ValueError
+                await client.invoke(
+                    agent,
+                    method="tools/list",
+                    credentials={"wrong_key": "value"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_signal_captures_auth_metadata(self) -> None:
+        """InvocationSignal should record auth_type and auth_applied."""
+        agent = _make_agent(auth_type="bearer")
+        transport, _ = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(
+                agent,
+                method="tools/list",
+                credentials={"token": "my-token"},
+            )
+
+        assert result.signal.auth_type == "bearer"
+        assert result.signal.auth_applied is True
+
+    @pytest.mark.asyncio
+    async def test_signal_no_auth_metadata_when_unauthenticated(self) -> None:
+        """InvocationSignal should have auth_applied=False when no auth."""
+        agent = _make_agent()  # no auth_type
+        transport, _ = _mock_transport_capturing_headers()
+        config = SDKConfig(timeout_seconds=5.0)
+
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(agent, method="tools/list")
+
+        assert result.signal.auth_type is None
+        assert result.signal.auth_applied is False

--- a/tests/unit/sdk/auth/test_http_msg_sig.py
+++ b/tests/unit/sdk/auth/test_http_msg_sig.py
@@ -200,6 +200,52 @@ class TestMlDsa65Signing:
         assert ml_dsa_65.verify(pk, sig_base.encode(), sig_bytes)
 
 
+class TestMissingCoveredComponent:
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_header(self) -> None:
+        """Signing a missing header must raise, not silently sign empty string."""
+        pem, _ = _generate_ed25519_keypair()
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=pem,
+            key_id="test",
+            covered_components=("@method", "@target-uri", "authorization"),
+        )
+        request = httpx.Request("GET", "https://example.com/api")
+        # "authorization" header is NOT on the request
+        with pytest.raises(ValueError, match="Covered component 'authorization' is not present"):
+            await handler.apply(request)
+
+    @pytest.mark.asyncio
+    async def test_derived_components_always_available(self) -> None:
+        """@method, @target-uri, @authority, @path are always available."""
+        pem, _ = _generate_ed25519_keypair()
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=pem,
+            key_id="test",
+            covered_components=("@method", "@target-uri", "@authority", "@path"),
+        )
+        request = httpx.Request("GET", "https://example.com/api")
+        result = await handler.apply(request)
+        assert "signature" in result.headers
+
+    @pytest.mark.asyncio
+    async def test_present_header_succeeds(self) -> None:
+        """A header that IS present on the request should sign fine."""
+        pem, _ = _generate_ed25519_keypair()
+        handler = HttpMsgSigAuthHandler(
+            private_key_pem=pem,
+            key_id="test",
+            covered_components=("@method", "x-custom-header"),
+        )
+        request = httpx.Request(
+            "GET",
+            "https://example.com/api",
+            headers={"X-Custom-Header": "value"},
+        )
+        result = await handler.apply(request)
+        assert "signature" in result.headers
+
+
 class TestAlgorithmValidation:
     def test_rejects_unsupported_algorithm(self) -> None:
         with pytest.raises(ValueError, match="Unsupported algorithm"):

--- a/tests/unit/sdk/auth/test_oauth2.py
+++ b/tests/unit/sdk/auth/test_oauth2.py
@@ -11,7 +11,23 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from dns_aid.sdk.auth.oauth2 import OAuth2AuthHandler
+from dns_aid.sdk.auth.oauth2 import OAuth2AuthHandler, OAuth2TokenError
+
+_noop_validate = lambda url: url  # noqa: E731
+
+
+@pytest.fixture(autouse=True)
+def _bypass_ssrf(request):
+    """Bypass SSRF validation for tests using fake hostnames.
+
+    Skips for tests marked with ``real_ssrf`` — those test the actual
+    SSRF protection and need the real ``validate_fetch_url``.
+    """
+    if "real_ssrf" in {m.name for m in request.node.iter_markers()}:
+        yield
+    else:
+        with patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=_noop_validate):
+            yield
 
 
 @pytest.fixture
@@ -169,3 +185,70 @@ class TestOAuth2AuthHandler:
             token_url="https://auth.example.com/token",
         )
         assert handler.auth_type == "oauth2"
+
+
+class TestOAuth2SSRFProtection:
+    """SSRF protection — prevent credential exfiltration to internal hosts."""
+
+    @pytest.mark.real_ssrf
+    @pytest.mark.asyncio
+    async def test_token_url_ssrf_blocked(self, request_obj: httpx.Request) -> None:
+        """Token URL pointing to private IP must be rejected."""
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://169.254.169.254/latest/meta-data/",
+        )
+
+        with pytest.raises(OAuth2TokenError, match="SSRF protection"):
+            await handler.apply(request_obj)
+
+    @pytest.mark.real_ssrf
+    @pytest.mark.asyncio
+    async def test_discovery_url_ssrf_blocked(self, request_obj: httpx.Request) -> None:
+        """Discovery URL pointing to non-HTTPS scheme must be rejected."""
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            discovery_url="http://10.0.0.1/.well-known/openid-configuration",
+        )
+
+        with pytest.raises(OAuth2TokenError, match="SSRF protection"):
+            await handler.apply(request_obj)
+
+    @pytest.mark.asyncio
+    async def test_discovered_token_endpoint_ssrf_blocked(
+        self, request_obj: httpx.Request
+    ) -> None:
+        """A legit discovery URL that returns a malicious token_endpoint must be rejected."""
+        from dns_aid.utils.url_safety import UnsafeURLError
+
+        handler = OAuth2AuthHandler(
+            client_id="id",
+            client_secret="secret",
+            discovery_url="https://legit-auth.example.com/.well-known/openid-configuration",
+        )
+
+        # Discovery response points token_endpoint at cloud metadata
+        malicious_discovery = {
+            "token_endpoint": "https://169.254.169.254/latest/meta-data/",
+            "issuer": "https://legit-auth.example.com",
+        }
+        mock_disc_resp = httpx.Response(200, json=malicious_discovery)
+
+        def ssrf_check(url: str) -> str:
+            """Allow the discovery URL, block the malicious token_endpoint."""
+            if "169.254" in url:
+                raise UnsafeURLError(f"URL resolves to non-public IP: {url}")
+            return url
+
+        with patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=ssrf_check):
+            with patch("dns_aid.sdk.auth.oauth2.httpx.AsyncClient") as mock_cls:
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(return_value=mock_disc_resp)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_cls.return_value = mock_client
+
+                with pytest.raises(OAuth2TokenError, match="token_endpoint blocked"):
+                    await handler.apply(request_obj)

--- a/tests/unit/sdk/auth/test_registry.py
+++ b/tests/unit/sdk/auth/test_registry.py
@@ -46,7 +46,9 @@ class TestResolveAuthHandler:
     def test_oauth2(self) -> None:
         handler = resolve_auth_handler(
             "oauth2",
-            auth_config={"oauth_discovery": "https://auth.example.com/.well-known/openid-configuration"},
+            auth_config={
+                "oauth_discovery": "https://auth.example.com/.well-known/openid-configuration"
+            },
             credentials={
                 "client_id": "id",
                 "client_secret": "secret",

--- a/tests/unit/sdk/test_top_level_api.py
+++ b/tests/unit/sdk/test_top_level_api.py
@@ -52,6 +52,58 @@ class TestTopLevelInvoke:
         assert callable(dns_aid.invoke)
 
     @pytest.mark.asyncio
+    async def test_invoke_with_credentials(self) -> None:
+        """Test that dns_aid.invoke() passes credentials through."""
+        import json
+
+        rpc_response = {
+            "jsonrpc": "2.0",
+            "result": {"content": [{"type": "text", "text": json.dumps({"ok": True})}]},
+            "id": 1,
+        }
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            return httpx.Response(200, json=rpc_response)
+
+        transport = httpx.MockTransport(handler)
+
+        from dns_aid.sdk import AgentClient, SDKConfig
+
+        agent = AgentRecord(
+            name="secure",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            port=443,
+            auth_type="bearer",
+        )
+
+        config = SDKConfig(timeout_seconds=5.0)
+        async with AgentClient(config=config) as client:
+            await client._http_client.aclose()
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(
+                agent,
+                method="tools/list",
+                credentials={"token": "test-bearer-token"},
+            )
+
+        assert result.success
+        assert captured["headers"]["authorization"] == "Bearer test-bearer-token"
+        assert result.signal.auth_type == "bearer"
+        assert result.signal.auth_applied is True
+
+    @pytest.mark.asyncio
+    async def test_auth_exports_from_top_level(self) -> None:
+        """AuthHandler and resolve_auth_handler are importable from dns_aid."""
+        import dns_aid
+
+        assert hasattr(dns_aid, "AuthHandler")
+        assert hasattr(dns_aid, "resolve_auth_handler")
+
+    @pytest.mark.asyncio
     async def test_rank_is_importable(self) -> None:
         """Test that rank is importable from the top-level package."""
         import dns_aid

--- a/tests/unit/test_auth_enrichment.py
+++ b/tests/unit/test_auth_enrichment.py
@@ -165,6 +165,38 @@ class TestApplyAuthFromMetadata:
             "oauth_discovery": "https://auth.example.com/.well-known/openid-configuration",
         }
 
+    def test_rejects_unknown_auth_type(self) -> None:
+        """Unknown auth_type from malicious metadata should be skipped."""
+        agent = _make_agent()
+        _apply_auth_from_metadata(
+            agent,
+            {
+                "auth": {
+                    "type": "evil_handler",
+                    "location": "header",
+                }
+            },
+        )
+
+        # auth_type should NOT be set — unknown type was rejected
+        assert agent.auth_type is None
+        assert agent.auth_config is None
+
+    def test_accepts_ztaip_alias_auth_type(self) -> None:
+        """ZTAIP aliases (e.g., bearer_token) should be accepted."""
+        agent = _make_agent()
+        _apply_auth_from_metadata(
+            agent,
+            {
+                "auth": {
+                    "type": "bearer_token",
+                    "header_name": "Authorization",
+                }
+            },
+        )
+
+        assert agent.auth_type == "bearer_token"
+
     def test_http_msg_sig_with_algorithms(self) -> None:
         agent = _make_agent()
         _apply_auth_from_metadata(


### PR DESCRIPTION
## Summary

Hardens the Phase 5.6 SDK auth implementation with security fixes, SSRF protection, input validation, and observability improvements — all verified against live AWS infrastructure (API Gateway IAM, Cognito OAuth2, httpbin).

## Changes

### Security Fixes (Critical/High)
- **HTTP Message Signature bypass** — `_build_signature_base()` silently signed empty strings for missing headers. An attacker could forge requests without required headers and still pass verification. Now raises `ValueError`.
- **OAuth2 SSRF** — `_get_token()` and `_discover_token_url()` would POST client credentials to any URL from untrusted agent metadata. Added `validate_fetch_url()` checks on token_url, discovery_url, AND the discovered token_endpoint (chained SSRF via OIDC response).
- **Auth type injection** — `_apply_auth_from_metadata()` accepted arbitrary auth_type strings from malicious agent-card.json. Now validates against the registry allowlist at discovery time.
- **Response size limits** — Added guards against oversized responses: agent-card.json (1MB), cap documents (256KB), agent.json (100KB).

### Reliability Fixes (High)
- **Auth error context** — `resolve_auth_handler()` errors now include agent FQDN and auth_type for multi-agent debugging.
- **Telemetry logging** — HTTP push failures logged at `warning` with `exc_info` instead of silently swallowed at `debug`.

### Enhancements
- `InvocationSignal` — new `auth_type` and `auth_applied` fields for observability
- `dns_aid.invoke()` — now accepts `credentials` and `auth_handler` params
- `dns_aid.AuthHandler` / `dns_aid.resolve_auth_handler` — exported from top-level package
- `__repr__` on all auth handlers — useful for debugging, never includes secrets

### Files Modified

| File | Changes |
|------|---------|
| `sdk/auth/http_msg_sig.py` | Missing component validation, `__repr__` |
| `sdk/auth/oauth2.py` | SSRF protection (3 points), `__repr__` |
| `sdk/auth/sigv4.py` | `__repr__` |
| `sdk/auth/simple.py` | `__repr__` for all 3 handlers |
| `sdk/client.py` | Error context, warning-level telemetry, signal auth fields |
| `sdk/models.py` | `auth_type`, `auth_applied` on InvocationSignal |
| `sdk/signals/collector.py` | Wire auth fields through |
| `core/discoverer.py` | Auth type allowlist, agent.json size limit |
| `core/a2a_card.py` | Agent card response size limit (1MB) |
| `core/cap_fetcher.py` | Cap document response size limit (256KB) |
| `__init__.py` | credentials/auth_handler on invoke(), export auth types |

## Test plan

- [x] 870 unit tests passing (`uv run pytest tests/unit/ -x -q`)
- [x] 28 integration tests passing against live AWS (`uv run pytest tests/integration/test_sdk_auth_live.py`)
- [x] Adversarial tests: malicious auth_type, SQL injection, SSRF to cloud metadata, signature bypass, oversized responses, secret leak in repr
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` — 0 issues in 60 source files