### PR TITLE
fix: streaming size guards and credential rotation

### DIFF
--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -264,42 +264,40 @@ async def fetch_agent_card(
     logger.debug("Fetching A2A Agent Card", url=card_url)
 
     try:
-        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
-            response = await client.get(card_url)
+        from dns_aid.utils.url_safety import ResponseTooLargeError, safe_fetch_bytes
 
-            if response.status_code != 200:
-                logger.debug(
-                    "Agent Card fetch failed",
-                    url=card_url,
-                    status_code=response.status_code,
-                )
-                return None
+        body = await safe_fetch_bytes(
+            card_url, max_bytes=_MAX_AGENT_CARD_RESPONSE_BYTES, timeout=timeout
+        )
+        if body is None:
+            logger.debug("Agent Card fetch failed (non-200)", url=card_url)
+            return None
 
-            if len(response.content) > _MAX_AGENT_CARD_RESPONSE_BYTES:
-                logger.warning(
-                    "Agent Card response too large — skipping",
-                    url=card_url,
-                    size_bytes=len(response.content),
-                    limit=_MAX_AGENT_CARD_RESPONSE_BYTES,
-                )
-                return None
+        import json
 
-            data = response.json()
+        data = json.loads(body)
 
-            if not isinstance(data, dict):
-                logger.debug("Agent Card is not a JSON object", url=card_url)
-                return None
+        if not isinstance(data, dict):
+            logger.debug("Agent Card is not a JSON object", url=card_url)
+            return None
 
-            card = A2AAgentCard.from_dict(data)
+        card = A2AAgentCard.from_dict(data)
 
-            logger.debug(
-                "Agent Card fetched successfully",
-                url=card_url,
-                name=card.name,
-                skills_count=len(card.skills),
-            )
-            return card
+        logger.debug(
+            "Agent Card fetched successfully",
+            url=card_url,
+            name=card.name,
+            skills_count=len(card.skills),
+        )
+        return card
 
+    except ResponseTooLargeError:
+        logger.warning(
+            "Agent Card response too large — skipping",
+            url=card_url,
+            limit=_MAX_AGENT_CARD_RESPONSE_BYTES,
+        )
+        return None
     except httpx.TimeoutException:
         logger.debug("Agent Card fetch timed out", url=card_url)
         return None

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -151,62 +151,59 @@ async def fetch_cap_document(
         return None
 
     try:
-        async with httpx.AsyncClient(timeout=timeout, max_redirects=3) as client:
-            response = await client.get(cap_uri)
+        from dns_aid.utils.url_safety import ResponseTooLargeError, safe_fetch_bytes
 
-            if response.status_code != 200:
-                logger.debug(
-                    "Cap document fetch failed",
-                    cap_uri=cap_uri,
-                    status_code=response.status_code,
-                )
-                return None
+        body = await safe_fetch_bytes(
+            cap_uri,
+            max_bytes=_MAX_CAP_RESPONSE_BYTES,
+            timeout=timeout,
+            follow_redirects=True,
+            max_redirects=3,
+        )
+        if body is None:
+            logger.debug("Cap document fetch failed (non-200)", cap_uri=cap_uri)
+            return None
 
-            if len(response.content) > _MAX_CAP_RESPONSE_BYTES:
-                logger.warning(
-                    "Cap document response too large — skipping",
-                    cap_uri=cap_uri,
-                    size_bytes=len(response.content),
-                    limit=_MAX_CAP_RESPONSE_BYTES,
-                )
-                return None
+        if expected_sha256 and not _verify_cap_digest(body, expected_sha256, cap_uri):
+            return None
 
-            if expected_sha256 and not _verify_cap_digest(
-                response.content, expected_sha256, cap_uri
-            ):
-                return None
+        import json
 
-            data = response.json()
+        data = json.loads(body)
 
-            if not isinstance(data, dict):
-                logger.debug(
-                    "Cap document is not a JSON object",
-                    cap_uri=cap_uri,
-                )
-                return None
+        if not isinstance(data, dict):
+            logger.debug("Cap document is not a JSON object", cap_uri=cap_uri)
+            return None
 
-            capabilities = _extract_capabilities_multi_format(data)
-            use_cases = _extract_string_list(data, "use_cases")
+        capabilities = _extract_capabilities_multi_format(data)
+        use_cases = _extract_string_list(data, "use_cases")
 
-            known_keys = {"capabilities", "version", "description", "use_cases"}
-            metadata = {k: v for k, v in data.items() if k not in known_keys}
+        known_keys = {"capabilities", "version", "description", "use_cases"}
+        metadata = {k: v for k, v in data.items() if k not in known_keys}
 
-            doc = CapabilityDocument(
-                capabilities=capabilities,
-                version=data.get("version"),
-                description=data.get("description"),
-                use_cases=use_cases,
-                metadata=metadata,
-                raw_data=data,
-            )
+        doc = CapabilityDocument(
+            capabilities=capabilities,
+            version=data.get("version"),
+            description=data.get("description"),
+            use_cases=use_cases,
+            metadata=metadata,
+            raw_data=data,
+        )
 
-            logger.debug(
-                "Cap document fetched successfully",
-                cap_uri=cap_uri,
-                capabilities_count=len(doc.capabilities),
-            )
-            return doc
+        logger.debug(
+            "Cap document fetched successfully",
+            cap_uri=cap_uri,
+            capabilities_count=len(doc.capabilities),
+        )
+        return doc
 
+    except ResponseTooLargeError:
+        logger.warning(
+            "Cap document response too large — skipping",
+            cap_uri=cap_uri,
+            limit=_MAX_CAP_RESPONSE_BYTES,
+        )
+        return None
     except httpx.TimeoutException:
         logger.debug("Cap document fetch timed out", cap_uri=cap_uri)
         return None

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -19,7 +19,6 @@ from urllib.parse import urlparse
 import dns.asyncresolver
 import dns.rdatatype
 import dns.resolver
-import httpx
 import structlog
 
 from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
@@ -914,29 +913,25 @@ async def _fetch_agent_json_auth(host: str, timeout: float = 5.0) -> dict | None
         return None
 
     try:
-        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
-            resp = await client.get(url)
-            if resp.status_code != 200:
-                return None
-            # Guard against oversized responses from malicious servers
-            if len(resp.content) > 100_000:
-                logger.warning(
-                    "agent.json response too large — skipping",
-                    host=host,
-                    size_bytes=len(resp.content),
-                    limit=100_000,
-                )
-                return None
-            data = resp.json()
-            if not isinstance(data, dict):
-                return None
-            # Discriminator: DNS-AID native documents have aid_version
-            if "aid_version" not in data:
-                return None
-            auth = data.get("auth")
-            if isinstance(auth, dict) and auth.get("type", "none") != "none":
-                logger.debug("Fetched auth from agent.json", host=host, auth_type=auth.get("type"))
-                return auth
+        from dns_aid.utils.url_safety import ResponseTooLargeError, safe_fetch_bytes
+
+        body = await safe_fetch_bytes(url, max_bytes=100_000, timeout=timeout)
+        if body is None:
+            return None
+        import json
+
+        data = json.loads(body)
+        if not isinstance(data, dict):
+            return None
+        # Discriminator: DNS-AID native documents have aid_version
+        if "aid_version" not in data:
+            return None
+        auth = data.get("auth")
+        if isinstance(auth, dict) and auth.get("type", "none") != "none":
+            logger.debug("Fetched auth from agent.json", host=host, auth_type=auth.get("type"))
+            return auth
+    except ResponseTooLargeError:
+        logger.warning("agent.json response too large — skipping", host=host)
     except Exception:
         pass
     return None

--- a/src/dns_aid/utils/url_safety.py
+++ b/src/dns_aid/utils/url_safety.py
@@ -80,6 +80,78 @@ def validate_fetch_url(url: str) -> str:
     return url
 
 
+class ResponseTooLargeError(ValueError):
+    """Raised when a response exceeds the configured size limit."""
+
+
+async def safe_fetch_bytes(
+    url: str,
+    *,
+    max_bytes: int,
+    timeout: float = 10.0,
+    follow_redirects: bool = False,
+    max_redirects: int = 0,
+) -> bytes | None:
+    """Fetch a URL with streaming size enforcement.
+
+    Reads the response body in chunks and aborts the connection if the
+    cumulative size exceeds *max_bytes*.  This prevents a malicious
+    server from forcing an OOM — the oversized payload never fully
+    lands in memory.
+
+    ``Content-Length`` is checked first as a fast-path reject, but
+    is not trusted (it can be spoofed or absent with chunked encoding).
+    The byte-counted stream read is the authoritative guard.
+
+    Returns the raw bytes on success, *None* on HTTP errors (non-200).
+
+    Raises:
+        ResponseTooLargeError: If the response exceeds *max_bytes*.
+    """
+    import httpx
+
+    kwargs: dict = {"timeout": timeout, "follow_redirects": follow_redirects}
+    if max_redirects:
+        kwargs["max_redirects"] = max_redirects
+
+    async with httpx.AsyncClient(**kwargs) as client, client.stream("GET", url) as resp:
+        if resp.status_code != 200:
+            return None
+
+        # Fast-path: reject via Content-Length header if present.
+        # Not authoritative (can be spoofed/absent) — stream read is.
+        cl = resp.headers.get("content-length")
+        if cl and cl.isdigit() and int(cl) > max_bytes:
+            logger.warning(
+                "Response Content-Length exceeds limit — aborting",
+                url=url,
+                content_length=int(cl),
+                limit=max_bytes,
+            )
+            raise ResponseTooLargeError(
+                f"Content-Length {cl} exceeds {max_bytes} byte limit: {url}"
+            )
+
+        # Stream with byte counting — the real guard.
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes(chunk_size=8192):
+            total += len(chunk)
+            if total > max_bytes:
+                logger.warning(
+                    "Response exceeded size limit mid-stream — aborting",
+                    url=url,
+                    bytes_read=total,
+                    limit=max_bytes,
+                )
+                raise ResponseTooLargeError(
+                    f"Response exceeded {max_bytes} byte limit at {total} bytes: {url}"
+                )
+            chunks.append(chunk)
+
+        return b"".join(chunks)
+
+
 def _get_allowlist() -> set[str]:
     """Get the fetch allowlist from environment variable."""
     raw = os.environ.get("DNS_AID_FETCH_ALLOWLIST", "")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -293,18 +293,35 @@ class MockDNSBridge:
         resolver_mock = self.build_resolver_mock()
         http_mock = self.build_http_client_mock()
 
+        # Build a safe_fetch_bytes mock that reuses the HTTP routing logic.
+        # safe_fetch_bytes returns raw bytes (not a Response object), so we
+        # adapt the existing mock_get → bytes conversion.
+        async def mock_safe_fetch(url: str, **kwargs: Any) -> bytes | None:
+            try:
+                resp = await http_mock.get(url)
+                if resp.status_code != 200:
+                    return None
+                return resp.content
+            except httpx.ConnectError:
+                return None
+
         with ExitStack() as stack:
             # DNS resolver — one patch covers all modules since they share
             # the same dns.asyncresolver module object
             stack.enter_context(patch("dns.asyncresolver.Resolver", return_value=resolver_mock))
-            # HTTP clients — patch each consumer module
+            # HTTP clients — validator and http_index still use httpx directly
             for mod in (
-                "dns_aid.core.cap_fetcher",
-                "dns_aid.core.a2a_card",
                 "dns_aid.core.validator",
                 "dns_aid.core.http_index",
             ):
                 stack.enter_context(patch(f"{mod}.httpx.AsyncClient", return_value=http_mock))
+            # cap_fetcher, a2a_card, and discoverer now use safe_fetch_bytes
+            stack.enter_context(
+                patch(
+                    "dns_aid.utils.url_safety.safe_fetch_bytes",
+                    side_effect=mock_safe_fetch,
+                )
+            )
             # SSRF bypass — validate_fetch_url is lazy-imported inside
             # cap_fetcher and a2a_card, so patching at the module level works
             stack.enter_context(

--- a/tests/integration/test_sdk_auth_live.py
+++ b/tests/integration/test_sdk_auth_live.py
@@ -18,12 +18,17 @@ Requires:
 - Public agent: https://1ls9mi4dp2.execute-api.us-east-1.amazonaws.com
 - SigV4 agent: https://lixqgn0ttl.execute-api.us-east-1.amazonaws.com
 - AWS okta-sso profile configured
+- Environment variables for OAuth2 (not hardcoded — see conftest.py):
+    DNS_AID_TEST_COGNITO_CLIENT_ID
+    DNS_AID_TEST_COGNITO_CLIENT_SECRET
 
 Run with:
     pytest tests/integration/test_sdk_auth_live.py -v
 """
 
 from __future__ import annotations
+
+import os
 
 import pytest
 
@@ -42,6 +47,12 @@ pytestmark = [pytest.mark.integration, pytest.mark.live]
 
 PUBLIC_HOST = "1ls9mi4dp2.execute-api.us-east-1.amazonaws.com"
 SIGV4_HOST = "lixqgn0ttl.execute-api.us-east-1.amazonaws.com"
+
+# OAuth2 credentials from environment — never hardcoded.
+# Set DNS_AID_TEST_COGNITO_CLIENT_ID and DNS_AID_TEST_COGNITO_CLIENT_SECRET.
+COGNITO_CLIENT_ID = os.environ.get("DNS_AID_TEST_COGNITO_CLIENT_ID", "")
+COGNITO_CLIENT_SECRET = os.environ.get("DNS_AID_TEST_COGNITO_CLIENT_SECRET", "")
+COGNITO_DISCOVERY = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_NE34GkEdc/.well-known/openid-configuration"
 
 
 def _agent(host: str, name: str = "test", **kwargs: object) -> AgentRecord:
@@ -152,15 +163,14 @@ class TestApiKeyAuth:
 
 class TestOAuth2Auth:
     @pytest.mark.asyncio
+    @pytest.mark.skipif(not COGNITO_CLIENT_ID, reason="DNS_AID_TEST_COGNITO_CLIENT_ID not set")
     async def test_oauth2_token_applied_to_request(self) -> None:
         """OAuth2 client-credentials token fetched from Cognito and applied."""
         agent = _agent(
             "httpbin.org",
             "oauth2-test",
             auth_type="oauth2",
-            auth_config={
-                "oauth_discovery": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_NE34GkEdc/.well-known/openid-configuration",
-            },
+            auth_config={"oauth_discovery": COGNITO_DISCOVERY},
             endpoint_override="https://httpbin.org/post",
         )
 
@@ -170,8 +180,8 @@ class TestOAuth2Auth:
                 method=None,
                 arguments={"test": "oauth2"},
                 credentials={
-                    "client_id": "17gid5tgiv7634o57kvo9ph6mm",
-                    "client_secret": "l6s8jli2fk18jisb6gouoaho9rf9va82c3vg6m2fnu141qhrpe9",
+                    "client_id": COGNITO_CLIENT_ID,
+                    "client_secret": COGNITO_CLIENT_SECRET,
                     "scopes": "dns-aid-api/invoke",
                 },
             )
@@ -520,15 +530,14 @@ class TestAdversarialMissingCredentials:
         assert "bearer" in error_msg
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(not COGNITO_CLIENT_ID, reason="DNS_AID_TEST_COGNITO_CLIENT_ID not set")
     async def test_wrong_oauth2_credentials_clear_error(self) -> None:
         """OAuth2 with bad client_secret gives clear error, not silent failure."""
         agent = _agent(
             "httpbin.org",
             "bad-oauth",
             auth_type="oauth2",
-            auth_config={
-                "oauth_discovery": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_NE34GkEdc/.well-known/openid-configuration",
-            },
+            auth_config={"oauth_discovery": COGNITO_DISCOVERY},
             endpoint_override="https://httpbin.org/post",
         )
 
@@ -541,7 +550,7 @@ class TestAdversarialMissingCredentials:
                     method=None,
                     arguments={"test": "bad-oauth"},
                     credentials={
-                        "client_id": "17gid5tgiv7634o57kvo9ph6mm",
+                        "client_id": COGNITO_CLIENT_ID,
                         "client_secret": "WRONG_SECRET_intentionally_bad",
                         "scopes": "dns-aid-api/invoke",
                     },

--- a/tests/integration/test_sdk_auth_live.py
+++ b/tests/integration/test_sdk_auth_live.py
@@ -612,25 +612,17 @@ class TestAdversarialAgentJson:
     @pytest.mark.asyncio
     async def test_size_limit_on_agent_json(self) -> None:
         """Verify the size limit is enforced on agent.json responses."""
-        import httpx
-
-        # Simulate a response > 100KB
-        oversized_body = b'{"aid_version": "1.0", "auth": {"type": "bearer"}, "pad": "' + b"x" * 110_000 + b'"}'
-
-        async def oversized_handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, content=oversized_body)
-
-        transport = httpx.MockTransport(oversized_handler)
-
-        # Patch httpx to use our mock transport
         from unittest.mock import patch
 
-        mock_client = httpx.AsyncClient(transport=transport)
+        from dns_aid.utils.url_safety import ResponseTooLargeError
 
-        with patch("dns_aid.core.discoverer.httpx.AsyncClient") as mock_cls:
-            mock_cls.return_value.__aenter__ = lambda self: mock_client.__aenter__()
-            mock_cls.return_value.__aexit__ = mock_client.__aexit__
+        async def mock_oversized_fetch(url, **kwargs):
+            raise ResponseTooLargeError(f"Response exceeded 100000 byte limit: {url}")
 
+        with (
+            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_oversized_fetch),
+        ):
             result = await _fetch_agent_json_auth("evil-server.example.com")
 
         assert result is None  # Oversized response should be rejected

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -284,26 +284,22 @@ class TestFetchAgentCard:
     @pytest.mark.asyncio
     async def test_fetch_success(self) -> None:
         """Test successful Agent Card fetch."""
+        import json
+
         mock_card_data = {
             "name": "Test Agent",
             "url": "https://agent.example.com",
             "skills": [{"id": "ping", "name": "Ping"}],
         }
 
-        with patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u):
-            with patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_card_data
+        async def mock_fetch(url, **kwargs):
+            return json.dumps(mock_card_data).encode()
 
-                mock_instance = AsyncMock()
-                mock_instance.get.return_value = mock_response
-                mock_instance.__aenter__.return_value = mock_instance
-                mock_instance.__aexit__.return_value = None
-
-                mock_client.return_value = mock_instance
-
-                card = await fetch_agent_card("https://agent.example.com")
+        with (
+            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
+        ):
+            card = await fetch_agent_card("https://agent.example.com")
 
         assert card is not None
         assert card.name == "Test Agent"
@@ -313,44 +309,33 @@ class TestFetchAgentCard:
     @pytest.mark.asyncio
     async def test_fetch_adds_https(self) -> None:
         """Test that https:// is added if missing."""
+        import json
+
+        captured_url: list[str] = []
+
+        async def mock_fetch(url, **kwargs):
+            captured_url.append(url)
+            return json.dumps({"name": "Test", "url": "https://x.com"}).encode()
+
         with (
             patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
         ):
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = {"name": "Test", "url": "https://x.com"}
-
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
             await fetch_agent_card("agent.example.com")
 
-            # Verify the URL was constructed correctly
-            call_args = mock_instance.get.call_args[0][0]
-            assert call_args == "https://agent.example.com/.well-known/agent-card.json"
+        assert captured_url[0] == "https://agent.example.com/.well-known/agent-card.json"
 
     @pytest.mark.asyncio
     async def test_fetch_404(self) -> None:
         """Test fetch returns None on 404."""
+
+        async def mock_fetch(url, **kwargs):
+            return None  # safe_fetch_bytes returns None for non-200
+
         with (
             patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
         ):
-            mock_response = MagicMock()
-            mock_response.status_code = 404
-
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
             card = await fetch_agent_card("https://agent.example.com")
 
         assert card is None
@@ -360,17 +345,13 @@ class TestFetchAgentCard:
         """Test fetch returns None on timeout."""
         import httpx
 
+        async def mock_fetch(url, **kwargs):
+            raise httpx.TimeoutException("timeout")
+
         with (
             patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
         ):
-            mock_instance = AsyncMock()
-            mock_instance.get.side_effect = httpx.TimeoutException("timeout")
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
             card = await fetch_agent_card("https://agent.example.com")
 
         assert card is None
@@ -380,39 +361,44 @@ class TestFetchAgentCard:
         """Test fetch returns None on connection error."""
         import httpx
 
+        async def mock_fetch(url, **kwargs):
+            raise httpx.ConnectError("failed")
+
         with (
             patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
         ):
-            mock_instance = AsyncMock()
-            mock_instance.get.side_effect = httpx.ConnectError("failed")
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
             card = await fetch_agent_card("https://agent.example.com")
 
         assert card is None
 
     @pytest.mark.asyncio
     async def test_fetch_invalid_json(self) -> None:
-        """Test fetch returns None on invalid JSON."""
+        """Test fetch returns None on invalid JSON (not a dict)."""
+
+        async def mock_fetch(url, **kwargs):
+            return b'"not an object"'
+
         with (
             patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
         ):
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = "not an object"
+            card = await fetch_agent_card("https://agent.example.com")
 
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
+        assert card is None
 
-            mock_client.return_value = mock_instance
+    @pytest.mark.asyncio
+    async def test_fetch_oversized_response(self) -> None:
+        """Test fetch returns None when response exceeds size limit."""
+        from dns_aid.utils.url_safety import ResponseTooLargeError
 
+        async def mock_fetch(url, **kwargs):
+            raise ResponseTooLargeError("too big")
+
+        with (
+            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
+        ):
             card = await fetch_agent_card("https://agent.example.com")
 
         assert card is None
@@ -424,22 +410,18 @@ class TestFetchAgentCardFromDomain:
     @pytest.mark.asyncio
     async def test_constructs_url_correctly(self) -> None:
         """Test that domain is converted to full URL."""
+        import json
+
+        captured_url: list[str] = []
+
+        async def mock_fetch(url, **kwargs):
+            captured_url.append(url)
+            return json.dumps({"name": "Test", "url": "https://x.com"}).encode()
+
         with (
             patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.a2a_card.httpx.AsyncClient") as mock_client,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch),
         ):
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.json.return_value = {"name": "Test", "url": "https://x.com"}
-
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
             await fetch_agent_card_from_domain("example.com")
 
-            call_args = mock_instance.get.call_args[0][0]
-            assert call_args == "https://example.com/.well-known/agent-card.json"
+        assert captured_url[0] == "https://example.com/.well-known/agent-card.json"

--- a/tests/unit/test_cap_fetcher.py
+++ b/tests/unit/test_cap_fetcher.py
@@ -3,12 +3,35 @@
 
 """Tests for DNS-AID capability document fetcher."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
 
 import httpx
 import pytest
 
 from dns_aid.core.cap_fetcher import CapabilityDocument, fetch_cap_document
+from dns_aid.utils.url_safety import ResponseTooLargeError
+
+_SSRF_BYPASS = patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u)
+
+
+def _mock_fetch(data: dict | list | str | None = None, *, raw: bytes | None = None):
+    """Create an async mock for safe_fetch_bytes."""
+    body = raw if raw is not None else (json.dumps(data).encode() if data is not None else None)
+
+    async def _fetch(url, **kwargs):
+        return body
+
+    return _fetch
+
+
+def _mock_fetch_error(exc):
+    async def _fetch(url, **kwargs):
+        raise exc
+
+    return _fetch
 
 
 class TestCapabilityDocument:
@@ -43,9 +66,7 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_successful_fetch(self):
         """Test fetching a valid capability document."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
+        cap_data = {
             "capabilities": ["travel", "booking", "calendar"],
             "version": "1.0.0",
             "description": "Booking agent for travel reservations",
@@ -54,14 +75,9 @@ class TestFetchCapDocument:
             "rate_limit": "100/min",
         }
 
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=_mock_fetch(cap_data)),
         ):
             doc = await fetch_cap_document("https://example.com/.well-known/agent-cap.json")
 
@@ -76,17 +92,9 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_returns_none_on_404(self):
         """Test that 404 returns None."""
-        mock_response = MagicMock()
-        mock_response.status_code = 404
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=_mock_fetch(None)),
         ):
             doc = await fetch_cap_document("https://example.com/.well-known/agent-cap.json")
 
@@ -95,17 +103,9 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_returns_none_on_500(self):
         """Test that server error returns None."""
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=_mock_fetch(None)),
         ):
             doc = await fetch_cap_document("https://example.com/.well-known/agent-cap.json")
 
@@ -114,14 +114,12 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_returns_none_on_timeout(self):
         """Test that timeout returns None."""
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch_error(httpx.TimeoutException("timeout")),
+            ),
         ):
             doc = await fetch_cap_document("https://example.com/.well-known/agent-cap.json")
 
@@ -130,14 +128,12 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_returns_none_on_connect_error(self):
         """Test that connection error returns None."""
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch_error(httpx.ConnectError("refused")),
+            ),
         ):
             doc = await fetch_cap_document("https://unreachable.example.com/cap.json")
 
@@ -146,18 +142,12 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_returns_none_on_invalid_json(self):
         """Test that invalid JSON returns None."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.side_effect = ValueError("invalid json")
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch(raw=b"not valid json{{{"),
+            ),
         ):
             doc = await fetch_cap_document("https://example.com/bad.json")
 
@@ -166,18 +156,12 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_returns_none_on_non_dict_json(self):
         """Test that non-dict JSON (e.g., array) returns None."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = ["not", "a", "dict"]
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch(["not", "a", "dict"]),
+            ),
         ):
             doc = await fetch_cap_document("https://example.com/array.json")
 
@@ -186,21 +170,12 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_empty_capabilities_list(self):
         """Test document with empty capabilities list."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "capabilities": [],
-            "version": "1.0.0",
-        }
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch({"capabilities": [], "version": "1.0.0"}),
+            ),
         ):
             doc = await fetch_cap_document("https://example.com/cap.json")
 
@@ -211,21 +186,12 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_missing_capabilities_field(self):
         """Test document without capabilities field."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "version": "1.0.0",
-            "description": "An agent without caps listed",
-        }
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch({"version": "1.0.0", "description": "An agent without caps"}),
+            ),
         ):
             doc = await fetch_cap_document("https://example.com/cap.json")
 
@@ -236,39 +202,47 @@ class TestFetchCapDocument:
     @pytest.mark.asyncio
     async def test_extra_metadata_preserved(self):
         """Test that unknown fields are preserved in metadata."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "capabilities": ["travel"],
-            "version": "2.0.0",
-            "description": "Travel agent",
-            "use_cases": ["booking"],
-            "protocols": ["mcp"],
-            "authentication": "oauth2",
-            "rate_limit": "100/min",
-            "contact": "ops@example.com",
-        }
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
         with (
-            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u),
-            patch("dns_aid.core.cap_fetcher.httpx.AsyncClient", return_value=mock_client),
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch(
+                    {
+                        "capabilities": ["travel"],
+                        "version": "2.0.0",
+                        "description": "Travel agent",
+                        "use_cases": ["booking"],
+                        "protocols": ["mcp"],
+                        "authentication": "oauth2",
+                        "rate_limit": "100/min",
+                        "contact": "ops@example.com",
+                    }
+                ),
+            ),
         ):
             doc = await fetch_cap_document("https://example.com/cap.json")
 
         assert doc is not None
         assert doc.capabilities == ["travel"]
-        # Known fields should NOT be in metadata
         assert "capabilities" not in doc.metadata
         assert "version" not in doc.metadata
         assert "description" not in doc.metadata
         assert "use_cases" not in doc.metadata
-        # Unknown fields SHOULD be in metadata
         assert doc.metadata["protocols"] == ["mcp"]
         assert doc.metadata["authentication"] == "oauth2"
         assert doc.metadata["rate_limit"] == "100/min"
         assert doc.metadata["contact"] == "ops@example.com"
+
+    @pytest.mark.asyncio
+    async def test_oversized_response_rejected(self):
+        """Test that oversized responses are rejected."""
+        with (
+            _SSRF_BYPASS,
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                side_effect=_mock_fetch_error(ResponseTooLargeError("too big")),
+            ),
+        ):
+            doc = await fetch_cap_document("https://evil.example.com/cap.json")
+
+        assert doc is None

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -102,10 +102,6 @@ class TestCapSha256Verification:
         import base64
         import hashlib
 
-        from unittest.mock import AsyncMock
-
-        import httpx
-
         from dns_aid.core.cap_fetcher import fetch_cap_document
 
         content = b'{"capabilities": ["test"]}'
@@ -113,19 +109,11 @@ class TestCapSha256Verification:
             base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode("ascii")
         )
 
-        mock_response = AsyncMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = content
-        mock_response.json.return_value = {"capabilities": ["test"]}
+        async def mock_fetch(url, **kwargs):
+            return content
 
         with patch("dns_aid.utils.url_safety.validate_fetch_url", return_value="https://ok.com"):
-            with patch("httpx.AsyncClient") as mock_client_cls:
-                mock_client = AsyncMock()
-                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                mock_client.__aexit__ = AsyncMock(return_value=False)
-                mock_client.get = AsyncMock(return_value=mock_response)
-                mock_client_cls.return_value = mock_client
-
+            with patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch):
                 doc = await fetch_cap_document(
                     "https://ok.com/cap.json",
                     expected_sha256=expected_hash,
@@ -136,27 +124,15 @@ class TestCapSha256Verification:
     @pytest.mark.asyncio
     async def test_hash_mismatch_returns_none(self):
         """Wrong hash should cause fetch to return None."""
-        from unittest.mock import AsyncMock
-
-        import httpx
-
         from dns_aid.core.cap_fetcher import fetch_cap_document
 
         content = b'{"capabilities": ["test"]}'
 
-        mock_response = AsyncMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = content
-        mock_response.json.return_value = {"capabilities": ["test"]}
+        async def mock_fetch(url, **kwargs):
+            return content
 
         with patch("dns_aid.utils.url_safety.validate_fetch_url", return_value="https://ok.com"):
-            with patch("httpx.AsyncClient") as mock_client_cls:
-                mock_client = AsyncMock()
-                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                mock_client.__aexit__ = AsyncMock(return_value=False)
-                mock_client.get = AsyncMock(return_value=mock_response)
-                mock_client_cls.return_value = mock_client
-
+            with patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch):
                 doc = await fetch_cap_document(
                     "https://ok.com/cap.json",
                     expected_sha256="WRONG_HASH",
@@ -166,27 +142,15 @@ class TestCapSha256Verification:
     @pytest.mark.asyncio
     async def test_no_hash_skips_verification(self):
         """When expected_sha256 is None, skip verification."""
-        from unittest.mock import AsyncMock
-
-        import httpx
-
         from dns_aid.core.cap_fetcher import fetch_cap_document
 
         content = b'{"capabilities": ["test"]}'
 
-        mock_response = AsyncMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = content
-        mock_response.json.return_value = {"capabilities": ["test"]}
+        async def mock_fetch(url, **kwargs):
+            return content
 
         with patch("dns_aid.utils.url_safety.validate_fetch_url", return_value="https://ok.com"):
-            with patch("httpx.AsyncClient") as mock_client_cls:
-                mock_client = AsyncMock()
-                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-                mock_client.__aexit__ = AsyncMock(return_value=False)
-                mock_client.get = AsyncMock(return_value=mock_response)
-                mock_client_cls.return_value = mock_client
-
+            with patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch):
                 doc = await fetch_cap_document(
                     "https://ok.com/cap.json",
                     expected_sha256=None,


### PR DESCRIPTION
## Summary

Two hardening improvements for LF readiness:

1. **Streaming size guards** — replaces post-buffer `len(resp.content)` checks with true streaming byte-counted reads via `safe_fetch_bytes()`. Oversized payloads abort mid-stream and never fully land in memory.

2. **Credential rotation** — Cognito test credentials removed from source. Old client deleted (invalidated). Tests read from `DNS_AID_TEST_COGNITO_CLIENT_ID` / `DNS_AID_TEST_COGNITO_CLIENT_SECRET` env vars and skip gracefully when absent.

## Changes

| File | What |
|------|------|
| `utils/url_safety.py` | New `safe_fetch_bytes()` — streaming fetch with byte-counted size limit |
| `core/a2a_card.py` | `fetch_agent_card()` uses `safe_fetch_bytes` (1MB limit) |
| `core/cap_fetcher.py` | `fetch_cap_document()` uses `safe_fetch_bytes` (256KB limit) |
| `core/discoverer.py` | `_fetch_agent_json_auth()` uses `safe_fetch_bytes` (100KB limit) |
| `tests/integration/test_sdk_auth_live.py` | Credentials from env vars, `skipif` when absent |
| `tests/unit/test_a2a_card.py` | Mock `safe_fetch_bytes` instead of `httpx.AsyncClient` |
| `tests/unit/test_cap_fetcher.py` | Same — mock at the `safe_fetch_bytes` boundary |
| `tests/unit/test_url_safety.py` | Same — SHA-256 verification tests updated |

## Test plan

- [x] 872 unit tests passing
- [x] 28 integration tests passing (with rotated Cognito credentials)
- [x] `ruff check`, `ruff format`, `mypy` — all clean
- [x] OAuth2 tests skip gracefully without env vars (CI-safe)