### PR TITLE
feat: Phase 6 policy foundation and validator enhancement

### DIFF
--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -56,6 +56,31 @@ def _normalize_connect_class(value: str | None) -> str | None:
     return validate_connect_class(value)
 
 
+class DNSSECDetail(BaseModel):
+    """Granular DNSSEC validation detail for trust scoring rubric."""
+
+    validated: bool = False
+    algorithm: str | None = None  # e.g., "ECDSAP256SHA256", "RSASHA256"
+    algorithm_strength: str | None = None  # "strong" | "acceptable" | "weak"
+    chain_complete: bool = False
+    chain_depth: int = 0
+    nsec3_present: bool = False
+    key_rotation_days: int | None = None
+    ad_flag: bool = False
+
+
+class TLSDetail(BaseModel):
+    """TLS connection detail for trust scoring rubric."""
+
+    connected: bool = False
+    tls_version: str | None = None  # "TLSv1.3", "TLSv1.2"
+    cipher_suite: str | None = None
+    cert_valid: bool = False
+    cert_days_remaining: int | None = None
+    hsts_enabled: bool = False
+    hsts_max_age: int | None = None
+
+
 class DNSSECError(Exception):
     """Raised when DNSSEC validation is required but the DNS response is unsigned.
 
@@ -516,6 +541,10 @@ class VerifyResult(BaseModel):
     )
     endpoint_reachable: bool = Field(default=False, description="Endpoint responds")
     endpoint_latency_ms: float | None = Field(default=None, description="Endpoint response time")
+
+    # Granular detail for trust scoring rubric (Phase 6)
+    dnssec_detail: DNSSECDetail = Field(default_factory=DNSSECDetail)
+    tls_detail: TLSDetail = Field(default_factory=TLSDetail)
 
     @property
     def security_score(self) -> int:

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -10,9 +10,11 @@ Handles DNSSEC validation, DANE/TLSA verification, and endpoint health checks.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import ssl
 import time
+from datetime import UTC
 
 import dns.asyncresolver
 import dns.flags
@@ -21,7 +23,7 @@ import dns.resolver
 import httpx
 import structlog
 
-from dns_aid.core.models import VerifyResult
+from dns_aid.core.models import DNSSECDetail, TLSDetail, VerifyResult
 
 logger = structlog.get_logger(__name__)
 
@@ -62,8 +64,10 @@ async def verify(fqdn: str, *, verify_dane_cert: bool = False) -> VerifyResult:
         target = None
         port = None
 
-    # 2. Check DNSSEC validation
-    result.dnssec_valid = await _check_dnssec(fqdn)
+    # 2. Check DNSSEC validation (with detail)
+    dnssec_detail = await _check_dnssec_detail(fqdn)
+    result.dnssec_detail = dnssec_detail
+    result.dnssec_valid = dnssec_detail.validated
 
     # 3. Check DANE/TLSA (if target is available)
     # Per IETF draft Section 4.4.1, DANE TLSA SHOULD be used to bind
@@ -97,6 +101,10 @@ async def verify(fqdn: str, *, verify_dane_cert: bool = False) -> VerifyResult:
         endpoint_result = await _check_endpoint(target, port)
         result.endpoint_reachable = endpoint_result.get("reachable", False)
         result.endpoint_latency_ms = endpoint_result.get("latency_ms")
+
+    # 5. Check TLS detail
+    if target and port:
+        result.tls_detail = await _check_tls(target, port)
 
     logger.info(
         "Verification complete",
@@ -214,6 +222,195 @@ async def _check_dnssec(fqdn: str) -> bool:
     # This is not necessarily an error
     logger.debug("DNSSEC not validated", fqdn=fqdn)
     return False
+
+
+# DNSSEC algorithm number → name mapping (RFC 8624)
+_DNSSEC_ALGORITHM_MAP: dict[int, str] = {
+    1: "RSAMD5",
+    3: "DSA",
+    5: "RSASHA1",
+    6: "DSA-NSEC3-SHA1",
+    7: "RSASHA1-NSEC3-SHA1",
+    8: "RSASHA256",
+    10: "RSASHA512",
+    12: "ECC-GOST",
+    13: "ECDSAP256SHA256",
+    14: "ECDSAP384SHA384",
+    15: "ED25519",
+    16: "ED448",
+}
+
+# Algorithm strength classifications per RFC 8624 recommendations
+_ALGORITHM_STRENGTH: dict[str, str] = {
+    "RSAMD5": "weak",
+    "DSA": "weak",
+    "RSASHA1": "weak",
+    "DSA-NSEC3-SHA1": "weak",
+    "RSASHA1-NSEC3-SHA1": "weak",
+    "RSASHA256": "acceptable",
+    "RSASHA512": "acceptable",
+    "ECC-GOST": "acceptable",
+    "ECDSAP256SHA256": "strong",
+    "ECDSAP384SHA384": "strong",
+    "ED25519": "strong",
+    "ED448": "strong",
+}
+
+
+async def _check_dnssec_detail(fqdn: str) -> DNSSECDetail:
+    """
+    Check DNSSEC validation and extract granular detail for trust scoring.
+
+    Extracts algorithm from DNSKEY records, checks for NSEC3, measures
+    chain depth by walking DS records up the tree, and checks the AD flag.
+
+    Returns:
+        DNSSECDetail with populated fields.
+    """
+    detail = DNSSECDetail()
+
+    try:
+        resolver = dns.asyncresolver.Resolver()
+        resolver.use_edns(edns=0, ednsflags=dns.flags.DO)
+
+        # Check AD flag on SVCB (or TXT fallback)
+        answer = None
+        try:
+            answer = await resolver.resolve(fqdn, "SVCB")
+        except dns.resolver.NoAnswer:
+            with contextlib.suppress(Exception):
+                answer = await resolver.resolve(fqdn, "TXT")
+
+        if answer and hasattr(answer.response, "flags"):
+            ad_flag = bool(answer.response.flags & dns.flags.AD)
+            detail.ad_flag = ad_flag
+            detail.validated = ad_flag
+
+        # Extract algorithm from DNSKEY records at the zone apex
+        # Walk from the FQDN up to find the zone with DNSKEY
+        parts = fqdn.rstrip(".").split(".")
+        algorithm_name: str | None = None
+        for i in range(len(parts)):
+            zone = ".".join(parts[i:])
+            try:
+                dnskey_answer = await resolver.resolve(zone, "DNSKEY")
+                for rdata in dnskey_answer:
+                    alg_num = rdata.algorithm
+                    algorithm_name = _DNSSEC_ALGORITHM_MAP.get(alg_num, f"UNKNOWN({alg_num})")
+                    detail.algorithm = algorithm_name
+                    detail.algorithm_strength = _ALGORITHM_STRENGTH.get(algorithm_name, "unknown")
+                    break  # Use first DNSKEY found
+                if algorithm_name:
+                    break
+            except Exception:
+                continue
+
+        # Check for NSEC3 records (query NSEC3PARAM at zone apex)
+        for i in range(len(parts)):
+            zone = ".".join(parts[i:])
+            try:
+                await resolver.resolve(zone, "NSEC3PARAM")
+                detail.nsec3_present = True
+                break
+            except Exception:
+                continue
+
+        # Measure chain depth by counting DS records from zone up to root
+        chain_depth = 0
+        for i in range(len(parts)):
+            zone = ".".join(parts[i:])
+            if not zone:
+                continue
+            try:
+                await resolver.resolve(zone, "DS")
+                chain_depth += 1
+            except Exception:
+                continue
+        detail.chain_depth = chain_depth
+        detail.chain_complete = chain_depth > 0 and detail.ad_flag
+
+    except Exception as e:
+        logger.debug("DNSSEC detail check failed", fqdn=fqdn, error=str(e))
+
+    return detail
+
+
+async def _check_tls(target: str, port: int) -> TLSDetail:
+    """
+    Connect to target:port via TLS and extract connection detail.
+
+    Extracts TLS version, cipher suite, certificate validity,
+    days remaining on cert, and checks for HSTS header.
+
+    Returns:
+        TLSDetail with populated fields.
+    """
+    detail = TLSDetail()
+
+    try:
+        ctx = ssl.create_default_context()
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(target, port, ssl=ctx),
+            timeout=10.0,
+        )
+
+        try:
+            ssl_object = writer.get_extra_info("ssl_object")
+            if ssl_object:
+                detail.connected = True
+
+                # TLS version
+                detail.tls_version = ssl_object.version()
+
+                # Cipher suite
+                cipher_info = ssl_object.cipher()
+                if cipher_info:
+                    detail.cipher_suite = cipher_info[0]
+
+                # Certificate info
+                cert = ssl_object.getpeercert()
+                if cert:
+                    detail.cert_valid = True
+                    # Calculate days remaining from notAfter
+                    not_after = cert.get("notAfter")
+                    if not_after:
+                        try:
+                            from datetime import datetime
+
+                            # Parse SSL date format: 'Mon DD HH:MM:SS YYYY GMT'
+                            expiry = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
+                            expiry = expiry.replace(tzinfo=UTC)
+                            now = datetime.now(UTC)
+                            days_remaining = (expiry - now).days
+                            detail.cert_days_remaining = days_remaining
+                            if days_remaining < 0:
+                                detail.cert_valid = False
+                        except (ValueError, TypeError):
+                            pass
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        # Check HSTS via HTTP request
+        try:
+            async with httpx.AsyncClient(timeout=5.0, verify=True) as client:
+                response = await client.head(f"https://{target}:{port}/")
+                hsts_header = response.headers.get("strict-transport-security")
+                if hsts_header:
+                    detail.hsts_enabled = True
+                    # Extract max-age
+                    for part in hsts_header.split(";"):
+                        part = part.strip()
+                        if part.lower().startswith("max-age="):
+                            with contextlib.suppress(ValueError, IndexError):
+                                detail.hsts_max_age = int(part.split("=", 1)[1])
+        except Exception:
+            pass  # HSTS check is best-effort
+
+    except Exception as e:
+        logger.debug("TLS detail check failed", target=target, port=port, error=str(e))
+
+    return detail
 
 
 async def _check_dane(target: str, port: int, *, verify_cert: bool = False) -> bool | None:

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -302,7 +302,7 @@ async def _check_dnssec_detail(fqdn: str) -> DNSSECDetail:
                     break  # Use first DNSKEY found
                 if algorithm_name:
                     break
-            except Exception:
+            except Exception:  # nosec B112 — walking DNS tree, zone may lack DNSKEY
                 continue
 
         # Check for NSEC3 records (query NSEC3PARAM at zone apex)
@@ -312,7 +312,7 @@ async def _check_dnssec_detail(fqdn: str) -> DNSSECDetail:
                 await resolver.resolve(zone, "NSEC3PARAM")
                 detail.nsec3_present = True
                 break
-            except Exception:
+            except Exception:  # nosec B112 — walking DNS tree, zone may lack NSEC3PARAM
                 continue
 
         # Measure chain depth by counting DS records from zone up to root
@@ -324,7 +324,7 @@ async def _check_dnssec_detail(fqdn: str) -> DNSSECDetail:
             try:
                 await resolver.resolve(zone, "DS")
                 chain_depth += 1
-            except Exception:
+            except Exception:  # nosec B112 — walking DNS tree, zone may lack DS
                 continue
         detail.chain_depth = chain_depth
         detail.chain_complete = chain_depth > 0 and detail.ad_flag

--- a/src/dns_aid/sdk/policy/__init__.py
+++ b/src/dns_aid/sdk/policy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""DNS-AID Policy enforcement models and evaluation."""

--- a/src/dns_aid/sdk/policy/models.py
+++ b/src/dns_aid/sdk/policy/models.py
@@ -1,0 +1,67 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DNS-AID Policy evaluation models.
+
+Provides the context, result, and error types used by the policy evaluator
+to decide whether a caller is allowed to invoke a target agent.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class PolicyContext(BaseModel):
+    """Context for evaluating a policy -- represents the caller's identity and request."""
+
+    caller_id: str | None = None
+    caller_domain: str | None = None
+    protocol: str | None = None
+    method: str | None = None
+    intent: str | None = None
+    auth_type: str | None = None
+    dnssec_validated: bool = False
+    tls_version: str | None = None
+    caller_trust_score: float | None = None
+    geo_country: str | None = None
+    payload_bytes: int | None = None
+    has_mutual_tls: bool = False
+    consent_token: str | None = None
+
+
+class PolicyViolation(BaseModel):
+    """A single policy rule violation."""
+
+    rule: str  # e.g., "required_auth_types"
+    detail: str  # e.g., "oauth2 required, got bearer"
+    layer: str  # "layer1" or "layer2"
+
+
+class PolicyResult(BaseModel):
+    """Result of policy evaluation."""
+
+    allowed: bool
+    violations: list[PolicyViolation] = []
+    warnings: list[PolicyViolation] = []
+
+    @property
+    def denied(self) -> bool:
+        """True when the policy evaluation denied the request."""
+        return not self.allowed
+
+    @property
+    def reason(self) -> str:
+        """Human-readable summary of violations, or 'allowed'."""
+        if self.violations:
+            return "; ".join(f"{v.rule}: {v.detail}" for v in self.violations)
+        return "allowed"
+
+
+class PolicyViolationError(Exception):
+    """Raised in strict mode when policy denies invocation."""
+
+    def __init__(self, result: PolicyResult) -> None:
+        self.result = result
+        super().__init__(f"Policy violation: {result.reason}")

--- a/src/dns_aid/sdk/policy/schema.py
+++ b/src/dns_aid/sdk/policy/schema.py
@@ -1,0 +1,113 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DNS-AID Policy Document schema.
+
+Defines the JSON schema for documents served at policy_uri.
+Each rule is annotated with enforcement_layers to indicate
+where it can be enforced (Layer 0=bind-aid, 1=caller SDK, 2=target SDK).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PolicyEnforcementLayer(StrEnum):
+    """Enforcement layer where a policy rule can be applied."""
+
+    DNS = "layer0"  # bind-aid (DNS resolver)
+    CALLER = "layer1"  # Caller SDK (AgentClient)
+    TARGET = "layer2"  # Target SDK (middleware)
+
+
+class RateLimitConfig(BaseModel):
+    """Rate limiting configuration for an agent endpoint."""
+
+    max_per_minute: int | None = None
+    max_per_hour: int | None = None
+
+
+class AvailabilityConfig(BaseModel):
+    """Time-of-day availability window for an agent."""
+
+    hours: str  # "08:00-22:00"
+    timezone: str = "UTC"
+
+
+class PolicyRules(BaseModel):
+    """All 16 policy rule types for DNS-AID agent governance."""
+
+    required_protocols: list[str] | None = None
+    required_auth_types: list[str] | None = None
+    require_dnssec: bool = False
+    require_mutual_tls: bool = False
+    min_tls_version: str | None = None
+    required_caller_trust_score: float | None = None
+    rate_limits: RateLimitConfig | None = None
+    max_payload_bytes: int | None = None
+    allowed_caller_domains: list[str] | None = None
+    blocked_caller_domains: list[str] | None = None
+    allowed_methods: list[str] | None = None
+    allowed_intents: list[str] | None = None
+    geo_restrictions: list[str] | None = None
+    availability: AvailabilityConfig | None = None
+    data_classification: str | None = None
+    consent_required: bool = False
+
+    @field_validator("min_tls_version")
+    @classmethod
+    def validate_tls_version(cls, v: str | None) -> str | None:
+        """Validate TLS version is 1.2 or 1.3."""
+        if v and v not in ("1.2", "1.3"):
+            raise ValueError(f"Invalid TLS version: {v}. Must be '1.2' or '1.3'")
+        return v
+
+    @field_validator("data_classification")
+    @classmethod
+    def validate_classification(cls, v: str | None) -> str | None:
+        """Validate data classification level."""
+        valid = {"public", "internal", "confidential", "restricted"}
+        if v and v not in valid:
+            raise ValueError(f"Invalid classification: {v}. Must be one of {valid}")
+        return v
+
+
+# bind-aid compile target annotations per rule
+RULE_ENFORCEMENT_LAYERS: dict[str, list[PolicyEnforcementLayer]] = {
+    "required_protocols": [PolicyEnforcementLayer.DNS, PolicyEnforcementLayer.CALLER],
+    "required_auth_types": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "require_dnssec": [PolicyEnforcementLayer.CALLER],
+    "require_mutual_tls": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "min_tls_version": [PolicyEnforcementLayer.CALLER],
+    "required_caller_trust_score": [PolicyEnforcementLayer.CALLER],
+    "rate_limits": [PolicyEnforcementLayer.TARGET],
+    "max_payload_bytes": [PolicyEnforcementLayer.TARGET],
+    "allowed_caller_domains": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "blocked_caller_domains": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "allowed_methods": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "allowed_intents": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "geo_restrictions": [PolicyEnforcementLayer.DNS, PolicyEnforcementLayer.TARGET],
+    "availability": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+    "data_classification": [PolicyEnforcementLayer.CALLER],
+    "consent_required": [PolicyEnforcementLayer.CALLER, PolicyEnforcementLayer.TARGET],
+}
+
+
+class PolicyDocument(BaseModel):
+    """JSON document served at policy_uri."""
+
+    version: str = "1.0"
+    agent: str  # FQDN of the agent this policy applies to
+    rules: PolicyRules = Field(default_factory=PolicyRules)
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, v: str) -> str:
+        """Validate policy document version."""
+        if v not in ("1.0",):
+            raise ValueError(f"Unsupported policy version: {v}")
+        return v

--- a/tests/unit/core/test_validator_detail.py
+++ b/tests/unit/core/test_validator_detail.py
@@ -1,0 +1,354 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DNSSECDetail, TLSDetail models and validator detail extraction."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import dns.flags
+import dns.resolver
+import pytest
+
+from dns_aid.core.models import DNSSECDetail, TLSDetail, VerifyResult
+from dns_aid.core.validator import (
+    _ALGORITHM_STRENGTH,
+    _DNSSEC_ALGORITHM_MAP,
+    _check_dnssec_detail,
+    _check_tls,
+)
+
+
+# =============================================================================
+# DNSSECDetail model tests
+# =============================================================================
+
+
+class TestDNSSECDetail:
+    """Test DNSSECDetail model creation with various inputs."""
+
+    def test_default_values(self) -> None:
+        detail = DNSSECDetail()
+        assert detail.validated is False
+        assert detail.algorithm is None
+        assert detail.algorithm_strength is None
+        assert detail.chain_complete is False
+        assert detail.chain_depth == 0
+        assert detail.nsec3_present is False
+        assert detail.key_rotation_days is None
+        assert detail.ad_flag is False
+
+    def test_fully_populated(self) -> None:
+        detail = DNSSECDetail(
+            validated=True,
+            algorithm="ECDSAP256SHA256",
+            algorithm_strength="strong",
+            chain_complete=True,
+            chain_depth=3,
+            nsec3_present=True,
+            key_rotation_days=90,
+            ad_flag=True,
+        )
+        assert detail.validated is True
+        assert detail.algorithm == "ECDSAP256SHA256"
+        assert detail.algorithm_strength == "strong"
+        assert detail.chain_complete is True
+        assert detail.chain_depth == 3
+        assert detail.nsec3_present is True
+        assert detail.key_rotation_days == 90
+        assert detail.ad_flag is True
+
+    def test_weak_algorithm(self) -> None:
+        detail = DNSSECDetail(
+            validated=True,
+            algorithm="RSASHA1",
+            algorithm_strength="weak",
+        )
+        assert detail.algorithm_strength == "weak"
+
+    def test_acceptable_algorithm(self) -> None:
+        detail = DNSSECDetail(
+            validated=True,
+            algorithm="RSASHA256",
+            algorithm_strength="acceptable",
+        )
+        assert detail.algorithm_strength == "acceptable"
+
+
+# =============================================================================
+# TLSDetail model tests
+# =============================================================================
+
+
+class TestTLSDetail:
+    """Test TLSDetail model creation with various inputs."""
+
+    def test_default_values(self) -> None:
+        detail = TLSDetail()
+        assert detail.connected is False
+        assert detail.tls_version is None
+        assert detail.cipher_suite is None
+        assert detail.cert_valid is False
+        assert detail.cert_days_remaining is None
+        assert detail.hsts_enabled is False
+        assert detail.hsts_max_age is None
+
+    def test_fully_populated(self) -> None:
+        detail = TLSDetail(
+            connected=True,
+            tls_version="TLSv1.3",
+            cipher_suite="TLS_AES_256_GCM_SHA384",
+            cert_valid=True,
+            cert_days_remaining=365,
+            hsts_enabled=True,
+            hsts_max_age=31536000,
+        )
+        assert detail.connected is True
+        assert detail.tls_version == "TLSv1.3"
+        assert detail.cipher_suite == "TLS_AES_256_GCM_SHA384"
+        assert detail.cert_valid is True
+        assert detail.cert_days_remaining == 365
+        assert detail.hsts_enabled is True
+        assert detail.hsts_max_age == 31536000
+
+    def test_tls_12(self) -> None:
+        detail = TLSDetail(
+            connected=True,
+            tls_version="TLSv1.2",
+            cert_valid=True,
+        )
+        assert detail.tls_version == "TLSv1.2"
+
+    def test_expired_cert(self) -> None:
+        detail = TLSDetail(
+            connected=True,
+            cert_valid=False,
+            cert_days_remaining=-5,
+        )
+        assert detail.cert_valid is False
+        assert detail.cert_days_remaining == -5
+
+
+# =============================================================================
+# VerifyResult integration tests
+# =============================================================================
+
+
+class TestVerifyResultDetail:
+    """Test that VerifyResult includes the new detail fields."""
+
+    def test_default_detail_fields(self) -> None:
+        result = VerifyResult(fqdn="_test._mcp._agents.example.com")
+        assert isinstance(result.dnssec_detail, DNSSECDetail)
+        assert isinstance(result.tls_detail, TLSDetail)
+        assert result.dnssec_detail.validated is False
+        assert result.tls_detail.connected is False
+
+    def test_custom_detail_fields(self) -> None:
+        dnssec = DNSSECDetail(validated=True, algorithm="ED25519", ad_flag=True)
+        tls = TLSDetail(connected=True, tls_version="TLSv1.3")
+        result = VerifyResult(
+            fqdn="_test._mcp._agents.example.com",
+            dnssec_detail=dnssec,
+            tls_detail=tls,
+        )
+        assert result.dnssec_detail.algorithm == "ED25519"
+        assert result.tls_detail.tls_version == "TLSv1.3"
+
+
+# =============================================================================
+# Algorithm mapping tests
+# =============================================================================
+
+
+class TestAlgorithmMaps:
+    """Test DNSSEC algorithm mapping and strength classification."""
+
+    def test_known_algorithms(self) -> None:
+        assert _DNSSEC_ALGORITHM_MAP[13] == "ECDSAP256SHA256"
+        assert _DNSSEC_ALGORITHM_MAP[15] == "ED25519"
+        assert _DNSSEC_ALGORITHM_MAP[8] == "RSASHA256"
+
+    def test_strong_algorithms(self) -> None:
+        for alg in ("ECDSAP256SHA256", "ECDSAP384SHA384", "ED25519", "ED448"):
+            assert _ALGORITHM_STRENGTH[alg] == "strong"
+
+    def test_weak_algorithms(self) -> None:
+        for alg in ("RSAMD5", "DSA", "RSASHA1"):
+            assert _ALGORITHM_STRENGTH[alg] == "weak"
+
+    def test_acceptable_algorithms(self) -> None:
+        for alg in ("RSASHA256", "RSASHA512"):
+            assert _ALGORITHM_STRENGTH[alg] == "acceptable"
+
+
+# =============================================================================
+# _check_dnssec_detail tests (mocked DNS)
+# =============================================================================
+
+
+class TestCheckDnssecDetail:
+    """Test DNSSEC detail extraction with mocked DNS responses."""
+
+    async def test_ad_flag_set(self) -> None:
+        """When AD flag is set, validated should be True."""
+        mock_answer = MagicMock()
+        mock_answer.response = MagicMock()
+        mock_answer.response.flags = dns.flags.AD | dns.flags.QR
+
+        with patch("dns_aid.core.validator.dns.asyncresolver.Resolver") as MockResolver:
+            resolver_instance = MockResolver.return_value
+            resolver_instance.use_edns = MagicMock()
+
+            # SVCB query returns answer with AD flag
+            resolver_instance.resolve = AsyncMock(return_value=mock_answer)
+
+            # Make DNSKEY/NSEC3PARAM/DS queries fail (not found)
+            async def side_effect(name: str, rdtype: str) -> MagicMock:
+                if rdtype == "SVCB":
+                    return mock_answer
+                raise dns.resolver.NXDOMAIN()
+
+            resolver_instance.resolve = AsyncMock(side_effect=side_effect)
+
+            detail = await _check_dnssec_detail("_test._mcp._agents.example.com")
+            assert detail.ad_flag is True
+            assert detail.validated is True
+
+    async def test_no_ad_flag(self) -> None:
+        """When AD flag is not set, validated should be False."""
+        mock_answer = MagicMock()
+        mock_answer.response = MagicMock()
+        mock_answer.response.flags = dns.flags.QR  # No AD flag
+
+        with patch("dns_aid.core.validator.dns.asyncresolver.Resolver") as MockResolver:
+            resolver_instance = MockResolver.return_value
+            resolver_instance.use_edns = MagicMock()
+
+            async def side_effect(name: str, rdtype: str) -> MagicMock:
+                if rdtype == "SVCB":
+                    return mock_answer
+                raise dns.resolver.NXDOMAIN()
+
+            resolver_instance.resolve = AsyncMock(side_effect=side_effect)
+
+            detail = await _check_dnssec_detail("_test._mcp._agents.example.com")
+            assert detail.ad_flag is False
+            assert detail.validated is False
+
+    async def test_algorithm_extraction(self) -> None:
+        """DNSKEY algorithm should be extracted and mapped."""
+        mock_svcb_answer = MagicMock()
+        mock_svcb_answer.response = MagicMock()
+        mock_svcb_answer.response.flags = dns.flags.AD | dns.flags.QR
+
+        mock_dnskey_rdata = MagicMock()
+        mock_dnskey_rdata.algorithm = 13  # ECDSAP256SHA256
+
+        mock_dnskey_answer = MagicMock()
+        mock_dnskey_answer.__iter__ = MagicMock(return_value=iter([mock_dnskey_rdata]))
+
+        with patch("dns_aid.core.validator.dns.asyncresolver.Resolver") as MockResolver:
+            resolver_instance = MockResolver.return_value
+            resolver_instance.use_edns = MagicMock()
+
+            async def side_effect(name: str, rdtype: str) -> MagicMock:
+                if rdtype == "SVCB":
+                    return mock_svcb_answer
+                if rdtype == "DNSKEY":
+                    return mock_dnskey_answer
+                raise dns.resolver.NXDOMAIN()
+
+            resolver_instance.resolve = AsyncMock(side_effect=side_effect)
+
+            detail = await _check_dnssec_detail("_test._mcp._agents.example.com")
+            assert detail.algorithm == "ECDSAP256SHA256"
+            assert detail.algorithm_strength == "strong"
+
+    async def test_resolver_failure_returns_empty_detail(self) -> None:
+        """On total resolver failure, return default empty detail."""
+        with patch("dns_aid.core.validator.dns.asyncresolver.Resolver") as MockResolver:
+            resolver_instance = MockResolver.return_value
+            resolver_instance.use_edns = MagicMock()
+            resolver_instance.resolve = AsyncMock(
+                side_effect=Exception("resolver error")
+            )
+
+            detail = await _check_dnssec_detail("_test._mcp._agents.example.com")
+            assert detail.validated is False
+            assert detail.algorithm is None
+
+
+# =============================================================================
+# _check_tls tests (mocked)
+# =============================================================================
+
+
+class TestCheckTls:
+    """Test TLS detail extraction with mocked connections."""
+
+    async def test_connection_failure(self) -> None:
+        """On connection failure, return default empty detail."""
+        with patch(
+            "dns_aid.core.validator.asyncio.open_connection",
+            side_effect=ConnectionRefusedError("refused"),
+        ):
+            detail = await _check_tls("example.com", 443)
+            assert detail.connected is False
+            assert detail.tls_version is None
+
+    async def test_successful_connection(self) -> None:
+        """Extract TLS version and cipher from successful connection."""
+        mock_ssl_object = MagicMock()
+        mock_ssl_object.version.return_value = "TLSv1.3"
+        mock_ssl_object.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+        mock_ssl_object.getpeercert.return_value = {
+            "notAfter": "Jan 01 00:00:00 2027 GMT",
+        }
+
+        mock_writer = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=mock_ssl_object)
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        mock_reader = MagicMock()
+
+        with (
+            patch(
+                "dns_aid.core.validator.asyncio.open_connection",
+                new_callable=AsyncMock,
+                return_value=(mock_reader, mock_writer),
+            ),
+            patch("dns_aid.core.validator.asyncio.wait_for") as mock_wait_for,
+            patch("dns_aid.core.validator.httpx.AsyncClient") as MockClient,
+        ):
+            mock_wait_for.return_value = (mock_reader, mock_writer)
+
+            # Mock HSTS check
+            mock_response = MagicMock()
+            mock_response.headers = {"strict-transport-security": "max-age=31536000"}
+            mock_client_instance = AsyncMock()
+            mock_client_instance.head = AsyncMock(return_value=mock_response)
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+            MockClient.return_value = mock_client_instance
+
+            detail = await _check_tls("example.com", 443)
+            assert detail.connected is True
+            assert detail.tls_version == "TLSv1.3"
+            assert detail.cipher_suite == "TLS_AES_256_GCM_SHA384"
+            assert detail.cert_valid is True
+            assert detail.hsts_enabled is True
+            assert detail.hsts_max_age == 31536000
+
+    async def test_timeout_returns_empty(self) -> None:
+        """On timeout, return default empty detail."""
+        import asyncio as _asyncio
+
+        with patch(
+            "dns_aid.core.validator.asyncio.wait_for",
+            side_effect=_asyncio.TimeoutError(),
+        ):
+            detail = await _check_tls("example.com", 443)
+            assert detail.connected is False

--- a/tests/unit/sdk/policy/test_models.py
+++ b/tests/unit/sdk/policy/test_models.py
@@ -1,0 +1,246 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for PolicyContext, PolicyResult, PolicyViolationError models."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.sdk.policy.models import (
+    PolicyContext,
+    PolicyResult,
+    PolicyViolation,
+    PolicyViolationError,
+)
+
+
+# =============================================================================
+# PolicyContext tests
+# =============================================================================
+
+
+class TestPolicyContext:
+    """Test PolicyContext creation."""
+
+    def test_creation_with_all_fields(self) -> None:
+        """PolicyContext with all fields populated."""
+        ctx = PolicyContext(
+            caller_id="agent-123",
+            caller_domain="infoblox.com",
+            protocol="mcp",
+            method="tools/call",
+            intent="query",
+            auth_type="oauth2",
+            dnssec_validated=True,
+            tls_version="1.3",
+            caller_trust_score=0.85,
+            geo_country="US",
+            payload_bytes=4096,
+            has_mutual_tls=True,
+            consent_token="tok-abc",
+        )
+        assert ctx.caller_id == "agent-123"
+        assert ctx.caller_domain == "infoblox.com"
+        assert ctx.protocol == "mcp"
+        assert ctx.method == "tools/call"
+        assert ctx.intent == "query"
+        assert ctx.auth_type == "oauth2"
+        assert ctx.dnssec_validated is True
+        assert ctx.tls_version == "1.3"
+        assert ctx.caller_trust_score == 0.85
+        assert ctx.geo_country == "US"
+        assert ctx.payload_bytes == 4096
+        assert ctx.has_mutual_tls is True
+        assert ctx.consent_token == "tok-abc"
+
+    def test_creation_with_defaults(self) -> None:
+        """PolicyContext with all defaults (no arguments)."""
+        ctx = PolicyContext()
+        assert ctx.caller_id is None
+        assert ctx.caller_domain is None
+        assert ctx.protocol is None
+        assert ctx.method is None
+        assert ctx.intent is None
+        assert ctx.auth_type is None
+        assert ctx.dnssec_validated is False
+        assert ctx.tls_version is None
+        assert ctx.caller_trust_score is None
+        assert ctx.geo_country is None
+        assert ctx.payload_bytes is None
+        assert ctx.has_mutual_tls is False
+        assert ctx.consent_token is None
+
+    def test_partial_fields(self) -> None:
+        """PolicyContext with only some fields set."""
+        ctx = PolicyContext(
+            caller_domain="example.com",
+            protocol="a2a",
+            dnssec_validated=True,
+        )
+        assert ctx.caller_domain == "example.com"
+        assert ctx.protocol == "a2a"
+        assert ctx.dnssec_validated is True
+        assert ctx.caller_id is None
+
+
+# =============================================================================
+# PolicyViolation tests
+# =============================================================================
+
+
+class TestPolicyViolation:
+    """Test PolicyViolation creation."""
+
+    def test_creation(self) -> None:
+        violation = PolicyViolation(
+            rule="required_auth_types",
+            detail="oauth2 required, got bearer",
+            layer="layer1",
+        )
+        assert violation.rule == "required_auth_types"
+        assert violation.detail == "oauth2 required, got bearer"
+        assert violation.layer == "layer1"
+
+    def test_target_layer(self) -> None:
+        violation = PolicyViolation(
+            rule="rate_limits",
+            detail="exceeded 60 req/min",
+            layer="layer2",
+        )
+        assert violation.layer == "layer2"
+
+
+# =============================================================================
+# PolicyResult tests
+# =============================================================================
+
+
+class TestPolicyResult:
+    """Test PolicyResult model and computed properties."""
+
+    def test_denied_is_true_when_not_allowed(self) -> None:
+        result = PolicyResult(
+            allowed=False,
+            violations=[
+                PolicyViolation(
+                    rule="require_dnssec",
+                    detail="DNSSEC required but not validated",
+                    layer="layer1",
+                )
+            ],
+        )
+        assert result.denied is True
+        assert result.allowed is False
+
+    def test_denied_is_false_when_allowed(self) -> None:
+        result = PolicyResult(allowed=True)
+        assert result.denied is False
+
+    def test_reason_formats_violations(self) -> None:
+        result = PolicyResult(
+            allowed=False,
+            violations=[
+                PolicyViolation(
+                    rule="require_dnssec",
+                    detail="DNSSEC required",
+                    layer="layer1",
+                ),
+                PolicyViolation(
+                    rule="min_tls_version",
+                    detail="TLS 1.3 required, got 1.2",
+                    layer="layer1",
+                ),
+            ],
+        )
+        reason = result.reason
+        assert "require_dnssec: DNSSEC required" in reason
+        assert "min_tls_version: TLS 1.3 required, got 1.2" in reason
+        assert "; " in reason
+
+    def test_reason_returns_allowed_when_no_violations(self) -> None:
+        result = PolicyResult(allowed=True)
+        assert result.reason == "allowed"
+
+    def test_reason_returns_allowed_with_empty_violations(self) -> None:
+        result = PolicyResult(allowed=True, violations=[])
+        assert result.reason == "allowed"
+
+    def test_warnings_separate_from_violations(self) -> None:
+        result = PolicyResult(
+            allowed=True,
+            warnings=[
+                PolicyViolation(
+                    rule="data_classification",
+                    detail="accessing confidential data",
+                    layer="layer1",
+                )
+            ],
+        )
+        assert result.allowed is True
+        assert len(result.warnings) == 1
+        assert len(result.violations) == 0
+        assert result.reason == "allowed"
+
+
+# =============================================================================
+# PolicyViolationError tests
+# =============================================================================
+
+
+class TestPolicyViolationError:
+    """Test PolicyViolationError exception."""
+
+    def test_message_includes_violation_details(self) -> None:
+        result = PolicyResult(
+            allowed=False,
+            violations=[
+                PolicyViolation(
+                    rule="require_dnssec",
+                    detail="DNSSEC required but not validated",
+                    layer="layer1",
+                ),
+            ],
+        )
+        error = PolicyViolationError(result)
+        assert "Policy violation" in str(error)
+        assert "require_dnssec" in str(error)
+        assert "DNSSEC required but not validated" in str(error)
+
+    def test_result_attached(self) -> None:
+        result = PolicyResult(
+            allowed=False,
+            violations=[
+                PolicyViolation(
+                    rule="min_tls_version",
+                    detail="TLS 1.3 required",
+                    layer="layer1",
+                ),
+            ],
+        )
+        error = PolicyViolationError(result)
+        assert error.result is result
+        assert error.result.denied is True
+
+    def test_raises_correctly(self) -> None:
+        result = PolicyResult(
+            allowed=False,
+            violations=[
+                PolicyViolation(rule="consent_required", detail="no consent", layer="layer1"),
+            ],
+        )
+        with pytest.raises(PolicyViolationError, match="Policy violation"):
+            raise PolicyViolationError(result)
+
+    def test_multiple_violations_in_message(self) -> None:
+        result = PolicyResult(
+            allowed=False,
+            violations=[
+                PolicyViolation(rule="rule_a", detail="detail_a", layer="layer1"),
+                PolicyViolation(rule="rule_b", detail="detail_b", layer="layer2"),
+            ],
+        )
+        error = PolicyViolationError(result)
+        msg = str(error)
+        assert "rule_a: detail_a" in msg
+        assert "rule_b: detail_b" in msg

--- a/tests/unit/sdk/policy/test_schema.py
+++ b/tests/unit/sdk/policy/test_schema.py
@@ -1,0 +1,248 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for PolicyDocument schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from dns_aid.sdk.policy.schema import (
+    AvailabilityConfig,
+    PolicyDocument,
+    PolicyEnforcementLayer,
+    PolicyRules,
+    RateLimitConfig,
+    RULE_ENFORCEMENT_LAYERS,
+)
+
+
+# =============================================================================
+# PolicyDocument tests
+# =============================================================================
+
+
+class TestPolicyDocument:
+    """Test PolicyDocument parsing and validation."""
+
+    def test_valid_document_parses(self) -> None:
+        """A fully populated valid document should parse correctly."""
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_network._mcp._agents.example.com",
+            rules=PolicyRules(
+                required_protocols=["mcp", "a2a"],
+                required_auth_types=["oauth2"],
+                require_dnssec=True,
+                require_mutual_tls=False,
+                min_tls_version="1.3",
+                required_caller_trust_score=0.7,
+                rate_limits=RateLimitConfig(max_per_minute=60, max_per_hour=1000),
+                max_payload_bytes=1048576,
+                allowed_caller_domains=["*.infoblox.com", "trusted.example.com"],
+                blocked_caller_domains=["evil.example.com"],
+                allowed_methods=["tools/list", "tools/call"],
+                allowed_intents=["query", "configure"],
+                geo_restrictions=["US", "EU"],
+                availability=AvailabilityConfig(hours="08:00-22:00", timezone="US/Eastern"),
+                data_classification="confidential",
+                consent_required=True,
+            ),
+        )
+        assert doc.version == "1.0"
+        assert doc.agent == "_network._mcp._agents.example.com"
+        assert doc.rules.require_dnssec is True
+        assert doc.rules.min_tls_version == "1.3"
+        assert doc.rules.data_classification == "confidential"
+        assert doc.rules.rate_limits is not None
+        assert doc.rules.rate_limits.max_per_minute == 60
+
+    def test_invalid_tls_version_rejected(self) -> None:
+        """TLS version '1.0' should be rejected."""
+        with pytest.raises(ValidationError, match="Invalid TLS version"):
+            PolicyRules(min_tls_version="1.0")
+
+    def test_invalid_tls_version_11_rejected(self) -> None:
+        """TLS version '1.1' should be rejected."""
+        with pytest.raises(ValidationError, match="Invalid TLS version"):
+            PolicyRules(min_tls_version="1.1")
+
+    def test_invalid_data_classification_rejected(self) -> None:
+        """Data classification 'secret' should be rejected."""
+        with pytest.raises(ValidationError, match="Invalid classification"):
+            PolicyRules(data_classification="secret")
+
+    def test_unsupported_version_rejected(self) -> None:
+        """Policy version '2.0' should be rejected."""
+        with pytest.raises(ValidationError, match="Unsupported policy version"):
+            PolicyDocument(
+                version="2.0",
+                agent="_test._mcp._agents.example.com",
+            )
+
+    def test_empty_rules_defaults(self) -> None:
+        """Empty rules (all defaults) should parse correctly."""
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+        )
+        assert doc.rules.require_dnssec is False
+        assert doc.rules.require_mutual_tls is False
+        assert doc.rules.consent_required is False
+        assert doc.rules.required_protocols is None
+        assert doc.rules.required_auth_types is None
+        assert doc.rules.min_tls_version is None
+        assert doc.rules.required_caller_trust_score is None
+        assert doc.rules.rate_limits is None
+        assert doc.rules.max_payload_bytes is None
+        assert doc.rules.allowed_caller_domains is None
+        assert doc.rules.blocked_caller_domains is None
+        assert doc.rules.allowed_methods is None
+        assert doc.rules.allowed_intents is None
+        assert doc.rules.geo_restrictions is None
+        assert doc.rules.availability is None
+        assert doc.rules.data_classification is None
+
+    def test_all_16_rules_parse(self) -> None:
+        """All 16 rule fields should parse with valid values."""
+        rules = PolicyRules(
+            required_protocols=["mcp"],
+            required_auth_types=["bearer"],
+            require_dnssec=True,
+            require_mutual_tls=True,
+            min_tls_version="1.2",
+            required_caller_trust_score=0.5,
+            rate_limits=RateLimitConfig(max_per_minute=10),
+            max_payload_bytes=65536,
+            allowed_caller_domains=["example.com"],
+            blocked_caller_domains=["bad.com"],
+            allowed_methods=["tools/list"],
+            allowed_intents=["query"],
+            geo_restrictions=["US"],
+            availability=AvailabilityConfig(hours="09:00-17:00"),
+            data_classification="public",
+            consent_required=True,
+        )
+        assert rules.required_protocols == ["mcp"]
+        assert rules.required_auth_types == ["bearer"]
+        assert rules.require_dnssec is True
+        assert rules.require_mutual_tls is True
+        assert rules.min_tls_version == "1.2"
+        assert rules.required_caller_trust_score == 0.5
+        assert rules.rate_limits.max_per_minute == 10
+        assert rules.max_payload_bytes == 65536
+        assert rules.allowed_caller_domains == ["example.com"]
+        assert rules.blocked_caller_domains == ["bad.com"]
+        assert rules.allowed_methods == ["tools/list"]
+        assert rules.allowed_intents == ["query"]
+        assert rules.geo_restrictions == ["US"]
+        assert rules.availability.hours == "09:00-17:00"
+        assert rules.data_classification == "public"
+        assert rules.consent_required is True
+
+    def test_valid_data_classifications(self) -> None:
+        """All four valid classifications should be accepted."""
+        for classification in ("public", "internal", "confidential", "restricted"):
+            rules = PolicyRules(data_classification=classification)
+            assert rules.data_classification == classification
+
+    def test_valid_tls_versions(self) -> None:
+        """Both valid TLS versions should be accepted."""
+        for version in ("1.2", "1.3"):
+            rules = PolicyRules(min_tls_version=version)
+            assert rules.min_tls_version == version
+
+
+# =============================================================================
+# RULE_ENFORCEMENT_LAYERS tests
+# =============================================================================
+
+
+class TestRuleEnforcementLayers:
+    """Test that RULE_ENFORCEMENT_LAYERS covers all 16 rules."""
+
+    def test_has_entries_for_all_16_rules(self) -> None:
+        """RULE_ENFORCEMENT_LAYERS should have entries for all 16 rules."""
+        expected_rules = {
+            "required_protocols",
+            "required_auth_types",
+            "require_dnssec",
+            "require_mutual_tls",
+            "min_tls_version",
+            "required_caller_trust_score",
+            "rate_limits",
+            "max_payload_bytes",
+            "allowed_caller_domains",
+            "blocked_caller_domains",
+            "allowed_methods",
+            "allowed_intents",
+            "geo_restrictions",
+            "availability",
+            "data_classification",
+            "consent_required",
+        }
+        assert set(RULE_ENFORCEMENT_LAYERS.keys()) == expected_rules
+        assert len(RULE_ENFORCEMENT_LAYERS) == 16
+
+    def test_all_values_are_valid_layers(self) -> None:
+        """All enforcement layer values should be valid PolicyEnforcementLayer members."""
+        for rule, layers in RULE_ENFORCEMENT_LAYERS.items():
+            assert len(layers) > 0, f"Rule {rule} has no enforcement layers"
+            for layer in layers:
+                assert isinstance(layer, PolicyEnforcementLayer)
+
+    def test_dns_layer_rules(self) -> None:
+        """Only specific rules should be enforceable at the DNS layer."""
+        dns_rules = [
+            rule
+            for rule, layers in RULE_ENFORCEMENT_LAYERS.items()
+            if PolicyEnforcementLayer.DNS in layers
+        ]
+        assert set(dns_rules) == {"required_protocols", "geo_restrictions"}
+
+
+# =============================================================================
+# PolicyEnforcementLayer tests
+# =============================================================================
+
+
+class TestPolicyEnforcementLayer:
+    """Test PolicyEnforcementLayer enum."""
+
+    def test_values(self) -> None:
+        assert PolicyEnforcementLayer.DNS == "layer0"
+        assert PolicyEnforcementLayer.CALLER == "layer1"
+        assert PolicyEnforcementLayer.TARGET == "layer2"
+
+
+# =============================================================================
+# Config model tests
+# =============================================================================
+
+
+class TestRateLimitConfig:
+    """Test RateLimitConfig model."""
+
+    def test_defaults(self) -> None:
+        config = RateLimitConfig()
+        assert config.max_per_minute is None
+        assert config.max_per_hour is None
+
+    def test_populated(self) -> None:
+        config = RateLimitConfig(max_per_minute=60, max_per_hour=3600)
+        assert config.max_per_minute == 60
+        assert config.max_per_hour == 3600
+
+
+class TestAvailabilityConfig:
+    """Test AvailabilityConfig model."""
+
+    def test_with_defaults(self) -> None:
+        config = AvailabilityConfig(hours="08:00-22:00")
+        assert config.hours == "08:00-22:00"
+        assert config.timezone == "UTC"
+
+    def test_custom_timezone(self) -> None:
+        config = AvailabilityConfig(hours="09:00-17:00", timezone="US/Eastern")
+        assert config.timezone == "US/Eastern"

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -424,20 +424,27 @@ class TestVerify:
     @pytest.mark.asyncio
     async def test_verify_all_checks_pass(self):
         """Test verify with all checks passing."""
+        from dns_aid.core.models import DNSSECDetail, TLSDetail
+
         with (
             patch("dns_aid.core.validator._check_svcb_record") as mock_svcb,
-            patch("dns_aid.core.validator._check_dnssec") as mock_dnssec,
+            patch("dns_aid.core.validator._check_dnssec_detail") as mock_dnssec_detail,
             patch("dns_aid.core.validator._check_dane") as mock_dane,
             patch("dns_aid.core.validator._check_endpoint") as mock_endpoint,
+            patch("dns_aid.core.validator._check_tls") as mock_tls,
         ):
             mock_svcb.return_value = {
                 "target": "agent.example.com",
                 "port": 443,
                 "valid": True,
             }
-            mock_dnssec.return_value = True
+            mock_dnssec_detail.return_value = DNSSECDetail(
+                validated=True, algorithm="ECDSAP256SHA256",
+                algorithm_strength="strong", ad_flag=True,
+            )
             mock_dane.return_value = True
             mock_endpoint.return_value = {"reachable": True, "latency_ms": 50.0}
+            mock_tls.return_value = TLSDetail(connected=True, tls_version="TLSv1.3")
 
             result = await verify("_agent._mcp._agents.example.com")
 
@@ -452,12 +459,15 @@ class TestVerify:
     @pytest.mark.asyncio
     async def test_verify_missing_svcb(self):
         """Test verify when SVCB record not found."""
+        from dns_aid.core.models import DNSSECDetail
+
         with (
             patch("dns_aid.core.validator._check_svcb_record") as mock_svcb,
-            patch("dns_aid.core.validator._check_dnssec") as mock_dnssec,
+            patch("dns_aid.core.validator._check_dnssec_detail") as mock_dnssec_detail,
+            patch("dns_aid.core.validator._check_tls") as mock_tls,
         ):
             mock_svcb.return_value = None
-            mock_dnssec.return_value = False
+            mock_dnssec_detail.return_value = DNSSECDetail(validated=False)
 
             result = await verify("_agent._mcp._agents.example.com")
 
@@ -467,20 +477,24 @@ class TestVerify:
     @pytest.mark.asyncio
     async def test_verify_no_dnssec(self):
         """Test verify when DNSSEC not validated."""
+        from dns_aid.core.models import DNSSECDetail, TLSDetail
+
         with (
             patch("dns_aid.core.validator._check_svcb_record") as mock_svcb,
-            patch("dns_aid.core.validator._check_dnssec") as mock_dnssec,
+            patch("dns_aid.core.validator._check_dnssec_detail") as mock_dnssec_detail,
             patch("dns_aid.core.validator._check_dane") as mock_dane,
             patch("dns_aid.core.validator._check_endpoint") as mock_endpoint,
+            patch("dns_aid.core.validator._check_tls") as mock_tls,
         ):
             mock_svcb.return_value = {
                 "target": "agent.example.com",
                 "port": 443,
                 "valid": True,
             }
-            mock_dnssec.return_value = False
+            mock_dnssec_detail.return_value = DNSSECDetail(validated=False)
             mock_dane.return_value = None
             mock_endpoint.return_value = {"reachable": True, "latency_ms": 50.0}
+            mock_tls.return_value = TLSDetail()
 
             result = await verify("_agent._mcp._agents.example.com")
 
@@ -490,20 +504,24 @@ class TestVerify:
     @pytest.mark.asyncio
     async def test_verify_endpoint_unreachable(self):
         """Test verify when endpoint is unreachable."""
+        from dns_aid.core.models import DNSSECDetail, TLSDetail
+
         with (
             patch("dns_aid.core.validator._check_svcb_record") as mock_svcb,
-            patch("dns_aid.core.validator._check_dnssec") as mock_dnssec,
+            patch("dns_aid.core.validator._check_dnssec_detail") as mock_dnssec_detail,
             patch("dns_aid.core.validator._check_dane") as mock_dane,
             patch("dns_aid.core.validator._check_endpoint") as mock_endpoint,
+            patch("dns_aid.core.validator._check_tls") as mock_tls,
         ):
             mock_svcb.return_value = {
                 "target": "agent.example.com",
                 "port": 443,
                 "valid": True,
             }
-            mock_dnssec.return_value = True
+            mock_dnssec_detail.return_value = DNSSECDetail(validated=True, ad_flag=True)
             mock_dane.return_value = None
             mock_endpoint.return_value = {"reachable": False}
+            mock_tls.return_value = TLSDetail()
 
             result = await verify("_agent._mcp._agents.example.com")
 


### PR DESCRIPTION
## Summary
- Add granular DNSSEC/TLS validation detail models for the trust scoring rubric (Phase 6 prerequisite)
- Create `sdk/policy/` package with PolicyDocument schema, evaluation models, and bind-aid layer annotations
- All 16 policy rule types defined with enforcement layer mapping for Phase 7 bind-aid compiler

## Changes
- `src/dns_aid/core/models.py` — Add `DNSSECDetail`, `TLSDetail` Pydantic models
- `src/dns_aid/core/validator.py` — Add `_check_dnssec_detail()` (algorithm, chain, NSEC3) and `_check_tls()` (version, cipher, cert, HSTS)
- `src/dns_aid/sdk/policy/schema.py` — `PolicyDocument`, `PolicyRules`, `RULE_ENFORCEMENT_LAYERS` with bind-aid annotations
- `src/dns_aid/sdk/policy/models.py` — `PolicyContext`, `PolicyResult`, `PolicyViolation`, `PolicyViolationError`
- `tests/unit/test_validator.py` — Update mocks for new `_check_dnssec_detail()` signature

## Test plan
- [x] 925 unit tests passing locally (53 new + 872 existing)
- [x] Lint clean (`ruff check src/`)
- [x] Format clean (`ruff format --check src/`)
- [x] Secrets scan clean
- [x] Zero regressions — existing validator tests updated for new function signature