### PR TITLE
feat: Phase 6.6 — tool-level governance + circuit breaker (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-03-24
+
+### Added
+- **Tool-level CEL context** — `request.tool_name` field in PolicyContext enables CEL rules that distinguish MCP tools (e.g., block `delete_user` but allow `read_user`). For MCP, extracted from `arguments["name"]` on `tools/call`; for A2A, the method itself is the tool name; for HTTPS, empty string.
+- **Agent-aware circuit breaker** — tracks consecutive failures per agent FQDN with a CLOSED → OPEN → HALF_OPEN → CLOSED state machine. Configurable via `DNS_AID_CIRCUIT_BREAKER`, `DNS_AID_CIRCUIT_BREAKER_THRESHOLD` (default 5), `DNS_AID_CIRCUIT_BREAKER_COOLDOWN` (default 60s). Disabled by default.
+- **Circuit state in CEL** — `request.target_circuit_state` field enables policy rules like `request.target_circuit_state != "open"` to combine circuit health with trust/identity checks.
+- **Middleware tool_name extraction** — Layer 2 middleware (`DnsAidPolicyMiddleware`) extracts `tool_name` from JSON-RPC body for MCP `tools/call` requests, enabling target-side tool-level governance.
+
 ## [0.14.5] - 2026-03-23
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.14.5"
-date-released: "2026-03-23"
+version: "0.15.0"
+date-released: "2026-03-24"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.14.5"
+version = "0.15.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/sdk/_circuit_breaker.py
+++ b/src/dns_aid/sdk/_circuit_breaker.py
@@ -1,0 +1,92 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Agent-aware circuit breaker for cascading failure protection.
+
+Tracks consecutive failures per agent FQDN (not per URL). After a
+configurable threshold, the circuit opens and rejects calls immediately.
+After a cooldown period, the circuit transitions to half-open to test
+recovery. One success closes the circuit; one failure reopens it.
+
+State machine::
+
+    CLOSED  ──N failures──▸  OPEN
+    OPEN    ──cooldown──▸    HALF_OPEN
+    HALF_OPEN ──success──▸   CLOSED
+    HALF_OPEN ──failure──▸   OPEN
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class _CircuitState:
+    """Per-agent circuit state."""
+
+    failures: int = 0
+    last_failure: float = 0.0
+    state: str = "closed"  # "closed" | "open" | "half_open"
+
+
+class CircuitBreaker:
+    """Agent-aware circuit breaker keyed by FQDN.
+
+    Thread-safety note: intended for use within a single AgentClient
+    instance. If shared across threads, external synchronization is needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        threshold: int = 5,
+        cooldown: float = 60.0,
+    ) -> None:
+        self._enabled = enabled
+        self._threshold = threshold
+        self._cooldown = cooldown
+        self._circuits: dict[str, _CircuitState] = {}
+
+    def get_state(self, fqdn: str) -> str:
+        """Get the current circuit state for an agent, applying cooldown transition.
+
+        Returns "closed", "open", or "half_open".
+        """
+        if not self._enabled:
+            return "closed"
+        circuit = self._circuits.get(fqdn)
+        if circuit is None:
+            return "closed"
+        if circuit.state == "open":
+            if (time.monotonic() - circuit.last_failure) >= self._cooldown:
+                circuit.state = "half_open"
+        return circuit.state
+
+    def record_success(self, fqdn: str) -> None:
+        """Record a successful invocation — resets failures and closes circuit."""
+        if not self._enabled:
+            return
+        circuit = self._circuits.get(fqdn)
+        if circuit is not None:
+            circuit.failures = 0
+            circuit.state = "closed"
+
+    def record_failure(self, fqdn: str) -> None:
+        """Record a failed invocation — increments failures, may open circuit."""
+        if not self._enabled:
+            return
+        circuit = self._circuits.get(fqdn, _CircuitState())
+        circuit.failures += 1
+        circuit.last_failure = time.monotonic()
+        if circuit.failures >= self._threshold:
+            circuit.state = "open"
+        self._circuits[fqdn] = circuit
+
+    @property
+    def circuits(self) -> dict[str, str]:
+        """Snapshot of all circuit states (for debugging/telemetry)."""
+        return {fqdn: c.state for fqdn, c in self._circuits.items()}

--- a/src/dns_aid/sdk/_config.py
+++ b/src/dns_aid/sdk/_config.py
@@ -81,6 +81,22 @@ class SDKConfig(BaseModel):
         description="Caller's domain for policy allowed/blocked_caller_domains matching.",
     )
 
+    # Circuit breaker (Phase 6.6)
+    circuit_breaker_enabled: bool = Field(
+        default=False,
+        description="Enable agent-aware circuit breaker for cascading failure protection.",
+    )
+    circuit_breaker_threshold: int = Field(
+        default=5,
+        ge=1,
+        description="Consecutive failures before opening the circuit.",
+    )
+    circuit_breaker_cooldown: float = Field(
+        default=60.0,
+        ge=1.0,
+        description="Seconds before an open circuit transitions to half-open.",
+    )
+
     @classmethod
     def from_env(cls) -> SDKConfig:
         """Build config from environment variables."""
@@ -97,4 +113,7 @@ class SDKConfig(BaseModel):
             policy_mode=os.getenv("DNS_AID_POLICY_MODE", "permissive"),
             policy_cache_ttl=int(os.getenv("DNS_AID_POLICY_CACHE_TTL", "300")),
             caller_domain=os.getenv("DNS_AID_CALLER_DOMAIN"),
+            circuit_breaker_enabled=os.getenv("DNS_AID_CIRCUIT_BREAKER", "").lower() == "true",
+            circuit_breaker_threshold=int(os.getenv("DNS_AID_CIRCUIT_BREAKER_THRESHOLD", "5")),
+            circuit_breaker_cooldown=float(os.getenv("DNS_AID_CIRCUIT_BREAKER_COOLDOWN", "60")),
         )

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -18,10 +18,11 @@ import httpx
 import structlog
 
 from dns_aid.core.models import AgentRecord
+from dns_aid.sdk._circuit_breaker import CircuitBreaker
 from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.auth import resolve_auth_handler
 from dns_aid.sdk.auth.base import AuthHandler
-from dns_aid.sdk.models import InvocationResult, InvocationSignal
+from dns_aid.sdk.models import InvocationResult, InvocationSignal, InvocationStatus
 from dns_aid.sdk.policy.evaluator import PolicyEvaluator
 from dns_aid.sdk.policy.models import PolicyContext, PolicyViolationError
 from dns_aid.sdk.policy.schema import PolicyEnforcementLayer
@@ -64,6 +65,11 @@ class AgentClient:
         )
         self._handlers: dict[str, ProtocolHandler] = {}
         self._policy_evaluator: PolicyEvaluator | None = None
+        self._circuit_breaker = CircuitBreaker(
+            enabled=self._config.circuit_breaker_enabled,
+            threshold=self._config.circuit_breaker_threshold,
+            cooldown=self._config.circuit_breaker_cooldown,
+        )
 
     async def __aenter__(self) -> AgentClient:
         self._http_client = httpx.AsyncClient(
@@ -174,6 +180,38 @@ class AgentClient:
             auth_type=resolved_auth.auth_type if resolved_auth else None,
         )
 
+        # --- Tool name extraction (Phase 6.6) ---
+        tool_name: str | None = None
+        if method == "tools/call" and isinstance(arguments, dict):
+            tool_name = arguments.get("name")
+        elif protocol == "a2a":
+            tool_name = method  # A2A method IS the "tool"
+
+        # --- Circuit breaker pre-check (Phase 6.6) ---
+        circuit_state = self._circuit_breaker.get_state(agent.fqdn)
+        if circuit_state == "open":
+            logger.warning(
+                "sdk.circuit_open",
+                agent_fqdn=agent.fqdn,
+                threshold=self._config.circuit_breaker_threshold,
+            )
+            signal = InvocationSignal(
+                agent_fqdn=agent.fqdn,
+                agent_endpoint=agent.endpoint_url,
+                protocol=protocol,
+                method=method,
+                invocation_latency_ms=0.0,
+                status=InvocationStatus.REFUSED,
+                error_type="circuit_open",
+                error_message=f"Circuit open for {agent.fqdn}",
+                caller_id=self._config.caller_id,
+            )
+            return InvocationResult(
+                success=False,
+                data={"error": "circuit_open", "agent_fqdn": agent.fqdn},
+                signal=signal,
+            )
+
         # --- Policy enforcement (Phase 6 §3.20) --- Layer 1: caller-side ---
         policy_result_data = None
         policy_doc = None
@@ -195,6 +233,8 @@ class AgentClient:
                     method=method,
                     auth_type=resolved_auth.auth_type if resolved_auth else None,
                     dnssec_validated=getattr(agent, "dnssec_validated", False),
+                    tool_name=tool_name,
+                    target_circuit_state=circuit_state,
                 )
                 policy_result_data = self._policy_evaluator.evaluate(
                     policy_doc,
@@ -228,6 +268,12 @@ class AgentClient:
             timeout=effective_timeout,
             auth_handler=resolved_auth,
         )
+
+        # --- Circuit breaker post-update (Phase 6.6) ---
+        if raw.status == InvocationStatus.SUCCESS:
+            self._circuit_breaker.record_success(agent.fqdn)
+        else:
+            self._circuit_breaker.record_failure(agent.fqdn)
 
         # Capture target-side policy result (Layer 2) from response header
         target_policy_result = None

--- a/src/dns_aid/sdk/policy/cel_evaluator.py
+++ b/src/dns_aid/sdk/policy/cel_evaluator.py
@@ -173,6 +173,8 @@ class CELRuleEvaluator:
             "payload_bytes": ctx.payload_bytes if ctx.payload_bytes is not None else 0,
             "dnssec_validated": ctx.dnssec_validated,
             "has_mutual_tls": ctx.has_mutual_tls,
+            "tool_name": ctx.tool_name or "",
+            "target_circuit_state": ctx.target_circuit_state or "closed",
         }
 
     def evaluate(

--- a/src/dns_aid/sdk/policy/middleware.py
+++ b/src/dns_aid/sdk/policy/middleware.py
@@ -144,6 +144,9 @@ class DnsAidPolicyMiddleware(BaseHTTPMiddleware):
             with contextlib.suppress(ValueError):
                 payload_bytes = int(cl_header)
 
+        # Extract tool_name from JSON-RPC body for MCP tool calls
+        tool_name = await _extract_tool_name_from_body(request, method)
+
         # Build evaluation context
         ctx = PolicyContext(
             caller_domain=caller_domain,
@@ -154,6 +157,7 @@ class DnsAidPolicyMiddleware(BaseHTTPMiddleware):
             payload_bytes=payload_bytes,
             has_mutual_tls=has_mutual_tls,
             consent_token=request.headers.get("x-dns-aid-consent-token"),
+            tool_name=tool_name,
         )
 
         # Evaluate policy
@@ -243,6 +247,29 @@ async def _extract_method_from_body(request: Request) -> str | None:
     except Exception:
         pass
     return request.headers.get("x-dns-aid-method")
+
+
+async def _extract_tool_name_from_body(request: Request, method: str | None) -> str | None:
+    """Extract tool name from JSON-RPC body for MCP tools/call requests.
+
+    For MCP, tool_name is in params.name when method == "tools/call".
+    """
+    if method != "tools/call":
+        return None
+    content_type = request.headers.get("content-type", "")
+    if "json" not in content_type:
+        return None
+    try:
+        body = await request.body()
+        if body:
+            data = json.loads(body)
+            if isinstance(data, dict):
+                params = data.get("params", {})
+                if isinstance(params, dict):
+                    return params.get("name")
+    except Exception:
+        pass
+    return None
 
 
 def _extract_domain_from_dn(dn: str) -> str | None:

--- a/src/dns_aid/sdk/policy/models.py
+++ b/src/dns_aid/sdk/policy/models.py
@@ -29,6 +29,8 @@ class PolicyContext(BaseModel):
     payload_bytes: int | None = None
     has_mutual_tls: bool = False
     consent_token: str | None = None
+    tool_name: str | None = None
+    target_circuit_state: str | None = None
 
 
 class PolicyViolation(BaseModel):

--- a/tests/unit/sdk/policy/test_cel_evaluator.py
+++ b/tests/unit/sdk/policy/test_cel_evaluator.py
@@ -502,3 +502,178 @@ class TestCELHardening:
         v, w = evaluator.evaluate(rules, _ctx(method=""), "layer1")
         assert len(v) == 1
         assert v[0].rule == "cel:zero"
+
+
+# =============================================================================
+# Tool-level CEL context (Phase 6.6)
+# =============================================================================
+
+
+class TestToolNameCEL:
+    """Test tool_name field in CEL evaluation."""
+
+    def test_tool_name_block_destructive(self) -> None:
+        """CEL can block specific tool names."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="no-delete",
+                expression='!(request.tool_name in ["delete_user", "drop_table"])',
+                effect="deny",
+                message="Destructive tool blocked",
+            )
+        ]
+        # Safe tool → passes
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name="read_user"), "layer1")
+        assert len(v) == 0
+        # Destructive tool → denied
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name="delete_user"), "layer1")
+        assert len(v) == 1
+        assert v[0].detail == "Destructive tool blocked"
+
+    def test_tool_name_allowlist(self) -> None:
+        """CEL can enforce a tool allowlist."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="allowlist",
+                expression='request.tool_name in ["search", "get_info", ""]',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name="search"), "layer1")
+        assert len(v) == 0
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name="hack_system"), "layer1")
+        assert len(v) == 1
+
+    def test_tool_name_starts_with_admin(self) -> None:
+        """CEL can restrict admin-prefixed tools."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="admin-restrict",
+                expression='!request.tool_name.startsWith("admin_")',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name="read_user"), "layer1")
+        assert len(v) == 0
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name="admin_delete"), "layer1")
+        assert len(v) == 1
+
+    def test_tool_name_none_coerces_to_empty(self) -> None:
+        """None tool_name coerces to empty string in CEL."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="check",
+                expression='request.tool_name == ""',
+                effect="deny",
+            )
+        ]
+        # None → "" → expression is true → no violation
+        v, _ = evaluator.evaluate(rules, _ctx(tool_name=None), "layer1")
+        assert len(v) == 0
+
+    def test_a2a_method_as_tool_name(self) -> None:
+        """For A2A, the method itself is the tool_name."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="a2a-method",
+                expression='request.tool_name == "tasks/send"',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(
+            rules, _ctx(protocol="a2a", tool_name="tasks/send"), "layer1"
+        )
+        assert len(v) == 0  # Expression true → allowed
+
+
+# =============================================================================
+# Circuit state CEL context (Phase 6.6)
+# =============================================================================
+
+
+class TestCircuitStateCEL:
+    """Test target_circuit_state field in CEL evaluation."""
+
+    def test_circuit_state_closed_passes(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="circuit",
+                expression='request.target_circuit_state == "closed"',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(target_circuit_state="closed"), "layer1")
+        assert len(v) == 0
+
+    def test_circuit_state_open_denied(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="circuit",
+                expression='request.target_circuit_state != "open"',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(target_circuit_state="open"), "layer1")
+        assert len(v) == 1
+
+    def test_circuit_state_none_defaults_to_closed(self) -> None:
+        """None circuit state coerces to 'closed' in CEL."""
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="circuit",
+                expression='request.target_circuit_state == "closed"',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(target_circuit_state=None), "layer1")
+        assert len(v) == 0  # None → "closed" → match → allowed
+
+    def test_circuit_combined_with_trust(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        rules = [
+            CELRule(
+                id="circuit-trust",
+                expression='request.target_circuit_state == "closed" && request.caller_trust_score >= 50.0',
+                effect="deny",
+            )
+        ]
+        # Both conditions met
+        v, _ = evaluator.evaluate(
+            rules,
+            _ctx(target_circuit_state="closed", caller_trust_score=80.0),
+            "layer1",
+        )
+        assert len(v) == 0
+        # Circuit half_open → denied
+        v, _ = evaluator.evaluate(
+            rules,
+            _ctx(target_circuit_state="half_open", caller_trust_score=80.0),
+            "layer1",
+        )
+        assert len(v) == 1

--- a/tests/unit/sdk/test_circuit_breaker.py
+++ b/tests/unit/sdk/test_circuit_breaker.py
@@ -1,0 +1,143 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agent-aware circuit breaker (Phase 6.6)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from dns_aid.sdk._circuit_breaker import CircuitBreaker
+
+
+class TestCircuitBreakerStateTransitions:
+    """Test the CLOSED → OPEN → HALF_OPEN → CLOSED state machine."""
+
+    def test_starts_closed(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        assert cb.get_state("agent.example.com") == "closed"
+
+    def test_stays_closed_below_threshold(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        cb.record_failure("agent.example.com")
+        cb.record_failure("agent.example.com")
+        assert cb.get_state("agent.example.com") == "closed"
+
+    def test_opens_at_threshold(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        for _ in range(3):
+            cb.record_failure("agent.example.com")
+        assert cb.get_state("agent.example.com") == "open"
+
+    def test_open_to_half_open_after_cooldown(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        for _ in range(3):
+            cb.record_failure("agent.example.com")
+        assert cb.get_state("agent.example.com") == "open"
+
+        # Simulate cooldown elapsed
+        with patch("dns_aid.sdk._circuit_breaker.time.monotonic", return_value=1e9):
+            assert cb.get_state("agent.example.com") == "half_open"
+
+    def test_half_open_to_closed_on_success(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        for _ in range(3):
+            cb.record_failure("agent.example.com")
+
+        # Transition to half_open via cooldown
+        with patch("dns_aid.sdk._circuit_breaker.time.monotonic", return_value=1e9):
+            assert cb.get_state("agent.example.com") == "half_open"
+
+        # Success closes it
+        cb.record_success("agent.example.com")
+        assert cb.get_state("agent.example.com") == "closed"
+
+    def test_half_open_to_open_on_failure(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        for _ in range(3):
+            cb.record_failure("agent.example.com")
+
+        # Transition to half_open via cooldown
+        with patch("dns_aid.sdk._circuit_breaker.time.monotonic", return_value=1e9):
+            assert cb.get_state("agent.example.com") == "half_open"
+
+        # Failure reopens (1 failure >= threshold=3? No, but half_open + failure → open)
+        cb.record_failure("agent.example.com")
+        assert cb.get_state("agent.example.com") == "open"
+
+    def test_success_resets_failure_count(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=3, cooldown=10.0)
+        cb.record_failure("agent.example.com")
+        cb.record_failure("agent.example.com")
+        cb.record_success("agent.example.com")
+        # Failures reset, so 2 more failures shouldn't open
+        cb.record_failure("agent.example.com")
+        cb.record_failure("agent.example.com")
+        assert cb.get_state("agent.example.com") == "closed"
+
+
+class TestCircuitBreakerIsolation:
+    """Test that different agents have independent circuits."""
+
+    def test_independent_circuits(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=2, cooldown=10.0)
+        # Open circuit for agent A
+        cb.record_failure("a.example.com")
+        cb.record_failure("a.example.com")
+        assert cb.get_state("a.example.com") == "open"
+        # Agent B should still be closed
+        assert cb.get_state("b.example.com") == "closed"
+
+    def test_circuits_snapshot(self) -> None:
+        cb = CircuitBreaker(enabled=True, threshold=2, cooldown=10.0)
+        cb.record_failure("a.example.com")
+        cb.record_failure("a.example.com")
+        cb.record_failure("b.example.com")
+        assert cb.circuits == {
+            "a.example.com": "open",
+            "b.example.com": "closed",
+        }
+
+
+class TestCircuitBreakerDisabled:
+    """Test that circuit breaker is a no-op when disabled."""
+
+    def test_disabled_always_closed(self) -> None:
+        cb = CircuitBreaker(enabled=False, threshold=1, cooldown=1.0)
+        cb.record_failure("agent.example.com")
+        cb.record_failure("agent.example.com")
+        assert cb.get_state("agent.example.com") == "closed"
+
+    def test_disabled_no_state_tracking(self) -> None:
+        cb = CircuitBreaker(enabled=False)
+        cb.record_failure("agent.example.com")
+        cb.record_success("agent.example.com")
+        assert cb.circuits == {}
+
+
+class TestCircuitBreakerConfig:
+    """Test circuit breaker configuration via SDKConfig."""
+
+    def test_config_from_env(self) -> None:
+        from dns_aid.sdk._config import SDKConfig
+
+        with patch.dict(
+            "os.environ",
+            {
+                "DNS_AID_CIRCUIT_BREAKER": "true",
+                "DNS_AID_CIRCUIT_BREAKER_THRESHOLD": "10",
+                "DNS_AID_CIRCUIT_BREAKER_COOLDOWN": "120",
+            },
+        ):
+            config = SDKConfig.from_env()
+            assert config.circuit_breaker_enabled is True
+            assert config.circuit_breaker_threshold == 10
+            assert config.circuit_breaker_cooldown == 120.0
+
+    def test_config_defaults(self) -> None:
+        from dns_aid.sdk._config import SDKConfig
+
+        config = SDKConfig()
+        assert config.circuit_breaker_enabled is False
+        assert config.circuit_breaker_threshold == 5
+        assert config.circuit_breaker_cooldown == 60.0

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.14.5"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **Tool-level CEL context** — `request.tool_name` exposed to CEL rules for MCP/A2A. Enables policies like "block `delete_user` but allow `read_user`". Extracted from MCP `arguments["name"]` on `tools/call`; A2A method = tool name; HTTPS = empty. Layer 2 middleware also extracts from JSON-RPC body.
- **Agent-aware circuit breaker** — tracks consecutive failures per agent FQDN (CLOSED → OPEN → HALF_OPEN → CLOSED). Open circuits reject with `REFUSED` status. State exposed as `request.target_circuit_state` in CEL for policy integration. Configurable via `DNS_AID_CIRCUIT_BREAKER*` env vars, disabled by default.
- **Version bump** 0.14.5 → 0.15.0

### Performance
| Feature | Overhead |
|---|---|
| Tool name extraction | <1µs (dict key lookup) |
| Circuit breaker check/update | <1µs (dict + timestamp) |
| CEL with new fields | +0µs (same eval, 2 more fields) |

### Files changed
- `sdk/policy/models.py` — `tool_name`, `target_circuit_state` on PolicyContext
- `sdk/policy/cel_evaluator.py` — new fields in `_build_activation()`
- `sdk/policy/middleware.py` — `_extract_tool_name_from_body()` for Layer 2
- `sdk/client.py` — tool extraction, circuit breaker pre/post hooks
- `sdk/_circuit_breaker.py` — **NEW** circuit breaker state machine
- `sdk/_config.py` — 3 new config fields + env vars

## Test plan
- [x] 1087 tests pass (22 new: 9 CEL tool_name/circuit, 13 circuit breaker)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/dns_aid/sdk/` — no issues
- [x] `bandit` — no findings
- [x] No secrets in diff