### PR TITLE
Add discovery resolver overrides and fix v0.14.4 version constant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # DNS_AID_LOG_LEVEL=INFO            # DEBUG | INFO | WARNING | ERROR
 # DNS_AID_TEST_ZONE=example.com     # Domain to use for publish/discover
 # DNS_AID_SVCB_STRING_KEYS=0        # 1 = human-readable SVCB param names
-# DNS_AID_RESOLVER=1.1.1.1          # Optional recursive resolver for discovery
+# DNS_AID_RESOLVER=1.1.1.1          # Optional recursive resolver for discovery; unset uses system resolver
 # DNS_AID_RESOLVER_PORT=53          # Optional resolver port (defaults to 53)
 
 # ─── AWS Route 53 ───────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@
 # DNS_AID_LOG_LEVEL=INFO            # DEBUG | INFO | WARNING | ERROR
 # DNS_AID_TEST_ZONE=example.com     # Domain to use for publish/discover
 # DNS_AID_SVCB_STRING_KEYS=0        # 1 = human-readable SVCB param names
+# DNS_AID_RESOLVER=1.1.1.1          # Optional recursive resolver for discovery
+# DNS_AID_RESOLVER_PORT=53          # Optional resolver port (defaults to 53)
 
 # ─── AWS Route 53 ───────────────────────────────────────
 # Route 53 uses boto3's credential chain — pick ONE method:
@@ -69,3 +71,5 @@
 # DDNS_KEY_ALGORITHM=hmac-sha256
 # DNS_AID_TEST_ZONE=test.dns-aid.local
 # DNS_AID_BACKEND=ddns
+# DNS_AID_RESOLVER=127.0.0.1
+# DNS_AID_RESOLVER_PORT=15353

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ dns-aid discover example.com --protocol mcp --name chat
 # Discover using a specific recursive resolver
 dns-aid discover example.com --resolver 127.0.0.1:15353
 
+# If no resolver flag or env override is set, discovery uses the system resolver
+dns-aid discover example.com
+
 # Discover via HTTP index (ANS-compatible, richer metadata)
 dns-aid discover example.com --use-http-index
 
@@ -896,6 +899,8 @@ DDNS (Dynamic DNS) is a universal backend that works with any DNS server support
 | `DDNS_PORT` | No | `53` | DNS server port |
 
 For discovery against a non-system resolver, set:
+
+If neither variable is set, discovery falls back to the system resolver.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cp .env.example .env
 
 # Publish and discover agents locally
 dns-aid publish my-agent --domain test.dns-aid.local --backend ddns
-dns-aid discover test.dns-aid.local --backend ddns
+dns-aid discover test.dns-aid.local
 
 # Clean up
 docker compose -f tests/integration/bind/docker-compose.yml down
@@ -155,6 +155,9 @@ dns-aid discover example.com
 
 # Discover with filters
 dns-aid discover example.com --protocol mcp --name chat
+
+# Discover using a specific recursive resolver
+dns-aid discover example.com --resolver 127.0.0.1:15353
 
 # Discover via HTTP index (ANS-compatible, richer metadata)
 dns-aid discover example.com --use-http-index
@@ -891,6 +894,13 @@ DDNS (Dynamic DNS) is a universal backend that works with any DNS server support
 | `DDNS_KEY_SECRET` | Yes | - | TSIG key secret (base64) |
 | `DDNS_KEY_ALGORITHM` | No | `hmac-sha256` | TSIG algorithm |
 | `DDNS_PORT` | No | `53` | DNS server port |
+
+For discovery against a non-system resolver, set:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DNS_AID_RESOLVER` | No | system resolver | Recursive resolver hostname or IP |
+| `DNS_AID_RESOLVER_PORT` | No | `53` | Recursive resolver port |
 
 #### Step-by-Step Setup
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -178,7 +178,7 @@ async def discover(
 | `name` | `str` | No | `None` | Filter by specific agent name |
 | `require_dnssec` | `bool` | No | `False` | Require DNSSEC validation |
 | `use_http_index` | `bool` | No | `False` | Use HTTP index endpoint instead of DNS-only discovery |
-| `resolver` | `str` | No | `None` | Recursive DNS resolver override in `host:port` form |
+| `resolver` | `str` | No | `None` | Recursive DNS resolver override in `host:port` form. When unset, the system resolver is used unless `DNS_AID_RESOLVER` is configured |
 
 #### Discovery Methods
 
@@ -820,7 +820,7 @@ dns-aid call --domain example.com --name network-specialist get_subnets \
 |----------|-------------|
 | `DNS_AID_BACKEND` | Default backend: "route53", "cloudflare", "infoblox", "nios", "ddns", or "mock" |
 | `DNS_AID_LOG_LEVEL` | Logging level: DEBUG, INFO, WARNING, ERROR |
-| `DNS_AID_RESOLVER` | Recursive resolver hostname/IP for discovery |
+| `DNS_AID_RESOLVER` | Recursive resolver hostname/IP for discovery. If unset, discovery uses the system resolver |
 | `DNS_AID_RESOLVER_PORT` | Recursive resolver port (default: 53 when `DNS_AID_RESOLVER` is set) |
 
 **AWS Route 53:**

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -165,6 +165,7 @@ async def discover(
     name: str | None = None,
     require_dnssec: bool = False,
     use_http_index: bool = False,
+    resolver: str | None = None,
 ) -> DiscoveryResult
 ```
 
@@ -177,6 +178,7 @@ async def discover(
 | `name` | `str` | No | `None` | Filter by specific agent name |
 | `require_dnssec` | `bool` | No | `False` | Require DNSSEC validation |
 | `use_http_index` | `bool` | No | `False` | Use HTTP index endpoint instead of DNS-only discovery |
+| `resolver` | `str` | No | `None` | Recursive DNS resolver override in `host:port` form |
 
 #### Discovery Methods
 
@@ -205,6 +207,9 @@ result = await discover("example.com", protocol="mcp", name="chat")
 
 # Discover via HTTP index (ANS-compatible, richer metadata)
 result = await discover("example.com", use_http_index=True)
+
+# Discover using a specific recursive resolver
+result = await discover("example.com", resolver="127.0.0.1:15353")
 
 for agent in result.agents:
     print(f"{agent.name}: {agent.endpoint_url}")
@@ -815,6 +820,8 @@ dns-aid call --domain example.com --name network-specialist get_subnets \
 |----------|-------------|
 | `DNS_AID_BACKEND` | Default backend: "route53", "cloudflare", "infoblox", "nios", "ddns", or "mock" |
 | `DNS_AID_LOG_LEVEL` | Logging level: DEBUG, INFO, WARNING, ERROR |
+| `DNS_AID_RESOLVER` | Recursive resolver hostname/IP for discovery |
+| `DNS_AID_RESOLVER_PORT` | Recursive resolver port (default: 53 when `DNS_AID_RESOLVER` is set) |
 
 **AWS Route 53:**
 

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -44,6 +44,21 @@ def run_async(coro):
     return asyncio.run(coro)
 
 
+def resolver_callback(value: str | None) -> str | None:
+    """Validate custom resolver overrides passed as ``host:port``."""
+    if value is None:
+        return None
+
+    from dns_aid.core.discoverer import _parse_resolver_target
+
+    try:
+        _parse_resolver_target(value)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    return value
+
+
 # ============================================================================
 # PUBLISH COMMAND
 # ============================================================================
@@ -288,6 +303,14 @@ def discover(
         str | None, typer.Option("--protocol", "-p", help="Filter by protocol")
     ] = None,
     name: Annotated[str | None, typer.Option("--name", "-n", help="Filter by agent name")] = None,
+    resolver: Annotated[
+        str | None,
+        typer.Option(
+            "--resolver",
+            callback=resolver_callback,
+            help="Recursive DNS resolver to use for discovery queries (host:port)",
+        ),
+    ] = None,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
     use_http_index: Annotated[
         bool,
@@ -318,6 +341,7 @@ def discover(
         dns-aid discover example.com
         dns-aid discover example.com --protocol mcp
         dns-aid discover example.com --name chat
+        dns-aid discover example.com --resolver 127.0.0.1:15353
         dns-aid discover example.com --use-http-index
     """
     from dns_aid.core.discoverer import discover as do_discover
@@ -332,6 +356,7 @@ def discover(
             name=name,
             use_http_index=use_http_index,
             verify_signatures=verify_signatures,
+            resolver=resolver,
         )
     )
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -308,7 +308,7 @@ def discover(
         typer.Option(
             "--resolver",
             callback=resolver_callback,
-            help="Recursive DNS resolver to use for discovery queries (host:port)",
+            help="Recursive DNS resolver to use for discovery queries (host:port). Defaults to the system resolver when unset.",
         ),
     ] = None,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
@@ -343,6 +343,9 @@ def discover(
         dns-aid discover example.com --name chat
         dns-aid discover example.com --resolver 127.0.0.1:15353
         dns-aid discover example.com --use-http-index
+
+    If neither --resolver nor DNS_AID_RESOLVER is set, discovery uses the
+    system resolver configuration.
     """
     from dns_aid.core import discoverer as discoverer_module
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -344,13 +344,18 @@ def discover(
         dns-aid discover example.com --resolver 127.0.0.1:15353
         dns-aid discover example.com --use-http-index
     """
-    from dns_aid.core.discoverer import discover as do_discover
+    from dns_aid.core import discoverer as discoverer_module
 
     method = "HTTP index" if use_http_index else "DNS"
     console.print(f"\n[bold]Discovering agents at {domain} via {method}...[/bold]\n")
 
+    try:
+        resolver = discoverer_module._resolve_resolver_override(resolver)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc), param_hint="--resolver") from exc
+
     result = run_async(
-        do_discover(
+        discoverer_module.discover(
             domain=domain,
             protocol=protocol,
             name=name,

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -11,6 +11,7 @@ records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
 import time
 from typing import Any, Literal
@@ -64,6 +65,55 @@ def _build_resolver(resolver: str) -> dns.asyncresolver.Resolver:
     async_resolver.nameservers = [host]
     async_resolver.port = port
     return async_resolver
+
+
+def _format_resolver_host(host: str) -> str:
+    """Bracket IPv6 literals when formatting ``host:port`` strings."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
+def _resolve_resolver_override(resolver: str | None) -> str | None:
+    """Resolve explicit or environment-backed resolver configuration."""
+    if resolver is not None:
+        return resolver
+
+    env_resolver = os.getenv("DNS_AID_RESOLVER")
+    env_port = os.getenv("DNS_AID_RESOLVER_PORT")
+
+    if not env_resolver and not env_port:
+        return None
+
+    if not env_resolver:
+        raise ValueError("DNS_AID_RESOLVER_PORT requires DNS_AID_RESOLVER")
+
+    if env_port:
+        try:
+            _parse_resolver_target(env_resolver)
+        except ValueError:
+            pass
+        else:
+            raise ValueError(
+                "Set DNS_AID_RESOLVER as host only when using DNS_AID_RESOLVER_PORT"
+            )
+
+        try:
+            port_num = int(env_port)
+        except ValueError as exc:
+            raise ValueError("DNS_AID_RESOLVER_PORT must be an integer") from exc
+
+        if not 1 <= port_num <= 65535:
+            raise ValueError("DNS_AID_RESOLVER_PORT must be between 1 and 65535")
+
+        return f"{_format_resolver_host(env_resolver)}:{port_num}"
+
+    try:
+        _parse_resolver_target(env_resolver)
+    except ValueError:
+        return f"{_format_resolver_host(env_resolver)}:53"
+
+    return env_resolver
 
 
 async def _execute_discovery(
@@ -186,6 +236,7 @@ async def discover(
     start_time = time.perf_counter()
 
     protocol = _normalize_protocol(protocol)
+    resolver = _resolve_resolver_override(resolver)
     dns_resolver = _build_resolver(resolver) if resolver else None
 
     # Build query based on filters
@@ -1061,6 +1112,8 @@ async def discover_at_fqdn(fqdn: str, resolver: str | None = None) -> AgentRecor
     except ValueError:
         logger.error("Unknown protocol", protocol=protocol_str)
         return None
+
+    resolver = _resolve_resolver_override(resolver)
 
     if resolver:
         dns_resolver = _build_resolver(resolver)

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -46,13 +46,7 @@ def _parse_resolver_target(resolver: str) -> tuple[str, int]:
     except ValueError as exc:
         raise ValueError("Resolver must be in host:port format") from exc
 
-    if (
-        not parsed.hostname
-        or port is None
-        or parsed.path
-        or parsed.query
-        or parsed.fragment
-    ):
+    if not parsed.hostname or port is None or parsed.path or parsed.query or parsed.fragment:
         raise ValueError("Resolver must be in host:port format")
 
     return parsed.hostname, port
@@ -94,9 +88,7 @@ def _resolve_resolver_override(resolver: str | None) -> str | None:
         except ValueError:
             pass
         else:
-            raise ValueError(
-                "Set DNS_AID_RESOLVER as host only when using DNS_AID_RESOLVER_PORT"
-            )
+            raise ValueError("Set DNS_AID_RESOLVER as host only when using DNS_AID_RESOLVER_PORT")
 
         try:
             port_num = int(env_port)

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -14,7 +14,7 @@ import asyncio
 import shlex
 import time
 from typing import Any, Literal
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit
 
 import dns.asyncresolver
 import dns.rdatatype
@@ -36,21 +36,59 @@ def _normalize_protocol(protocol: str | Protocol | None) -> Protocol | None:
     return protocol
 
 
+def _parse_resolver_target(resolver: str) -> tuple[str, int]:
+    """Parse a resolver override in ``host:port`` form."""
+    parsed = urlsplit(f"//{resolver}")
+
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("Resolver must be in host:port format") from exc
+
+    if (
+        not parsed.hostname
+        or port is None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Resolver must be in host:port format")
+
+    return parsed.hostname, port
+
+
+def _build_resolver(resolver: str) -> dns.asyncresolver.Resolver:
+    """Build an async resolver pinned to a specific recursive resolver."""
+    host, port = _parse_resolver_target(resolver)
+    async_resolver = dns.asyncresolver.Resolver(configure=False)
+    async_resolver.nameservers = [host]
+    async_resolver.port = port
+    return async_resolver
+
+
 async def _execute_discovery(
     domain: str,
     protocol: Protocol | None,
     name: str | None,
     use_http_index: bool,
     query: str,
+    resolver: dns.asyncresolver.Resolver | None = None,
 ) -> list[AgentRecord]:
     """Execute the appropriate discovery strategy and handle DNS errors."""
     try:
         if use_http_index:
+            if resolver is not None:
+                return await _discover_via_http_index(domain, protocol, name, resolver=resolver)
             return await _discover_via_http_index(domain, protocol, name)
         elif name and protocol:
-            agent = await _query_single_agent(domain, name, protocol)
+            if resolver is not None:
+                agent = await _query_single_agent(domain, name, protocol, resolver=resolver)
+            else:
+                agent = await _query_single_agent(domain, name, protocol)
             return [agent] if agent else []
         else:
+            if resolver is not None:
+                return await _discover_agents_in_zone(domain, protocol, resolver=resolver)
             return await _discover_agents_in_zone(domain, protocol)
     except dns.resolver.NXDOMAIN:
         logger.debug("No DNS-AID records found", query=query)
@@ -69,6 +107,7 @@ async def _apply_post_discovery(
     enrich_endpoints: bool,
     verify_signatures: bool,
     domain: str,
+    resolver: dns.asyncresolver.Resolver | None = None,
 ) -> bool:
     """Apply DNSSEC enforcement, endpoint enrichment, and JWS verification.
 
@@ -79,7 +118,10 @@ async def _apply_post_discovery(
     if agents and require_dnssec:
         from dns_aid.core.validator import _check_dnssec
 
-        dnssec_validated = await _check_dnssec(agents[0].fqdn)
+        if resolver is not None:
+            dnssec_validated = await _check_dnssec(agents[0].fqdn, resolver=resolver)
+        else:
+            dnssec_validated = await _check_dnssec(agents[0].fqdn)
         if not dnssec_validated:
             raise DNSSECError(
                 f"DNSSEC validation required but DNS response for "
@@ -106,6 +148,7 @@ async def discover(
     use_http_index: bool = False,
     enrich_endpoints: bool = True,
     verify_signatures: bool = False,
+    resolver: str | None = None,
 ) -> DiscoveryResult:
     """
     Discover AI agents at a domain using DNS-AID protocol.
@@ -127,6 +170,7 @@ async def discover(
         verify_signatures: If True, verify JWS signatures on agents that have
                           a `sig` parameter but no DNSSEC validation. Invalid
                           signatures are logged but don't block discovery.
+        resolver: Optional recursive DNS resolver override in ``host:port`` form.
 
     Returns:
         DiscoveryResult with list of discovered agents
@@ -142,6 +186,7 @@ async def discover(
     start_time = time.perf_counter()
 
     protocol = _normalize_protocol(protocol)
+    dns_resolver = _build_resolver(resolver) if resolver else None
 
     # Build query based on filters
     if name and protocol:
@@ -161,11 +206,24 @@ async def discover(
         name=name,
         query=query,
         use_http_index=use_http_index,
+        resolver=resolver,
     )
 
-    agents = await _execute_discovery(domain, protocol, name, use_http_index, query)
+    agents = await _execute_discovery(
+        domain,
+        protocol,
+        name,
+        use_http_index,
+        query,
+        resolver=dns_resolver,
+    )
     dnssec_validated = await _apply_post_discovery(
-        agents, require_dnssec, enrich_endpoints, verify_signatures, domain
+        agents,
+        require_dnssec,
+        enrich_endpoints,
+        verify_signatures,
+        domain,
+        resolver=dns_resolver,
     )
 
     elapsed_ms = (time.perf_counter() - start_time) * 1000
@@ -194,21 +252,22 @@ async def _query_single_agent(
     domain: str,
     name: str,
     protocol: Protocol,
+    resolver: dns.asyncresolver.Resolver | None = None,
 ) -> AgentRecord | None:
     """Query DNS for a specific agent's SVCB record."""
     fqdn = f"_{name}._{protocol.value}._agents.{domain}"
 
     try:
-        resolver = dns.asyncresolver.Resolver()
+        dns_resolver = resolver or dns.asyncresolver.Resolver()
 
         # Query SVCB record
         # Note: dnspython uses type 64 for SVCB
         try:
-            answers = await resolver.resolve(fqdn, "SVCB")
+            answers = await dns_resolver.resolve(fqdn, "SVCB")
         except dns.resolver.NoAnswer:
             # Try HTTPS record as fallback (type 65)
             try:
-                answers = await resolver.resolve(fqdn, "HTTPS")
+                answers = await dns_resolver.resolve(fqdn, "HTTPS")
             except dns.resolver.NoAnswer:
                 return None
 
@@ -225,7 +284,7 @@ async def _query_single_agent(
                         alias_target=alias_target,
                     )
                     try:
-                        answers = await resolver.resolve(alias_target, "SVCB")
+                        answers = await dns_resolver.resolve(alias_target, "SVCB")
                         # Recurse into the resolved answers (ServiceMode expected)
                         for alias_rdata in answers:
                             if alias_rdata.priority > 0:
@@ -328,7 +387,10 @@ async def _query_single_agent(
 
             # Tier 4: TXT record fallback (lowest priority)
             if not capabilities:
-                capabilities = await _query_capabilities(fqdn)
+                if resolver is not None:
+                    capabilities = await _query_capabilities(fqdn, resolver=resolver)
+                else:
+                    capabilities = await _query_capabilities(fqdn)
                 if capabilities:
                     capability_source = "txt_fallback"
 
@@ -410,7 +472,10 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
     return custom_params
 
 
-async def _query_capabilities(fqdn: str) -> list[str]:
+async def _query_capabilities(
+    fqdn: str,
+    resolver: dns.asyncresolver.Resolver | None = None,
+) -> list[str]:
     """Query TXT record for agent capabilities (fallback only).
 
     Per DNS-AID draft-01 Section 4.4.3, rich agent metadata (description,
@@ -427,8 +492,8 @@ async def _query_capabilities(fqdn: str) -> list[str]:
     capabilities = []
 
     try:
-        resolver = dns.asyncresolver.Resolver()
-        answers = await resolver.resolve(fqdn, "TXT")
+        dns_resolver = resolver or dns.asyncresolver.Resolver()
+        answers = await dns_resolver.resolve(fqdn, "TXT")
 
         for rdata in answers:
             # TXT records can have multiple strings
@@ -470,6 +535,7 @@ def _collect_agent_results(results: list[Any]) -> list[AgentRecord]:
 async def _discover_agents_in_zone(
     domain: str,
     protocol: Protocol | None = None,
+    resolver: dns.asyncresolver.Resolver | None = None,
 ) -> list[AgentRecord]:
     """
     Discover all agents in a domain's _agents zone.
@@ -479,12 +545,17 @@ async def _discover_agents_in_zone(
     """
     from dns_aid.core.indexer import read_index_via_dns
 
-    index_entries = await read_index_via_dns(domain)
+    if resolver is not None:
+        index_entries = await read_index_via_dns(domain, resolver=resolver)
+    else:
+        index_entries = await read_index_via_dns(domain)
 
     sem = asyncio.Semaphore(20)
 
     async def _query_with_sem(name: str, proto: Protocol) -> AgentRecord | None:
         async with sem:
+            if resolver is not None:
+                return await _query_single_agent(domain, name, proto, resolver=resolver)
             return await _query_single_agent(domain, name, proto)
 
     if index_entries:
@@ -587,6 +658,7 @@ async def _process_http_agent(
     domain: str,
     protocol: Protocol | None,
     name: str | None,
+    resolver: dns.asyncresolver.Resolver | None = None,
 ) -> AgentRecord | None:
     """Process a single HTTP index entry: parse FQDN, filter, resolve via DNS."""
     if name and http_agent.name != name:
@@ -615,7 +687,15 @@ async def _process_http_agent(
     if protocol and agent_protocol != protocol:
         return None
 
-    agent = await _query_single_agent(domain, dns_agent_name, agent_protocol)
+    if resolver is not None:
+        agent = await _query_single_agent(
+            domain,
+            dns_agent_name,
+            agent_protocol,
+            resolver=resolver,
+        )
+    else:
+        agent = await _query_single_agent(domain, dns_agent_name, agent_protocol)
 
     if agent:
         _enrich_from_http_index(agent, http_agent)
@@ -633,6 +713,7 @@ async def _discover_via_http_index(
     domain: str,
     protocol: Protocol | None = None,
     name: str | None = None,
+    resolver: dns.asyncresolver.Resolver | None = None,
 ) -> list[AgentRecord]:
     """
     Discover agents using HTTP index endpoint.
@@ -663,7 +744,7 @@ async def _discover_via_http_index(
 
     agents: list[AgentRecord] = []
     for http_agent in http_agents:
-        agent = await _process_http_agent(http_agent, domain, protocol, name)
+        agent = await _process_http_agent(http_agent, domain, protocol, name, resolver=resolver)
         if agent:
             agents.append(agent)
 
@@ -937,12 +1018,13 @@ async def _fetch_agent_json_auth(host: str, timeout: float = 5.0) -> dict | None
     return None
 
 
-async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
+async def discover_at_fqdn(fqdn: str, resolver: str | None = None) -> AgentRecord | None:
     """
     Discover agent at a specific FQDN.
 
     Args:
         fqdn: Full DNS-AID record name (e.g., "_chat._a2a._agents.example.com")
+        resolver: Optional recursive DNS resolver override in ``host:port`` form.
 
     Returns:
         AgentRecord if found, None otherwise
@@ -979,6 +1061,10 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
     except ValueError:
         logger.error("Unknown protocol", protocol=protocol_str)
         return None
+
+    if resolver:
+        dns_resolver = _build_resolver(resolver)
+        return await _query_single_agent(domain, name, protocol, resolver=dns_resolver)
 
     return await _query_single_agent(domain, name, protocol)
 

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -221,6 +221,8 @@ async def discover(
                           a `sig` parameter but no DNSSEC validation. Invalid
                           signatures are logged but don't block discovery.
         resolver: Optional recursive DNS resolver override in ``host:port`` form.
+                 When unset, the system resolver is used unless env overrides
+                 are configured.
 
     Returns:
         DiscoveryResult with list of discovered agents

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -154,7 +154,10 @@ async def read_index(
     return []
 
 
-async def read_index_via_dns(domain: str) -> list[IndexEntry]:
+async def read_index_via_dns(
+    domain: str,
+    resolver: dns.asyncresolver.Resolver | None = None,
+) -> list[IndexEntry]:
     """
     Read the agent index via a direct DNS TXT query (no backend/credentials needed).
 
@@ -162,6 +165,7 @@ async def read_index_via_dns(domain: str) -> list[IndexEntry]:
 
     Args:
         domain: Domain to read index from
+        resolver: Optional configured async resolver override
 
     Returns:
         List of IndexEntry objects (empty if no index exists)
@@ -170,8 +174,8 @@ async def read_index_via_dns(domain: str) -> list[IndexEntry]:
     logger.debug("Reading index via DNS", fqdn=fqdn)
 
     try:
-        resolver = dns.asyncresolver.Resolver()
-        answers = await resolver.resolve(fqdn, "TXT")
+        dns_resolver = resolver or dns.asyncresolver.Resolver()
+        answers = await dns_resolver.resolve(fqdn, "TXT")
 
         for rdata in answers:
             for txt_string in rdata.strings:

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -173,7 +173,10 @@ async def _check_svcb_record(fqdn: str) -> dict | None:
     return None
 
 
-async def _check_dnssec(fqdn: str) -> bool:
+async def _check_dnssec(
+    fqdn: str,
+    resolver: dns.asyncresolver.Resolver | None = None,
+) -> bool:
     """
     Check if DNSSEC is validated for the FQDN.
 
@@ -187,14 +190,14 @@ async def _check_dnssec(fqdn: str) -> bool:
     Returns True if DNSSEC AD (Authenticated Data) flag is set.
     """
     try:
-        resolver = dns.asyncresolver.Resolver()
+        dns_resolver = resolver or dns.asyncresolver.Resolver()
 
         # Enable DNSSEC validation
-        resolver.use_edns(edns=0, ednsflags=dns.flags.DO)
+        dns_resolver.use_edns(edns=0, ednsflags=dns.flags.DO)
 
         # Query with DNSSEC
         try:
-            answer = await resolver.resolve(fqdn, "SVCB")
+            answer = await dns_resolver.resolve(fqdn, "SVCB")
 
             # Check AD (Authenticated Data) flag in response
             if hasattr(answer.response, "flags"):
@@ -206,7 +209,7 @@ async def _check_dnssec(fqdn: str) -> bool:
         except dns.resolver.NoAnswer:
             # Try TXT as fallback for DNSSEC check
             try:
-                answer = await resolver.resolve(fqdn, "TXT")
+                answer = await dns_resolver.resolve(fqdn, "TXT")
                 if hasattr(answer.response, "flags"):
                     ad_flag = answer.response.flags & dns.flags.AD
                     if ad_flag:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -187,6 +187,34 @@ class TestDiscoverCommand:
         assert result.exit_code == 2
         assert "Resolver must be in host:port format" in _strip_ansi(result.output)
 
+    @patch("dns_aid.core.discoverer.discover", new_callable=AsyncMock)
+    def test_discover_uses_env_resolver(self, mock_discover):
+        from dns_aid.core.models import DiscoveryResult
+
+        mock_discover.return_value = DiscoveryResult(
+            domain="example.com",
+            query="_agents.example.com",
+            agents=[],
+            query_time_ms=10.0,
+        )
+
+        with patch.dict(
+            "os.environ",
+            {"DNS_AID_RESOLVER": "127.0.0.1", "DNS_AID_RESOLVER_PORT": "15353"},
+            clear=False,
+        ):
+            result = runner.invoke(app, ["discover", "example.com"])
+
+        assert result.exit_code == 0
+        mock_discover.assert_awaited_once_with(
+            domain="example.com",
+            protocol=None,
+            name=None,
+            use_http_index=False,
+            verify_signatures=False,
+            resolver="127.0.0.1:15353",
+        )
+
 
 class TestVerifyCommand:
     """Test verify CLI command."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,8 +4,7 @@
 """Unit tests for CLI commands."""
 
 import re
-from dataclasses import dataclass
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
 
@@ -155,6 +154,38 @@ class TestDiscoverCommand:
         result = runner.invoke(app, ["discover", "example.com", "--use-http-index"])
         assert result.exit_code == 0
         assert "HTTP index" in result.output
+
+    @patch("dns_aid.core.discoverer.discover", new_callable=AsyncMock)
+    def test_discover_with_custom_resolver(self, mock_discover):
+        from dns_aid.core.models import DiscoveryResult
+
+        mock_discover.return_value = DiscoveryResult(
+            domain="example.com",
+            query="_agents.example.com",
+            agents=[],
+            query_time_ms=10.0,
+        )
+
+        result = runner.invoke(
+            app,
+            ["discover", "example.com", "--resolver", "127.0.0.1:15353"],
+        )
+
+        assert result.exit_code == 0
+        mock_discover.assert_awaited_once_with(
+            domain="example.com",
+            protocol=None,
+            name=None,
+            use_http_index=False,
+            verify_signatures=False,
+            resolver="127.0.0.1:15353",
+        )
+
+    def test_discover_rejects_invalid_custom_resolver(self):
+        result = runner.invoke(app, ["discover", "example.com", "--resolver", "127.0.0.1"])
+
+        assert result.exit_code == 2
+        assert "Resolver must be in host:port format" in _strip_ansi(result.output)
 
 
 class TestVerifyCommand:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -215,6 +215,30 @@ class TestDiscoverCommand:
             resolver="127.0.0.1:15353",
         )
 
+    @patch("dns_aid.core.discoverer.discover", new_callable=AsyncMock)
+    def test_discover_uses_system_resolver_when_env_unset(self, mock_discover):
+        from dns_aid.core.models import DiscoveryResult
+
+        mock_discover.return_value = DiscoveryResult(
+            domain="example.com",
+            query="_agents.example.com",
+            agents=[],
+            query_time_ms=10.0,
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            result = runner.invoke(app, ["discover", "example.com"])
+
+        assert result.exit_code == 0
+        mock_discover.assert_awaited_once_with(
+            domain="example.com",
+            protocol=None,
+            name=None,
+            use_http_index=False,
+            verify_signatures=False,
+            resolver=None,
+        )
+
 
 class TestVerifyCommand:
     """Test verify CLI command."""

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -114,6 +114,12 @@ class TestResolverHelpers:
 
         assert resolver == "8.8.8.8:53"
 
+    def test_resolve_resolver_override_uses_system_resolver_when_env_unset(self):
+        with patch.dict("os.environ", {}, clear=True):
+            resolver = _resolve_resolver_override(None)
+
+        assert resolver is None
+
 
 class TestDiscover:
     """Tests for the main discover() function."""
@@ -201,6 +207,20 @@ class TestDiscover:
         configured_resolver = mock_zone.call_args.kwargs["resolver"]
         assert configured_resolver.nameservers == ["127.0.0.1"]
         assert configured_resolver.port == 15353
+
+    @pytest.mark.asyncio
+    async def test_discover_uses_system_resolver_when_env_unset(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "dns_aid.core.discoverer._discover_agents_in_zone",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_zone,
+        ):
+            await discover("example.com")
+
+        mock_zone.assert_awaited_once_with("example.com", None)
 
     @pytest.mark.asyncio
     async def test_discover_with_http_index(self):

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -11,12 +11,14 @@ import pytest
 from dns_aid.core.cap_fetcher import CapabilityDocument
 from dns_aid.core.discoverer import (
     _build_index_tasks,
+    _build_resolver,
     _collect_agent_results,
     _discover_via_http_index,
     _enrich_from_http_index,
     _http_agent_to_record,
     _normalize_protocol,
     _parse_fqdn,
+    _parse_resolver_target,
     _parse_svcb_custom_params,
     _process_http_agent,
     _query_capabilities,
@@ -56,6 +58,32 @@ class TestParseFqdn:
         assert _parse_fqdn("_booking.mcp._agents.example.com") == (None, None)
 
 
+class TestResolverHelpers:
+    """Tests for custom resolver parsing and construction."""
+
+    def test_parse_resolver_target(self):
+        host, port = _parse_resolver_target("127.0.0.1:15353")
+
+        assert host == "127.0.0.1"
+        assert port == 15353
+
+    def test_parse_resolver_target_bracketed_ipv6(self):
+        host, port = _parse_resolver_target("[::1]:15353")
+
+        assert host == "::1"
+        assert port == 15353
+
+    def test_parse_resolver_target_requires_port(self):
+        with pytest.raises(ValueError, match="host:port"):
+            _parse_resolver_target("127.0.0.1")
+
+    def test_build_resolver(self):
+        resolver = _build_resolver("127.0.0.1:15353")
+
+        assert resolver.nameservers == ["127.0.0.1"]
+        assert resolver.port == 15353
+
+
 class TestDiscover:
     """Tests for the main discover() function."""
 
@@ -70,6 +98,24 @@ class TestDiscover:
             mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
             assert result.domain == "example.com"
             assert result.query == "_chat._mcp._agents.example.com"
+
+    @pytest.mark.asyncio
+    async def test_discover_passes_custom_resolver_to_single_agent(self):
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_query:
+            await discover(
+                "example.com",
+                protocol="mcp",
+                name="chat",
+                resolver="127.0.0.1:15353",
+            )
+
+        configured_resolver = mock_query.call_args.kwargs["resolver"]
+        assert configured_resolver.nameservers == ["127.0.0.1"]
+        assert configured_resolver.port == 15353
 
     @pytest.mark.asyncio
     async def test_discover_with_protocol_only(self):
@@ -91,6 +137,19 @@ class TestDiscover:
         ):
             result = await discover("example.com")
             assert result.query == "_index._agents.example.com"
+
+    @pytest.mark.asyncio
+    async def test_discover_passes_custom_resolver_to_zone_discovery(self):
+        with patch(
+            "dns_aid.core.discoverer._discover_agents_in_zone",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_zone:
+            await discover("example.com", resolver="127.0.0.1:15353")
+
+        configured_resolver = mock_zone.call_args.kwargs["resolver"]
+        assert configured_resolver.nameservers == ["127.0.0.1"]
+        assert configured_resolver.port == 15353
 
     @pytest.mark.asyncio
     async def test_discover_with_http_index(self):
@@ -313,6 +372,23 @@ class TestDiscoverAtFqdn:
             result = await discover_at_fqdn("_chat._a2a._agents.example.com")
             mock_query.assert_called_once_with("example.com", "chat", Protocol.A2A)
             assert result is None
+
+    @pytest.mark.asyncio
+    async def test_valid_fqdn_with_custom_resolver(self):
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_query:
+            result = await discover_at_fqdn(
+                "_chat._a2a._agents.example.com",
+                resolver="127.0.0.1:15353",
+            )
+
+        configured_resolver = mock_query.call_args.kwargs["resolver"]
+        assert configured_resolver.nameservers == ["127.0.0.1"]
+        assert configured_resolver.port == 15353
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_invalid_fqdn_too_short(self):

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -22,6 +22,7 @@ from dns_aid.core.discoverer import (
     _parse_svcb_custom_params,
     _process_http_agent,
     _query_capabilities,
+    _resolve_resolver_override,
     discover,
     discover_at_fqdn,
 )
@@ -82,6 +83,36 @@ class TestResolverHelpers:
 
         assert resolver.nameservers == ["127.0.0.1"]
         assert resolver.port == 15353
+
+    def test_resolve_resolver_override_from_env(self):
+        with patch.dict(
+            "os.environ",
+            {"DNS_AID_RESOLVER": "127.0.0.1", "DNS_AID_RESOLVER_PORT": "15353"},
+            clear=False,
+        ):
+            resolver = _resolve_resolver_override(None)
+
+        assert resolver == "127.0.0.1:15353"
+
+    def test_resolve_resolver_override_from_env_defaults_port(self):
+        with patch.dict(
+            "os.environ",
+            {"DNS_AID_RESOLVER": "127.0.0.1"},
+            clear=False,
+        ):
+            resolver = _resolve_resolver_override(None)
+
+        assert resolver == "127.0.0.1:53"
+
+    def test_resolve_resolver_override_prefers_explicit_value(self):
+        with patch.dict(
+            "os.environ",
+            {"DNS_AID_RESOLVER": "127.0.0.1", "DNS_AID_RESOLVER_PORT": "15353"},
+            clear=False,
+        ):
+            resolver = _resolve_resolver_override("8.8.8.8:53")
+
+        assert resolver == "8.8.8.8:53"
 
 
 class TestDiscover:
@@ -146,6 +177,26 @@ class TestDiscover:
             return_value=[],
         ) as mock_zone:
             await discover("example.com", resolver="127.0.0.1:15353")
+
+        configured_resolver = mock_zone.call_args.kwargs["resolver"]
+        assert configured_resolver.nameservers == ["127.0.0.1"]
+        assert configured_resolver.port == 15353
+
+    @pytest.mark.asyncio
+    async def test_discover_uses_env_resolver_when_flag_not_provided(self):
+        with (
+            patch.dict(
+                "os.environ",
+                {"DNS_AID_RESOLVER": "127.0.0.1", "DNS_AID_RESOLVER_PORT": "15353"},
+                clear=False,
+            ),
+            patch(
+                "dns_aid.core.discoverer._discover_agents_in_zone",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_zone,
+        ):
+            await discover("example.com")
 
         configured_resolver = mock_zone.call_args.kwargs["resolver"]
         assert configured_resolver.nameservers == ["127.0.0.1"]


### PR DESCRIPTION
## Summary
- fix the v0.14.4 runtime version constant so the package reports the published version
- add `--resolver host:port` support to `dns-aid discover`
- support `DNS_AID_RESOLVER` and `DNS_AID_RESOLVER_PORT` env overrides, falling back to the system resolver when unset
- thread the configured resolver through discovery, index, and DNSSEC validation paths
- document the new discovery resolver behavior and add focused unit coverage

## Testing
- `./.venv/bin/ruff check src/dns_aid/core/discoverer.py src/dns_aid/cli/main.py src/dns_aid/core/indexer.py src/dns_aid/core/validator.py tests/unit/test_discoverer.py tests/unit/test_cli.py`
- `./.venv/bin/pytest tests/unit/test_discoverer.py tests/unit/test_cli.py -q`