### PR TITLE
feat(policy): add CEL custom rules in PolicyEvaluator

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.14.3"
+version: "0.14.4"
 date-released: "2026-03-22"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.14.3"
+version = "0.14.4"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -82,6 +82,12 @@ otel = [
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
 ]
+cel = [
+    # CEL (Common Expression Language) custom policy rules
+    # Rust backend (~2µs/eval); falls back to cel-python (~200µs/eval) if unavailable
+    "common-expression-language>=0.5.0",
+    "cel-python>=0.5.0",
+]
 pqc = [
     # Post-quantum cryptography (ML-DSA-65 for HTTP Message Signatures)
     "pqcrypto>=0.4.0",
@@ -97,6 +103,8 @@ dev = [
     "cryptography>=41.0.0",
     "cyclonedx-bom>=4.0.0",
     "pqcrypto>=0.4.0",
+    "common-expression-language>=0.5.0",
+    "cel-python>=0.5.0",
 ]
 all = [
     # CLI

--- a/src/dns_aid/sdk/policy/cel_evaluator.py
+++ b/src/dns_aid/sdk/policy/cel_evaluator.py
@@ -1,0 +1,223 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CEL (Common Expression Language) rule evaluator for DNS-AID policy.
+
+Compiles, caches, and evaluates CEL expressions against PolicyContext.
+CEL guarantees termination and hermetic evaluation (no I/O, no loops).
+
+Backend priority:
+  1. ``common-expression-language`` (Rust, ~2µs/eval) — ``pip install dns-aid[cel]``
+  2. ``cel-python`` (pure Python, ~200µs/eval) — automatic fallback
+
+Both backends are thread-safe: compiled programs are immutable and context
+objects are created per-evaluation, so concurrent agents evaluating the
+same target policy is safe without locks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+import structlog
+
+if TYPE_CHECKING:
+    from dns_aid.sdk.policy.models import PolicyContext, PolicyViolation
+    from dns_aid.sdk.policy.schema import CELRule
+
+logger = structlog.get_logger(__name__)
+
+_MAX_CACHE_SIZE = 256  # Max compiled programs per evaluator instance
+
+
+# ── Backend abstraction ─────────────────────────────────────────
+
+
+class _CELBackend(Protocol):
+    """Minimal interface for a CEL backend."""
+
+    def compile(self, expression: str) -> Any: ...
+    def execute(self, program: Any, ctx: dict[str, Any]) -> Any: ...
+
+
+class _RustBackend:
+    """Rust-based CEL backend (common-expression-language). ~2µs/eval."""
+
+    def __init__(self) -> None:
+        import cel  # noqa: F811
+
+        self._cel = cel
+
+    def compile(self, expression: str) -> Any:
+        return self._cel.compile(expression)
+
+    def execute(self, program: Any, ctx: dict[str, Any]) -> Any:
+        cel_ctx = self._cel.Context()
+        cel_ctx.add_variable("request", ctx)
+        return program.execute(cel_ctx)
+
+
+class _PythonBackend:
+    """Pure-Python CEL backend (cel-python/celpy). ~200µs/eval."""
+
+    def __init__(self) -> None:
+        import celpy
+        from celpy import celtypes
+
+        self._celpy = celpy
+        self._celtypes = celtypes
+        self._env = celpy.Environment()
+
+    def compile(self, expression: str) -> Any:
+        ast = self._env.compile(expression)
+        return self._env.program(ast)
+
+    def execute(self, program: Any, ctx: dict[str, Any]) -> Any:
+        ct = self._celtypes
+        activation = {"request": self._dict_to_cel_map(ctx, ct)}
+        return program.evaluate(activation)
+
+    @staticmethod
+    def _dict_to_cel_map(d: dict[str, Any], ct: Any) -> Any:
+        """Convert a plain dict to celpy MapType with proper type coercion."""
+        cel_map: dict[Any, Any] = {}
+        for k, v in d.items():
+            key = ct.StringType(k)
+            if isinstance(v, bool):
+                cel_map[key] = ct.BoolType(v)
+            elif isinstance(v, int):
+                cel_map[key] = ct.IntType(v)
+            elif isinstance(v, float):
+                cel_map[key] = ct.DoubleType(v)
+            else:
+                cel_map[key] = ct.StringType(str(v))
+        return ct.MapType(cel_map)
+
+
+def _select_backend() -> _CELBackend:
+    """Select the fastest available CEL backend."""
+    backend: _CELBackend
+    try:
+        backend = _RustBackend()
+        logger.debug("policy.cel_backend", backend="rust")
+        return backend
+    except ImportError:
+        pass
+    try:
+        backend = _PythonBackend()
+        logger.debug("policy.cel_backend", backend="python")
+        return backend
+    except ImportError:
+        raise ImportError("No CEL backend available. Install: pip install dns-aid[cel]") from None
+
+
+# ── Evaluator ───────────────────────────────────────────────────
+
+
+class CELRuleEvaluator:
+    """Compile, cache, and evaluate CEL custom rules against PolicyContext.
+
+    Thread-safe: compiled programs are cached and immutable.
+    Context objects are created per-evaluation (no shared mutable state).
+    """
+
+    def __init__(self) -> None:
+        self._backend = _select_backend()
+        self._cache: dict[str, Any] = {}
+
+    def _compile(self, expression: str) -> Any:
+        """Compile a CEL expression, returning a cached program.
+
+        Cache is bounded to _MAX_CACHE_SIZE entries to prevent unbounded
+        memory growth from attacker-crafted unique expressions.
+        """
+        if expression in self._cache:
+            return self._cache[expression]
+        prog = self._backend.compile(expression)
+        if len(self._cache) >= _MAX_CACHE_SIZE:
+            # Evict oldest entry (FIFO via dict insertion order)
+            oldest = next(iter(self._cache))
+            del self._cache[oldest]
+        self._cache[expression] = prog
+        return prog
+
+    @staticmethod
+    def _build_activation(ctx: PolicyContext) -> dict[str, Any]:
+        """Map PolicyContext fields to a plain dict for CEL evaluation.
+
+        None values are coerced to zero-values (CEL has no null):
+        str→"", float→0.0, int→0, bool→False.
+        """
+        return {
+            "caller_domain": ctx.caller_domain or "",
+            "protocol": ctx.protocol or "",
+            "method": ctx.method or "",
+            "auth_type": ctx.auth_type or "",
+            "geo_country": ctx.geo_country or "",
+            "caller_trust_score": float(ctx.caller_trust_score)
+            if ctx.caller_trust_score is not None
+            else 0.0,
+            "payload_bytes": ctx.payload_bytes if ctx.payload_bytes is not None else 0,
+            "dnssec_validated": ctx.dnssec_validated,
+            "has_mutual_tls": ctx.has_mutual_tls,
+        }
+
+    def evaluate(
+        self,
+        rules: list[CELRule],
+        ctx: PolicyContext,
+        layer: str,
+    ) -> tuple[list[PolicyViolation], list[PolicyViolation]]:
+        """Evaluate CEL rules against a PolicyContext.
+
+        Returns:
+            Tuple of (violations, warnings). Fails open on errors.
+        """
+        from dns_aid.sdk.policy.models import PolicyViolation
+
+        violations: list[PolicyViolation] = []
+        warnings: list[PolicyViolation] = []
+        activation = self._build_activation(ctx)
+
+        for rule in rules:
+            # Layer filtering: if rule specifies layers, skip if current layer not included
+            if rule.enforcement_layers and layer not in rule.enforcement_layers:
+                continue
+
+            try:
+                prog = self._compile(rule.expression)
+                result = self._backend.execute(prog, activation)
+
+                # Warn on non-boolean return — likely a misconfigured expression
+                if not isinstance(result, bool):
+                    logger.warning(
+                        "policy.cel_non_boolean_result",
+                        rule_id=rule.id,
+                        result_type=type(result).__name__,
+                        hint="CEL rules should return bool; non-bool is coerced via truthiness",
+                    )
+
+                # CEL expression should return truthy for "allowed"
+                # If falsy → the rule condition is not met → trigger effect
+                if not result:
+                    pv = PolicyViolation(
+                        rule=f"cel:{rule.id}",
+                        detail=rule.message or f"CEL rule '{rule.id}' denied request",
+                        layer=layer,
+                    )
+                    if rule.effect == "deny":
+                        violations.append(pv)
+                    else:
+                        warnings.append(pv)
+
+            except Exception as exc:
+                logger.warning(
+                    "policy.cel_error",
+                    rule_id=rule.id,
+                    expression=rule.expression[:200],
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+
+        return violations, warnings

--- a/src/dns_aid/sdk/policy/evaluator.py
+++ b/src/dns_aid/sdk/policy/evaluator.py
@@ -54,6 +54,7 @@ class PolicyEvaluator:
         self._cache_ttl = cache_ttl
         self._cache: dict[str, _CacheEntry] = {}
         self._lock = asyncio.Lock()
+        self._cel_evaluator: object | None = None  # Lazy-init CELRuleEvaluator
 
     # ── Fetch with SSRF protection + TTL cache ───────────────
 
@@ -279,6 +280,27 @@ class PolicyEvaluator:
         if rules.consent_required and _applicable("consent_required"):
             if not ctx.consent_token:
                 _violation("consent_required", "consent token required but not provided")
+
+        # ── CEL custom rules (optional, requires cel backend) ────
+        if rules.cel_rules:
+            try:
+                from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+                if self._cel_evaluator is None:
+                    self._cel_evaluator = CELRuleEvaluator()
+                cel_violations, cel_warnings = self._cel_evaluator.evaluate(  # type: ignore[attr-defined]
+                    rules.cel_rules,
+                    ctx,
+                    layer.value,
+                )
+                violations.extend(cel_violations)
+                warnings.extend(cel_warnings)
+            except ImportError:
+                logger.warning(
+                    "policy.cel_unavailable",
+                    rule_count=len(rules.cel_rules),
+                    hint="Install CEL backend: pip install dns-aid[cel]",
+                )
 
         return PolicyResult(
             allowed=len(violations) == 0,

--- a/src/dns_aid/sdk/policy/schema.py
+++ b/src/dns_aid/sdk/policy/schema.py
@@ -38,8 +38,41 @@ class AvailabilityConfig(BaseModel):
     timezone: str = "UTC"
 
 
+class CELRule(BaseModel):
+    """A custom policy rule expressed in CEL (Common Expression Language).
+
+    Expressions evaluate against ``request.*`` variables mapped from PolicyContext.
+    CEL guarantees termination and hermetic evaluation (no I/O, no loops).
+    """
+
+    id: str = Field(..., min_length=1, max_length=128, pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+    expression: str = Field(..., min_length=1, max_length=2048)
+    effect: str = Field(default="deny")  # "deny" or "warn"
+    message: str = Field(default="", max_length=512)
+    enforcement_layers: list[str] | None = None  # e.g., ["layer1", "layer2"]
+
+    @field_validator("effect")
+    @classmethod
+    def validate_effect(cls, v: str) -> str:
+        """Validate effect is 'deny' or 'warn'."""
+        if v not in ("deny", "warn"):
+            raise ValueError(f"Invalid CEL rule effect: {v}. Must be 'deny' or 'warn'")
+        return v
+
+    @field_validator("enforcement_layers")
+    @classmethod
+    def validate_layers(cls, v: list[str] | None) -> list[str] | None:
+        """Validate enforcement layers are valid."""
+        valid = {"layer0", "layer1", "layer2"}
+        if v:
+            for layer in v:
+                if layer not in valid:
+                    raise ValueError(f"Invalid enforcement layer: {layer}. Must be one of {valid}")
+        return v
+
+
 class PolicyRules(BaseModel):
-    """All 16 policy rule types for DNS-AID agent governance."""
+    """All 16 native policy rule types plus optional CEL custom rules."""
 
     required_protocols: list[str] | None = None
     required_auth_types: list[str] | None = None
@@ -57,6 +90,7 @@ class PolicyRules(BaseModel):
     availability: AvailabilityConfig | None = None
     data_classification: str | None = None
     consent_required: bool = False
+    cel_rules: list[CELRule] | None = Field(default=None, max_length=64)
 
     @field_validator("min_tls_version")
     @classmethod
@@ -115,6 +149,6 @@ class PolicyDocument(BaseModel):
     @classmethod
     def validate_version(cls, v: str) -> str:
         """Validate policy document version."""
-        if v not in ("1.0",):
+        if v not in ("1.0", "1.1"):
             raise ValueError(f"Unsupported policy version: {v}")
         return v

--- a/tests/unit/sdk/policy/test_cel_evaluator.py
+++ b/tests/unit/sdk/policy/test_cel_evaluator.py
@@ -1,0 +1,504 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for CEL custom rule evaluation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from dns_aid.sdk.policy.evaluator import PolicyEvaluator
+from dns_aid.sdk.policy.models import PolicyContext
+from dns_aid.sdk.policy.schema import (
+    CELRule,
+    PolicyDocument,
+    PolicyEnforcementLayer,
+    PolicyRules,
+)
+
+
+def _ctx(**kwargs) -> PolicyContext:
+    """Helper to build a PolicyContext with defaults."""
+    defaults = {
+        "caller_id": "test-caller",
+        "caller_domain": "caller.example.com",
+        "protocol": "mcp",
+        "method": "tools/call",
+        "auth_type": "bearer",
+        "dnssec_validated": True,
+        "tls_version": "1.3",
+        "caller_trust_score": 80.0,
+        "geo_country": "US",
+        "has_mutual_tls": True,
+        "consent_token": "tok-abc",
+        "intent": "query",
+    }
+    defaults.update(kwargs)
+    return PolicyContext(**defaults)
+
+
+def _doc(cel_rules: list[CELRule], native_rules: dict | None = None) -> PolicyDocument:
+    """Helper to build a PolicyDocument with CEL rules."""
+    rules_kwargs = native_rules or {}
+    rules_kwargs["cel_rules"] = cel_rules
+    return PolicyDocument(
+        version="1.1",
+        agent="_test._mcp._agents.example.com",
+        rules=PolicyRules(**rules_kwargs),
+    )
+
+
+# =============================================================================
+# CELRuleEvaluator unit tests
+# =============================================================================
+
+
+class TestCELRuleEvaluator:
+    """Test the CELRuleEvaluator class directly."""
+
+    def test_trust_score_pass(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(id="trust", expression="request.caller_trust_score >= 50.0", effect="deny")
+        ]
+        violations, warnings = evaluator.evaluate(rules, _ctx(caller_trust_score=80.0), "layer1")
+        assert len(violations) == 0
+
+    def test_trust_score_fail(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="trust",
+                expression="request.caller_trust_score >= 90.0",
+                effect="deny",
+                message="Too low",
+            )
+        ]
+        violations, warnings = evaluator.evaluate(rules, _ctx(caller_trust_score=80.0), "layer1")
+        assert len(violations) == 1
+        assert violations[0].rule == "cel:trust"
+        assert violations[0].detail == "Too low"
+
+    def test_method_starts_with(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(id="no-admin", expression='!request.method.startsWith("admin/")', effect="deny")
+        ]
+        # Should pass for tools/call
+        v, w = evaluator.evaluate(rules, _ctx(method="tools/call"), "layer1")
+        assert len(v) == 0
+        # Should fail for admin/delete
+        v, w = evaluator.evaluate(rules, _ctx(method="admin/delete"), "layer1")
+        assert len(v) == 1
+
+    def test_geo_sanctions(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="geo",
+                expression='!(request.geo_country in ["KP", "IR", "SY"])',
+                effect="deny",
+                message="Sanctioned country",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(geo_country="US"), "layer1")
+        assert len(v) == 0
+        v, _ = evaluator.evaluate(rules, _ctx(geo_country="KP"), "layer1")
+        assert len(v) == 1
+
+    def test_warn_effect(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="protocol-warn",
+                expression='request.protocol == "mcp"',
+                effect="warn",
+                message="Not MCP",
+            )
+        ]
+        v, w = evaluator.evaluate(rules, _ctx(protocol="a2a"), "layer1")
+        assert len(v) == 0
+        assert len(w) == 1
+        assert w[0].rule == "cel:protocol-warn"
+
+    def test_boolean_field_dnssec(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [CELRule(id="dnssec", expression="request.dnssec_validated", effect="deny")]
+        v, _ = evaluator.evaluate(rules, _ctx(dnssec_validated=True), "layer1")
+        assert len(v) == 0
+        v, _ = evaluator.evaluate(rules, _ctx(dnssec_validated=False), "layer1")
+        assert len(v) == 1
+
+    def test_payload_bytes_int(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(id="payload", expression="request.payload_bytes <= 1048576", effect="deny")
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(payload_bytes=512), "layer1")
+        assert len(v) == 0
+        v, _ = evaluator.evaluate(rules, _ctx(payload_bytes=2_000_000), "layer1")
+        assert len(v) == 1
+
+    def test_none_coercion_to_zero_values(self) -> None:
+        """None fields coerce to zero-values: '' for str, 0 for int, 0.0 for float, false for bool."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        # None trust score → 0.0, so >= 50.0 fails
+        rules = [
+            CELRule(id="trust", expression="request.caller_trust_score >= 50.0", effect="deny")
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(caller_trust_score=None), "layer1")
+        assert len(v) == 1
+
+    def test_compilation_caching(self) -> None:
+        """Second evaluation of same expression should use cached runner."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(id="cached", expression="request.caller_trust_score >= 0.5", effect="deny")
+        ]
+        evaluator.evaluate(rules, _ctx(), "layer1")
+        assert "request.caller_trust_score >= 0.5" in evaluator._cache
+        # Evaluate again — should hit cache
+        evaluator.evaluate(rules, _ctx(), "layer1")
+        assert len(evaluator._cache) == 1
+
+    def test_multiple_rules_all_evaluated(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="r1",
+                expression="request.caller_trust_score >= 90.0",
+                effect="deny",
+                message="r1 fail",
+            ),
+            CELRule(
+                id="r2", expression='request.protocol == "a2a"', effect="deny", message="r2 fail"
+            ),
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(caller_trust_score=80.0, protocol="mcp"), "layer1")
+        assert len(v) == 2
+        assert {x.rule for x in v} == {"cel:r1", "cel:r2"}
+
+    def test_layer_filtering(self) -> None:
+        """Rules with enforcement_layers should only run on matching layers."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="l2-only",
+                expression="request.caller_trust_score >= 90.0",
+                effect="deny",
+                enforcement_layers=["layer2"],
+            )
+        ]
+        # Layer 1 → should skip
+        v, _ = evaluator.evaluate(rules, _ctx(caller_trust_score=10.0), "layer1")
+        assert len(v) == 0
+        # Layer 2 → should fire
+        v, _ = evaluator.evaluate(rules, _ctx(caller_trust_score=10.0), "layer2")
+        assert len(v) == 1
+
+    def test_no_enforcement_layers_runs_everywhere(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(id="global", expression="request.caller_trust_score >= 90.0", effect="deny")
+        ]
+        for layer in ("layer0", "layer1", "layer2"):
+            v, _ = evaluator.evaluate(rules, _ctx(caller_trust_score=10.0), layer)
+            assert len(v) == 1, f"Expected violation on {layer}"
+
+
+# =============================================================================
+# CEL error handling
+# =============================================================================
+
+
+class TestCELErrorHandling:
+    """Test CEL fail-open behavior on errors."""
+
+    def test_syntax_error_fails_open(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [CELRule(id="bad-syntax", expression="!!! invalid CEL ???", effect="deny")]
+        v, w = evaluator.evaluate(rules, _ctx(), "layer1")
+        assert len(v) == 0  # Fail open
+
+    def test_runtime_error_fails_open(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        # Access a key that doesn't exist in the request map
+        rules = [
+            CELRule(id="missing-key", expression="request.nonexistent_field == 'x'", effect="deny")
+        ]
+        v, w = evaluator.evaluate(rules, _ctx(), "layer1")
+        # Should fail open (either no violation or graceful error)
+        assert len(v) == 0
+
+    def test_mixed_good_and_bad_rules(self) -> None:
+        """Bad rules fail open, good rules still evaluate."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(id="bad", expression="!!! invalid", effect="deny"),
+            CELRule(
+                id="good",
+                expression="request.caller_trust_score >= 90.0",
+                effect="deny",
+                message="Low trust",
+            ),
+        ]
+        v, w = evaluator.evaluate(rules, _ctx(caller_trust_score=50.0), "layer1")
+        # Only the good rule should fire
+        assert len(v) == 1
+        assert v[0].rule == "cel:good"
+
+    def test_celpy_not_installed_graceful(self) -> None:
+        """When celpy is not installed, PolicyEvaluator should log warning and skip CEL rules."""
+        doc = _doc([CELRule(id="r1", expression="true", effect="deny")])
+        with patch("dns_aid.sdk.policy.evaluator.logger") as mock_logger:
+            with patch.dict(
+                "sys.modules", {"celpy": None, "dns_aid.sdk.policy.cel_evaluator": None}
+            ):
+                import sys
+
+                # Remove cached module so import fails
+                saved = sys.modules.pop("dns_aid.sdk.policy.cel_evaluator", None)
+                sys.modules["dns_aid.sdk.policy.cel_evaluator"] = None  # type: ignore[assignment]
+                try:
+                    result = PolicyEvaluator().evaluate(doc, _ctx())
+                    # Should fail open — allowed
+                    assert result.allowed
+                    mock_logger.warning.assert_called()
+                finally:
+                    if saved is not None:
+                        sys.modules["dns_aid.sdk.policy.cel_evaluator"] = saved
+                    else:
+                        sys.modules.pop("dns_aid.sdk.policy.cel_evaluator", None)
+
+    def test_empty_cel_rules_list(self) -> None:
+        """Empty cel_rules list should be a no-op."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        v, w = evaluator.evaluate([], _ctx(), "layer1")
+        assert len(v) == 0
+        assert len(w) == 0
+
+
+# =============================================================================
+# Integration: native + CEL rules together
+# =============================================================================
+
+
+class TestCELIntegration:
+    """Test CEL rules alongside native policy rules via PolicyEvaluator.evaluate()."""
+
+    def test_native_pass_cel_deny(self) -> None:
+        """Native rules pass but CEL rule denies → overall denied."""
+        doc = _doc(
+            cel_rules=[
+                CELRule(
+                    id="trust",
+                    expression="request.caller_trust_score >= 90.0",
+                    effect="deny",
+                    message="CEL: low trust",
+                )
+            ],
+            native_rules={"required_protocols": ["mcp"]},
+        )
+        result = PolicyEvaluator().evaluate(doc, _ctx(protocol="mcp", caller_trust_score=50.0))
+        assert result.denied
+        assert any(v.rule == "cel:trust" for v in result.violations)
+
+    def test_native_deny_cel_pass(self) -> None:
+        """Native rules deny, CEL passes → overall denied (from native)."""
+        doc = _doc(
+            cel_rules=[CELRule(id="ok", expression="true", effect="deny")],
+            native_rules={"required_protocols": ["a2a"]},
+        )
+        result = PolicyEvaluator().evaluate(doc, _ctx(protocol="mcp"))
+        assert result.denied
+        assert any(v.rule == "required_protocols" for v in result.violations)
+        # No CEL violations
+        assert not any(v.rule.startswith("cel:") for v in result.violations)
+
+    def test_both_pass(self) -> None:
+        """Both native and CEL pass → allowed."""
+        doc = _doc(
+            cel_rules=[
+                CELRule(id="ok", expression="request.caller_trust_score >= 10.0", effect="deny")
+            ],
+            native_rules={"required_protocols": ["mcp"]},
+        )
+        result = PolicyEvaluator().evaluate(doc, _ctx(protocol="mcp", caller_trust_score=80.0))
+        assert result.allowed
+
+    def test_cel_layer_filtering_via_evaluator(self) -> None:
+        """CEL rules with layer restrictions respected through PolicyEvaluator."""
+        doc = _doc(
+            cel_rules=[
+                CELRule(
+                    id="target-only",
+                    expression="request.caller_trust_score >= 99.0",
+                    effect="deny",
+                    enforcement_layers=["layer2"],
+                )
+            ],
+        )
+        # Caller layer → should skip CEL rule
+        result = PolicyEvaluator().evaluate(
+            doc,
+            _ctx(caller_trust_score=10.0),
+            layer=PolicyEnforcementLayer.CALLER,
+        )
+        assert result.allowed
+        # Target layer → should fire
+        result = PolicyEvaluator().evaluate(
+            doc,
+            _ctx(caller_trust_score=10.0),
+            layer=PolicyEnforcementLayer.TARGET,
+        )
+        assert result.denied
+
+    def test_cel_warnings_in_result(self) -> None:
+        """CEL warn rules appear in result.warnings."""
+        doc = _doc(
+            cel_rules=[
+                CELRule(
+                    id="advisory",
+                    expression='request.protocol == "mcp"',
+                    effect="warn",
+                    message="Not MCP",
+                )
+            ],
+        )
+        result = PolicyEvaluator().evaluate(doc, _ctx(protocol="a2a"))
+        assert result.allowed  # Warnings don't deny
+        assert any(w.rule == "cel:advisory" for w in result.warnings)
+
+
+# =============================================================================
+# Hardening tests
+# =============================================================================
+
+
+class TestCELHardening:
+    """Test security hardening: cache bounds, input validation, DoS resistance."""
+
+    def test_cache_eviction_at_max_size(self) -> None:
+        """Compilation cache should evict oldest entry when full."""
+        from dns_aid.sdk.policy.cel_evaluator import _MAX_CACHE_SIZE, CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        # Fill the cache to max
+        for i in range(_MAX_CACHE_SIZE):
+            evaluator._compile(f"request.caller_trust_score >= {i}.0")
+        assert len(evaluator._cache) == _MAX_CACHE_SIZE
+
+        # One more should evict the oldest
+        evaluator._compile("request.caller_trust_score >= 999.0")
+        assert len(evaluator._cache) == _MAX_CACHE_SIZE
+        # First entry should be evicted
+        assert "request.caller_trust_score >= 0.0" not in evaluator._cache
+        # New entry should be present
+        assert "request.caller_trust_score >= 999.0" in evaluator._cache
+
+    def test_invalid_cel_id_empty_rejected(self) -> None:
+        """Empty CEL rule ID should be rejected by schema."""
+        with pytest.raises(ValidationError):
+            CELRule(id="", expression="true")
+
+    def test_invalid_cel_id_special_chars_rejected(self) -> None:
+        """CEL rule IDs with special characters should be rejected."""
+        with pytest.raises(ValidationError):
+            CELRule(id="rule with spaces", expression="true")
+
+    def test_invalid_cel_id_leading_dash_rejected(self) -> None:
+        """CEL rule IDs starting with dash/dot should be rejected."""
+        with pytest.raises(ValidationError):
+            CELRule(id="-bad-start", expression="true")
+
+    def test_valid_cel_id_patterns(self) -> None:
+        """Valid CEL rule IDs: alphanumeric, dots, dashes, underscores."""
+        for valid_id in ("rule1", "my-rule", "my_rule", "my.rule", "Rule.v2-beta_1"):
+            rule = CELRule(id=valid_id, expression="true")
+            assert rule.id == valid_id
+
+    def test_cel_rules_max_count_enforced(self) -> None:
+        """PolicyRules should reject more than 64 CEL rules."""
+        rules = [CELRule(id=f"r{i}", expression="true") for i in range(65)]
+        with pytest.raises(ValidationError):
+            PolicyRules(cel_rules=rules)
+
+    def test_cel_rules_at_max_count_accepted(self) -> None:
+        """64 CEL rules should be accepted."""
+        rules = [CELRule(id=f"r{i}", expression="true") for i in range(64)]
+        pr = PolicyRules(cel_rules=rules)
+        assert len(pr.cel_rules) == 64
+
+    def test_empty_expression_rejected(self) -> None:
+        """Empty expression should be rejected by schema."""
+        with pytest.raises(ValidationError):
+            CELRule(id="bad", expression="")
+
+    def test_message_max_length(self) -> None:
+        """Message over 512 chars should be rejected."""
+        with pytest.raises(ValidationError):
+            CELRule(id="bad", expression="true", message="x" * 513)
+
+    def test_non_boolean_expression_warns(self) -> None:
+        """Expressions returning non-bool should log warning but still evaluate."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        # size() returns int, not bool — should warn
+        rules = [CELRule(id="size-check", expression="size(request.method)", effect="deny")]
+        with patch("dns_aid.sdk.policy.cel_evaluator.logger") as mock_logger:
+            v, w = evaluator.evaluate(rules, _ctx(method="tools/call"), "layer1")
+            # size("tools/call") = 10, truthy → no violation
+            assert len(v) == 0
+            mock_logger.warning.assert_called_with(
+                "policy.cel_non_boolean_result",
+                rule_id="size-check",
+                result_type="int",
+                hint="CEL rules should return bool; non-bool is coerced via truthiness",
+            )
+
+    def test_non_boolean_zero_triggers_violation(self) -> None:
+        """Expression returning 0 (falsy non-bool) should trigger violation and warn."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        # size("") = 0, falsy → triggers deny
+        rules = [CELRule(id="zero", expression="size(request.method)", effect="deny")]
+        v, w = evaluator.evaluate(rules, _ctx(method=""), "layer1")
+        assert len(v) == 1
+        assert v[0].rule == "cel:zero"

--- a/tests/unit/sdk/policy/test_evaluator.py
+++ b/tests/unit/sdk/policy/test_evaluator.py
@@ -6,17 +6,18 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import time
+from datetime import UTC
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
 from dns_aid.sdk.policy.evaluator import PolicyEvaluator, _CacheEntry
-from dns_aid.sdk.policy.models import PolicyContext, PolicyResult
+from dns_aid.sdk.policy.models import PolicyContext
 from dns_aid.sdk.policy.schema import (
     AvailabilityConfig,
+    CELRule,
     PolicyDocument,
     PolicyEnforcementLayer,
     PolicyRules,
@@ -78,7 +79,10 @@ class TestFetch:
             return httpx.Response(200, content=body, headers={"content-type": "application/json"})
 
         evaluator = PolicyEvaluator(cache_ttl=300)
-        with patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", return_value="https://example.com/policy.json"):
+        with patch(
+            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            return_value="https://example.com/policy.json",
+        ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
                 mock_client = AsyncMock()
                 mock_resp = AsyncMock()
@@ -109,7 +113,10 @@ class TestFetch:
         big_body = b"x" * (65 * 1024)  # > 64KB
 
         evaluator = PolicyEvaluator()
-        with patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", return_value="https://example.com/policy.json"):
+        with patch(
+            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            return_value="https://example.com/policy.json",
+        ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
                 mock_client = AsyncMock()
                 mock_resp = AsyncMock()
@@ -127,7 +134,10 @@ class TestFetch:
     @pytest.mark.asyncio
     async def test_fetch_wrong_content_type(self) -> None:
         evaluator = PolicyEvaluator()
-        with patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", return_value="https://example.com/policy.json"):
+        with patch(
+            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            return_value="https://example.com/policy.json",
+        ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
                 mock_client = AsyncMock()
                 mock_resp = AsyncMock()
@@ -162,7 +172,10 @@ class TestFetch:
         new_doc = _doc(rules=PolicyRules(require_dnssec=True))
         body = new_doc.model_dump_json()
 
-        with patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", return_value="https://example.com/p.json"):
+        with patch(
+            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            return_value="https://example.com/p.json",
+        ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
                 mock_client = AsyncMock()
                 mock_resp = AsyncMock()
@@ -197,7 +210,10 @@ class TestFetch:
             return resp
 
         evaluator = PolicyEvaluator(cache_ttl=300)
-        with patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", return_value="https://example.com/p.json"):
+        with patch(
+            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            return_value="https://example.com/p.json",
+        ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
                 mock_client = AsyncMock()
                 mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -334,14 +350,18 @@ class TestRuleMaxPayloadBytes:
     def test_pass(self) -> None:
         doc = _doc(PolicyRules(max_payload_bytes=1024))
         result = PolicyEvaluator().evaluate(
-            doc, _ctx(payload_bytes=512), layer=PolicyEnforcementLayer.TARGET,
+            doc,
+            _ctx(payload_bytes=512),
+            layer=PolicyEnforcementLayer.TARGET,
         )
         assert result.allowed
 
     def test_fail(self) -> None:
         doc = _doc(PolicyRules(max_payload_bytes=1024))
         result = PolicyEvaluator().evaluate(
-            doc, _ctx(payload_bytes=2048), layer=PolicyEnforcementLayer.TARGET,
+            doc,
+            _ctx(payload_bytes=2048),
+            layer=PolicyEnforcementLayer.TARGET,
         )
         assert result.denied
 
@@ -349,7 +369,9 @@ class TestRuleMaxPayloadBytes:
         """None payload_bytes passes (can't check what we don't know)."""
         doc = _doc(PolicyRules(max_payload_bytes=1024))
         result = PolicyEvaluator().evaluate(
-            doc, _ctx(payload_bytes=None), layer=PolicyEnforcementLayer.TARGET,
+            doc,
+            _ctx(payload_bytes=None),
+            layer=PolicyEnforcementLayer.TARGET,
         )
         assert result.allowed
 
@@ -452,16 +474,18 @@ class TestRuleGeoRestrictions:
 
 class TestRuleAvailability:
     def test_normal_window_pass(self) -> None:
-        doc = _doc(PolicyRules(availability=AvailabilityConfig(hours="00:00-23:59", timezone="UTC")))
+        doc = _doc(
+            PolicyRules(availability=AvailabilityConfig(hours="00:00-23:59", timezone="UTC"))
+        )
         result = PolicyEvaluator().evaluate(doc, _ctx())
         assert result.allowed
 
     def test_normal_window_fail(self) -> None:
         """Test a window that's definitely not now (unless test runs in that exact minute)."""
         # Use a 1-minute window in the past relative to now
-        from datetime import datetime, timezone
+        from datetime import datetime
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         # Create a window that ended 2 hours ago
         end_h = (now.hour - 2) % 24
         start_h = (end_h - 1) % 24
@@ -474,7 +498,9 @@ class TestRuleAvailability:
 
     def test_midnight_wrap(self) -> None:
         """22:00-06:00 should allow midnight hours."""
-        doc = _doc(PolicyRules(availability=AvailabilityConfig(hours="00:00-23:59", timezone="UTC")))
+        doc = _doc(
+            PolicyRules(availability=AvailabilityConfig(hours="00:00-23:59", timezone="UTC"))
+        )
         result = PolicyEvaluator().evaluate(doc, _ctx())
         assert result.allowed
 
@@ -515,7 +541,9 @@ class TestLayerFiltering:
         """max_payload_bytes is TARGET-only — should not fire for CALLER layer."""
         doc = _doc(PolicyRules(max_payload_bytes=100))
         result = PolicyEvaluator().evaluate(
-            doc, _ctx(payload_bytes=9999), layer=PolicyEnforcementLayer.CALLER,
+            doc,
+            _ctx(payload_bytes=9999),
+            layer=PolicyEnforcementLayer.CALLER,
         )
         # max_payload_bytes should not appear in violations for CALLER layer
         assert not any(v.rule == "max_payload_bytes" for v in result.violations)
@@ -524,20 +552,26 @@ class TestLayerFiltering:
         """max_payload_bytes is TARGET-only — should fire for TARGET layer."""
         doc = _doc(PolicyRules(max_payload_bytes=100))
         result = PolicyEvaluator().evaluate(
-            doc, _ctx(payload_bytes=9999), layer=PolicyEnforcementLayer.TARGET,
+            doc,
+            _ctx(payload_bytes=9999),
+            layer=PolicyEnforcementLayer.TARGET,
         )
         assert any(v.rule == "max_payload_bytes" for v in result.violations)
 
     def test_caller_layer_includes_caller_rules(self) -> None:
         """require_dnssec is CALLER-only — should fire for CALLER."""
         doc = _doc(PolicyRules(require_dnssec=True))
-        result = PolicyEvaluator().evaluate(doc, _ctx(dnssec_validated=False), layer=PolicyEnforcementLayer.CALLER)
+        result = PolicyEvaluator().evaluate(
+            doc, _ctx(dnssec_validated=False), layer=PolicyEnforcementLayer.CALLER
+        )
         assert result.denied
 
     def test_target_layer_skips_caller_only_rules(self) -> None:
         """require_dnssec is CALLER-only — should not fire for TARGET."""
         doc = _doc(PolicyRules(require_dnssec=True))
-        result = PolicyEvaluator().evaluate(doc, _ctx(dnssec_validated=False), layer=PolicyEnforcementLayer.TARGET)
+        result = PolicyEvaluator().evaluate(
+            doc, _ctx(dnssec_validated=False), layer=PolicyEnforcementLayer.TARGET
+        )
         assert result.allowed
 
 
@@ -564,3 +598,64 @@ class TestDomainWildcards:
         doc = _doc(PolicyRules(blocked_caller_domains=["*.evil.com"]))
         result = PolicyEvaluator().evaluate(doc, _ctx(caller_domain="api.evil.com"))
         assert result.denied
+
+
+# ── CEL rule integration in evaluator ─────────────────────────
+
+
+class TestCELRulesInEvaluator:
+    """Test that CEL rules are correctly wired into evaluate()."""
+
+    def test_cel_deny_rule(self) -> None:
+        doc = _doc(
+            PolicyRules(
+                cel_rules=[
+                    CELRule(
+                        id="trust",
+                        expression="request.caller_trust_score >= 90.0",
+                        effect="deny",
+                        message="Low trust",
+                    )
+                ],
+            )
+        )
+        result = PolicyEvaluator().evaluate(doc, _ctx(caller_trust_score=50.0))
+        assert result.denied
+        assert any(v.rule == "cel:trust" for v in result.violations)
+
+    def test_cel_warn_rule(self) -> None:
+        doc = _doc(
+            PolicyRules(
+                cel_rules=[
+                    CELRule(
+                        id="advisory",
+                        expression='request.protocol == "mcp"',
+                        effect="warn",
+                        message="Not MCP",
+                    )
+                ],
+            )
+        )
+        result = PolicyEvaluator().evaluate(doc, _ctx(protocol="a2a"))
+        assert result.allowed
+        assert any(w.rule == "cel:advisory" for w in result.warnings)
+
+    def test_no_celpy_graceful_skip(self) -> None:
+        """When cel_evaluator module import fails, CEL rules are skipped."""
+        import sys
+
+        doc = _doc(
+            PolicyRules(
+                cel_rules=[CELRule(id="blocked", expression="false", effect="deny")],
+            )
+        )
+        saved = sys.modules.pop("dns_aid.sdk.policy.cel_evaluator", None)
+        sys.modules["dns_aid.sdk.policy.cel_evaluator"] = None  # type: ignore[assignment]
+        try:
+            result = PolicyEvaluator().evaluate(doc, _ctx())
+            assert result.allowed  # Fail open
+        finally:
+            if saved is not None:
+                sys.modules["dns_aid.sdk.policy.cel_evaluator"] = saved
+            else:
+                sys.modules.pop("dns_aid.sdk.policy.cel_evaluator", None)

--- a/tests/unit/sdk/policy/test_schema.py
+++ b/tests/unit/sdk/policy/test_schema.py
@@ -9,14 +9,14 @@ import pytest
 from pydantic import ValidationError
 
 from dns_aid.sdk.policy.schema import (
+    RULE_ENFORCEMENT_LAYERS,
     AvailabilityConfig,
+    CELRule,
     PolicyDocument,
     PolicyEnforcementLayer,
     PolicyRules,
     RateLimitConfig,
-    RULE_ENFORCEMENT_LAYERS,
 )
-
 
 # =============================================================================
 # PolicyDocument tests
@@ -246,3 +246,76 @@ class TestAvailabilityConfig:
     def test_custom_timezone(self) -> None:
         config = AvailabilityConfig(hours="09:00-17:00", timezone="US/Eastern")
         assert config.timezone == "US/Eastern"
+
+
+# =============================================================================
+# CELRule tests
+# =============================================================================
+
+
+class TestCELRule:
+    """Test CELRule schema validation."""
+
+    def test_valid_deny_rule(self) -> None:
+        rule = CELRule(
+            id="test-deny",
+            expression="request.caller_trust_score >= 0.7",
+            effect="deny",
+            message="Trust too low",
+        )
+        assert rule.id == "test-deny"
+        assert rule.effect == "deny"
+
+    def test_valid_warn_rule(self) -> None:
+        rule = CELRule(
+            id="test-warn",
+            expression="request.protocol == 'mcp'",
+            effect="warn",
+            message="Non-MCP protocol",
+        )
+        assert rule.effect == "warn"
+
+    def test_invalid_effect_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid CEL rule effect"):
+            CELRule(id="bad", expression="true", effect="block")
+
+    def test_expression_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            CELRule(id="long", expression="x" * 2049)
+
+    def test_valid_enforcement_layers(self) -> None:
+        rule = CELRule(
+            id="layered",
+            expression="true",
+            enforcement_layers=["layer1", "layer2"],
+        )
+        assert rule.enforcement_layers == ["layer1", "layer2"]
+
+    def test_invalid_enforcement_layer_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid enforcement layer"):
+            CELRule(id="bad", expression="true", enforcement_layers=["layer99"])
+
+    def test_none_enforcement_layers_means_all(self) -> None:
+        rule = CELRule(id="all", expression="true")
+        assert rule.enforcement_layers is None
+
+
+class TestPolicyVersion11:
+    """Test version 1.1 acceptance for CEL rules."""
+
+    def test_version_11_accepted(self) -> None:
+        doc = PolicyDocument(
+            version="1.1",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(
+                cel_rules=[
+                    CELRule(id="r1", expression="request.caller_trust_score >= 0.5"),
+                ]
+            ),
+        )
+        assert doc.version == "1.1"
+        assert len(doc.rules.cel_rules) == 1
+
+    def test_version_20_still_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Unsupported policy version"):
+            PolicyDocument(version="2.0", agent="_test._mcp._agents.example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version != '3.13.*'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -121,6 +125,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
+]
+
+[[package]]
+name = "cel-python"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-re2" },
+    { name = "jmespath" },
+    { name = "lark" },
+    { name = "pendulum" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/4e/f821948a5bbd7a98a218720f831a62216f79a98e43b13d9ab2f98e37c5f8/cel_python-0.5.0.tar.gz", hash = "sha256:3eb0a619e8df0f338d0430cda01427a742e77e3c433a1c7c3ebd409cd804c45a", size = 13364027, upload-time = "2026-01-31T19:07:13.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/f8/38812adc3f787c2c2e8ba56f524185ed379656c10b40347a32796ba61c08/cel_python-0.5.0-py3-none-any.whl", hash = "sha256:d0f85008b89655c2bb18d797d2fa3f96f2ed80f4a3b43b0e8138c6646581e5f6", size = 84950, upload-time = "2026-01-31T19:07:11.821Z" },
 ]
 
 [[package]]
@@ -319,6 +339,71 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "common-expression-language"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/07/223e74662165acf74c38880a952887ed7ebf1fbf440a5d12cd29bd0cf883/common_expression_language-0.5.6.tar.gz", hash = "sha256:7286433de9418b10088e112913c4c2fc67e56067165c49d3bf152184ca61def4", size = 161867, upload-time = "2026-02-08T03:04:41.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/93/568e79bd5588a066c5413962bbbef0bad6d8bc740bb3b55510f1818ae2d4/common_expression_language-0.5.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:91d2c4c9851152b84c9afd2f48a7710ea8afb8036c6039a14cee375a5e578552", size = 1605638, upload-time = "2026-02-08T03:04:35.728Z" },
+    { url = "https://files.pythonhosted.org/packages/83/24/990b8e8670a9559ccdc88aba753ca4d5b750f3493307aec641efa81c7fbc/common_expression_language-0.5.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d2d5682754c896687d58846b8384bb48318664771000527d623cd04c370b6cd", size = 1545033, upload-time = "2026-02-08T03:04:29.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/64/3b395d23fd417a013b04173567c755ef41b92570977da6d4c26c5fb4b8cf/common_expression_language-0.5.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:614197bf6ae6c18181654ec356083bf92901067d58f241f8dd58a15daea285e6", size = 1783704, upload-time = "2026-02-08T03:03:31.935Z" },
+    { url = "https://files.pythonhosted.org/packages/52/dd/eb5fdc8af7721aab83368340c4dc4b79faca8b180050d5c7f588c79dbf6f/common_expression_language-0.5.6-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9d0438930d6221c980efb951c907587a8c0c220e4772c7dec532b21fd06c1892", size = 1703544, upload-time = "2026-02-08T03:03:44.318Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9d/22420e613cc14691418ec13ec8eb58c4b3ce62d8e02e5c708043b6c63bbb/common_expression_language-0.5.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:264108f28626ca8afd8b48dd5ee9e96b2953a5bf9ec4edb8e0dce55b71ad60ae", size = 2010396, upload-time = "2026-02-08T03:03:54.085Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/416d77f7182aec36df3c3fcc2f41625bb9177f982dedcf100de94b373c62/common_expression_language-0.5.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fea2a0a197f963e086975d84ac0139b09066dc7431559c56416eba78e4108177", size = 1856556, upload-time = "2026-02-08T03:04:06.515Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1f/449c3af65ef2438dc12490bef2debdd70b79694b76d096a6029b18c9b083/common_expression_language-0.5.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:713e994c1a08fe1920c050d31ac72f1db3a8cd265c0e3b4e5ebeb78ab1cc84a8", size = 1777923, upload-time = "2026-02-08T03:04:22.179Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9b/7def012007076f0bef4fdc07a9369ca2be0edc9361643f31b8450774cf1d/common_expression_language-0.5.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0d6076beb2d754d278672f15070c954f39e249ed3cb29458dbb39b2dc37152d8", size = 1848931, upload-time = "2026-02-08T03:04:15.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4d/62f5b90c048a6d78cc57c7c2638613086aec985ea33e2d060912162e97a2/common_expression_language-0.5.6-cp311-cp311-win32.whl", hash = "sha256:68b7b807b4d30469ac616a5fff6ec66d222a1df3267491e89c0d649278ea6192", size = 1212786, upload-time = "2026-02-08T03:04:47.75Z" },
+    { url = "https://files.pythonhosted.org/packages/44/87/f9b27275e479c6a21dd261c0ac560b9cfe6f0b3118b440bce31ed440d832/common_expression_language-0.5.6-cp311-cp311-win_amd64.whl", hash = "sha256:926b3b4c114f287b31387bcb37ba9e772dabf445a783a2348b166beccddce38b", size = 1376872, upload-time = "2026-02-08T03:04:42.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b1/19492645c0e1abea080810d08b985ecc1da79429e99ecd4dc01684d02b4f/common_expression_language-0.5.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d7fa2be3ef704a27ada7cd6c90144d97967f3ef035b09e5748b5b8466fc95db3", size = 1604941, upload-time = "2026-02-08T03:04:37.013Z" },
+    { url = "https://files.pythonhosted.org/packages/40/9a/b82ac14d54d7758ccb09949d633cb49c1756f99c94e1e85d82126c8b72f5/common_expression_language-0.5.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:acf71b07dfbbffa2175a6dc2594ae3bd4a2b38eb6f2bce2d0bcf0ef80daa5083", size = 1544466, upload-time = "2026-02-08T03:04:31.534Z" },
+    { url = "https://files.pythonhosted.org/packages/62/30/467a66348180320971777e443ef0a4ebb5ebfd3fd36dbace562cb2b61ab0/common_expression_language-0.5.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:112c2a1865c2769f40d336752390e0e779afbd4717b332645808166c1f1c94a6", size = 1778939, upload-time = "2026-02-08T03:03:33.831Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4b/681554692205ec4beb02fdd399a9e592715bf59b62a7d01ee45565fb0f63/common_expression_language-0.5.6-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1271e5fb08d9925aa01e91b25c8cff974f14752538defcef613c31a2f10cd71b", size = 1702229, upload-time = "2026-02-08T03:03:45.66Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ef/85a26c22326d69a87e9d144cd4c16f9142a9075b3644f56624e28b898503/common_expression_language-0.5.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be15788994d3c7bc64cba010154e0fd12b25175c35a43f608dbe41bc7b4ea6a6", size = 2009063, upload-time = "2026-02-08T03:03:55.864Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ad/7f2fef6d8dd8245a9b42da6f4b209d52f3cd956c69a8e16b9fce6fd29bb3/common_expression_language-0.5.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23ff92256f801ae1c16e61fe41b7df60553241581b16220922e13c689ee86653", size = 1856118, upload-time = "2026-02-08T03:04:07.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/dd/c45b21f3169b65140ab0d534d29a0b0d8d4baa2acabe3fcf0a0b7e80dda9/common_expression_language-0.5.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3fcab791f3b0627ae1ef5e8c8cbafb5fb54c399258c26ae4258363f63387686", size = 1774829, upload-time = "2026-02-08T03:04:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/58/24/e584cebe3c7e6f8da6c1551b5c0f5b9fef437cd99096376736f8032ff8c3/common_expression_language-0.5.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efe8babdb3c61acb6ade673667c09d3b9f80dd84247e5452c257b23dfa2974c9", size = 1842237, upload-time = "2026-02-08T03:04:17.151Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/62/e250feb4e22efb0cabb237e55dee223e55f9a81913bc0e3258b102eb5ab4/common_expression_language-0.5.6-cp312-cp312-win_amd64.whl", hash = "sha256:b4bcbe8eb5c40a7e07ba738f38496e6c0d629c894ade2db87e03878ed714b08b", size = 1375598, upload-time = "2026-02-08T03:04:43.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f1/71e5c84bc13e5f9143f74e9568c3c192b92d71e85f841db0cc9210622d72/common_expression_language-0.5.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a7753aa1040ad3b389c6136f894b4239034f801be2f7736cb45b1c02b5d427db", size = 1604348, upload-time = "2026-02-08T03:04:38.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/78/7291f8661c2b18d4e60e56b43fce9aee7ef53e6247431e9187d3ae4a9986/common_expression_language-0.5.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa559ab2d734160348919516f163197ea495a38cb9a2e1433a412d34bcbc1180", size = 1543535, upload-time = "2026-02-08T03:04:32.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ed/ada6279b55d2689700beec40b452263feec372c928c55d73baaaaa58b1ca/common_expression_language-0.5.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d55e65f6e14865963453bbb729c83cd5ebdbec3b37391286ccbcdb6cfa94dfb", size = 1778828, upload-time = "2026-02-08T03:03:35.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/91/5a831a2e64d1248414fee9e0f2565759e565301b7a3d8e65637aebe84e02/common_expression_language-0.5.6-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e459dc944b03f7b962fd1f84475fbe3adcca930fcf6a14d9945d2ad029705a63", size = 1702930, upload-time = "2026-02-08T03:03:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/37/2d665ba3035c6062615de87cad64399d6a535eced2a0c8048fd22eacbd23/common_expression_language-0.5.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74c7789a128ac34d285f795cb54c12de65e3b6855270d5be33c6346d6d2bd3f8", size = 2008247, upload-time = "2026-02-08T03:03:57.778Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/95f0fe5a6feecafa0c95a96b916e89943a35e7a08c10ef4231d6a5e0d552/common_expression_language-0.5.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d690625fc6906ae49b6e14656c16846eaaa177846075c59d8d7cf3475838de10", size = 1856226, upload-time = "2026-02-08T03:04:09.108Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/af/0089c6e999e5d6ad4537d3f1890f16bef328ae99f77f29005a76f40c345d/common_expression_language-0.5.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a16bab612fa97b453d789efd424e45e29f07e50da7035989ad729ce178dd697c", size = 1774433, upload-time = "2026-02-08T03:04:24.834Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/73/9ad4b5e7e2e1e1cb9ad55c6e0b8c328e6bd8bb96ccdc4f8bd4159e4a8c70/common_expression_language-0.5.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c28a4853c3461d14a9040a0c67551a1372047a094a44915a1cf384a1c8027e2", size = 1843551, upload-time = "2026-02-08T03:04:18.403Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ab/2deed39174aeca5a9f2d2a0aaa02413b9a033cef8096d949282d9b06f304/common_expression_language-0.5.6-cp313-cp313-win_amd64.whl", hash = "sha256:b98357954cc2797eba1318a220b1cc798753a8157fd454d9c1c20399af940c80", size = 1375199, upload-time = "2026-02-08T03:04:45.223Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ab/b2c9ea451b745a5c349d20c8e328bb5f0cf85c9f5ea982e8d963395b97db/common_expression_language-0.5.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0113fed33e6f27f0a7b22a93edd4cb1612399e941d0736572d3c74d15ead7613", size = 1780474, upload-time = "2026-02-08T03:03:37.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b9/5b3d9f6003b67dc6837d3198f538fe4d1f884b997c63453188ce628cbf43/common_expression_language-0.5.6-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9f9d16c67d6be3ad0f75552760818cff7c6f1e4c7f69368d42e4c0a72fb97b8a", size = 1700764, upload-time = "2026-02-08T03:03:48.2Z" },
+    { url = "https://files.pythonhosted.org/packages/27/36/2d06be7844bd0990712bf20f725c437a08912224042e5c3e8c77669c7097/common_expression_language-0.5.6-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a2eb44c14b1a9b0ac24f37ffdec7160fb8c1b0b9f325601071b01f09e7b8cc3", size = 2009056, upload-time = "2026-02-08T03:03:59.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/6f/028543261933873f6d9d715078fc3100cc798ee1378ea4065490ee5624cf/common_expression_language-0.5.6-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:356a1da6350548be6750a46ec2a0f9cd8dd668b11e85e050e1bbaea5ebaac144", size = 1854105, upload-time = "2026-02-08T03:04:10.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b0/2fc23076967ab19f69f94838c53eca60f86510a76a3dd928634421d5773a/common_expression_language-0.5.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:8124f01e330e0cdd4fb08d0614ce1554378aee353f559b969fe55fd1d13e1972", size = 1604688, upload-time = "2026-02-08T03:04:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/06/28/d7776ec742718beac911607ed7257597de05dc4f52937cee7f5f343bacbf/common_expression_language-0.5.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f3a41a36fc34bc5ff3a7f7a8ebc2c8eba10b08d081b8a848b9daa37b21150201", size = 1543685, upload-time = "2026-02-08T03:04:34.513Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0e/90c11799b055931c0fce9070fd766657e96d74eebc1f691ca7e5d69decae/common_expression_language-0.5.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f17a64ca7934cc1223285a3252adb673ccd2c163919cbe298b509af800f5faff", size = 1777449, upload-time = "2026-02-08T03:03:39.511Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/03/77a921e728699afcf91ecaacb4324afa2ae4a29aba3436f8df0c8c1bc16f/common_expression_language-0.5.6-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:09a2dd727d01591f328ee670b800e65c071389728582183f8e301c9170428d53", size = 1702111, upload-time = "2026-02-08T03:03:49.77Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/60/fbae6d7814278ffe69c0e31f714cdf7142465f39c1524cf21c7670306f3f/common_expression_language-0.5.6-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62a8065284d9dfa83f3e9a89144c0904f82ca96143428cb94c59c6035aa61b97", size = 2008864, upload-time = "2026-02-08T03:04:01.585Z" },
+    { url = "https://files.pythonhosted.org/packages/47/69/312962b89a32861c2ecbd30b69520a7d1f38f4bc10fd853e8379e506e629/common_expression_language-0.5.6-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a1cc6441bdd75d615c9c08715b24e5edfd9c68b9195b96bf58beeb38c4b34358", size = 1856294, upload-time = "2026-02-08T03:04:11.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/aee0a8fc735de80d81028c4da3f7f3f70e50701a382ab803f28d876f5324/common_expression_language-0.5.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:020c4ad047d48f92de8e9c86cf6c964c0e8dfcd95153efb32fa2d684ffde21c5", size = 1775152, upload-time = "2026-02-08T03:04:26.056Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/da/82f62a6e0e8666ccb14ee46a04950cac036e12489e311ebc35bbde7d3c20/common_expression_language-0.5.6-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:99a30aff68c9b06ede6ea18ed4cc621a50f74a681d833b92db0828af3e2b83ff", size = 1842951, upload-time = "2026-02-08T03:04:19.618Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/65/b1fd9cd3e937e2e075fc1305b172c2f9e9df4bf3847311e2f24c85b74f13/common_expression_language-0.5.6-cp314-cp314-win_amd64.whl", hash = "sha256:e34cc0be2a2e6f1ec9aba333d3652b65e9068722df6e0caf2ef0781fb3bfb6e3", size = 1375276, upload-time = "2026-02-08T03:04:46.516Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a0/cd997119ece32571a942d65883c915c807e06bbd61695e9620b1f57f4226/common_expression_language-0.5.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b18899bda26d84bc905261e852fa975f01c3c27b3b547aa9a820fc812eb9076", size = 1778808, upload-time = "2026-02-08T03:03:41.612Z" },
+    { url = "https://files.pythonhosted.org/packages/48/96/e500529a24e0cd9383728f0046613c85b10c30a7b0255748a9ade7e31a61/common_expression_language-0.5.6-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d6c868f80e7068d8117ffa371e6df13e39e8fe9bfbe7f9588e792723f9ef5eb1", size = 1702266, upload-time = "2026-02-08T03:03:51.03Z" },
+    { url = "https://files.pythonhosted.org/packages/09/40/a97748426063b5df8e8ead0fc30dc262e856c292a46f16e2589a0a05f0d5/common_expression_language-0.5.6-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c8e405d0defdf41d1f3866ace8c9efe92b0c499c8f282298c03324d6ebbcc06a", size = 2010708, upload-time = "2026-02-08T03:04:03.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/40/b6d98f1316050b2bd85f0c06c1b88f69851ca4a3c9d91d399d07f5311d50/common_expression_language-0.5.6-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f91d399159838637e52084186ed69d1991d7fb445ff50930676c74d6c1d16ff", size = 1854159, upload-time = "2026-02-08T03:04:13.463Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/39/4a83234d616b9046a41493483fe70d3b3fafe3428adca96af857a1c1a3c3/common_expression_language-0.5.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f25b91d784123f4994f91dbb5830e221fbde480f3af11f7ee9ebdab829390afa", size = 1787705, upload-time = "2026-02-08T03:03:42.907Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/29eccd9cbbaaee3454fbd38a14852db336a2e6988352aad9549b7fad2d5a/common_expression_language-0.5.6-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dda6993475b06fd5017a4ff695474cadbfff13a7369d7f3a71c94d186c1794c1", size = 1707233, upload-time = "2026-02-08T03:03:52.326Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/33f5d5d9939352a9ade70ceb58ab9106afa896a0472bcc4f0e4a0f189624/common_expression_language-0.5.6-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ed85099073d8e4d78af2fde2df1e812c23bff952e553c0577a133d8796f096f", size = 2014911, upload-time = "2026-02-08T03:04:05.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2c/63e2286c9d34ba90284cf3a42a2d1a286e6e3f4dba6d8d58b2e9be8de320/common_expression_language-0.5.6-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a0190f2b5cb91b735b61c6f1b76dab6e4cdafeffdb84490dfb61289753179da5", size = 1858928, upload-time = "2026-02-08T03:04:14.688Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ac/c1de22b298292338624d563512c64028747bbb1cc7c77167f972790b8ada/common_expression_language-0.5.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd638ef8c195e229548d5ade00d739b3d5c03e8f758a7619d0dd2c3b05979dea", size = 1781377, upload-time = "2026-02-08T03:04:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/37d1915873503e1553aa43ae98561da109f1a9c2a22e5abc56d33d9642b2/common_expression_language-0.5.6-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a996aeb656a723494cc9adf83f91364ddadf5b8eb9eccbec8fc00c46d4ace9d", size = 1854158, upload-time = "2026-02-08T03:04:20.959Z" },
 ]
 
 [[package]]
@@ -534,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.13.1"
+version = "0.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -562,6 +647,10 @@ all = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
+cel = [
+    { name = "cel-python" },
+    { name = "common-expression-language" },
+]
 cli = [
     { name = "rich" },
     { name = "typer" },
@@ -572,10 +661,13 @@ cloud-dns = [
 ]
 dev = [
     { name = "boto3-stubs", extra = ["route53"] },
+    { name = "cel-python" },
+    { name = "common-expression-language" },
     { name = "cryptography" },
     { name = "cyclonedx-bom" },
     { name = "httpx" },
     { name = "mypy" },
+    { name = "pqcrypto" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -592,6 +684,9 @@ otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
 ]
+pqc = [
+    { name = "pqcrypto" },
+]
 route53 = [
     { name = "boto3" },
 ]
@@ -602,6 +697,10 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'route53'", specifier = ">=1.34.0" },
     { name = "boto3-stubs", extras = ["route53"], marker = "extra == 'all'", specifier = ">=1.34.0" },
     { name = "boto3-stubs", extras = ["route53"], marker = "extra == 'dev'", specifier = ">=1.34.0" },
+    { name = "cel-python", marker = "extra == 'cel'", specifier = ">=0.5.0" },
+    { name = "cel-python", marker = "extra == 'dev'", specifier = ">=0.5.0" },
+    { name = "common-expression-language", marker = "extra == 'cel'", specifier = ">=0.5.0" },
+    { name = "common-expression-language", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "cryptography", marker = "extra == 'all'", specifier = ">=41.0.0" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=41.0.0" },
     { name = "cryptography", marker = "extra == 'jws'", specifier = ">=41.0.0" },
@@ -619,6 +718,8 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "pqcrypto", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "pqcrypto", marker = "extra == 'pqc'", specifier = ">=0.4.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pytest", marker = "extra == 'all'", specifier = ">=8.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -638,7 +739,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "cel", "pqc", "dev", "all"]
 
 [[package]]
 name = "dnspython"
@@ -669,6 +770,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
+]
+
+[[package]]
+name = "google-re2"
+version = "1.1.20251105"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/60/805c654ba53d685513df955ee745f71920fe8e6a284faf0f9b9dc19b659c/google_re2-1.1.20251105.tar.gz", hash = "sha256:1db14a292ee8303b91e91e7c37e05ac17d3c467f29416c79ac70a78be3e65bda", size = 11676, upload-time = "2025-11-05T14:58:07.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/4d/203a08dab1bdb5c83b46dd424c01a789ecb5a37dbc80f33d016bd116a9d7/google_re2-1.1.20251105-1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:329efa209ea7baa44f0facf0402fa34e655dc97fdeb10d0b83fc06354f5575fd", size = 483717, upload-time = "2025-11-05T14:57:04.808Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/466026b43ff5c7d740f5ede090992ec63b60d1810ab14fe35dfc00677e0a/google_re2-1.1.20251105-1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:aa2ad5f6f48921ec137a7b7f1b1da903ddef8627a2dc30bc878a9a69d9925719", size = 515547, upload-time = "2025-11-05T14:57:06.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6a/c6c9fdb00c98990e4f7a6cd650e209d7b5d2754ca0404b72c69ac9909a69/google_re2-1.1.20251105-1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ac1cb2526cc88f050a0661fc7245ad009ee454bddc541b2e653f1d007585000d", size = 485396, upload-time = "2025-11-05T14:57:07.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/f6/529c44f607c47f96cfa29c1fe3a690fe75b2fdb48e9b0d6b54e5f0a75e59/google_re2-1.1.20251105-1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:50c7205182ad66c23c07abe8072f720ca2f7d595b61e28fd9b63623614f9afd6", size = 517150, upload-time = "2025-11-05T14:57:09.376Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/ccc07860e31ab81965c63f9ed4eb69ea0d3449a9b4e1610f71883694bbe8/google_re2-1.1.20251105-1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4cb5acee61e35772503b8b1db3c592a46b8e6a9bc0ab54d7d6233654ea2bf93d", size = 482807, upload-time = "2025-11-05T14:57:11.057Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/43/5fb20d16664457f61670bdd95f39039d43ee8b7732511c688e2f322a4317/google_re2-1.1.20251105-1-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:1617097d63620c2d46bdfc0e48f24f66cd341664fc75718636d234f67473fe7f", size = 508839, upload-time = "2025-11-05T14:57:12.338Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f2/6e470338271e164dd3c5e508876f99aec3ed23bf419c7d54a5672fd5b05f/google_re2-1.1.20251105-1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a5610b26742b90cb1d64ead2b16fe0e3bd7e67add03fd3779cd1b85e401661", size = 573718, upload-time = "2025-11-05T14:57:13.635Z" },
+    { url = "https://files.pythonhosted.org/packages/91/21/4566fc344c21cf3c49082d13ddab785994b5e3b8b7fd4631242538f698a2/google_re2-1.1.20251105-1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03156291269f145eccddff63118f2df02d395792f51fc039f09955818943815a", size = 590749, upload-time = "2025-11-05T14:57:14.864Z" },
+    { url = "https://files.pythonhosted.org/packages/94/19/5981fb798bb8d08933b815b1fd9e55d179c380b9d8c21a49197b9b7c5967/google_re2-1.1.20251105-1-cp311-cp311-win32.whl", hash = "sha256:54f51762b51dc238eceddf49b56cc2b64594fe72d9328c1c39d615aa990e1f87", size = 434066, upload-time = "2025-11-05T14:57:16.22Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e5/f83053a36cfc4762d843748e4f7a9c1141937dcf74cd6fc3f4598292dda3/google_re2-1.1.20251105-1-cp311-cp311-win_amd64.whl", hash = "sha256:f5f856ff5036a8f22b3bad57f376d4e3b97b59b64f311bdb1f83c8dabded2492", size = 491025, upload-time = "2025-11-05T14:57:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/56/be/4315c3b38f42f9a2888fa76260545c98547502f1c35aa63a672d39011b2e/google_re2-1.1.20251105-1-cp311-cp311-win_arm64.whl", hash = "sha256:913864f97de4151eaa8bb7746ca230fd193656501e07fb658ce2cd46d4f6efcc", size = 642194, upload-time = "2025-11-05T14:57:19.374Z" },
+    { url = "https://files.pythonhosted.org/packages/67/20/73b487538e9107c2fd96aed737e3f3890dfce3e292622e4ffb2f9c810ee5/google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b30f09b4d63249c72e65ccae4cbf6b331b48c22fc7cb439f1d85f347b9d07ceb", size = 485591, upload-time = "2025-11-05T14:57:20.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9a/ca3a993bdb5dc6d5b2616b9657b2872a83d1827f8bd3ab50cd629eb751c7/google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9a77892c524b8bdf3d47d7cad1cc2ac3a0108bdd65007ef4c02888fa46baf8ee", size = 518780, upload-time = "2025-11-05T14:57:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/df/37/b2e367987371514253ec9e514637f457deaacb7acc1c900814f3a6421e0f/google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a3ac51b28cbf25c100dfd8849212d878d7005d1d4a7e129a10789043c56b6021", size = 486966, upload-time = "2025-11-05T14:57:24.575Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/1db6742943c0ac254bfb7d8a37a5d3f73f016a65cfa1f84fe3a0451820f6/google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:9f7158afc9825ac2654c6561aea94a1f7edb5b5b88e6e3639bb80bb817d102ac", size = 520225, upload-time = "2025-11-05T14:57:26.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0a/0747c92dbebe2c09a26bd7386d372b5c5a9926236b4f3d69bb8f15db05cb/google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:5320da07dc3b7ac7f407514f42ac17d67e771ac7c7562d449571185e6fb601b2", size = 482943, upload-time = "2025-11-05T14:57:27.353Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/6bfc6838bb6cb561824ac03deeab2bd11d5d9a93505f536c8fa2f6bd46c4/google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:5a4e5785bc30d52ce655d805b07ad2d8a4905429a5f690ae9c2f1caa76665709", size = 510384, upload-time = "2025-11-05T14:57:29.139Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0a/6add090c917ee39f6f0be753037cafceb3bad904b424efc155fb38082635/google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b7a3b90f747130310d4b3b8e19ebb845d0d97c1deb63b36f76c7242dacbd736", size = 572446, upload-time = "2025-11-05T14:57:30.495Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1c/8b1ccbeade96a21435d55b5185cd6d9b2ceab5a9af998a4d9099e0540759/google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:809c5fa5d08279413b29c2e2c5c528e85cd94a0e0fd897db595a0c09eeee2782", size = 591348, upload-time = "2025-11-05T14:57:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cf/7bdd7a1ae7828b613011da808eafec4da3132f43c3be6af5e0bd670ebe8b/google_re2-1.1.20251105-1-cp312-cp312-win32.whl", hash = "sha256:d8424e63a9ec0fe5bde03d97876b2431f8a746af33eb475fa1ae39144bd05b2a", size = 433787, upload-time = "2025-11-05T14:57:33.071Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e9/5dd951c35acaabfe87c67228b9af2cdcd7779d9167edbe6b9094b8a8e529/google_re2-1.1.20251105-1-cp312-cp312-win_amd64.whl", hash = "sha256:062313c309f93dfeb6966372f4c446580e98879133ec155522eea8aaf568a5cd", size = 491726, upload-time = "2025-11-05T14:57:34.39Z" },
+    { url = "https://files.pythonhosted.org/packages/60/8d/c1afd29fc2cb475fd4c634f3d3c8099c0efb662362c10b27a9eaf11c9357/google_re2-1.1.20251105-1-cp312-cp312-win_arm64.whl", hash = "sha256:558f144b26a9555ae4e9467cc3aa3299a8ce13217f328b21ae326ca0633be19b", size = 642673, upload-time = "2025-11-05T14:57:35.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/c441722196598fc3de0f654606ad9975a968c71dc27f516b5a4c9ebb94fd/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:9f3cf610e857a7d6f02916cf2b7fc159a5429b8bcb23164500d46e5e233f2924", size = 485549, upload-time = "2025-11-05T14:57:36.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/87/cf588255e5ada1dfb555cc96de35be78438bb0b6faba64df5fe91cecc224/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a21c2807bf4d5d00f206a4ecb3b043aad674e28c451b697b740280f608872078", size = 518840, upload-time = "2025-11-05T14:57:38.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/39/da66e4ca9be0c51546efc6fb39cf1683c4be8245d8199cb54a9808e8d5fa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8314144eefeee7b88b742081c2038418f677e63901039ca9dbfbc0c5bb6d2911", size = 487037, upload-time = "2025-11-05T14:57:39.467Z" },
+    { url = "https://files.pythonhosted.org/packages/75/dd/24ba65692dd58dca6ff178428551f4e9b776d1489a1251f5c8539e598baa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:28a46be978e53c772139d0f5c9ba69f53563fcdd4225407e4d34d51208b828f1", size = 520285, upload-time = "2025-11-05T14:57:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/61/12/cfdbb92bed24af6474970a75a26145c424f98cfbcc633fdd185985f0efe0/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:83292e23963aa1b219d5f64a65365b0880448a6a060276027b55270bc5b18c7e", size = 482981, upload-time = "2025-11-05T14:57:41.928Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bf/5fc32ded9279e69a87b88d7261e7e77e2e26325d4e27ca1303a3215e430a/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:1920b15dc9b1bdfeca5aa2c60900373c6f27cd1056d53cd299456ea5540a6fff", size = 510366, upload-time = "2025-11-05T14:57:43.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/71/f927ddc7aef1b8d7ccc8a649c335d311f29f3dea658209e30e37720e4891/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b1458d9ca588124cd61aa1bf5388a216e1247e7d474f8e5e1530498044f5c87", size = 572390, upload-time = "2025-11-05T14:57:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8c/23075e589038284c9487f41cde531d35873f9da622fb4ac7d1d97bd9086e/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a52cb204e49d20cdbb66faf394d57f476e96c39c23a328442ab0194fc6bd1a2b", size = 591386, upload-time = "2025-11-05T14:57:45.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/858453ef689f6b9895cd02b466836a9d1a6e4ba535d1a275b01bf73baa1d/google_re2-1.1.20251105-1-cp313-cp313-win32.whl", hash = "sha256:67c5c73d7ebcf3f0e0a3b528b41bd8c6c04900f1598aebf05bbdf15a06cf5f9a", size = 433807, upload-time = "2025-11-05T14:57:46.92Z" },
+    { url = "https://files.pythonhosted.org/packages/08/24/6ea87fe682e115ffd296e91eb5c5a266349d1ee8414ce8ece3f99ec1ac84/google_re2-1.1.20251105-1-cp313-cp313-win_amd64.whl", hash = "sha256:0bcba63ad3ea8926fb0c71bb5044e33d405bb9395f5b5444393cd5f28f0bf6d3", size = 491734, upload-time = "2025-11-05T14:57:48.304Z" },
+    { url = "https://files.pythonhosted.org/packages/34/85/32ba71b06f3cf5f9856ae95b3d6463b971742453631a5ae2c5be338ea377/google_re2-1.1.20251105-1-cp313-cp313-win_arm64.whl", hash = "sha256:64ee189ea857f2126c5e42073cfa9b03e9f4cbaf073edbedb575059074841aa0", size = 642654, upload-time = "2025-11-05T14:57:49.602Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7f/7eb238bdcd06182b5f427afd305cf413b7cf4ea71047308bbf35912cf923/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:cc151cf6a585d9ebe711da32b23683fcff40f78db8c8587c7f4b209ef4658809", size = 484719, upload-time = "2025-11-05T14:57:51.326Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/62/eed28eab67f939f4b9383c47b1db11638ade6ac30785c15cb960de85ba43/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7e2186d2c90488c1e11895343941f35ca2f58e9ba6c6b034fd531abe22ef77cc", size = 517698, upload-time = "2025-11-05T14:57:52.597Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/16/a1e6768513f788bf9c67a1cfe379ef34a793983eee46e4b653e42b558b78/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:41be22359c3dceb582937739b4365dd8e279de24ad0a5b10e653503abaff2ed7", size = 486421, upload-time = "2025-11-05T14:57:53.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/7a97ffd36d451e5a8bfaff2f9022b14807795d588f98227ff96e8da99856/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:f3168d7bbac247c862ea85b2f3c011d3a04bedcb6892b37f14d488f4133b206e", size = 519037, upload-time = "2025-11-05T14:57:55.078Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ee/8b6f7d94bb689dafdf60de8dd8f8f6296ad40d4d15c933fcda4da7a3a06b/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:79ce664038194a31bbcf422137f9607ae3d9946a5cff98cf0efbeb7f9411e64b", size = 483373, upload-time = "2025-11-05T14:57:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a6/16a09e03d1de128f821869e4252688c21319f5017d9209f4d0e71ea5c951/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:0476b07421b8882b279d5ceb5b760c15c62d581ded95274697fc1227e3869ee6", size = 510167, upload-time = "2025-11-05T14:57:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/9d/213dce5de401527369fb5af11096b18c06001d9eb71f3318fe5eba1ec706/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85feec3161ffdc12f6b144e37a2f91f80b771c72ffadde60191e89a49f6d7e81", size = 573176, upload-time = "2025-11-05T14:57:59.211Z" },
+    { url = "https://files.pythonhosted.org/packages/03/be/a8def96aa4a80b233e105767d22e3de961dcde5a04f0a05cb4f3ddb4df78/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7bfaa2cf55daf0c5c650e68526bb20b61e37d7f3ae53f6893013acc1c91c116", size = 591483, upload-time = "2025-11-05T14:58:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ea/144bbc4b9359da89aec07b4c2a91a6bfe7119914885386577c665b07bb01/google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8", size = 433773, upload-time = "2025-11-05T14:58:01.594Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/74e301211699f1b650ba7690a3e4e52146ac4266fcd62f3ea0a945b9eda4/google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6", size = 491893, upload-time = "2025-11-05T14:58:02.969Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/4adcfcb9c95e3d064c9f7aaf6cb3a4fc842d86115014b9d4094db4d465b5/google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5", size = 643093, upload-time = "2025-11-05T14:58:05.761Z" },
 ]
 
 [[package]]
@@ -1177,6 +1330,66 @@ wheels = [
 ]
 
 [[package]]
+name = "pendulum"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/27/a4be6ec12161b503dd036f8d7cc57f8626170ae31bb298038be9af0001ce/pendulum-3.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5d775cc608c909ad415c8e789c84a9f120bb6a794c4215b2d8d910893cf0ec6a", size = 337923, upload-time = "2026-01-30T11:20:51.61Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/2a214e18355ec2a6ce3f683a97eecdb6050866ff3a6cf165d411450aeb1b/pendulum-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8de794a7f665aebc8c1ba4dd4b05ab8fe1a36ce9c0498366adf1d1edd79b2686", size = 327379, upload-time = "2026-01-30T11:20:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/01/7392e58ebc1d9e70b987dc8bb0c89710b47ac8125067efe7aa4c420b616f/pendulum-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bac7df7696e1c942e17c0556b3a7bcdd1d7aa5b24faee7620cb071e754a0622", size = 340115, upload-time = "2026-01-30T11:20:54.635Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/80de84c5ca1a3e4f7f3b75090c9b61b6dbb6d095e302ee592cebbaf0bbfb/pendulum-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0f6a8a04475d9cba26ce701e7d66d266fd97227f2f5f499270eba04be1c7e9", size = 373969, upload-time = "2026-01-30T11:20:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/f7b4c1818927ab394a2a0a9b7011f360a0a75839a22678833c5bc0a84183/pendulum-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c352c63c1ff05f2198409b28498d7158547a8be23e1fbd4aa2cf5402fb239b55", size = 379058, upload-time = "2026-01-30T11:20:57.618Z" },
+    { url = "https://files.pythonhosted.org/packages/36/94/9947cf710620afcc68751683f2f8de88d902505e7c13c0349d7e9d362f97/pendulum-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de8c1ad1d1aa7d4ceae341528bab35a0f8c88a5aa63f2f5d84e16b517d1b32c2", size = 348403, upload-time = "2026-01-30T11:20:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/12/0e6ba0bb00fa57907af2a3fca8643bded5dba1e87072d50673776a0d6ed2/pendulum-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1ba955511c12fec2252038b0c866c25c0c30b720bf74d3023710f121e42b1498", size = 517457, upload-time = "2026-01-30T11:21:01.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fe/dae5fbfe67bd41d943def0ad8f1e7f6988aa8e527255e433cd7c494f9ad5/pendulum-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4115bf364a2ec6d5ddc476751ceaa4164a04f2c15589f0d29aa210ddb784b15d", size = 561103, upload-time = "2026-01-30T11:21:03.924Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a0/8f646160b98abfc19152505af19bd643a4279ec2bdbe0959f16b7025fc6b/pendulum-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:4151a903356413fdd9549de0997b708fb95a214ed97803ffb479ffd834088378", size = 260595, upload-time = "2026-01-30T11:21:05.495Z" },
+    { url = "https://files.pythonhosted.org/packages/79/01/feead7af9ded7a13f2d798fb6573e70f469113eafcd8cc8f59671584ca3e/pendulum-3.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:acfdee9ddc56053cb7c8c075afbfde0857322d09e56a56195b9cd127fae87e4c", size = 255382, upload-time = "2026-01-30T11:21:06.847Z" },
+    { url = "https://files.pythonhosted.org/packages/41/56/dd0ea9f97d25a0763cda09e2217563b45714786118d8c68b0b745395d6eb/pendulum-3.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bf0b489def51202a39a2a665dcc4162d5e46934a740fe4c4fe3068979610156c", size = 337830, upload-time = "2026-01-30T11:21:08.298Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/98/83d62899bf7226fc12396de4bc1fb2b5da27e451c7c60790043aaf8b4731/pendulum-3.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:937a529aa302efa18dcf25e53834964a87ffb2df8f80e3669ab7757a6126beaf", size = 327574, upload-time = "2026-01-30T11:21:09.715Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fa/ff2aa992b23f0543c709b1a3f3f9ed760ec71fd02c8bb01f93bf008b52e4/pendulum-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85c7689defc65c4dc29bf257f7cca55d210fabb455de9476e1748d2ab2ae80d7", size = 339891, upload-time = "2026-01-30T11:21:11.089Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4e/25b4fa11d19503d50d7b52d7ef943c0f20fd54422aaeb9e38f588c815c50/pendulum-3.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e216e5a412563ea2ecf5de467dcf3d02717947fcdabe6811d5ee360726b02b", size = 373726, upload-time = "2026-01-30T11:21:12.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/30/0acad6396c4e74e5c689aa4f0b0c49e2ecdcfce368e7b5bf35ca1c0fc61a/pendulum-3.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a2af22eeec438fbaac72bb7fba783e0950a514fba980d9a32db394b51afccec", size = 379827, upload-time = "2026-01-30T11:21:14.08Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f7/e6a2fdf2a23d59b4b48b8fa89e8d4bf2dd371aea2c6ba8fcecec20a4acb9/pendulum-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3159cceb54f5aa8b85b141c7f0ce3fac8bdd1ffdc7c79e67dca9133eac7c4d11", size = 348921, upload-time = "2026-01-30T11:21:15.816Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f2/c15fa7f9ad4e181aa469b6040b574988bd108ccdf4ae509ad224f9e4db44/pendulum-3.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c39ea5e9ffa20ea8bae986d00e0908bd537c8468b71d6b6503ab0b4c3d76e0ea", size = 517188, upload-time = "2026-01-30T11:21:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c7/5f80b12ee88ec26e930c3a5a602608a63c29cf60c81a0eb066d583772550/pendulum-3.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e5afc753e570cce1f44197676371f68953f7d4f022303d141bb09f804d5fe6d7", size = 561833, upload-time = "2026-01-30T11:21:19.232Z" },
+    { url = "https://files.pythonhosted.org/packages/90/15/1ac481626cb63db751f6281e294661947c1f0321ebe5d1c532a3b51a8006/pendulum-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:fd55c12560816d9122ca2142d9e428f32c0c083bf77719320b1767539c7a3a3b", size = 258725, upload-time = "2026-01-30T11:21:20.558Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/50b0398d7d027eb70a3e1e336de7b6e599c6b74431cb7d3863287e1292bb/pendulum-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:faef52a7ed99729f0838353b956f3fabf6c550c062db247e9e2fc2b48fcb9457", size = 253089, upload-time = "2026-01-30T11:21:22.497Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8c/400c8b8dbd7524424f3d9902ded64741e82e5e321d1aabbd68ade89e71cf/pendulum-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:addb0512f919fe5b70c8ee534ee71c775630d3efe567ea5763d92acff857cfc3", size = 337820, upload-time = "2026-01-30T11:21:24.305Z" },
+    { url = "https://files.pythonhosted.org/packages/59/38/7c16f26cc55d9206d71da294ce6857d0da381e26bc9e0c2a069424c2b173/pendulum-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3aaa50342dc174acebdc21089315012e63789353957b39ac83cac9f9fc8d1075", size = 327551, upload-time = "2026-01-30T11:21:25.747Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/f36ec5d56d55104232380fdbf84ff53cc05607574af3cbdc8a43991ac8a7/pendulum-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:927e9c9ab52ff68e71b76dd410e5f1cd78f5ea6e7f0a9f5eb549aea16a4d5354", size = 339894, upload-time = "2026-01-30T11:21:27.229Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/b9a1e546519c3a92d5bc17787cea925e06a20def2ae344fa136d2fc40338/pendulum-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:249d18f5543c9f43aba3bd77b34864ec8cf6f64edbead405f442e23c94fce63d", size = 373766, upload-time = "2026-01-30T11:21:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a6/6471ab87ae2260594501f071586a765fc894817043b7d2d4b04e2eff4f31/pendulum-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c644cc15eec5fb02291f0f193195156780fd5a0affd7a349592403826d1a35e", size = 379837, upload-time = "2026-01-30T11:21:30.637Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/0ba0c14e862388f7b822626e6e989163c23bebe7f96de5ec4b207cbe7c3d/pendulum-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:063ab61af953bb56ad5bc8e131fd0431c915ed766d90ccecd7549c8090b51004", size = 348904, upload-time = "2026-01-30T11:21:32.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/34/df922c7c0b12719589d4954bfa5bdca9e02bcde220f5c5c1838a87118960/pendulum-3.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:26a3ae26c9dd70a4256f1c2f51addc43641813574c0db6ce5664f9861cd93621", size = 517173, upload-time = "2026-01-30T11:21:34.428Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/3b9e061eeee97b72a47c1434ee03f6d85f0284d9285d92b12b0fff2d19ac/pendulum-3.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2b10d91dc00f424444a42f47c69e6b3bfd79376f330179dc06bc342184b35f9a", size = 561744, upload-time = "2026-01-30T11:21:35.861Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7e/f12fdb6070b7975c1fcfa5685dbe4ab73c788878a71f4d1d7e3c87979e37/pendulum-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:63070ff03e30a57b16c8e793ee27da8dac4123c1d6e0cf74c460ce9ee8a64aa4", size = 258746, upload-time = "2026-01-30T11:21:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/5abd872056357f069ae34a9b24a75ac58e79092d16201d779a8dd31386bb/pendulum-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8dde63e2796b62070a49ce813ce200aba9186130307f04ec78affcf6c2e8122", size = 253028, upload-time = "2026-01-30T11:21:39.381Z" },
+    { url = "https://files.pythonhosted.org/packages/82/99/5b9cc823862450910bcb2c7cdc6884c0939b268639146d30e4a4f55eb1f1/pendulum-3.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c17ac069e88c5a1e930a5ae0ef17357a14b9cc5a28abadda74eaa8106d241c8e", size = 338281, upload-time = "2026-01-30T11:21:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3a/64a35260f6ac36c0ad50eeb5f1a465b98b0d7603f79a5c2077c41326d639/pendulum-3.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e1fbb540edecb21f8244aebfb05a1f2333ddc6c7819378c099d4a61cc91ae93c", size = 328030, upload-time = "2026-01-30T11:21:42.778Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6b/1140e09310035a2afb05bb90a2b8fbda9d3222e03b92de9533123afe6b65/pendulum-3.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8c67fb9a1fe8fc1adae2cc01b0c292b268c12475b4609ff4aed71c9dd367b4d", size = 340206, upload-time = "2026-01-30T11:21:44.148Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4a/a493de56cbc24a64b21ac6ba98513a9ec5c67daa3dba325e39a8e53f30d8/pendulum-3.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:baa9a66c980defda6cfe1275103a94b22e90d83ebd7a84cc961cee6cbd25a244", size = 373976, upload-time = "2026-01-30T11:21:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/f083c4fd1a161d4ab218680cc906338c541497b3098373f2241f58c429cb/pendulum-3.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef8f783fa7a14973b0596d8af2a5b2d90858a55030e9b4c6885eb4284b88314f", size = 380075, upload-time = "2026-01-30T11:21:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/333a0fcb33bf15eb879a46a11ce6300c1698a141e689665fe430783ff8d6/pendulum-3.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7d2e9bfb065727d8676e7ada3793b47a24349500a5e9637404355e482c822be", size = 349026, upload-time = "2026-01-30T11:21:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1a/dfb526ec0cba1e7cd6a5e4f4dd64a6ada7428d1449c54b15f7b295f6e122/pendulum-3.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:55d7ba6bb74171c3ee409bf30076ee3a259a3c2bb147ac87ebb76aaa3cf5d3a2", size = 517395, upload-time = "2026-01-30T11:21:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/37/b4f2b5f1200351c4869b8b46ad5c21019e3dbe0417f5867ae969fad7b5fe/pendulum-3.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:a50d8cf42f06d3d8c3f8bb2a7ac47fa93b5145e69de6a7209be6a47afdd9cf76", size = 561926, upload-time = "2026-01-30T11:21:51.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9e/567376582da58f5fe8e4f579db2bcfbf243cf619a5825bdf1023ad1436b3/pendulum-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e5bbb92b155cd5018b3cf70ee49ed3b9c94398caaaa7ed97fe41e5bb5a968418", size = 258817, upload-time = "2026-01-30T11:21:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/95/67/dfffd7eb50d67fa821cd4d92cf71575ead6162930202bc40dfcedf78c38c/pendulum-3.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:d53134418e04335c3029a32e9341cccc9b085a28744fb5ee4e6a8f5039363b1a", size = 253292, upload-time = "2026-01-30T11:21:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0d/d5ac8468a1b40f09a62d6e91654088de432367907579dd161c0fb1bdf222/pendulum-3.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9585594d32faa71efa5a78f576f1ee4f79e9c5340d7c6f0cd6c5dfe725effaaa", size = 338760, upload-time = "2026-01-30T11:22:12.225Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/7fa8c8be6caac8e0be78fbe7668df571f44820ed779cb3736fab645fcba8/pendulum-3.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:26401e2de77c437e8f3b6160c08c6c5d45518d906f8f9b48fd7cb5aa0f4e2aff", size = 328333, upload-time = "2026-01-30T11:22:13.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/78/73a1031b7d1bf7986e8e655cea3f018164b3470aecfea25a4074e77dda73/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:637e65af042f383a2764a886aa28ccc6f853bf7a142df18e41c720542934c13b", size = 340841, upload-time = "2026-01-30T11:22:15.278Z" },
+    { url = "https://files.pythonhosted.org/packages/49/40/4e36e9074e92b0164c088b9ada3c02bfea386d83e24fa98b30fe9b6e61a8/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6e46c28f4d067233c4a4c42748f4ffa641d9289c09e0e81488beb6d4b3fab51", size = 348959, upload-time = "2026-01-30T11:22:16.718Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/8bf7fcb91b526e1efe17d047faa845709b88800fff915ff848ff26054293/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:71d46bcc86269f97bfd8c5f1475d55e717696a0a010b1871023605ca94624031", size = 518102, upload-time = "2026-01-30T11:22:18.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b0/a36c468d2d0dec62ddea7c5e4177e93abb12f48ac90f09f24d0581c5189f/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6", size = 561884, upload-time = "2026-01-30T11:22:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4d/dad105261898907bf806cabca53d3878529a9fa2c0d5d7f95f2035246fc2/pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716", size = 261236, upload-time = "2026-01-30T11:22:21.059Z" },
+    { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111, upload-time = "2026-01-30T11:22:22.361Z" },
+]
+
+[[package]]
 name = "pip-requirements-parser"
 version = "32.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1196,6 +1409,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pqcrypto"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/75/8864b99d3fb703914b734b9a6e468e76a1c208c66a297124e3ee795336b3/pqcrypto-0.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdbf308452a183fc6c47a994207ff3ebd820c8a8aa1f09e9dbb1b697ab6e7cd9", size = 8945667, upload-time = "2026-01-25T20:59:06.325Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/22/15f3f28b3e0763879336ae7c7d9f83e9bb3131beaf47ddece4418b9edbe1/pqcrypto-0.4.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0e4ea504eabec4d51085fa62de61b471ac123a624fe44bd4dac289e8803b8f", size = 18247129, upload-time = "2026-01-25T20:59:09.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6a/2f15dacd72df897ba15e051d0517ad3b8676e27feac189d8ac540edfdde0/pqcrypto-0.4.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a0f221f06f4af1029d55c21eaa4456630119d5205bb12390637ae31e710cd4f", size = 20470357, upload-time = "2026-01-25T20:59:12.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/32/f63a16adec538fe74e3bb1f7cc208127d06e9333330d5b363e223461e27f/pqcrypto-0.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b098557eb6ed727f96f32d388a0a36494f347e8b4be3cdbd413997cfc82712bd", size = 18020987, upload-time = "2026-01-25T20:59:15.682Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ab/8d4270445ea0d5d5e4d5cbd28b9186e97b32185459a1b67273d3046bf288/pqcrypto-0.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f8fa254a42751bd3dc53dff0897c74bc1f0be2c100ab7c86bda17905983a7f4c", size = 20429001, upload-time = "2026-01-25T20:59:17.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f5/633a869fe0c0b9b7bb9086e7f767a06932b77db7d5ef7aea2162359f8c8a/pqcrypto-0.4.0-cp311-cp311-win32.whl", hash = "sha256:1517264111b95b572c0a73470f76795bd9aadce1af27f5fb02890c8bb92789b4", size = 4439677, upload-time = "2026-01-25T20:59:20.323Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/9dc4f354c594d86bb617dbacbeb09c8163ffa5223e09a8b9e029d5db9c1c/pqcrypto-0.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cae6d57a0098d9a703f627de72f9688b0cbcc6d4b6d9f67be7a44a98da9d063f", size = 5351587, upload-time = "2026-01-25T20:59:22.496Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2b/3cfe832c7c365cf715d04a1cc220961ce442deb88888f259890fb6af175a/pqcrypto-0.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:001d2b473bd64c1ff59ed3ef57ad5b4d351a2b75b589015a8385a6e29d44cb55", size = 11005504, upload-time = "2026-01-25T20:59:24.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c9/13f965ada9bbccb9633cb13123327022dfd537e12d10ad033bd83053dab3/pqcrypto-0.4.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e79f8d9148db5a83e8a842ad59402f3421a2cc678f2c3c43015b26f4b5cad93", size = 24322618, upload-time = "2026-01-25T20:59:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f4/80b7aacc93249d5735f8d150096f0b6eed8347cff99e0f032e3170c94aaf/pqcrypto-0.4.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:280db9aa8e173b6756bf45a7eda042f02692c32e06ed47c57d6909026be17d48", size = 27288989, upload-time = "2026-01-25T20:59:30.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/63/3f941d65571f4faa9dfa3ba0c672a72a8d783c1ac3dbfea041e3844eb9a2/pqcrypto-0.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:61d5cad03791a892d9d1896fd268604a9912df1760e7fe70efe53fef7a3e31a4", size = 24019376, upload-time = "2026-01-25T20:59:33.051Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e4/6f4a22da1e74eb925a5f08887c450af474abd6bc4d6898384a1fce554fa2/pqcrypto-0.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7a6515e74bf05bbefc8e1a33a18c0c2e0494185675b6f8aaa8c931191272b565", size = 27235541, upload-time = "2026-01-25T20:59:35.561Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2c/333b2e41f863a3a6453192a18c1e437b471b02351154972e2add6d42f903/pqcrypto-0.4.0-cp312-cp312-win32.whl", hash = "sha256:ab62730b19e1d810bd8adbac783b5e7b2a21db03da39e05e7e175242ff556189", size = 6211191, upload-time = "2026-01-25T20:59:37.755Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b9/3425250bfad6e1bff4f855555c8d043a918d8b5619dc316ce0b6ad58ad54/pqcrypto-0.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8a5b74ddc4e257469b3ad44aa65e839eeb7da5c0fabc68a8e469507445e731cd", size = 7123468, upload-time = "2026-01-25T20:59:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5d/dd3752d741f8772eb7f0a49226bb02966c1fd7b85c7aa83027213a2e9973/pqcrypto-0.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ede8f0adfb30df35f0fedfab3277792792f5fae5eb66c4b4b3d7a7bd89a64778", size = 13065315, upload-time = "2026-01-25T20:59:41.564Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d6/98abb4e44df8c361a1a0f67e0306e6f0257c3ca8aef6bedefc0956047949/pqcrypto-0.4.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:239cc1b60cdf54f45e7f13c45caab784500ce8e4e7f9fde8657b9fadeb125008", size = 30396217, upload-time = "2026-01-25T20:59:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/01/9c57f061b6798bc478cb552d3653bff4f447b34f989e0f49326fa558719e/pqcrypto-0.4.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ee2954eca84149e29064b9f82f130bd1ac5e0d963b0a35e48a7c9737c2e394e", size = 34105773, upload-time = "2026-01-25T20:59:47.453Z" },
+    { url = "https://files.pythonhosted.org/packages/38/29/b63e8b9489bb8f7a41a63121cc442e9a6909a2ea761b921a75488e90f6df/pqcrypto-0.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:68a7ce6889450732154405cc71a30233e16d47ba4588529ea365d46655c35889", size = 30017344, upload-time = "2026-01-25T20:59:50.287Z" },
+    { url = "https://files.pythonhosted.org/packages/86/35/18b6949229c3157d54feeee2a7dfe29d1e327a04b39b0b9fa3feb2f58e04/pqcrypto-0.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f2de5cedff213cc874341c6618e5d70f050f444ee0793a3a3adec0f81d86f20", size = 34041682, upload-time = "2026-01-25T20:59:52.856Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/19/76610175111e2e4298fd1e5fd48ef6eebbb5b54a8c685af3a7d4b3e90691/pqcrypto-0.4.0-cp313-cp313-win32.whl", hash = "sha256:af474a7530daec502642964a4a9ed0ac110ecb1abd7b6cb010ffee3405721cb5", size = 7983085, upload-time = "2026-01-25T20:59:55.236Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/39/c22a01f0ae8b4e843d9aaf6095ad5a3708230f50fca523fd8c70081cd62b/pqcrypto-0.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:04fce6e234727a96e94a7e7b05e8959edf7db39fa94b092f6bab5fe51ecdf29e", size = 8895365, upload-time = "2026-01-25T20:59:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f2/335ca98cf32d0723b86e672cd0b06da92bd091e3599b881b70e93f4faef4/pqcrypto-0.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6087c6e46fb601fa76ae40bc3eb56189e7ce3da9b50740669315be3fb5757010", size = 15125559, upload-time = "2026-01-25T20:59:59.266Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6d/fa97f2003a8b2124970bd238aedaebe36364401042ac49e929e70abb24bd/pqcrypto-0.4.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:573ec11e103c7185f4b298af5924a7ee24ec76e1c6fb5f11af332b7360950ad8", size = 36472090, upload-time = "2026-01-25T21:00:01.795Z" },
+    { url = "https://files.pythonhosted.org/packages/57/60/98ed5d9d959c3b5c9d604a832d12e30d249c2cffce3496330fe3855a1599/pqcrypto-0.4.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:103b0586582323f443efc071893c775bdd9c74851b88523c086ef3bae2b536f1", size = 40924718, upload-time = "2026-01-25T21:00:04.431Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/95/d395cd05d62d3b68edcf7c593abd2c5cd019ea885daca63c9d04aa978daa/pqcrypto-0.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9d423baf62fa26735164ca1b69768b523506e6d60350f102d0024ae7d74203ea", size = 36017244, upload-time = "2026-01-25T21:00:07.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/47/4df448a5849c5c6233bd17f25c2259517c0a93be7141f5447b528dcc13de/pqcrypto-0.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1bf65702d8ab1e3d02c4d53fa6b903000057d755662d7fe3ca1783b350b34966", size = 40849480, upload-time = "2026-01-25T21:00:10.888Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/ddb254db90743e192ffc16767b6dc3b2029fc6d1ac70cd700a05466fb90e/pqcrypto-0.4.0-cp314-cp314-win32.whl", hash = "sha256:750581ed553bf7fd29841208eba43fe6cee50c99caa69484e31b518a0bcf090e", size = 10019373, upload-time = "2026-01-25T21:00:13.213Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/10/f8d588c225b376586049adb4eb906746cf4e74b2cd239de45ff355dd7d2c/pqcrypto-0.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:e6f4cbe97a44bdd409a7f0369de1e711e0869b529bd69ade62333eb335600326", size = 11843433, upload-time = "2026-01-25T21:00:20.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/15/b54a7ee8bd54e90c84f17f12ee46ff0a30864f1f7d6ecf4eef9f6f821a96/pqcrypto-0.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9c9c5e27eca7b7d116ed113e16382866f22d082a3341e591972ec89903efdcd3", size = 17189402, upload-time = "2026-01-25T21:00:22.608Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3f/fac94272f7b79e08479018566e1af246c75a6868e6e866f563da48df1768/pqcrypto-0.4.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2458d7ccf2f18c8fb3d58a8082e170b8f40ab3614658d59a81e51e7070b6901", size = 42715115, upload-time = "2026-01-25T21:00:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/32/073ba0d775997239c56408c8b8e93ca505bf67da5e636ba82ec95f34d6b1/pqcrypto-0.4.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9aeea794ec2ff456941bb6d95234c255121cd3e65d6f443f51e9791f37f28898", size = 47916041, upload-time = "2026-01-25T21:00:28.427Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f3/f7ddf073fdc02cfcda78c033787e9bda8b4ff2261ded1bf1bf7fef047e37/pqcrypto-0.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:39608d8b8fcf39add4e08d8501d475e212063e4f671c74321995e1ec8167b419", size = 42184151, upload-time = "2026-01-25T21:00:31.31Z" },
+    { url = "https://files.pythonhosted.org/packages/73/78/a0844b5aaf0f5c3c715c7e4c963b47bbf6535809531e410a7c047aa559b9/pqcrypto-0.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:10f2879e3eb5734304dff538978b14b4cb3c92f5c72f0aada710afeab0ee0c87", size = 47822622, upload-time = "2026-01-25T21:00:34.258Z" },
+    { url = "https://files.pythonhosted.org/packages/30/58/60563c3e53d5bf8aec4e83e13f9342f7f5cf392abb133a5c9462ca006046/pqcrypto-0.4.0-cp314-cp314t-win32.whl", hash = "sha256:ca1b7245c4f6a9c42a1431adae9c3cc87aab62403c7421bca57b9dcf053716ba", size = 10906754, upload-time = "2026-01-25T21:00:36.841Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e7/c52783e5f71c01590b16d8d8e98d7484edfe61b62eaf133327e08f25da07/pqcrypto-0.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d9907a1cb40d359ea02fd81ef63ea73b7b55fd42c29a18957ca942cb05d2b1a6", size = 12784543, upload-time = "2026-01-25T21:00:38.666Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1488,6 +1758,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -1918,6 +2243,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add CEL (Common Expression Language) custom rules to the PolicyEvaluator, enabling flexible policy expressions like HTTP method rules, trust score thresholds, and geo-sanctions — without hardcoding each one.
- Dual-backend: Rust (`common-expression-language`, ~2µs/eval) with Python (`cel-python`, ~200µs/eval) fallback. 93x speedup on the fast path.
- Graceful degradation: when no CEL backend is installed, native rules still work; CEL rules are skipped with a warning.

## Changes
- `src/dns_aid/sdk/policy/schema.py` — `CELRule` model, `cel_rules` field on `PolicyRules`, version `"1.1"` support
- `src/dns_aid/sdk/policy/cel_evaluator.py` — **New** — `CELRuleEvaluator` class with backend abstraction, compilation cache, context mapping
- `src/dns_aid/sdk/policy/evaluator.py` — Wire CEL evaluation after 16 native rules; lazy-init `CELRuleEvaluator` on instance
- `pyproject.toml` — `[cel]` optional dependency group, version bump 0.14.3→0.14.4
- `CITATION.cff` — Version bump

## Security Hardening
- Rule ID: regex-validated `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`, 1–128 chars (prevents log injection)
- Expression: 1–2048 chars (bounds nesting depth)
- Max 64 CEL rules per document (prevents computational DoS)
- Compilation cache: 256 entries with FIFO eviction (prevents memory DoS)
- Both backends use RE2 regex (linear time, ReDoS-safe)
- Non-boolean return type warning for misconfigured expressions
- Fail-open on all error paths (compile, runtime, missing backend)
- CEL guarantees: no loops, no recursion, no I/O — hermetic evaluation

## Example Policy
```json
{
  "version": "1.1",
  "agent": "_security-analyzer._a2a._agents.ai.infoblox.com",
  "rules": {
    "required_auth_types": ["oauth2"],
    "cel_rules": [
      {
        "id": "high-trust-only",
        "expression": "request.caller_trust_score >= 0.7",
        "effect": "deny",
        "message": "Caller trust score too low"
      },
      {
        "id": "geo-sanctions",
        "expression": "!(request.geo_country in [\"KP\", \"IR\", \"SY\"])",
        "effect": "deny",
        "enforcement_layers": ["layer0", "layer1", "layer2"]
      }
    ]
  }
}
```

## Test Plan
- [x] 35 new CEL tests (expressions, caching, errors, layer filtering, integration, hardening)
- [x] 1065/1065 full unit tests passing
- [x] Lint + format clean (`ruff check` + `ruff format --check`)
- [x] Type check clean (`mypy`)
- [x] Secrets scan clean
- [x] No regressions in existing 130 policy tests