### PR TITLE
chore: update CITATION.cff version to 0.14.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.13.6"
+version: "0.14.0"
 date-released: "2026-03-22"
 
 keywords:


### PR DESCRIPTION
## Summary
- Update CITATION.cff version from 0.13.6 to 0.14.0 (missed in version bump PR #63)

## Changes
- `CITATION.cff` — version field

## Test plan
- [x] No code change, metadata only