### PR TITLE
fix: v0.14.5 — version drift fix, CEL improvements, code quality hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ PLAN.md
 docs/demo-talking-points.md
 *.jnl
 .serena/
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.5] - 2026-03-23
+
+### Fixed
+- **Version drift eliminated** — `__version__` now derived from `importlib.metadata.version("dns-aid")` instead of a hardcoded string. Single source of truth is `pyproject.toml`. Fixes the 0.14.3→0.14.4 sync miss where `__init__.py` was stale while pyproject.toml and CITATION.cff were correct.
+
+### Improved
+- **CEL evaluator: missing context fields** — `caller_id`, `intent`, and `tls_version` from PolicyContext are now exposed to CEL expressions as `request.caller_id`, `request.intent`, `request.tls_version`.
+- **CEL evaluator: negative compilation cache** — invalid expressions are cached after first failure, preventing repeated compile errors and log spam on every request from attacker-crafted policy documents.
+- **CEL schema: `Literal` type for effect** — `CELRule.effect` uses `Literal["deny", "warn"]` instead of `str` + validator for better type safety and cleaner Pydantic error messages.
+- **CEL evaluator: `backend_name` property** — exposes which CEL backend is active (`_RustBackend` or `_PythonBackend`) for telemetry and debugging.
+
 ## [0.14.4] - 2026-03-22
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.14.4"
-date-released: "2026-03-22"
+version: "0.14.5"
+date-released: "2026-03-23"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.14.4"
+version = "0.14.5"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -56,7 +56,12 @@ if TYPE_CHECKING:
 # Alias for convenience
 delete = unpublish
 
-__version__ = "0.14.3"
+try:
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("dns-aid")
+except (ImportError, ModuleNotFoundError, ValueError):
+    __version__ = "0.0.0-dev"  # Fallback for editable installs without metadata
 __all__ = [
     # Core functions (Tier 0)
     "publish",

--- a/src/dns_aid/backends/infoblox/__init__.py
+++ b/src/dns_aid/backends/infoblox/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> await backend.create_svcb_record(...)
 
     >>> from dns_aid.backends.infoblox import InfobloxNIOSBackend
-    >>> backend = InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
+    >>> backend = InfobloxNIOSBackend(host="nios.example.com", username="admin", password=os.environ["NIOS_PASSWORD"])
     >>> await backend.create_svcb_record(...)
 """
 

--- a/src/dns_aid/sdk/policy/cel_evaluator.py
+++ b/src/dns_aid/sdk/policy/cel_evaluator.py
@@ -45,7 +45,7 @@ class _RustBackend:
     """Rust-based CEL backend (common-expression-language). ~2µs/eval."""
 
     def __init__(self) -> None:
-        import cel  # noqa: F811
+        import cel
 
         self._cel = cel
 
@@ -125,16 +125,25 @@ class CELRuleEvaluator:
     def __init__(self) -> None:
         self._backend = _select_backend()
         self._cache: dict[str, Any] = {}
+        self._bad_expressions: set[str] = set()  # Negative cache for compile errors
+        self.backend_name: str = type(self._backend).__name__  # For telemetry/debugging
 
     def _compile(self, expression: str) -> Any:
         """Compile a CEL expression, returning a cached program.
 
         Cache is bounded to _MAX_CACHE_SIZE entries to prevent unbounded
         memory growth from attacker-crafted unique expressions.
+        Bad expressions are negatively cached to avoid repeated compile errors.
         """
         if expression in self._cache:
             return self._cache[expression]
-        prog = self._backend.compile(expression)
+        if expression in self._bad_expressions:
+            raise ValueError(f"Previously failed to compile: {expression[:80]}")
+        try:
+            prog = self._backend.compile(expression)
+        except Exception:
+            self._bad_expressions.add(expression)
+            raise
         if len(self._cache) >= _MAX_CACHE_SIZE:
             # Evict oldest entry (FIFO via dict insertion order)
             oldest = next(iter(self._cache))
@@ -150,11 +159,14 @@ class CELRuleEvaluator:
         str→"", float→0.0, int→0, bool→False.
         """
         return {
+            "caller_id": ctx.caller_id or "",
             "caller_domain": ctx.caller_domain or "",
             "protocol": ctx.protocol or "",
             "method": ctx.method or "",
+            "intent": ctx.intent or "",
             "auth_type": ctx.auth_type or "",
             "geo_country": ctx.geo_country or "",
+            "tls_version": ctx.tls_version or "",
             "caller_trust_score": float(ctx.caller_trust_score)
             if ctx.caller_trust_score is not None
             else 0.0,

--- a/src/dns_aid/sdk/policy/evaluator.py
+++ b/src/dns_aid/sdk/policy/evaluator.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import httpx
 import structlog
@@ -26,6 +28,9 @@ from dns_aid.sdk.policy.schema import (
     PolicyRules,
 )
 from dns_aid.utils.url_safety import validate_fetch_url
+
+if TYPE_CHECKING:
+    from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
 
 logger = structlog.get_logger(__name__)
 
@@ -54,7 +59,7 @@ class PolicyEvaluator:
         self._cache_ttl = cache_ttl
         self._cache: dict[str, _CacheEntry] = {}
         self._lock = asyncio.Lock()
-        self._cel_evaluator: object | None = None  # Lazy-init CELRuleEvaluator
+        self._cel_evaluator: CELRuleEvaluator | None = None
 
     # ── Fetch with SSRF protection + TTL cache ───────────────
 
@@ -288,7 +293,7 @@ class PolicyEvaluator:
 
                 if self._cel_evaluator is None:
                     self._cel_evaluator = CELRuleEvaluator()
-                cel_violations, cel_warnings = self._cel_evaluator.evaluate(  # type: ignore[attr-defined]
+                cel_violations, cel_warnings = self._cel_evaluator.evaluate(
                     rules.cel_rules,
                     ctx,
                     layer.value,
@@ -312,14 +317,15 @@ class PolicyEvaluator:
     def _check_availability(
         rules: PolicyRules,
         ctx: PolicyContext,
-        _violation: object,
-        _warning: object,
+        _violation: Callable[[str, str], None],
+        _warning: Callable[[str, str], None],
     ) -> None:
         """Check time-of-day availability with midnight-wrap support.
 
         Fails open on parse errors (logs warning).
         """
-        assert rules.availability is not None
+        if rules.availability is None:
+            return
         try:
             from datetime import datetime
             from zoneinfo import ZoneInfo
@@ -348,7 +354,7 @@ class PolicyEvaluator:
                 in_window = now_minutes >= start_minutes or now_minutes <= end_minutes
 
             if not in_window:
-                _violation(  # type: ignore[operator]
+                _violation(
                     "availability",
                     f"current time {now.strftime('%H:%M')} outside "
                     f"window {rules.availability.hours} ({rules.availability.timezone})",

--- a/src/dns_aid/sdk/policy/guard.py
+++ b/src/dns_aid/sdk/policy/guard.py
@@ -28,7 +28,7 @@ _evaluator: PolicyEvaluator | None = None
 
 def _get_evaluator() -> PolicyEvaluator:
     """Get or create the module-level PolicyEvaluator."""
-    global _evaluator  # noqa: PLW0603
+    global _evaluator
     if _evaluator is None:
         ttl = int(os.getenv("DNS_AID_POLICY_CACHE_TTL", "300"))
         _evaluator = PolicyEvaluator(cache_ttl=ttl)

--- a/src/dns_aid/sdk/policy/middleware.py
+++ b/src/dns_aid/sdk/policy/middleware.py
@@ -18,6 +18,7 @@ Security notes:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import time
 from collections import defaultdict
@@ -140,8 +141,6 @@ class DnsAidPolicyMiddleware(BaseHTTPMiddleware):
         payload_bytes = None
         cl_header = request.headers.get("content-length")
         if cl_header:
-            import contextlib
-
             with contextlib.suppress(ValueError):
                 payload_bytes = int(cl_header)
 

--- a/src/dns_aid/sdk/policy/schema.py
+++ b/src/dns_aid/sdk/policy/schema.py
@@ -12,6 +12,7 @@ where it can be enforced (Layer 0=bind-aid, 1=caller SDK, 2=target SDK).
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -47,17 +48,9 @@ class CELRule(BaseModel):
 
     id: str = Field(..., min_length=1, max_length=128, pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
     expression: str = Field(..., min_length=1, max_length=2048)
-    effect: str = Field(default="deny")  # "deny" or "warn"
+    effect: Literal["deny", "warn"] = "deny"
     message: str = Field(default="", max_length=512)
     enforcement_layers: list[str] | None = None  # e.g., ["layer1", "layer2"]
-
-    @field_validator("effect")
-    @classmethod
-    def validate_effect(cls, v: str) -> str:
-        """Validate effect is 'deny' or 'warn'."""
-        if v not in ("deny", "warn"):
-            raise ValueError(f"Invalid CEL rule effect: {v}. Must be 'deny' or 'warn'")
-        return v
 
     @field_validator("enforcement_layers")
     @classmethod

--- a/tests/unit/sdk/policy/test_schema.py
+++ b/tests/unit/sdk/policy/test_schema.py
@@ -276,7 +276,7 @@ class TestCELRule:
         assert rule.effect == "warn"
 
     def test_invalid_effect_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="Invalid CEL rule effect"):
+        with pytest.raises(ValidationError, match="Input should be 'deny' or 'warn'"):
             CELRule(id="bad", expression="true", effect="block")
 
     def test_expression_max_length(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.14.4"
+version = "0.14.5"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary
- Permanently fix version drift: `__version__` now reads from `importlib.metadata` (single source of truth)
- CEL evaluator: add missing context fields, negative compile cache, `Literal` type, `backend_name`
- Code quality: eliminate all `type: ignore`, `assert`, `noqa` in policy module
- Bump 0.14.4 → 0.14.5

## Changes
- `src/dns_aid/__init__.py` — `importlib.metadata.version()` replaces hardcoded `__version__`
- `src/dns_aid/sdk/policy/cel_evaluator.py` — 3 new context fields, negative cache, backend_name
- `src/dns_aid/sdk/policy/schema.py` — `Literal["deny","warn"]` replaces str + validator
- `src/dns_aid/sdk/policy/evaluator.py` — proper `TYPE_CHECKING` import, `Callable` typing, guard clause
- `src/dns_aid/sdk/policy/guard.py` — remove unused `noqa`
- `src/dns_aid/sdk/policy/middleware.py` — top-level `contextlib` import
- `src/dns_aid/backends/infoblox/__init__.py` — docstring credential cleanup
- `.gitignore` — add `coverage.xml`
- `pyproject.toml` / `CITATION.cff` / `CHANGELOG.md` — version bump

## LF Readiness Audit
- [x] SPDX headers: 67/67 files
- [x] Bandit SAST: 0 issues (13,720 lines)
- [x] 0 `type: ignore` in policy module
- [x] 0 `assert` in production code
- [x] 0 `noqa` in policy module
- [x] 0 hardcoded credentials
- [x] 0 unsafe patterns (eval/exec/pickle/subprocess)
- [x] Secrets scan clean
- [x] 1065/1065 tests passing
- [x] 77% coverage
- [x] Lint + format + mypy clean