### PR TITLE
feat: Phase 6 target-side middleware, MCP guard, E2E tests

### DIFF
--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -515,6 +515,7 @@ def call_agent_tool(
     endpoint: str,
     tool_name: str,
     arguments: dict | None = None,
+    policy_uri: str | None = None,
 ) -> dict:
     """
     Call a tool on a discovered MCP agent.
@@ -526,17 +527,47 @@ def call_agent_tool(
         endpoint: The agent's MCP endpoint URL (e.g., "https://booking.example.com/mcp").
         tool_name: Name of the tool to call on the remote agent.
         arguments: Arguments to pass to the tool (as a dictionary).
+        policy_uri: The target agent's policy document URL (from discovery).
+                    If provided, policy is checked before invocation.
 
     Returns:
         dict with:
         - success: Whether the call succeeded
         - result: The tool's response content
         - telemetry: Invocation telemetry (latency, status) when SDK is available
+        - policy: Policy check result when policy_uri is provided
         - error: Error message if failed
     """
     from dns_aid.core.invoke import call_mcp_tool
+    from dns_aid.sdk.policy.guard import check_target_policy
 
     try:
+        # Policy guard: check target's policy before invocation
+        policy_result = _run_async(
+            check_target_policy(
+                policy_uri,
+                protocol="mcp",
+                method=f"tools/call:{tool_name}",
+                caller_id="dns-aid-mcp-server",
+            ),
+            timeout=10,
+        )
+        if policy_result.denied:
+            import os
+
+            mode = os.getenv("DNS_AID_POLICY_MODE", "permissive")
+            if mode == "strict":
+                return {
+                    "success": False,
+                    "error": f"Policy denied: {policy_result.reason}",
+                    "policy": {
+                        "result": "denied",
+                        "violations": [
+                            {"rule": v.rule, "detail": v.detail} for v in policy_result.violations
+                        ],
+                    },
+                }
+
         result = _run_async(
             call_mcp_tool(endpoint, tool_name, arguments, caller_id="dns-aid-mcp-server"),
             timeout=90,
@@ -548,6 +579,10 @@ def call_agent_tool(
             response["error"] = result.error or "Invocation failed"
         if result.telemetry:
             response["telemetry"] = result.telemetry
+        if policy_uri:
+            response["policy"] = {
+                "result": "allowed" if policy_result.allowed else "denied",
+            }
         return response
     except Exception as e:
         return {"success": False, "error": str(e)}
@@ -1011,6 +1046,7 @@ def send_a2a_message(
     domain: str | None = None,
     name: str | None = None,
     timeout: float = 60.0,
+    policy_uri: str | None = None,
 ) -> dict:
     """
     Send a message to an A2A (Agent-to-Agent) agent and get its response.
@@ -1039,6 +1075,8 @@ def send_a2a_message(
         name: Agent name to discover (e.g., "security-analyzer").
               Use with ``domain`` for automatic DNS discovery.
         timeout: Request timeout in seconds (default 30).
+        policy_uri: The target agent's policy document URL (from discovery).
+                    If provided, policy is checked before invocation.
 
     Returns:
         dict with:
@@ -1047,9 +1085,11 @@ def send_a2a_message(
         - agent_endpoint: The endpoint that was called
         - agent_info: Agent metadata (name, description, skills, how endpoint was resolved)
         - telemetry: Invocation telemetry (latency, status) when SDK is available
+        - policy: Policy check result when policy_uri is provided
         - error: Error message if failed
     """
     from dns_aid.core.invoke import send_a2a_message as _send_a2a
+    from dns_aid.sdk.policy.guard import check_target_policy
 
     if not endpoint and not (domain and name):
         return {
@@ -1060,6 +1100,33 @@ def send_a2a_message(
     agent_label = endpoint or f"{name}.{domain}" if (name and domain) else endpoint or ""
 
     try:
+        # Policy guard: check target's policy before invocation
+        policy_result = _run_async(
+            check_target_policy(
+                policy_uri,
+                protocol="a2a",
+                method="message/send",
+                caller_id="dns-aid-mcp-server",
+            ),
+            timeout=10,
+        )
+        if policy_result.denied:
+            import os
+
+            mode = os.getenv("DNS_AID_POLICY_MODE", "permissive")
+            if mode == "strict":
+                return {
+                    "success": False,
+                    "error": f"Policy denied: {policy_result.reason}",
+                    "agent_endpoint": agent_label,
+                    "policy": {
+                        "result": "denied",
+                        "violations": [
+                            {"rule": v.rule, "detail": v.detail} for v in policy_result.violations
+                        ],
+                    },
+                }
+
         result = _run_async(
             _send_a2a(
                 endpoint,

--- a/src/dns_aid/sdk/policy/guard.py
+++ b/src/dns_aid/sdk/policy/guard.py
@@ -1,0 +1,99 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MCP server policy guard — pre-invocation policy check.
+
+Checks the target agent's policy_uri before invocation via
+call_agent_tool or send_a2a_message. Uses the same PolicyEvaluator
+as the SDK client and target middleware — single evaluation engine,
+three enforcement points.
+"""
+
+from __future__ import annotations
+
+import os
+
+import structlog
+
+from dns_aid.sdk.policy.evaluator import PolicyEvaluator
+from dns_aid.sdk.policy.models import PolicyContext, PolicyResult
+from dns_aid.sdk.policy.schema import PolicyEnforcementLayer
+
+logger = structlog.get_logger(__name__)
+
+# Module-level evaluator instance shared across guard calls
+_evaluator: PolicyEvaluator | None = None
+
+
+def _get_evaluator() -> PolicyEvaluator:
+    """Get or create the module-level PolicyEvaluator."""
+    global _evaluator  # noqa: PLW0603
+    if _evaluator is None:
+        ttl = int(os.getenv("DNS_AID_POLICY_CACHE_TTL", "300"))
+        _evaluator = PolicyEvaluator(cache_ttl=ttl)
+    return _evaluator
+
+
+async def check_target_policy(
+    policy_uri: str | None,
+    *,
+    protocol: str = "mcp",
+    method: str | None = None,
+    caller_id: str = "dns-aid-mcp-server",
+) -> PolicyResult:
+    """Check target agent's policy before invocation.
+
+    Args:
+        policy_uri: The target agent's policy document URL (from SVCB key65403
+                    or agent card). If None, returns allowed (no-policy).
+        protocol: Protocol being used (mcp, a2a, https).
+        method: Method being invoked (e.g., tools/call).
+        caller_id: Identifier for the calling MCP server.
+
+    Returns:
+        PolicyResult indicating whether invocation is allowed.
+    """
+    if not policy_uri:
+        return PolicyResult(allowed=True)
+
+    policy_mode = os.getenv("DNS_AID_POLICY_MODE", "permissive")
+    if policy_mode == "disabled":
+        return PolicyResult(allowed=True)
+
+    evaluator = _get_evaluator()
+
+    try:
+        policy_doc = await evaluator.fetch(policy_uri)
+        ctx = PolicyContext(
+            caller_id=caller_id,
+            caller_domain=os.getenv("DNS_AID_CALLER_DOMAIN"),
+            protocol=protocol,
+            method=method,
+        )
+        result = evaluator.evaluate(
+            policy_doc,
+            ctx,
+            layer=PolicyEnforcementLayer.CALLER,
+        )
+
+        if result.denied:
+            logger.warning(
+                "mcp.policy_denied",
+                policy_uri=policy_uri,
+                protocol=protocol,
+                method=method,
+                violations=[f"{v.rule}:{v.detail}" for v in result.violations],
+                mode=policy_mode,
+            )
+
+        return result
+
+    except Exception as exc:
+        logger.warning(
+            "mcp.policy_check_failed",
+            policy_uri=policy_uri,
+            error=str(exc),
+        )
+        # Fail-open: allow invocation when policy fetch fails
+        return PolicyResult(allowed=True)

--- a/src/dns_aid/sdk/policy/middleware.py
+++ b/src/dns_aid/sdk/policy/middleware.py
@@ -1,0 +1,256 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Target-side policy enforcement middleware (Layer 2).
+
+FastAPI/Starlette ASGI middleware that enforces the target agent's
+published policy on incoming requests. This is the MANDATORY enforcement
+layer — regardless of whether the caller SDK cooperates, the target
+rejects non-compliant requests.
+
+Security notes:
+- X-DNS-AID-Caller-Domain is ADVISORY without mTLS (header can be spoofed)
+- Method is extracted from JSON-RPC body, not from headers (body is truth)
+- X-Forwarded-For requires trusted_proxies configuration for geo
+- When require_mutual_tls=true, caller domain is verified against cert SAN
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import defaultdict
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from dns_aid.sdk.policy.evaluator import PolicyEvaluator
+from dns_aid.sdk.policy.models import PolicyContext
+from dns_aid.sdk.policy.schema import PolicyEnforcementLayer
+
+logger = structlog.get_logger(__name__)
+
+
+class RateLimitState:
+    """Sliding window rate limiter per caller with LRU eviction."""
+
+    _MAX_CALLERS = 10_000
+
+    def __init__(self) -> None:
+        self._windows: dict[str, list[float]] = defaultdict(list)
+
+    def check(
+        self,
+        caller: str,
+        max_per_minute: int | None,
+        max_per_hour: int | None,
+    ) -> bool:
+        """Returns True if within limits."""
+        now = time.monotonic()
+        entries = self._windows[caller]
+        # Prune entries older than 1 hour
+        entries[:] = [t for t in entries if now - t < 3600]
+
+        if max_per_minute and sum(1 for t in entries if now - t < 60) >= max_per_minute:
+            return False
+        if max_per_hour and len(entries) >= max_per_hour:
+            return False
+
+        entries.append(now)
+
+        # LRU eviction: remove oldest caller when over capacity
+        if len(self._windows) > self._MAX_CALLERS:
+            oldest = min(
+                self._windows,
+                key=lambda k: self._windows[k][-1] if self._windows[k] else 0,
+            )
+            del self._windows[oldest]
+
+        return True
+
+
+class DnsAidPolicyMiddleware(BaseHTTPMiddleware):
+    """FastAPI/Starlette middleware for target-side policy enforcement (Layer 2).
+
+    Usage::
+
+        app = FastAPI()
+        app.add_middleware(
+            DnsAidPolicyMiddleware,
+            policy_uri="https://example.com/policy.json",
+            mode="strict",  # or "permissive" (log only)
+        )
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        policy_uri: str,
+        mode: str = "strict",
+        trusted_proxies: list[str] | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.policy_uri = policy_uri
+        self.mode = mode  # "strict" | "permissive"
+        self.trusted_proxies = set(trusted_proxies or [])
+        self._evaluator = PolicyEvaluator(cache_ttl=300)
+        self._rate_limiter = RateLimitState()
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Evaluate target policy on every incoming request."""
+        # Extract caller identity from request
+        caller_domain = request.headers.get("x-dns-aid-caller-domain")
+        authorization = request.headers.get("authorization", "")
+        auth_type = _extract_auth_type(authorization)
+
+        # Extract method from JSON-RPC body (security: body is source of truth)
+        method = await _extract_method_from_body(request)
+
+        # Extract intent from header (advisory — caller self-reports)
+        intent = request.headers.get("x-dns-aid-intent")
+
+        # Geo from trusted proxy only
+        geo_country = None
+        client_ip = request.client.host if request.client else None
+        if client_ip and client_ip in self.trusted_proxies:
+            # Geo lookup integration point for Phase 7 (MaxMind/GeoIP2)
+            # Without it, geo_restrictions are NOT enforced at Layer 2
+            pass
+
+        # mTLS verification: when present, cert domain overrides claimed domain
+        has_mutual_tls = False
+        cert_dn = request.headers.get("x-client-certificate-dn")
+        if cert_dn:
+            has_mutual_tls = True
+            cert_domain = _extract_domain_from_dn(cert_dn)
+            if cert_domain and caller_domain and caller_domain != cert_domain:
+                logger.warning(
+                    "policy.caller_domain_mismatch",
+                    claimed=caller_domain,
+                    cert=cert_domain,
+                )
+                caller_domain = cert_domain  # Trust the cert, not the header
+
+        # Parse Content-Length safely
+        payload_bytes = None
+        cl_header = request.headers.get("content-length")
+        if cl_header:
+            import contextlib
+
+            with contextlib.suppress(ValueError):
+                payload_bytes = int(cl_header)
+
+        # Build evaluation context
+        ctx = PolicyContext(
+            caller_domain=caller_domain,
+            auth_type=auth_type,
+            method=method,
+            intent=intent,
+            geo_country=geo_country,
+            payload_bytes=payload_bytes,
+            has_mutual_tls=has_mutual_tls,
+            consent_token=request.headers.get("x-dns-aid-consent-token"),
+        )
+
+        # Evaluate policy
+        try:
+            policy_doc = await self._evaluator.fetch(self.policy_uri)
+            result = self._evaluator.evaluate(
+                policy_doc,
+                ctx,
+                layer=PolicyEnforcementLayer.TARGET,
+            )
+        except Exception as exc:
+            logger.error("policy.fetch_failed", error=str(exc))
+            # Fail-open: let request through but mark as no-policy
+            response = await call_next(request)
+            response.headers["X-DNS-AID-Policy-Result"] = "no-policy"
+            return response
+
+        # Rate limit check (separate from rule evaluation — stateful)
+        if policy_doc.rules.rate_limits and caller_domain:
+            rl = policy_doc.rules.rate_limits
+            if not self._rate_limiter.check(
+                caller_domain,
+                rl.max_per_minute,
+                rl.max_per_hour,
+            ):
+                return JSONResponse(
+                    status_code=429,
+                    content={"error": "rate_limited", "reason": "rate limit exceeded"},
+                    headers={"X-DNS-AID-Policy-Result": "denied"},
+                )
+
+        # Enforce policy
+        if result.denied and self.mode == "strict":
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "policy_denied",
+                    "violations": [{"rule": v.rule, "detail": v.detail} for v in result.violations],
+                },
+                headers={"X-DNS-AID-Policy-Result": "denied"},
+            )
+
+        if result.denied and self.mode == "permissive":
+            logger.warning(
+                "policy.permissive_violation",
+                caller_domain=caller_domain,
+                violations=[f"{v.rule}:{v.detail}" for v in result.violations],
+            )
+
+        # Proceed with request — attach result header
+        response = await call_next(request)
+        response.headers["X-DNS-AID-Policy-Result"] = "allowed" if result.allowed else "denied"
+        return response
+
+
+def _extract_auth_type(authorization: str) -> str | None:
+    """Extract auth type from Authorization header value."""
+    if not authorization:
+        return None
+    lower = authorization.lower()
+    if lower.startswith("bearer "):
+        return "bearer"
+    if lower.startswith("basic "):
+        return "api_key"
+    return "unknown"
+
+
+async def _extract_method_from_body(request: Request) -> str | None:
+    """Extract JSON-RPC method from request body.
+
+    Security: the body is the source of truth for what the caller is actually
+    doing. The X-DNS-AID-Method header is only used as fallback for non-JSON
+    payloads.
+    """
+    content_type = request.headers.get("content-type", "")
+    if "json" not in content_type:
+        method = request.headers.get("x-dns-aid-method")
+        if method:
+            logger.debug("policy.method_from_header_fallback", method=method)
+        return method
+    try:
+        body = await request.body()
+        if body:
+            data = json.loads(body)
+            if isinstance(data, dict):
+                return data.get("method")
+    except Exception:
+        pass
+    return request.headers.get("x-dns-aid-method")
+
+
+def _extract_domain_from_dn(dn: str) -> str | None:
+    """Extract domain from X.509 Distinguished Name (CN field)."""
+    for part in dn.split(","):
+        part = part.strip()
+        if part.upper().startswith("CN="):
+            cn = part[3:]
+            return cn.lstrip("*.")
+    return None

--- a/tests/integration/test_policy_e2e.py
+++ b/tests/integration/test_policy_e2e.py
@@ -1,0 +1,521 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end integration test for the 3-layer policy enforcement model.
+
+Spins up a real FastAPI app with DnsAidPolicyMiddleware (Layer 2),
+then calls it via AgentClient.invoke() with policy gate (Layer 1).
+Verifies the full flow:
+  discover → Layer 1 policy check → invoke → Layer 2 enforcement
+  → X-DNS-AID-Policy-Result header → signal enrichment
+
+No mocks on the policy evaluation path — this tests real code.
+The only mock is httpx transport (to avoid network calls).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.policy.middleware import DnsAidPolicyMiddleware
+from dns_aid.sdk.policy.models import PolicyViolationError
+from dns_aid.sdk.policy.schema import PolicyDocument, PolicyRules
+
+
+@pytest.fixture(autouse=True)
+def _allow_localhost_http():
+    """Allow HTTP URLs to localhost for integration tests.
+
+    Production enforces HTTPS-only via validate_fetch_url(). In tests,
+    we run a local HTTP policy server, so we bypass the scheme check
+    for 127.0.0.1 URLs only.
+    """
+    original = None
+    try:
+        from dns_aid.utils.url_safety import validate_fetch_url as _orig
+
+        original = _orig
+    except ImportError:
+        pass
+
+    def _test_validate(url: str) -> str:
+        parsed = urlparse(url)
+        if parsed.hostname == "127.0.0.1":
+            return url  # Allow localhost HTTP in tests
+        return original(url) if original else url
+
+    with (
+        patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", side_effect=_test_validate),
+        patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=_test_validate),
+    ):
+        yield
+
+
+# =============================================================================
+# Test infrastructure: policy server + target agent
+# =============================================================================
+
+
+POLICY_DOC_ALLOW_ALL = PolicyDocument(
+    version="1.0",
+    agent="_test._mcp._agents.example.com",
+    rules=PolicyRules(),
+)
+
+POLICY_DOC_STRICT = PolicyDocument(
+    version="1.0",
+    agent="_test._mcp._agents.example.com",
+    rules=PolicyRules(
+        required_auth_types=["oauth2"],
+        allowed_caller_domains=["*.infoblox.com"],
+        allowed_methods=["tools/list", "tools/call"],
+        require_dnssec=True,
+    ),
+)
+
+POLICY_DOC_GEO_RESTRICTED = PolicyDocument(
+    version="1.0",
+    agent="_test._mcp._agents.example.com",
+    rules=PolicyRules(
+        geo_restrictions=["US", "CA"],
+    ),
+)
+
+
+class PolicyServer:
+    """Simple HTTP server that serves policy documents."""
+
+    def __init__(self, doc: PolicyDocument, port: int = 0) -> None:
+        self.doc = doc
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self.port = port
+
+    def start(self) -> str:
+        doc_json = self.doc.model_dump_json()
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(inner_self) -> None:
+                inner_self.send_response(200)
+                inner_self.send_header("Content-Type", "application/json")
+                inner_self.end_headers()
+                inner_self.wfile.write(doc_json.encode())
+
+            def log_message(inner_self, format, *args) -> None:
+                pass  # Suppress request logging
+
+        self._server = HTTPServer(("127.0.0.1", self.port), Handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return f"http://127.0.0.1:{self.port}/policy.json"
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+
+
+def _make_target_app(policy_uri: str, mode: str = "strict") -> Starlette:
+    """Build a target agent FastAPI app with DnsAidPolicyMiddleware."""
+
+    async def mcp_endpoint(request: Request) -> JSONResponse:
+        """Simulated MCP tools/list endpoint."""
+        body = await request.body()
+        data = json.loads(body) if body else {}
+        method = data.get("method", "unknown")
+
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "id": data.get("id", 1),
+            "result": {
+                "tools": [{"name": "test-tool", "description": "A test tool"}],
+            },
+        })
+
+    app = Starlette(
+        routes=[Route("/mcp", mcp_endpoint, methods=["POST"])],
+    )
+    app.add_middleware(
+        DnsAidPolicyMiddleware,
+        policy_uri=policy_uri,
+        mode=mode,
+    )
+    return app
+
+
+def _make_agent_record(
+    endpoint: str,
+    policy_uri: str | None = None,
+) -> AgentRecord:
+    """Build an AgentRecord pointing at the test target."""
+    parsed = urlparse(endpoint)
+    return AgentRecord(
+        name="test-agent",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host=parsed.hostname or "127.0.0.1",
+        port=parsed.port or 443,
+        endpoint_override=endpoint,
+        policy_uri=policy_uri,
+    )
+
+
+# =============================================================================
+# E2E Tests
+# =============================================================================
+
+
+class TestE2EPolicyAllowAll:
+    """Test with a permissive policy — everything should pass both layers."""
+
+    def test_full_flow_allowed(self) -> None:
+        # 1. Start policy server
+        policy_server = PolicyServer(POLICY_DOC_ALLOW_ALL)
+        policy_uri = policy_server.start()
+
+        try:
+            # 2. Build target app with middleware
+            app = _make_target_app(policy_uri, mode="strict")
+            client = TestClient(app)
+
+            # 3. Send request — should pass Layer 2
+            resp = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+                headers={"X-DNS-AID-Caller-Domain": "api.infoblox.com"},
+            )
+
+            assert resp.status_code == 200
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "allowed"
+            data = resp.json()
+            assert data["result"]["tools"][0]["name"] == "test-tool"
+        finally:
+            policy_server.stop()
+
+
+class TestE2EPolicyStrictDenied:
+    """Test with strict policy — caller without oauth2 should be denied at Layer 2."""
+
+    def test_denied_at_layer2_returns_403(self) -> None:
+        policy_server = PolicyServer(POLICY_DOC_STRICT)
+        policy_uri = policy_server.start()
+
+        try:
+            app = _make_target_app(policy_uri, mode="strict")
+            client = TestClient(app)
+
+            # Send without oauth2 auth — should be denied by required_auth_types
+            resp = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+                headers={
+                    "X-DNS-AID-Caller-Domain": "api.infoblox.com",
+                    "Authorization": "Bearer some-token",  # bearer, not oauth2
+                },
+            )
+
+            assert resp.status_code == 403
+            data = resp.json()
+            assert data["error"] == "policy_denied"
+            assert any(v["rule"] == "required_auth_types" for v in data["violations"])
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "denied"
+        finally:
+            policy_server.stop()
+
+
+class TestE2EPolicyPermissiveMode:
+    """Test permissive mode — violations logged but request proceeds."""
+
+    def test_permissive_allows_with_denied_header(self) -> None:
+        policy_server = PolicyServer(POLICY_DOC_STRICT)
+        policy_uri = policy_server.start()
+
+        try:
+            app = _make_target_app(policy_uri, mode="permissive")
+            client = TestClient(app)
+
+            # Same violation as above, but permissive mode lets it through
+            resp = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+                headers={"Authorization": "Bearer some-token"},
+            )
+
+            assert resp.status_code == 200
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "denied"
+            # Response still contains the actual tool data
+            data = resp.json()
+            assert data["result"]["tools"][0]["name"] == "test-tool"
+        finally:
+            policy_server.stop()
+
+
+class TestE2EMethodFromBody:
+    """Test that Layer 2 extracts method from JSON-RPC body, not header."""
+
+    def test_spoofed_header_ignored(self) -> None:
+        # Policy only allows tools/list
+        policy_doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(allowed_methods=["tools/list"]),
+        )
+        policy_server = PolicyServer(policy_doc)
+        policy_uri = policy_server.start()
+
+        try:
+            app = _make_target_app(policy_uri, mode="strict")
+            client = TestClient(app)
+
+            # Header says tools/list (allowed) but body says tools/call (not allowed)
+            resp = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+                headers={"X-DNS-AID-Method": "tools/list"},  # spoofed!
+            )
+
+            # Should be denied because body method (tools/call) is not allowed
+            assert resp.status_code == 403
+            data = resp.json()
+            assert any(v["rule"] == "allowed_methods" for v in data["violations"])
+        finally:
+            policy_server.stop()
+
+
+class TestE2EMTLSOverride:
+    """Test that mTLS cert domain overrides claimed X-DNS-AID-Caller-Domain."""
+
+    def test_cert_domain_wins(self) -> None:
+        policy_doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(allowed_caller_domains=["*.infoblox.com"]),
+        )
+        policy_server = PolicyServer(policy_doc)
+        policy_uri = policy_server.start()
+
+        try:
+            app = _make_target_app(policy_uri, mode="strict")
+            client = TestClient(app)
+
+            # Header claims infoblox.com but cert says evil.com
+            resp = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+                headers={
+                    "X-DNS-AID-Caller-Domain": "api.infoblox.com",
+                    "X-Client-Certificate-DN": "CN=evil.com,O=Evil Corp",
+                },
+            )
+
+            # Denied — cert domain evil.com doesn't match *.infoblox.com
+            assert resp.status_code == 403
+        finally:
+            policy_server.stop()
+
+
+class TestE2ERateLimiting:
+    """Test rate limiting with real policy server."""
+
+    def test_rate_limit_enforced(self) -> None:
+        policy_doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(rate_limits={"max_per_minute": 2}),
+        )
+        policy_server = PolicyServer(policy_doc)
+        policy_uri = policy_server.start()
+
+        try:
+            app = _make_target_app(policy_uri, mode="strict")
+            client = TestClient(app)
+
+            headers = {
+                "X-DNS-AID-Caller-Domain": "rate-test.com",
+            }
+
+            # First 2 requests pass
+            r1 = client.post("/mcp", json={"jsonrpc": "2.0", "method": "test", "id": 1}, headers=headers)
+            r2 = client.post("/mcp", json={"jsonrpc": "2.0", "method": "test", "id": 2}, headers=headers)
+            assert r1.status_code == 200
+            assert r2.status_code == 200
+
+            # Third request hits rate limit
+            r3 = client.post("/mcp", json={"jsonrpc": "2.0", "method": "test", "id": 3}, headers=headers)
+            assert r3.status_code == 429
+            assert r3.json()["error"] == "rate_limited"
+        finally:
+            policy_server.stop()
+
+
+class TestE2ELayer1CallerSide:
+    """Test Layer 1 (caller SDK) policy gate with real policy server.
+
+    Uses AgentClient.invoke() which checks the agent's policy_uri
+    before calling handler.invoke().
+    """
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_raises_on_violation(self) -> None:
+        """Layer 1 in strict mode should raise PolicyViolationError."""
+        policy_server = PolicyServer(POLICY_DOC_STRICT)
+        policy_uri = policy_server.start()
+
+        try:
+            agent = _make_agent_record(
+                endpoint="https://unreachable.example.com/mcp",
+                policy_uri=policy_uri,
+            )
+
+            config = SDKConfig(
+                timeout_seconds=5,
+                policy_mode="strict",
+                caller_domain="evil.com",  # Not in *.infoblox.com allowlist
+            )
+
+            async with AgentClient(config=config) as client:
+                with pytest.raises(PolicyViolationError) as exc_info:
+                    await client.invoke(agent, method="tools/list")
+
+                # Verify the violation details
+                result = exc_info.value.result
+                assert result.denied
+                # Should have multiple violations (auth, dnssec, domain)
+                rule_names = {v.rule for v in result.violations}
+                # At minimum, required_auth_types should fire (no auth provided)
+                assert "required_auth_types" in rule_names
+        finally:
+            policy_server.stop()
+
+    @pytest.mark.asyncio
+    async def test_permissive_mode_proceeds_with_warning(self) -> None:
+        """Layer 1 in permissive mode should log warning but not raise."""
+        policy_server = PolicyServer(POLICY_DOC_STRICT)
+        policy_uri = policy_server.start()
+
+        try:
+            agent = _make_agent_record(
+                endpoint="https://unreachable.example.com/mcp",
+                policy_uri=policy_uri,
+            )
+
+            config = SDKConfig(
+                timeout_seconds=2,
+                policy_mode="permissive",
+                caller_domain="evil.com",
+            )
+
+            async with AgentClient(config=config) as client:
+                # Should NOT raise — permissive mode logs warning
+                # It will fail at the network level (unreachable), not policy
+                try:
+                    result = await client.invoke(agent, method="tools/list")
+                except Exception as e:
+                    # Expected: network error, NOT PolicyViolationError
+                    assert not isinstance(e, PolicyViolationError)
+                    assert "PolicyViolation" not in type(e).__name__
+        finally:
+            policy_server.stop()
+
+    @pytest.mark.asyncio
+    async def test_disabled_mode_skips_policy(self) -> None:
+        """Disabled mode should not fetch policy at all."""
+        # Use a bad URI — if policy were fetched, it would fail
+        agent = _make_agent_record(
+            endpoint="https://unreachable.example.com/mcp",
+            policy_uri="https://also-unreachable.example.com/bad-policy",
+        )
+
+        config = SDKConfig(
+            timeout_seconds=2,
+            policy_mode="disabled",
+        )
+
+        async with AgentClient(config=config) as client:
+            try:
+                await client.invoke(agent, method="tools/list")
+            except PolicyViolationError:
+                pytest.fail("PolicyViolationError should not be raised in disabled mode")
+            except Exception:
+                pass  # Expected: network error
+
+    @pytest.mark.asyncio
+    async def test_no_policy_uri_skips_check(self) -> None:
+        """Agent without policy_uri should skip policy check entirely."""
+        agent = _make_agent_record(
+            endpoint="https://unreachable.example.com/mcp",
+            policy_uri=None,
+        )
+
+        config = SDKConfig(
+            timeout_seconds=2,
+            policy_mode="strict",  # Even strict mode should skip
+        )
+
+        async with AgentClient(config=config) as client:
+            try:
+                await client.invoke(agent, method="tools/list")
+            except PolicyViolationError:
+                pytest.fail("PolicyViolationError should not be raised without policy_uri")
+            except Exception:
+                pass  # Expected: network error
+
+
+class TestE2EPolicyGuard:
+    """Test the MCP server policy guard (check_target_policy)."""
+
+    @pytest.mark.asyncio
+    async def test_guard_with_real_policy_server(self) -> None:
+        """Guard fetches from real HTTP server and evaluates."""
+        from dns_aid.sdk.policy.guard import check_target_policy
+
+        policy_server = PolicyServer(POLICY_DOC_STRICT)
+        policy_uri = policy_server.start()
+
+        try:
+            import os
+
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setenv("DNS_AID_POLICY_MODE", "strict")
+                mp.setenv("DNS_AID_CALLER_DOMAIN", "api.infoblox.com")
+
+                # Reset module-level evaluator to pick up fresh env
+                import dns_aid.sdk.policy.guard as guard_mod
+                guard_mod._evaluator = None
+
+                result = await check_target_policy(
+                    policy_uri,
+                    protocol="mcp",
+                    method="tools/list",
+                )
+
+                # Should be denied — no auth type provided, but oauth2 required
+                assert result.denied
+                rule_names = {v.rule for v in result.violations}
+                assert "required_auth_types" in rule_names
+        finally:
+            policy_server.stop()
+
+    @pytest.mark.asyncio
+    async def test_guard_no_policy_uri_allowed(self) -> None:
+        from dns_aid.sdk.policy.guard import check_target_policy
+
+        result = await check_target_policy(None)
+        assert result.allowed

--- a/tests/unit/mcp/test_policy_guard.py
+++ b/tests/unit/mcp/test_policy_guard.py
@@ -1,0 +1,174 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MCP server policy guard."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.sdk.policy.guard import check_target_policy
+from dns_aid.sdk.policy.models import PolicyResult, PolicyViolation
+from dns_aid.sdk.policy.schema import PolicyDocument, PolicyRules
+
+
+# =============================================================================
+# check_target_policy tests
+# =============================================================================
+
+
+class TestCheckTargetPolicy:
+    @pytest.mark.asyncio
+    async def test_no_policy_uri_returns_allowed(self) -> None:
+        """No policy_uri means no policy — always allowed."""
+        result = await check_target_policy(None)
+        assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_disabled_mode_returns_allowed(self) -> None:
+        """Disabled mode skips policy check entirely."""
+        with patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "disabled"}):
+            result = await check_target_policy("https://example.com/policy.json")
+            assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_policy_allowed(self) -> None:
+        """Policy check passes — invocation allowed."""
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(),  # No rules = everything allowed
+        )
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(return_value=doc)
+        mock_eval.evaluate = lambda doc, ctx, **kw: PolicyResult(allowed=True)
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "strict"}),
+        ):
+            result = await check_target_policy(
+                "https://example.com/policy.json",
+                protocol="mcp",
+                method="tools/call",
+            )
+            assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_policy_denied(self) -> None:
+        """Policy check fails — returns denied result."""
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(required_auth_types=["oauth2"]),
+        )
+        violations = [
+            PolicyViolation(
+                rule="required_auth_types",
+                detail="no auth provided, requires ['oauth2']",
+                layer="layer1",
+            )
+        ]
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(return_value=doc)
+        mock_eval.evaluate = lambda doc, ctx, **kw: PolicyResult(
+            allowed=False, violations=violations,
+        )
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "strict"}),
+        ):
+            result = await check_target_policy(
+                "https://example.com/policy.json",
+                protocol="mcp",
+                method="tools/call",
+            )
+            assert result.denied
+            assert len(result.violations) == 1
+            assert result.violations[0].rule == "required_auth_types"
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_is_fail_open(self) -> None:
+        """Fetch failure should not block invocation (fail-open)."""
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(side_effect=Exception("network error"))
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "strict"}),
+        ):
+            result = await check_target_policy(
+                "https://example.com/policy.json",
+            )
+            assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_respects_policy_mode_env(self) -> None:
+        """Guard reads DNS_AID_POLICY_MODE from environment."""
+        with patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "disabled"}):
+            result = await check_target_policy("https://example.com/policy.json")
+            assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_passes_caller_domain_from_env(self) -> None:
+        """Guard reads DNS_AID_CALLER_DOMAIN from environment."""
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(allowed_caller_domains=["*.infoblox.com"]),
+        )
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(return_value=doc)
+        # Use real evaluator to check domain matching
+        from dns_aid.sdk.policy.evaluator import PolicyEvaluator
+
+        real_evaluator = PolicyEvaluator()
+        mock_eval.evaluate = real_evaluator.evaluate
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {
+                "DNS_AID_POLICY_MODE": "strict",
+                "DNS_AID_CALLER_DOMAIN": "api.infoblox.com",
+            }),
+        ):
+            result = await check_target_policy(
+                "https://example.com/policy.json",
+                protocol="mcp",
+                method="tools/call",
+            )
+            assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_protocol_forwarded_to_context(self) -> None:
+        """Protocol and method are forwarded to PolicyContext."""
+        captured_ctx = {}
+
+        def capture_evaluate(doc, ctx, **kw):
+            captured_ctx["protocol"] = ctx.protocol
+            captured_ctx["method"] = ctx.method
+            return PolicyResult(allowed=True)
+
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(),
+        )
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(return_value=doc)
+        mock_eval.evaluate = capture_evaluate
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "permissive"}),
+        ):
+            await check_target_policy(
+                "https://example.com/policy.json",
+                protocol="a2a",
+                method="message/send",
+            )
+            assert captured_ctx["protocol"] == "a2a"
+            assert captured_ctx["method"] == "message/send"

--- a/tests/unit/sdk/policy/test_middleware.py
+++ b/tests/unit/sdk/policy/test_middleware.py
@@ -1,0 +1,372 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DnsAidPolicyMiddleware (Layer 2 target-side enforcement)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from dns_aid.sdk.policy.middleware import (
+    DnsAidPolicyMiddleware,
+    RateLimitState,
+    _extract_auth_type,
+    _extract_domain_from_dn,
+)
+from dns_aid.sdk.policy.models import PolicyResult, PolicyViolation
+from dns_aid.sdk.policy.schema import (
+    AvailabilityConfig,
+    PolicyDocument,
+    PolicyRules,
+    RateLimitConfig,
+)
+
+
+# -- Helpers ------------------------------------------------------------------
+
+def _make_app(
+    policy_uri: str = "https://example.com/policy.json",
+    mode: str = "strict",
+    trusted_proxies: list[str] | None = None,
+) -> Starlette:
+    """Build a Starlette app with DnsAidPolicyMiddleware for testing."""
+
+    async def homepage(request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    async def jsonrpc(request: Request) -> JSONResponse:
+        return JSONResponse({"jsonrpc": "2.0", "result": "ok"})
+
+    app = Starlette(
+        routes=[
+            Route("/", homepage),
+            Route("/mcp", jsonrpc, methods=["POST"]),
+        ],
+    )
+    app.add_middleware(
+        DnsAidPolicyMiddleware,
+        policy_uri=policy_uri,
+        mode=mode,
+        trusted_proxies=trusted_proxies,
+    )
+    return app
+
+
+def _policy_doc(**rule_kwargs: object) -> PolicyDocument:
+    return PolicyDocument(
+        version="1.0",
+        agent="_test._mcp._agents.example.com",
+        rules=PolicyRules(**rule_kwargs),
+    )
+
+
+# -- Mock the evaluator -------------------------------------------------------
+
+def _mock_evaluator_class(allowed: bool = True, violations: list | None = None):
+    """Return a mock PolicyEvaluator class that creates mock instances."""
+    mock_instance = AsyncMock()
+    mock_instance.fetch = AsyncMock(return_value=_policy_doc())
+    mock_instance.evaluate = lambda doc, ctx, **kw: PolicyResult(
+        allowed=allowed,
+        violations=violations or [],
+    )
+
+    def constructor(*args, **kwargs):
+        return mock_instance
+
+    return constructor, mock_instance
+
+
+def _patch_evaluator(allowed: bool = True, violations: list | None = None):
+    """Patch PolicyEvaluator at the import site in middleware."""
+    factory, instance = _mock_evaluator_class(allowed, violations)
+    return patch(
+        "dns_aid.sdk.policy.middleware.PolicyEvaluator",
+        side_effect=factory,
+    ), instance
+
+
+# =============================================================================
+# Strict mode tests
+# =============================================================================
+
+
+class TestStrictMode:
+    def test_allowed_request_returns_200(self) -> None:
+        p, _ = _patch_evaluator(allowed=True)
+        with p:
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "allowed"
+
+    def test_denied_request_returns_403(self) -> None:
+        violations = [
+            PolicyViolation(
+                rule="required_auth_types",
+                detail="oauth2 required",
+                layer="layer2",
+            )
+        ]
+        p, _ = _patch_evaluator(allowed=False, violations=violations)
+        with p:
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp = client.get("/")
+            assert resp.status_code == 403
+            data = resp.json()
+            assert data["error"] == "policy_denied"
+            assert len(data["violations"]) == 1
+            assert data["violations"][0]["rule"] == "required_auth_types"
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "denied"
+
+
+# =============================================================================
+# Permissive mode tests
+# =============================================================================
+
+
+class TestPermissiveMode:
+    def test_denied_request_returns_200_with_denied_header(self) -> None:
+        violations = [
+            PolicyViolation(
+                rule="require_dnssec",
+                detail="DNSSEC required",
+                layer="layer2",
+            )
+        ]
+        p, _ = _patch_evaluator(allowed=False, violations=violations)
+        with p:
+            app = _make_app(mode="permissive")
+            client = TestClient(app)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "denied"
+
+
+# =============================================================================
+# X-DNS-AID-Policy-Result header
+# =============================================================================
+
+
+class TestPolicyResultHeader:
+    def test_always_present_on_allowed(self) -> None:
+        p, _ = _patch_evaluator(allowed=True)
+        with p:
+            app = _make_app()
+            client = TestClient(app)
+            resp = client.get("/")
+            assert "X-DNS-AID-Policy-Result" in resp.headers
+
+    def test_no_policy_on_fetch_failure(self) -> None:
+        mock_instance = AsyncMock()
+        mock_instance.fetch = AsyncMock(side_effect=Exception("network error"))
+
+        with patch(
+            "dns_aid.sdk.policy.middleware.PolicyEvaluator",
+            return_value=mock_instance,
+        ):
+            app = _make_app()
+            client = TestClient(app)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert resp.headers["X-DNS-AID-Policy-Result"] == "no-policy"
+
+
+# =============================================================================
+# Method extraction from body (security: body is truth)
+# =============================================================================
+
+
+class TestMethodExtraction:
+    def test_method_from_jsonrpc_body(self) -> None:
+        """Method should be extracted from JSON-RPC body, not header."""
+        mock_instance = AsyncMock()
+        doc = _policy_doc(allowed_methods=["tools/list"])
+        mock_instance.fetch = AsyncMock(return_value=doc)
+        from dns_aid.sdk.policy.evaluator import PolicyEvaluator as RealEvaluator
+
+        real_evaluator = RealEvaluator()
+        mock_instance.evaluate = real_evaluator.evaluate
+
+        with patch("dns_aid.sdk.policy.middleware.PolicyEvaluator", return_value=mock_instance):
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+                headers={"X-DNS-AID-Method": "tools/list"},  # spoofed header
+            )
+            assert resp.status_code == 403
+
+    def test_header_fallback_for_non_json(self) -> None:
+        mock_instance = AsyncMock()
+        doc = _policy_doc(allowed_methods=["upload"])
+        mock_instance.fetch = AsyncMock(return_value=doc)
+        from dns_aid.sdk.policy.evaluator import PolicyEvaluator as RealEvaluator
+
+        real_evaluator = RealEvaluator()
+        mock_instance.evaluate = real_evaluator.evaluate
+
+        with patch("dns_aid.sdk.policy.middleware.PolicyEvaluator", return_value=mock_instance):
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp = client.post(
+                "/mcp",
+                content=b"binary data",
+                headers={
+                    "Content-Type": "application/octet-stream",
+                    "X-DNS-AID-Method": "upload",
+                },
+            )
+            assert resp.status_code == 200
+
+
+# =============================================================================
+# mTLS cert overrides caller domain
+# =============================================================================
+
+
+class TestMTLSOverride:
+    def test_cert_domain_overrides_claimed_domain(self) -> None:
+        """When mTLS cert is present, cert domain wins over header claim."""
+        mock_instance = AsyncMock()
+        doc = _policy_doc(allowed_caller_domains=["*.infoblox.com"])
+        mock_instance.fetch = AsyncMock(return_value=doc)
+        from dns_aid.sdk.policy.evaluator import PolicyEvaluator as RealEvaluator
+
+        real_evaluator = RealEvaluator()
+        mock_instance.evaluate = real_evaluator.evaluate
+
+        with patch("dns_aid.sdk.policy.middleware.PolicyEvaluator", return_value=mock_instance):
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp = client.get(
+                "/",
+                headers={
+                    "X-DNS-AID-Caller-Domain": "api.infoblox.com",
+                    "X-Client-Certificate-DN": "CN=evil.com,O=Evil Corp",
+                },
+            )
+            assert resp.status_code == 403
+
+
+# =============================================================================
+# Rate limiting
+# =============================================================================
+
+
+class TestRateLimiting:
+    def test_rate_limit_exceeded_returns_429(self) -> None:
+        mock_instance = AsyncMock()
+        doc = _policy_doc(rate_limits=RateLimitConfig(max_per_minute=2))
+        mock_instance.fetch = AsyncMock(return_value=doc)
+        mock_instance.evaluate = lambda doc, ctx, **kw: PolicyResult(allowed=True)
+
+        with patch("dns_aid.sdk.policy.middleware.PolicyEvaluator", return_value=mock_instance):
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp1 = client.get("/", headers={"X-DNS-AID-Caller-Domain": "test.com"})
+            resp2 = client.get("/", headers={"X-DNS-AID-Caller-Domain": "test.com"})
+            assert resp1.status_code == 200
+            assert resp2.status_code == 200
+            resp3 = client.get("/", headers={"X-DNS-AID-Caller-Domain": "test.com"})
+            assert resp3.status_code == 429
+            assert resp3.headers["X-DNS-AID-Policy-Result"] == "denied"
+
+    def test_no_rate_limit_without_caller_domain(self) -> None:
+        """Rate limiting requires caller_domain to key on."""
+        mock_instance = AsyncMock()
+        doc = _policy_doc(rate_limits=RateLimitConfig(max_per_minute=1))
+        mock_instance.fetch = AsyncMock(return_value=doc)
+        mock_instance.evaluate = lambda doc, ctx, **kw: PolicyResult(allowed=True)
+
+        with patch("dns_aid.sdk.policy.middleware.PolicyEvaluator", return_value=mock_instance):
+            app = _make_app(mode="strict")
+            client = TestClient(app)
+            resp1 = client.get("/")
+            resp2 = client.get("/")
+            assert resp1.status_code == 200
+            assert resp2.status_code == 200
+
+
+# =============================================================================
+# RateLimitState unit tests
+# =============================================================================
+
+
+class TestRateLimitState:
+    def test_within_limit(self) -> None:
+        state = RateLimitState()
+        assert state.check("a.com", max_per_minute=5, max_per_hour=None)
+
+    def test_exceeds_per_minute(self) -> None:
+        state = RateLimitState()
+        for _ in range(3):
+            state.check("a.com", max_per_minute=3, max_per_hour=None)
+        assert not state.check("a.com", max_per_minute=3, max_per_hour=None)
+
+    def test_different_callers_independent(self) -> None:
+        state = RateLimitState()
+        for _ in range(3):
+            state.check("a.com", max_per_minute=3, max_per_hour=None)
+        # b.com should still have quota
+        assert state.check("b.com", max_per_minute=3, max_per_hour=None)
+
+    def test_lru_eviction(self) -> None:
+        state = RateLimitState()
+        state._MAX_CALLERS = 3
+        state.check("a.com", max_per_minute=100, max_per_hour=None)
+        state.check("b.com", max_per_minute=100, max_per_hour=None)
+        state.check("c.com", max_per_minute=100, max_per_hour=None)
+        state.check("d.com", max_per_minute=100, max_per_hour=None)
+        # After adding d, oldest (a) should be evicted
+        assert len(state._windows) <= 4  # d triggers eviction after add
+
+
+# =============================================================================
+# Helper function tests
+# =============================================================================
+
+
+class TestExtractAuthType:
+    def test_bearer(self) -> None:
+        assert _extract_auth_type("Bearer tok123") == "bearer"
+
+    def test_basic(self) -> None:
+        assert _extract_auth_type("Basic dXNlcjpwYXNz") == "api_key"
+
+    def test_unknown(self) -> None:
+        assert _extract_auth_type("Digest realm=test") == "unknown"
+
+    def test_empty(self) -> None:
+        assert _extract_auth_type("") is None
+
+    def test_none(self) -> None:
+        # Handles the case where header is missing
+        assert _extract_auth_type("") is None
+
+
+class TestExtractDomainFromDN:
+    def test_simple_cn(self) -> None:
+        assert _extract_domain_from_dn("CN=api.infoblox.com") == "api.infoblox.com"
+
+    def test_wildcard_cn(self) -> None:
+        assert _extract_domain_from_dn("CN=*.infoblox.com") == "infoblox.com"
+
+    def test_full_dn(self) -> None:
+        assert _extract_domain_from_dn("CN=api.infoblox.com,O=Infoblox,C=US") == "api.infoblox.com"
+
+    def test_no_cn(self) -> None:
+        assert _extract_domain_from_dn("O=Infoblox,C=US") is None
+
+    def test_empty(self) -> None:
+        assert _extract_domain_from_dn("") is None


### PR DESCRIPTION
## Summary
- DnsAidPolicyMiddleware (Layer 2) — mandatory target-side enforcement
- MCP server policy guard for call_agent_tool + send_a2a_message
- 12 E2E integration tests with real HTTP policy server (no mocks on evaluation path)

## Security
- Method extracted from JSON-RPC body, not spoofable X-DNS-AID-Method header
- mTLS cert domain overrides claimed X-DNS-AID-Caller-Domain
- Rate limiting with sliding window + LRU eviction (10K callers)
- X-DNS-AID-Policy-Result header on every response
- Fail-open on policy fetch errors

## Changes
- `src/dns_aid/sdk/policy/middleware.py` — DnsAidPolicyMiddleware (255 lines)
- `src/dns_aid/sdk/policy/guard.py` — check_target_policy() (99 lines)
- `src/dns_aid/mcp/server.py` — policy_uri param + guard on call_agent_tool, send_a2a_message
- `tests/unit/sdk/policy/test_middleware.py` — 24 unit tests
- `tests/unit/mcp/test_policy_guard.py` — 8 unit tests
- `tests/integration/test_policy_e2e.py` — 12 E2E integration tests

## Test plan
- [x] 1032 tests passing (44 new + 988 existing)
- [x] E2E: Layer 2 allow/deny/permissive/rate-limit/mTLS/method-from-body
- [x] E2E: Layer 1 strict/permissive/disabled/no-policy
- [x] E2E: MCP guard with real policy server
- [x] Lint/format/secrets scan clean