### PR TITLE
chore: bump version to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] - 2026-03-22
+
+### Added
+- **DnsAidPolicyMiddleware** — target-side ASGI middleware (Layer 2) for mandatory policy enforcement. Extracts method from JSON-RPC body (not spoofable header), verifies mTLS cert domain against claimed caller, sliding-window rate limiting with LRU eviction. Returns `X-DNS-AID-Policy-Result` header on every response.
+- **MCP server policy guard** — `check_target_policy()` pre-invocation check for `call_agent_tool` and `send_a2a_message`. Accepts `policy_uri` parameter from discovery flow.
+- **`policy/guard.py`** — standalone policy guard module for MCP server with module-level evaluator (shared cache).
+- **E2E integration tests** — 12 tests against real HTTP policy server covering Layer 1 strict/permissive/disabled, Layer 2 allow/deny/permissive/rate-limit/mTLS/method-from-body, and MCP guard.
+
 ## [0.14.1] - 2026-03-22
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.14.1"
+version: "0.14.2"
 date-released: "2026-03-22"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.14.1"
+version = "0.14.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"
 __all__ = [
     # Core functions (Tier 0)
     "publish",


### PR DESCRIPTION
## Summary
- Version bump 0.14.1 → 0.14.2 for target-side enforcement release
- Updates pyproject.toml, __init__.py, CITATION.cff, CHANGELOG.md

## Test plan
- [x] 1032 tests passing
- [x] Metadata only