### PR TITLE
chore: bump version to 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.6] - 2026-03-22
+
+### Security
+- **Streaming size guards** — replaced post-buffer `len(resp.content)` checks with true streaming byte-counted reads via `safe_fetch_bytes()`. Oversized payloads are now aborted mid-stream — they never fully land in memory. Applies to `fetch_agent_card` (1MB), `fetch_cap_document` (256KB), and `_fetch_agent_json_auth` (100KB). `Content-Length` is checked as fast-path reject; stream byte count is the authoritative guard.
+- **Credential rotation** — Cognito test client rotated. Old client `17gid5tgiv7634o57kvo9ph6mm` deleted and invalidated. Integration tests now read from `DNS_AID_TEST_COGNITO_CLIENT_ID` / `DNS_AID_TEST_COGNITO_CLIENT_SECRET` environment variables. Tests skip gracefully when env vars are absent (CI-safe).
+
+### Added
+- **`safe_fetch_bytes()`** in `dns_aid.utils.url_safety` — reusable async streaming fetch with byte-counted size enforcement, `Content-Length` fast-path, and `ResponseTooLargeError`.
+
 ## [0.13.5] - 2026-03-22
 
 ### Security

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.13.5"
+version: "0.13.6"
 date-released: "2026-03-22"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.13.5"
+version = "0.13.6"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.13.5"
+__version__ = "0.13.6"
 __all__ = [
     # Core functions (Tier 0)
     "publish",


### PR DESCRIPTION
## Summary
- Version bump to 0.13.6 for streaming size guards + credential rotation (PR #60)
- Updated: `pyproject.toml`, `__init__.py`, `CITATION.cff`, `CHANGELOG.md`

## Test plan
- [x] Version-only changes — no code changes