### PR TITLE
chore: bump version to 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] - 2026-03-22
+
+### Fixed
+- **Auth bypass in invoke.py** — MCP server and CLI invocation paths now thread auth_type, auth_config, credentials, and policy_uri through to AgentClient.invoke(). Previously, invoke.py built synthetic AgentRecords that discarded all auth/policy metadata from DNS discovery, causing requests to go out unsigned.
+- **ResolvedAgent preserves AgentRecord** — DNS discovery results now carry the full AgentRecord through the resolution chain, preserving auth and policy metadata for the SDK invocation path.
+- **Raw httpx path sends X-DNS-AID-Caller-Domain** — the fallback path (SDK not installed) now sends the caller domain header from DNS_AID_CALLER_DOMAIN env var, enabling Layer 2 target-side domain matching.
+
 ## [0.14.2] - 2026-03-22
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.14.2"
+version: "0.14.3"
 date-released: "2026-03-22"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.14.2"
+version = "0.14.3"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 __all__ = [
     # Core functions (Tier 0)
     "publish",


### PR DESCRIPTION
## Summary
- Version bump 0.14.2 → 0.14.3 for auth threading fix
- Updates pyproject.toml, __init__.py, CITATION.cff, CHANGELOG.md

## Test plan
- [x] 1032 tests passing
- [x] Metadata only