### PR TITLE
feat: add NS1 (IBM) DNS backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Backend-specific variables only needed for the backend you choose.
 
 # ─── General ─────────────────────────────────────────────
-# DNS_AID_BACKEND=mock              # route53 | cloudflare | infoblox | nios | ddns | mock
+# DNS_AID_BACKEND=mock              # route53 | cloudflare | ns1 | infoblox | nios | ddns | mock
 # DNS_AID_LOG_LEVEL=INFO            # DEBUG | INFO | WARNING | ERROR
 # DNS_AID_TEST_ZONE=example.com     # Domain to use for publish/discover
 # DNS_AID_SVCB_STRING_KEYS=0        # 1 = human-readable SVCB param names
@@ -26,6 +26,10 @@
 # ─── Cloudflare ─────────────────────────────────────────
 # CLOUDFLARE_API_TOKEN=
 # CLOUDFLARE_ZONE_ID=                # Optional — auto-discovered from domain
+
+# ─── NS1 (IBM) ─────────────────────────────────────────
+# NS1_API_KEY=
+# NS1_BASE_URL=https://api.nsone.net/v2
 
 # ─── Infoblox BloxOne ───────────────────────────────────
 # INFOBLOX_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **NS1 (IBM) DNS backend** — new `NS1Backend` for the NS1 REST API v2 with API key authentication (`X-NSONE-Key`). Supports SVCB + TXT record CRUD with PUT/POST upsert semantics, zone caching, and efficient single-record lookup. Private-use SVCB keys demoted to TXT via base class. Configured via `NS1_API_KEY` and optional `NS1_BASE_URL` env vars. 48 unit tests.
+
 ## [0.15.0] - 2026-03-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ uv run pytest tests/unit/ -q
 dns-aid-core/
 ├── src/dns_aid/
 │   ├── core/           # Discovery, publishing, validation (Tier 0)
-│   ├── backends/       # DNS backends (Route 53, Cloudflare, Infoblox BloxOne, NIOS, DDNS, Mock)
+│   ├── backends/       # DNS backends (Route 53, Cloudflare, NS1, Infoblox BloxOne, NIOS, DDNS, Mock)
 │   ├── sdk/            # Telemetry SDK, ranking, protocol handlers (Tier 1)
 │   ├── cli/            # CLI commands (publish, discover, verify, list, init, doctor)
 │   ├── mcp/            # MCP server for AI agents
@@ -44,10 +44,77 @@ dns-aid-core/
 ```
 
 **Where does new code go?**
-- New DNS backend → `src/dns_aid/backends/` + add to `_BACKEND_CLASSES` in `backends/__init__.py` + register in `cli/backends.py`
+- New DNS backend → see [Adding a New Backend](#adding-a-new-backend) below
 - New CLI command → `src/dns_aid/cli/` + register in `cli/main.py`
 - New SDK feature → `src/dns_aid/sdk/`
 - New MCP tool → `src/dns_aid/mcp/server.py`
+
+## Adding a New Backend
+
+Use the Cloudflare backend as a reference implementation (`src/dns_aid/backends/cloudflare.py`). Every new backend touches **12 locations** across the codebase. Use this checklist to avoid missing any.
+
+### Implementation checklist
+
+#### 1. Backend module (required)
+
+- [ ] **`src/dns_aid/backends/<name>.py`** — Create backend class inheriting from `DNSBackend`
+  - Add SPDX header: `# Copyright 2024-2026 The DNS-AID Authors` + `# SPDX-License-Identifier: Apache-2.0`
+  - Implement all abstract methods: `name`, `create_svcb_record`, `create_txt_record`, `delete_record`, `list_records`, `zone_exists`
+  - Override `get_record` for efficient single-record lookup (optional but recommended)
+  - Override `publish_agent` only if the backend supports private-use SVCB keys natively (like NIOS)
+  - Constructor: accept optional params with env var fallbacks, do NOT validate credentials at init
+  - HTTP client: use `httpx.AsyncClient` with event-loop tracking pattern (see `_get_client()` in cloudflare.py)
+  - Zone lookup: cache results in `_zone_cache`
+  - `zone_exists()`: must return `False` on any error, never raise
+  - Add `close()` method that cleans up the HTTP client
+
+#### 2. Backend registration (required)
+
+- [ ] **`src/dns_aid/backends/__init__.py`** — Add entry to `_BACKEND_CLASSES` dict AND add eager re-export try/except block
+- [ ] **`src/dns_aid/cli/backends.py`** — Add `BackendInfo` to `BACKEND_REGISTRY` with `required_env`, `optional_env`, `setup_url`, `setup_steps`
+
+#### 3. MCP server (required)
+
+- [ ] **`src/dns_aid/mcp/server.py`** — Add backend name to ALL `Literal[...]` type hints for `backend` parameters (currently 5 locations — search for `Literal["route53"`)
+
+#### 4. Package config (required)
+
+- [ ] **`pyproject.toml`** — Add `[project.optional-dependencies]` group (e.g., `ns1 = [# Uses httpx from core deps]`). Update `all` extras comment if needed
+- [ ] **`.env.example`** — Add backend section with env vars. Update `DNS_AID_BACKEND` comment on line 7
+
+#### 5. Tests (required)
+
+- [ ] **`tests/unit/test_<name>_backend.py`** — Unit tests covering: init, client creation, zone lookup, SVCB/TXT CRUD, delete, list_records, zone_exists, get_record, close. Use mocked httpx responses (see `test_cloudflare_backend.py`)
+- [ ] **`tests/unit/test_backend_factory.py`** — Add backend name to `expected` set in `test_contains_all_backends`
+
+#### 6. Documentation (required)
+
+- [ ] **`README.md`** — Add `pip install dns-aid[<name>]` line to installation section
+- [ ] **`docs/getting-started.md`** — Add `pip install -e ".[<name>]"` to dev install list AND add backend name to `DNS_AID_BACKEND` env var table
+- [ ] **`docs/api-reference.md`** — Add backend name to `DNS_AID_BACKEND` env var description
+- [ ] **`CHANGELOG.md`** — Add entry under `[Unreleased]` or the next version
+- [ ] **`CONTRIBUTING.md`** — Update the backends list in the project structure tree
+- [ ] **`src/dns_aid/core/publisher.py`** — Update `Supported values:` in `get_default_backend()` docstring
+
+### Verification
+
+```bash
+# 1. Factory smoke test
+uv run python -c "from dns_aid.backends import create_backend; b = create_backend('<name>'); print(b.name)"
+
+# 2. Unit tests
+uv run pytest tests/unit/test_<name>_backend.py tests/unit/test_backend_factory.py -v
+
+# 3. Lint + format
+uv run ruff check src/dns_aid/backends/<name>.py tests/unit/test_<name>_backend.py
+uv run ruff format --check src/dns_aid/backends/<name>.py tests/unit/test_<name>_backend.py
+
+# 4. Full test suite (check for regressions)
+uv run pytest tests/unit/ -q
+
+# 5. Grep for missed references (should return 0 hits for old list without your backend)
+grep -rn 'route53.*cloudflare.*infoblox' src/ docs/ --include='*.py' --include='*.md' | grep -v '<name>'
+```
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pip install dns-aid[mcp]
 pip install dns-aid[route53]      # AWS Route 53
 pip install dns-aid[cloud-dns]    # Google Cloud DNS
 pip install dns-aid[cloudflare]   # Cloudflare DNS
+pip install dns-aid[ns1]          # NS1 (IBM)
 pip install dns-aid[infoblox]     # Infoblox BloxOne (cloud)
 pip install dns-aid[nios]         # Infoblox NIOS (on-prem)
 pip install dns-aid[ddns]         # RFC 2136 Dynamic DNS (BIND, PowerDNS)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -813,7 +813,7 @@ dns-aid call --domain example.com --name network-specialist get_subnets \
 
 | Variable | Description |
 |----------|-------------|
-| `DNS_AID_BACKEND` | Default backend: "route53", "cloudflare", "infoblox", "nios", "ddns", or "mock" |
+| `DNS_AID_BACKEND` | Default backend: "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", or "mock" |
 | `DNS_AID_LOG_LEVEL` | Logging level: DEBUG, INFO, WARNING, ERROR |
 
 **AWS Route 53:**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,6 +42,7 @@ pip install -e ".[mcp]"         # Core + MCP server
 pip install -e ".[route53]"     # Core + Route 53 backend
 pip install -e ".[cloud-dns]"   # Core + Google Cloud DNS backend
 pip install -e ".[cloudflare]"  # Core + Cloudflare backend
+pip install -e ".[ns1]"         # Core + NS1 (IBM) backend
 pip install -e ".[infoblox]"    # Core + Infoblox BloxOne backend
 pip install -e ".[nios]"        # Core + Infoblox NIOS (on-prem) backend
 pip install -e ".[ddns]"        # Core + RFC 2136 Dynamic DNS backend
@@ -1365,7 +1366,7 @@ python examples/demo_full.py
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `DNS_AID_BACKEND` | Yes (if no `backend=` arg) | — | DNS backend: `route53`, `cloudflare`, `infoblox`, `nios`, `ddns`, `mock` |
+| `DNS_AID_BACKEND` | Yes (if no `backend=` arg) | — | DNS backend: `route53`, `cloudflare`, `ns1`, `infoblox`, `nios`, `ddns`, `mock` |
 | `DNS_AID_SVCB_STRING_KEYS` | No | `0` | Set `1` to emit human-readable SVCB param names instead of keyNNNNN |
 | `DNS_AID_FETCH_ALLOWLIST` | No | — | Comma-separated hostnames to bypass SSRF protection (testing only) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ infoblox = [
 cloudflare = [
     # Uses httpx from core deps
 ]
+ns1 = [
+    # Uses httpx from core deps
+]
 nios = [
     # Uses httpx from core deps
 ]
@@ -113,7 +116,7 @@ all = [
     # MCP
     "mcp>=1.0.0",
     "uvicorn>=0.30.0",
-    # Backends: Route53, Infoblox BloxOne, NIOS, Cloudflare, DDNS (last 4 use core deps)
+    # Backends: Route53, Cloudflare, NS1, Cloud DNS, Infoblox BloxOne, NIOS, DDNS
     "boto3>=1.34.0",
     "google-auth>=2.30.0",
     # JWS

--- a/src/dns_aid/backends/__init__.py
+++ b/src/dns_aid/backends/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2024-2026 The DNS-AID Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""DNS backend implementations: Route53, Infoblox BloxOne, DDNS, Mock."""
+"""DNS backend implementations: Route53, Cloudflare, Cloud DNS, NS1, Infoblox BloxOne, DDNS, Mock."""
 
 from __future__ import annotations
 
@@ -20,6 +20,7 @@ _BACKEND_CLASSES: dict[str, tuple[str, str]] = {
     "route53": ("dns_aid.backends.route53", "Route53Backend"),
     "cloudflare": ("dns_aid.backends.cloudflare", "CloudflareBackend"),
     "cloud-dns": ("dns_aid.backends.cloud_dns", "CloudDNSBackend"),
+    "ns1": ("dns_aid.backends.ns1", "NS1Backend"),
     "infoblox": ("dns_aid.backends.infoblox", "InfobloxBackend"),
     "nios": ("dns_aid.backends.infoblox.nios", "InfobloxNIOSBackend"),
     "ddns": ("dns_aid.backends.ddns", "DDNSBackend"),
@@ -100,5 +101,13 @@ try:
     from dns_aid.backends.cloud_dns import CloudDNSBackend  # noqa: F401
 
     __all__.append("CloudDNSBackend")
+except ImportError:
+    pass
+
+# NS1 backend - uses httpx (already a core dep)
+try:
+    from dns_aid.backends.ns1 import NS1Backend  # noqa: F401
+
+    __all__.append("NS1Backend")
 except ImportError:
     pass

--- a/src/dns_aid/backends/ns1.py
+++ b/src/dns_aid/backends/ns1.py
@@ -1,0 +1,426 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+NS1 (IBM) DNS backend.
+
+Creates DNS-AID records (SVCB, TXT) in NS1 managed zones.
+Uses the NS1 REST API v2 with API key authentication.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import structlog
+
+from dns_aid.backends.base import DNSBackend
+
+logger = structlog.get_logger(__name__)
+
+# Private-use SVCB key demotion is handled by the DNSBackend base class.
+# NS1 rejects key65280–key65534 — base class demotes them to TXT.
+
+
+class NS1Backend(DNSBackend):
+    """
+    NS1 (IBM) DNS backend using REST API v2.
+
+    Creates and manages DNS-AID records in NS1 zones.
+
+    Example:
+        >>> backend = NS1Backend()
+        >>> await backend.create_svcb_record(
+        ...     zone="example.com",
+        ...     name="_chat._a2a._agents",
+        ...     priority=1,
+        ...     target="chat.example.com.",
+        ...     params={"alpn": "a2a", "port": "443"}
+        ... )
+
+    Environment Variables:
+        NS1_API_KEY: NS1 API key with DNS edit permissions
+        NS1_BASE_URL: Optional API base URL (default: https://api.nsone.net/v2)
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ):
+        """
+        Initialize NS1 backend.
+
+        Args:
+            api_key: NS1 API key (defaults to NS1_API_KEY env var)
+            base_url: API base URL (defaults to NS1_BASE_URL env var or https://api.nsone.net/v2)
+        """
+        self._api_key = api_key or os.environ.get("NS1_API_KEY")
+        self._base_url = base_url or os.environ.get("NS1_BASE_URL") or "https://api.nsone.net/v2"
+        self._client: httpx.AsyncClient | None = None
+        self._client_loop_id: int | None = None
+        self._zone_cache: dict[str, dict] = {}
+
+    @property
+    def name(self) -> str:
+        return "ns1"
+
+    def _normalize(self, zone: str, name: str | None = None) -> tuple[str, str]:
+        """Normalize zone and build FQDN.
+
+        Returns:
+            (domain, fqdn) tuple with trailing dots stripped.
+        """
+        domain = zone.lower().rstrip(".")
+        fqdn = f"{name}.{domain}" if name else domain
+        return domain, fqdn
+
+    @staticmethod
+    def _extract_values(answers: list[dict]) -> list[str]:
+        """Extract rdata values from NS1 answer objects."""
+        return [" ".join(str(p) for p in a.get("answer", [])) for a in answers]
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create httpx async client.
+
+        Recreates client if the event loop has changed (e.g., when CLI
+        uses multiple asyncio.run() calls).
+        """
+        import asyncio
+
+        current_loop_id = id(asyncio.get_running_loop())
+
+        if self._client is not None and self._client_loop_id != current_loop_id:
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None
+
+        if self._client is None:
+            if not self._api_key:
+                raise ValueError(
+                    "NS1 API key not configured. "
+                    "Set NS1_API_KEY environment variable or pass api_key parameter."
+                )
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                headers={
+                    "X-NSONE-Key": self._api_key,
+                    "Content-Type": "application/json",
+                },
+                timeout=30.0,
+            )
+            self._client_loop_id = current_loop_id
+        return self._client
+
+    async def _get_zone(self, zone: str) -> dict:
+        """
+        Get NS1 zone metadata.
+
+        Args:
+            zone: Domain name (e.g., "example.com")
+
+        Returns:
+            Zone metadata dict
+
+        Raises:
+            ValueError: If zone not found
+        """
+        domain = zone.lower().rstrip(".")
+
+        if domain in self._zone_cache:
+            return self._zone_cache[domain]
+
+        client = await self._get_client()
+
+        response = await client.get(f"/zones/{domain}")
+        if response.status_code == 404:
+            raise ValueError(f"No zone found for domain: {zone}")
+        response.raise_for_status()
+
+        data = response.json()
+        self._zone_cache[domain] = data
+        logger.debug("Found zone", domain=domain, zone=data.get("zone"))
+        return data
+
+    async def _upsert_record(
+        self,
+        domain: str,
+        fqdn: str,
+        record_type: str,
+        request_data: dict[str, Any],
+    ) -> httpx.Response:
+        """Create or update a record via PUT (update) with POST fallback (create).
+
+        NS1 uses PUT to update existing records and POST to create new ones.
+        """
+        client = await self._get_client()
+        path = f"/zones/{domain}/{fqdn}/{record_type}"
+
+        response = await client.put(path, json=request_data)
+        if response.status_code == 404:
+            response = await client.post(path, json=request_data)
+
+        response.raise_for_status()
+        return response
+
+    def _format_svcb_rdata(
+        self,
+        priority: int,
+        target: str,
+        params: dict[str, str],
+    ) -> str:
+        """
+        Format SVCB record data as presentation format string.
+
+        NS1 accepts SVCB records in standard presentation format.
+        """
+        if not target.endswith("."):
+            target = f"{target}."
+
+        param_parts = []
+        for key, value in params.items():
+            param_parts.append(f'{key}="{value}"')
+        params_str = " ".join(param_parts)
+
+        if params_str:
+            return f"{priority} {target} {params_str}"
+        return f"{priority} {target}"
+
+    async def create_svcb_record(
+        self,
+        zone: str,
+        name: str,
+        priority: int,
+        target: str,
+        params: dict[str, str],
+        ttl: int = 3600,
+    ) -> str:
+        """Create SVCB record in NS1."""
+        await self._get_zone(zone)
+        domain, fqdn = self._normalize(zone, name)
+
+        logger.info(
+            "Creating SVCB record",
+            zone=zone,
+            name=fqdn,
+            priority=priority,
+            target=target,
+            params=params,
+            ttl=ttl,
+        )
+
+        rdata = self._format_svcb_rdata(priority, target, params)
+
+        request_data: dict[str, Any] = {
+            "zone": domain,
+            "domain": fqdn,
+            "type": "SVCB",
+            "ttl": ttl,
+            "answers": [{"answer": [rdata]}],
+        }
+
+        await self._upsert_record(domain, fqdn, "SVCB", request_data)
+        logger.info("SVCB record created", fqdn=fqdn)
+        return fqdn
+
+    async def create_txt_record(
+        self,
+        zone: str,
+        name: str,
+        values: list[str],
+        ttl: int = 3600,
+    ) -> str:
+        """Create TXT record in NS1."""
+        await self._get_zone(zone)
+        domain, fqdn = self._normalize(zone, name)
+
+        logger.info(
+            "Creating TXT record",
+            zone=zone,
+            name=fqdn,
+            values=values,
+            ttl=ttl,
+        )
+
+        answers = [{"answer": [v]} for v in values]
+
+        request_data: dict[str, Any] = {
+            "zone": domain,
+            "domain": fqdn,
+            "type": "TXT",
+            "ttl": ttl,
+            "answers": answers,
+        }
+
+        await self._upsert_record(domain, fqdn, "TXT", request_data)
+        logger.info("TXT record created", fqdn=fqdn)
+        return fqdn
+
+    # publish_agent() inherited from DNSBackend base class — automatically
+    # demotes private-use SVCB keys to TXT since NS1 rejects them.
+
+    async def delete_record(
+        self,
+        zone: str,
+        name: str,
+        record_type: str,
+    ) -> bool:
+        """Delete a DNS record from NS1."""
+        await self._get_zone(zone)
+        client = await self._get_client()
+        domain, fqdn = self._normalize(zone, name)
+
+        logger.info(
+            "Deleting record",
+            zone=zone,
+            name=fqdn,
+            type=record_type,
+        )
+
+        response = await client.delete(f"/zones/{domain}/{fqdn}/{record_type}")
+
+        if response.status_code == 404:
+            logger.warning("Record not found", fqdn=fqdn, type=record_type)
+            return False
+
+        response.raise_for_status()
+        logger.info("Record deleted", fqdn=fqdn, type=record_type)
+        return True
+
+    async def list_records(
+        self,
+        zone: str,
+        name_pattern: str | None = None,
+        record_type: str | None = None,
+    ) -> AsyncIterator[dict]:
+        """List DNS records in NS1 zone.
+
+        Always fetches fresh zone data to avoid returning stale records.
+        """
+        domain = zone.lower().rstrip(".")
+        client = await self._get_client()
+
+        logger.debug(
+            "Listing records",
+            zone=zone,
+            name_pattern=name_pattern,
+            record_type=record_type,
+        )
+
+        # Always fetch fresh zone data — cached data goes stale after
+        # create/delete operations and the records list would be wrong.
+        response = await client.get(f"/zones/{domain}")
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+        zone_data = response.json()
+
+        records = zone_data.get("records", [])
+
+        for record in records:
+            rname = record.get("domain", "")
+            rtype = record.get("type", "")
+
+            if record_type and rtype != record_type:
+                continue
+
+            if name_pattern and name_pattern not in rname:
+                continue
+
+            # Fetch full record details for answers
+            try:
+                resp = await client.get(f"/zones/{domain}/{rname}/{rtype}")
+                if resp.status_code != 200:
+                    logger.debug(
+                        "Skipping record (non-200 response)",
+                        fqdn=rname,
+                        type=rtype,
+                        status=resp.status_code,
+                    )
+                    continue
+                full_record = resp.json()
+            except httpx.HTTPError as exc:
+                logger.debug(
+                    "Skipping record (HTTP error)",
+                    fqdn=rname,
+                    type=rtype,
+                    error=str(exc),
+                )
+                continue
+
+            values = self._extract_values(full_record.get("answers", []))
+            short_name = rname.replace(f".{domain}", "") if rname != domain else "@"
+
+            yield {
+                "name": short_name,
+                "fqdn": rname,
+                "type": rtype,
+                "ttl": full_record.get("ttl", 0),
+                "values": values,
+            }
+
+    async def zone_exists(self, zone: str) -> bool:
+        """Check if zone exists in NS1.
+
+        Returns False (rather than raising) on any API or network error,
+        since the zone is effectively inaccessible.
+        """
+        try:
+            await self._get_zone(zone)
+            return True
+        except (ValueError, httpx.HTTPStatusError):
+            return False
+        except Exception as exc:
+            logger.warning(
+                "Failed to check zone existence in NS1",
+                zone=zone,
+                error=str(exc),
+            )
+            return False
+
+    async def get_record(
+        self,
+        zone: str,
+        name: str,
+        record_type: str,
+    ) -> dict | None:
+        """
+        Get a specific DNS record by querying NS1 API directly.
+
+        More efficient than list_records for single record lookup.
+        """
+        await self._get_zone(zone)
+        client = await self._get_client()
+        domain, fqdn = self._normalize(zone, name)
+
+        try:
+            response = await client.get(f"/zones/{domain}/{fqdn}/{record_type}")
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            data = response.json()
+
+            return {
+                "name": name,
+                "fqdn": fqdn,
+                "type": record_type,
+                "ttl": data.get("ttl", 0),
+                "values": self._extract_values(data.get("answers", [])),
+            }
+
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.debug("Record not found", fqdn=fqdn, type=record_type, error=str(exc))
+            return None
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+            self._client_loop_id = None

--- a/src/dns_aid/cli/backends.py
+++ b/src/dns_aid/cli/backends.py
@@ -79,6 +79,23 @@ BACKEND_REGISTRY: dict[str, BackendInfo] = {
             "Set CLOUDFLARE_API_TOKEN",
         ],
     ),
+    "ns1": BackendInfo(
+        name="ns1",
+        display_name="NS1 (IBM)",
+        required_env={
+            "NS1_API_KEY": "NS1 API key",
+        },
+        optional_env={
+            "NS1_BASE_URL": "API base URL (default: https://api.nsone.net/v2)",
+        },
+        optional_dep="ns1",
+        setup_url="https://ns1.com/api",
+        setup_steps=[
+            "Create an API key at my.nsone.net → Account Settings → API Keys",
+            "Grant the key DNS read/write permissions for your zone",
+            "Set NS1_API_KEY",
+        ],
+    ),
     "cloud-dns": BackendInfo(
         name="cloud-dns",
         display_name="Google Cloud DNS",

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -37,7 +37,7 @@ def reset_default_backend() -> None:
 def get_default_backend() -> DNSBackend:
     """Get the default DNS backend based on DNS_AID_BACKEND env var.
 
-    Supported values: route53, cloudflare, infoblox, nios, ddns, mock
+    Supported values: route53, cloudflare, ns1, infoblox, nios, ddns, mock
 
     Raises:
         ValueError: If DNS_AID_BACKEND is not set (no silent fallback to mock).

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -224,7 +224,7 @@ def publish_agent_to_dns(
     use_cases: list[str] | None = None,
     category: str | None = None,
     ttl: int = 3600,
-    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
     update_index: bool = True,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
@@ -706,7 +706,7 @@ def verify_agent_dns(fqdn: str) -> dict:
 @mcp.tool()
 def list_published_agents(
     domain: str,
-    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
 ) -> dict:
     """
     List all agents published at a domain you manage via DNS-AID.
@@ -792,7 +792,7 @@ def delete_agent_from_dns(
     name: str,
     domain: str,
     protocol: Literal["mcp", "a2a"] = "mcp",
-    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
     update_index: bool = True,
 ) -> dict:
     """
@@ -884,7 +884,7 @@ def delete_agent_from_dns(
 @mcp.tool()
 def list_agent_index(
     domain: str,
-    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
 ) -> dict:
     """
     List agents in a domain's index record.
@@ -945,7 +945,7 @@ def list_agent_index(
 @mcp.tool()
 def sync_agent_index(
     domain: str,
-    backend: Literal["route53", "cloudflare", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
     ttl: int = 3600,
 ) -> dict:
     """

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -224,7 +224,9 @@ def publish_agent_to_dns(
     use_cases: list[str] | None = None,
     category: str | None = None,
     ttl: int = 3600,
-    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "route53",
     update_index: bool = True,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
@@ -706,7 +708,9 @@ def verify_agent_dns(fqdn: str) -> dict:
 @mcp.tool()
 def list_published_agents(
     domain: str,
-    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "route53",
 ) -> dict:
     """
     List all agents published at a domain you manage via DNS-AID.
@@ -792,7 +796,9 @@ def delete_agent_from_dns(
     name: str,
     domain: str,
     protocol: Literal["mcp", "a2a"] = "mcp",
-    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "route53",
     update_index: bool = True,
 ) -> dict:
     """
@@ -884,7 +890,9 @@ def delete_agent_from_dns(
 @mcp.tool()
 def list_agent_index(
     domain: str,
-    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "route53",
 ) -> dict:
     """
     List agents in a domain's index record.
@@ -945,7 +953,9 @@ def list_agent_index(
 @mcp.tool()
 def sync_agent_index(
     domain: str,
-    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"] = "route53",
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "route53",
     ttl: int = 3600,
 ) -> dict:
     """

--- a/tests/unit/test_backend_factory.py
+++ b/tests/unit/test_backend_factory.py
@@ -24,7 +24,7 @@ class TestValidBackendNames:
         assert isinstance(VALID_BACKEND_NAMES, frozenset)
 
     def test_contains_all_backends(self):
-        expected = {"route53", "cloudflare", "cloud-dns", "infoblox", "nios", "ddns", "mock"}
+        expected = {"route53", "cloudflare", "cloud-dns", "ns1", "infoblox", "nios", "ddns", "mock"}
         assert expected == VALID_BACKEND_NAMES
 
 

--- a/tests/unit/test_cli_onboarding.py
+++ b/tests/unit/test_cli_onboarding.py
@@ -26,6 +26,7 @@ class TestBackendRegistry:
             "route53",
             "cloud-dns",
             "cloudflare",
+            "ns1",
             "infoblox",
             "nios",
             "ddns",

--- a/tests/unit/test_ns1_backend.py
+++ b/tests/unit/test_ns1_backend.py
@@ -1,0 +1,840 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dns_aid.backends.ns1 module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from dns_aid.backends.ns1 import NS1Backend
+
+
+class TestNS1BackendInit:
+    """Tests for NS1Backend initialization."""
+
+    def test_init_with_api_key(self):
+        """Test initialization with API key."""
+        backend = NS1Backend(api_key="test-key-123")
+        assert backend._api_key == "test-key-123"
+
+    def test_init_with_base_url(self):
+        """Test initialization with custom base URL."""
+        backend = NS1Backend(api_key="key", base_url="https://custom.ns1.net/v2")
+        assert backend._base_url == "https://custom.ns1.net/v2"
+
+    def test_init_from_env_key(self):
+        """Test API key from environment variable."""
+        with patch.dict("os.environ", {"NS1_API_KEY": "env-key"}):
+            backend = NS1Backend()
+            assert backend._api_key == "env-key"
+
+    def test_init_from_env_base_url(self):
+        """Test base URL from environment variable."""
+        with patch.dict(
+            "os.environ",
+            {"NS1_API_KEY": "key", "NS1_BASE_URL": "https://env.ns1.net/v2"},
+        ):
+            backend = NS1Backend()
+            assert backend._base_url == "https://env.ns1.net/v2"
+
+    def test_init_defaults(self):
+        """Test default values."""
+        backend = NS1Backend(api_key="key")
+        assert backend._client is None
+        assert backend._zone_cache == {}
+        assert backend._base_url == "https://api.nsone.net/v2"
+
+
+class TestNS1BackendProperties:
+    """Tests for NS1Backend properties."""
+
+    def test_name_property(self):
+        """Test name property returns 'ns1'."""
+        backend = NS1Backend(api_key="key")
+        assert backend.name == "ns1"
+
+
+class TestNS1BackendHelpers:
+    """Tests for _normalize and _extract_values helpers."""
+
+    def test_normalize_with_name(self):
+        """Test _normalize returns (domain, fqdn)."""
+        backend = NS1Backend(api_key="key")
+        domain, fqdn = backend._normalize("example.com", "_chat._mcp._agents")
+        assert domain == "example.com"
+        assert fqdn == "_chat._mcp._agents.example.com"
+
+    def test_normalize_without_name(self):
+        """Test _normalize with no name returns domain as fqdn."""
+        backend = NS1Backend(api_key="key")
+        domain, fqdn = backend._normalize("example.com")
+        assert domain == "example.com"
+        assert fqdn == "example.com"
+
+    def test_normalize_strips_trailing_dot(self):
+        """Test _normalize strips trailing dot from zone."""
+        backend = NS1Backend(api_key="key")
+        domain, fqdn = backend._normalize("example.com.", "_chat")
+        assert domain == "example.com"
+        assert fqdn == "_chat.example.com"
+
+    def test_normalize_lowercases(self):
+        """Test _normalize lowercases the domain."""
+        backend = NS1Backend(api_key="key")
+        domain, fqdn = backend._normalize("Example.COM", "_chat")
+        assert domain == "example.com"
+        assert fqdn == "_chat.example.com"
+
+    def test_extract_values_single_answer(self):
+        """Test _extract_values with a single answer."""
+        answers = [{"answer": ['1 chat.example.com. alpn="mcp" port="443"']}]
+        values = NS1Backend._extract_values(answers)
+        assert values == ['1 chat.example.com. alpn="mcp" port="443"']
+
+    def test_extract_values_multiple_answers(self):
+        """Test _extract_values with multiple answers."""
+        answers = [
+            {"answer": ["version=1.0.0"]},
+            {"answer": ["capabilities=chat,search"]},
+        ]
+        values = NS1Backend._extract_values(answers)
+        assert values == ["version=1.0.0", "capabilities=chat,search"]
+
+    def test_extract_values_empty(self):
+        """Test _extract_values with no answers."""
+        assert NS1Backend._extract_values([]) == []
+
+    def test_extract_values_missing_answer_key(self):
+        """Test _extract_values with missing answer key in dict."""
+        answers = [{"meta": {}}]
+        values = NS1Backend._extract_values(answers)
+        assert values == [""]
+
+
+class TestNS1BackendClient:
+    """Tests for httpx client creation."""
+
+    @pytest.mark.asyncio
+    async def test_get_client_creates_client(self):
+        """Test that _get_client creates httpx client."""
+        backend = NS1Backend(api_key="test-key")
+
+        client = await backend._get_client()
+
+        assert isinstance(client, httpx.AsyncClient)
+        assert client.headers["X-NSONE-Key"] == "test-key"
+        assert client.headers["Content-Type"] == "application/json"
+
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_caches_client(self):
+        """Test that client is cached."""
+        backend = NS1Backend(api_key="test-key")
+
+        client1 = await backend._get_client()
+        client2 = await backend._get_client()
+
+        assert client1 is client2
+
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_raises_without_key(self):
+        """Test that missing API key raises ValueError."""
+        backend = NS1Backend()
+        backend._api_key = None
+
+        with pytest.raises(ValueError, match="API key not configured"):
+            await backend._get_client()
+
+
+class TestNS1BackendZone:
+    """Tests for zone resolution."""
+
+    @pytest.mark.asyncio
+    async def test_get_zone_from_cache(self):
+        """Test that cached zone is returned."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        zone = await backend._get_zone("example.com")
+        assert zone == {"zone": "example.com"}
+
+    @pytest.mark.asyncio
+    async def test_get_zone_from_api(self):
+        """Test zone lookup from API."""
+        backend = NS1Backend(api_key="key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "zone": "example.com",
+            "records": [],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            zone = await backend._get_zone("example.com")
+            assert zone["zone"] == "example.com"
+            assert "example.com" in backend._zone_cache
+
+    @pytest.mark.asyncio
+    async def test_get_zone_not_found(self):
+        """Test zone lookup when zone doesn't exist."""
+        backend = NS1Backend(api_key="key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(backend, "_get_client", return_value=mock_client),
+            pytest.raises(ValueError, match="No zone found"),
+        ):
+            await backend._get_zone("notfound.com")
+
+    @pytest.mark.asyncio
+    async def test_get_zone_strips_trailing_dot(self):
+        """Test that trailing dots are stripped from zone names."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        zone = await backend._get_zone("example.com.")
+        assert zone == {"zone": "example.com"}
+
+
+class TestNS1BackendFormatSvcb:
+    """Tests for SVCB data formatting."""
+
+    def test_format_svcb_rdata_basic(self):
+        """Test basic SVCB rdata formatting."""
+        backend = NS1Backend(api_key="key")
+        rdata = backend._format_svcb_rdata(
+            priority=1,
+            target="chat.example.com",
+            params={"alpn": "a2a", "port": "443"},
+        )
+        assert "1 chat.example.com." in rdata
+        assert 'alpn="a2a"' in rdata
+        assert 'port="443"' in rdata
+
+    def test_format_svcb_rdata_adds_trailing_dot(self):
+        """Test that trailing dot is added to target."""
+        backend = NS1Backend(api_key="key")
+        rdata = backend._format_svcb_rdata(
+            priority=1,
+            target="chat.example.com",
+            params={},
+        )
+        assert rdata == "1 chat.example.com."
+
+    def test_format_svcb_rdata_preserves_trailing_dot(self):
+        """Test that existing trailing dot is preserved."""
+        backend = NS1Backend(api_key="key")
+        rdata = backend._format_svcb_rdata(
+            priority=1,
+            target="chat.example.com.",
+            params={},
+        )
+        assert rdata == "1 chat.example.com."
+
+    def test_format_svcb_rdata_no_params(self):
+        """Test SVCB rdata with no params."""
+        backend = NS1Backend(api_key="key")
+        rdata = backend._format_svcb_rdata(
+            priority=0,
+            target="alias.example.com.",
+            params={},
+        )
+        assert rdata == "0 alias.example.com."
+
+
+class TestNS1BackendUpsert:
+    """Tests for the _upsert_record method (PUT with POST fallback)."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_put_succeeds(self):
+        """Test upsert when PUT succeeds (record exists)."""
+        backend = NS1Backend(api_key="key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            resp = await backend._upsert_record(
+                "example.com", "_chat.example.com", "SVCB", {"type": "SVCB"}
+            )
+            assert resp.status_code == 200
+            mock_client.put.assert_called_once()
+            mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upsert_falls_back_to_post_on_404(self):
+        """Test upsert falls back to POST when PUT returns 404."""
+        backend = NS1Backend(api_key="key")
+
+        mock_404 = MagicMock()
+        mock_404.status_code = 404
+
+        mock_201 = MagicMock()
+        mock_201.status_code = 201
+        mock_201.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_404)
+        mock_client.post = AsyncMock(return_value=mock_201)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            resp = await backend._upsert_record(
+                "example.com", "_chat.example.com", "SVCB", {"type": "SVCB"}
+            )
+            assert resp.status_code == 201
+            mock_client.put.assert_called_once()
+            mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_upsert_propagates_non_404_errors(self):
+        """Test upsert propagates server errors from PUT."""
+        backend = NS1Backend(api_key="key")
+
+        mock_500 = MagicMock()
+        mock_500.status_code = 500
+        mock_500.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server Error", request=MagicMock(), response=mock_500
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_500)
+
+        with (
+            patch.object(backend, "_get_client", return_value=mock_client),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await backend._upsert_record(
+                "example.com", "_chat.example.com", "SVCB", {"type": "SVCB"}
+            )
+
+
+class TestNS1BackendCreateSvcb:
+    """Tests for SVCB record creation."""
+
+    @pytest.mark.asyncio
+    async def test_create_svcb_record_success(self):
+        """Test successful SVCB record creation via PUT."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"domain": "_chat._a2a._agents.example.com"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                priority=1,
+                target="chat.example.com",
+                params={"alpn": "a2a", "port": "443"},
+                ttl=3600,
+            )
+
+            assert result == "_chat._a2a._agents.example.com"
+            mock_client.put.assert_called_once()
+
+            # Verify the request payload
+            call_kwargs = mock_client.put.call_args
+            json_data = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+            assert json_data["type"] == "SVCB"
+            assert json_data["ttl"] == 3600
+            assert len(json_data["answers"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_create_svcb_record_post_fallback(self):
+        """Test SVCB creation falls back to POST when record doesn't exist."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_404 = MagicMock()
+        mock_404.status_code = 404
+
+        mock_201 = MagicMock()
+        mock_201.status_code = 201
+        mock_201.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_404)
+        mock_client.post = AsyncMock(return_value=mock_201)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                priority=1,
+                target="chat.example.com",
+                params={"alpn": "a2a", "port": "443"},
+            )
+
+            assert result == "_chat._a2a._agents.example.com"
+            mock_client.put.assert_called_once()
+            mock_client.post.assert_called_once()
+
+
+class TestNS1BackendCreateTxt:
+    """Tests for TXT record creation."""
+
+    @pytest.mark.asyncio
+    async def test_create_txt_record_success(self):
+        """Test successful TXT record creation."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"domain": "_chat._a2a._agents.example.com"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_txt_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                values=["version=1.0.0", "capabilities=chat,search"],
+                ttl=3600,
+            )
+
+            assert result == "_chat._a2a._agents.example.com"
+            mock_client.put.assert_called_once()
+
+            # Verify multiple TXT values become separate answers
+            call_kwargs = mock_client.put.call_args
+            json_data = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+            assert json_data["type"] == "TXT"
+            assert len(json_data["answers"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_create_txt_record_post_fallback(self):
+        """Test TXT creation falls back to POST when record doesn't exist."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_404 = MagicMock()
+        mock_404.status_code = 404
+
+        mock_201 = MagicMock()
+        mock_201.status_code = 201
+        mock_201.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=mock_404)
+        mock_client.post = AsyncMock(return_value=mock_201)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_txt_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                values=["version=1.0.0"],
+            )
+
+            assert result == "_chat._a2a._agents.example.com"
+            mock_client.post.assert_called_once()
+
+
+class TestNS1BackendDeleteRecord:
+    """Tests for record deletion."""
+
+    @pytest.mark.asyncio
+    async def test_delete_record_success(self):
+        """Test successful record deletion."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.delete_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                record_type="SVCB",
+            )
+
+            assert result is True
+            mock_client.delete.assert_called_once_with(
+                "/zones/example.com/_chat._a2a._agents.example.com/SVCB"
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_record_not_found(self):
+        """Test deletion of non-existent record."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.delete_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                record_type="SVCB",
+            )
+
+            assert result is False
+
+
+class TestNS1BackendZoneExists:
+    """Tests for zone existence check."""
+
+    @pytest.mark.asyncio
+    async def test_zone_exists_true(self):
+        """Test zone_exists returns True for existing zone."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        result = await backend.zone_exists("example.com")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_zone_exists_false(self):
+        """Test zone_exists returns False for missing zone."""
+        backend = NS1Backend(api_key="key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.zone_exists("notfound.com")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_zone_exists_false_on_error(self):
+        """Test zone_exists returns False on network error."""
+        backend = NS1Backend(api_key="key")
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.zone_exists("example.com")
+            assert result is False
+
+
+class TestNS1BackendGetRecord:
+    """Tests for single record lookup."""
+
+    @pytest.mark.asyncio
+    async def test_get_record_found(self):
+        """Test get_record returns record when found."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "domain": "_chat._a2a._agents.example.com",
+            "type": "SVCB",
+            "ttl": 3600,
+            "answers": [{"answer": ['1 chat.example.com. alpn="a2a" port="443"']}],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.get_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                record_type="SVCB",
+            )
+
+            assert result is not None
+            assert result["fqdn"] == "_chat._a2a._agents.example.com"
+            assert result["type"] == "SVCB"
+            assert result["ttl"] == 3600
+            assert len(result["values"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_record_not_found(self):
+        """Test get_record returns None when not found."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.get_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                record_type="SVCB",
+            )
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_record_returns_none_on_http_error(self):
+        """Test get_record returns None on HTTP error (not programming error)."""
+        backend = NS1Backend(api_key="key")
+        backend._zone_cache["example.com"] = {"zone": "example.com"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.get_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                record_type="SVCB",
+            )
+            assert result is None
+
+
+class TestNS1BackendListRecords:
+    """Tests for listing records."""
+
+    @pytest.mark.asyncio
+    async def test_list_records_fetches_fresh_zone_data(self):
+        """Test that list_records does a fresh GET, not using stale cache."""
+        backend = NS1Backend(api_key="key")
+        # Seed cache with stale data (no records)
+        backend._zone_cache["example.com"] = {"zone": "example.com", "records": []}
+
+        # Fresh zone response has a record
+        mock_zone_resp = MagicMock()
+        mock_zone_resp.status_code = 200
+        mock_zone_resp.json.return_value = {
+            "zone": "example.com",
+            "records": [
+                {"domain": "_chat._mcp._agents.example.com", "type": "SVCB"},
+            ],
+        }
+        mock_zone_resp.raise_for_status = MagicMock()
+
+        mock_detail_resp = MagicMock()
+        mock_detail_resp.status_code = 200
+        mock_detail_resp.json.return_value = {
+            "domain": "_chat._mcp._agents.example.com",
+            "type": "SVCB",
+            "ttl": 3600,
+            "answers": [{"answer": ['1 chat.example.com. alpn="mcp" port="443"']}],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[mock_zone_resp, mock_detail_resp])
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            records = []
+            async for record in backend.list_records(zone="example.com"):
+                records.append(record)
+
+            # Should find the record from the fresh fetch, not the empty cache
+            assert len(records) == 1
+            assert records[0]["fqdn"] == "_chat._mcp._agents.example.com"
+
+    @pytest.mark.asyncio
+    async def test_list_records_with_type_filter(self):
+        """Test listing records with type filter."""
+        backend = NS1Backend(api_key="key")
+
+        mock_zone_resp = MagicMock()
+        mock_zone_resp.status_code = 200
+        mock_zone_resp.json.return_value = {
+            "zone": "example.com",
+            "records": [
+                {"domain": "_chat._mcp._agents.example.com", "type": "SVCB"},
+                {"domain": "_chat._mcp._agents.example.com", "type": "TXT"},
+                {"domain": "www.example.com", "type": "A"},
+            ],
+        }
+        mock_zone_resp.raise_for_status = MagicMock()
+
+        mock_detail_resp = MagicMock()
+        mock_detail_resp.status_code = 200
+        mock_detail_resp.json.return_value = {
+            "domain": "_chat._mcp._agents.example.com",
+            "type": "SVCB",
+            "ttl": 3600,
+            "answers": [{"answer": ['1 chat.example.com. alpn="mcp" port="443"']}],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[mock_zone_resp, mock_detail_resp])
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            records = []
+            async for record in backend.list_records(
+                zone="example.com",
+                record_type="SVCB",
+            ):
+                records.append(record)
+
+            assert len(records) == 1
+            assert records[0]["type"] == "SVCB"
+
+    @pytest.mark.asyncio
+    async def test_list_records_with_name_filter(self):
+        """Test listing records with name pattern filter."""
+        backend = NS1Backend(api_key="key")
+
+        mock_zone_resp = MagicMock()
+        mock_zone_resp.status_code = 200
+        mock_zone_resp.json.return_value = {
+            "zone": "example.com",
+            "records": [
+                {"domain": "_chat._mcp._agents.example.com", "type": "SVCB"},
+                {"domain": "_search._mcp._agents.example.com", "type": "SVCB"},
+            ],
+        }
+        mock_zone_resp.raise_for_status = MagicMock()
+
+        mock_detail_resp = MagicMock()
+        mock_detail_resp.status_code = 200
+        mock_detail_resp.json.return_value = {
+            "domain": "_chat._mcp._agents.example.com",
+            "type": "SVCB",
+            "ttl": 3600,
+            "answers": [{"answer": ['1 chat.example.com. alpn="mcp" port="443"']}],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[mock_zone_resp, mock_detail_resp])
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            records = []
+            async for record in backend.list_records(
+                zone="example.com",
+                name_pattern="_chat",
+            ):
+                records.append(record)
+
+            assert len(records) == 1
+            assert "_chat" in records[0]["fqdn"]
+
+    @pytest.mark.asyncio
+    async def test_list_records_empty_zone(self):
+        """Test listing records in zone with no records."""
+        backend = NS1Backend(api_key="key")
+
+        mock_zone_resp = MagicMock()
+        mock_zone_resp.status_code = 200
+        mock_zone_resp.json.return_value = {
+            "zone": "example.com",
+            "records": [],
+        }
+        mock_zone_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_zone_resp)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            records = []
+            async for record in backend.list_records(zone="example.com"):
+                records.append(record)
+
+            assert records == []
+
+    @pytest.mark.asyncio
+    async def test_list_records_zone_not_found(self):
+        """Test listing records when zone doesn't exist returns empty."""
+        backend = NS1Backend(api_key="key")
+
+        mock_404 = MagicMock()
+        mock_404.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_404)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            records = []
+            async for record in backend.list_records(zone="notfound.com"):
+                records.append(record)
+
+            assert records == []
+
+    @pytest.mark.asyncio
+    async def test_list_records_skips_on_detail_http_error(self):
+        """Test that HTTP errors on detail fetch skip the record, not crash."""
+        backend = NS1Backend(api_key="key")
+
+        mock_zone_resp = MagicMock()
+        mock_zone_resp.status_code = 200
+        mock_zone_resp.json.return_value = {
+            "zone": "example.com",
+            "records": [
+                {"domain": "_broken.example.com", "type": "SVCB"},
+            ],
+        }
+        mock_zone_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[
+                mock_zone_resp,
+                httpx.ConnectError("Connection refused"),
+            ]
+        )
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            records = []
+            async for record in backend.list_records(zone="example.com"):
+                records.append(record)
+
+            assert records == []
+
+
+class TestNS1BackendClose:
+    """Tests for client cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_close_with_client(self):
+        """Test closing an active client."""
+        backend = NS1Backend(api_key="key")
+        await backend._get_client()
+
+        assert backend._client is not None
+        assert backend._client_loop_id is not None
+        await backend.close()
+        assert backend._client is None
+        assert backend._client_loop_id is None
+
+    @pytest.mark.asyncio
+    async def test_close_without_client(self):
+        """Test closing when no client exists."""
+        backend = NS1Backend(api_key="key")
+        await backend.close()  # Should not raise

--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "nios", "ddns", "jws", "sdk", "otel", "cel", "pqc", "dev", "all"]
+provides-extras = ["cli", "mcp", "route53", "cloud-dns", "infoblox", "cloudflare", "ns1", "nios", "ddns", "jws", "sdk", "otel", "cel", "pqc", "dev", "all"]
 
 [[package]]
 name = "dnspython"


### PR DESCRIPTION
## Summary

- **NS1 (IBM) DNS backend** — new `NS1Backend` for the NS1 REST API v2 with API key authentication (`X-NSONE-Key`). Supports SVCB + TXT record CRUD with PUT/POST upsert semantics, zone caching, and efficient single-record lookup. Private-use SVCB keys demoted to TXT via base class.
- **Full integration** — registered in backend factory, CLI registry, MCP server `Literal` types, pyproject.toml extras, `.env.example`, and all documentation
- **"Adding a New Backend" checklist** — 12-item checklist added to CONTRIBUTING.md covering all locations that need updating when adding a backend

### Files changed (15 files, +1388/-15)

| Category | Files |
|----------|-------|
| Backend | `backends/ns1.py` (new), `backends/__init__.py`, `cli/backends.py` |
| MCP | `mcp/server.py` (5 Literal types updated) |
| Config | `pyproject.toml`, `.env.example` |
| Docs | `README.md`, `getting-started.md`, `api-reference.md`, `CHANGELOG.md`, `CONTRIBUTING.md` |
| Core | `core/publisher.py` (docstring) |
| Tests | `test_ns1_backend.py` (new, 48 tests), `test_backend_factory.py` |

### Environment Variables

| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `NS1_API_KEY` | Yes | — | NS1 API key |
| `NS1_BASE_URL` | No | `https://api.nsone.net/v2` | API base URL |

## Test plan

- [x] 48 NS1 unit tests pass (init, client, zone, SVCB/TXT CRUD, upsert fallback, delete, list, get_record, zone_exists, close)
- [x] 15 factory tests pass (including `ns1` in expected backend set)
- [x] `ruff check` + `ruff format --check` clean
- [x] No regressions in full unit suite (pre-existing failures only: CEL backend not installed)
- [x] Factory smoke test: `create_backend('ns1')` returns `NS1Backend`