### PR TITLE
feat: Phase 7 — policy-to-RPZ compiler, Infoblox TD enforcement (v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-03-29
+
+### Added
+- **Policy-to-RPZ compiler** (`PolicyCompiler`) — transforms `PolicyDocument` JSON into RPZ directives (standard CNAME-based) and bind-aid directives (TXT-based with `ACTION:` and `key654xx=op:value` syntax). Supports all 16 native policy rules + CEL custom rules. Domain-based CEL patterns (endsWith, ==, !=) compile to DNS zone entries; complex CEL (trust scores, tool restrictions) is skipped at Layer 0 with documented reasons and enforced at Layer 1/2 by the CEL evaluator.
+- **RPZ zone writer** (`write_rpz_zone()`) — renders compilation results to standard RFC 8010 RPZ zone files with SOA, NS, and CNAME records. Includes audit comments and source rule tracking.
+- **bind-aid zone writer** (`write_bindaid_zone()`) — renders compilation results to bind-aid policy zone files per Ingmar's BIND 9 fork format. Uses `$ORIGIN` directive, separate TXT records for ACTION and SvcParam operations.
+- **SvcParam policy operations** (`svcparam_ops`) — new policy rule type for bind-aid rdata enforcement: `strip`, `require`, `validate`, `enforce`, `whitelist`, `blacklist` operations on SVCB keys.
+- **Infoblox BloxOne Threat Defense integration** — full TD API support:
+  - `create_or_update_named_list()` — push blocked domains as TD named lists via `/api/atcfw/v1/named_lists`
+  - `bind_named_list_to_policy()` — bind named lists to security policies with action support (`action_block`, `action_log`, `action_allow`, `action_redirect`). Handles action switching (removes old rule, adds new one) without duplicates.
+  - `unbind_named_list_from_policy()` — remove named list rules from policies
+  - `list_security_policies()` / `get_security_policy()` — query TD policies
+  - `list_named_lists()` / `delete_named_list()` — manage named lists
+- **Infoblox NIOS RPZ support** — WAPI methods for on-prem RPZ:
+  - `create_rpz_cname_record()` — create/update `record:rpz:cname` entries
+  - `delete_rpz_cname_record()` / `list_rpz_cname_records()` — manage RPZ records
+  - `ensure_rpz_zone()` — create RPZ zones (`zone_rp`) if needed
+- **CLI `policy` sub-app** — `dns-aid policy compile` (generate RPZ/bind-aid zone files), `dns-aid policy show` (compilation report with tables)
+- **CLI `enforce` command** — full pipeline: discover agents → compile policy → generate zones → push to Infoblox TD. Supports `--mode shadow` (dry run), `--mode enforce` (live push), `--td-action` (block/log/allow/redirect), `--td-policy-id` (target specific policy), `--auto-policy` (fetch policy_uri from discovered agents' SVCB records), `--output-dir` (write zone files).
+- **MCP tools** — 4 new tools:
+  - `compile_policy_to_rpz` — compile policy JSON to RPZ + bind-aid zone content
+  - `publish_rpz_zone` — compile + push to TD with security policy binding, supports `td_action` and `td_policy_id` params
+  - `list_rpz_rules` — query TD named lists and security policies
+  - `list_td_security_policies` — list all TD security policies
+- **RPZ deduplication** — compiler removes duplicate directives (same owner+action from native rules + CEL) with warnings
+- **Test fixtures** — `sample-policy.json` (general) and `nordstrom-agent-governance.json` (enterprise governance scenario with CEL rules and SvcParam ops)
+- **Nordstrom POC documentation** (`docs/nordstrom-poc.md`) — end-to-end deployment guide with dual MCP server architecture, CEL enforcement diagrams, TD action options, and before/after framing
+
+### Changed
+- **CEL compiler patterns** — now recognizes both evaluator-convention (`!endsWith`, `!=`) and positive forms (`endsWith`, `==`) for domain-based CEL rules. Both produce the same RPZ output.
+- **`__init__.py` exports** — `dns_aid.sdk.policy` now exports all compiler types: `PolicyCompiler`, `CompilationResult`, `RPZDirective`, `RPZAction`, `BindAidDirective`, `BindAidAction`, `BindAidParamOp`, `SkippedRule`, `write_rpz_zone`, `write_bindaid_zone`
+
 ## [0.16.0] - 2026-03-28
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.16.0"
+version: "0.17.0"
 date-released: "2026-03-28"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,30 @@ dns-aid call --endpoint https://mcp.example.com/mcp search_flights \
 # Note: discover-first flow fetches /.well-known/agent-card.json to resolve
 # the canonical endpoint URL and agent metadata before invoking. If the agent
 # card's url hostname differs from the DNS endpoint, DNS takes precedence.
+
+# =============================================================================
+# Policy Enforcement (compile policy → push to Threat Defense)
+# =============================================================================
+
+# Compile a policy document to RPZ + bind-aid zone files
+dns-aid policy compile -i policy.json -o /tmp/zone -f both
+
+# Show compilation report (what compiles to DNS vs SDK layers)
+dns-aid policy show -i policy.json
+
+# Shadow mode — see what WOULD be blocked (safe, no changes to TD)
+dns-aid enforce -d nordstrom.com -p policy.json --mode shadow
+
+# Monitor mode — log matches in TD without blocking
+dns-aid enforce -d nordstrom.com -p policy.json \
+  --mode enforce -b infoblox --td-action action_log
+
+# Enforce mode — blocked domains get NXDOMAIN from Threat Defense
+dns-aid enforce -d nordstrom.com -p policy.json \
+  --mode enforce -b infoblox --td-action action_block
+
+# Auto-policy — fetch each agent's policy_uri from DNS and compile all
+dns-aid enforce -d nordstrom.com --auto-policy --mode shadow
 ```
 
 ### Python SDK
@@ -340,6 +364,10 @@ dns-aid-mcp --transport http --port 8000
 | `delete_agent_from_dns` | Remove an agent from DNS (auto-updates index) |
 | `list_agent_index` | List agents in domain's index record |
 | `sync_agent_index` | Sync index with actual DNS records |
+| `compile_policy_to_rpz` | Compile a policy document to RPZ + bind-aid zone content |
+| `publish_rpz_zone` | Compile policy + push to Infoblox TD (named list + security policy binding) |
+| `list_rpz_rules` | List RPZ rules / TD named lists from a backend |
+| `list_td_security_policies` | List all Infoblox TD security policies |
 | `diagnose_environment` | Run environment diagnostics (deps, DNS, backends). Optional `domain` param for discovery check |
 
 ### Claude Desktop Integration

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 This guide will walk you through installing, configuring, and testing DNS-AID.
 
-> **Version 0.6.2** - Adds DNSSEC enforcement (`require_dnssec=True`), DANE full certificate matching (`verify_dane_cert=True`), Sigstore release signing, Route53/Cloudflare SVCB custom param demotion to TXT, and environment variable documentation.
+> **Version 0.17.0** - Adds policy-to-RPZ compiler, Infoblox Threat Defense integration (`dns-aid enforce`), CEL-to-DNS compilation, bind-aid zone writer, and 4 new MCP tools for policy enforcement.
 
 ## Prerequisites
 
@@ -885,6 +885,69 @@ async def main():
 asyncio.run(main())
 ```
 
+
+## Policy Enforcement via Threat Defense
+
+DNS-AID can compile policy documents into Infoblox Threat Defense named lists,
+enforcing agent access control at the DNS layer.
+
+### Step 1: Write a Policy Document
+
+```json
+{
+  "version": "1.0",
+  "agent": "_inventory._mcp._agents.example.com",
+  "rules": {
+    "allowed_caller_domains": ["ai-platform.example.com"],
+    "blocked_caller_domains": ["*.sandbox.example.com"],
+    "cel_rules": [
+      {
+        "id": "block-shadow",
+        "expression": "!request.caller_domain.endsWith(\".shadow.example.com\")",
+        "effect": "deny",
+        "enforcement_layers": ["layer0", "layer1"]
+      }
+    ]
+  }
+}
+```
+
+### Step 2: Shadow Mode (Safe Dry Run)
+
+```bash
+dns-aid enforce -d example.com -p policy.json --mode shadow
+```
+
+This shows what WOULD be blocked without making any changes.
+
+### Step 3: Monitor Mode (Log Without Blocking)
+
+```bash
+dns-aid enforce -d example.com -p policy.json \
+  --mode enforce -b infoblox --td-action action_log
+```
+
+This pushes a named list to Infoblox TD and binds it with `action_log` —
+matching queries are logged but not blocked. Check TD dashboards to see matches.
+
+### Step 4: Enforce (Block Unauthorized Callers)
+
+```bash
+dns-aid enforce -d example.com -p policy.json \
+  --mode enforce -b infoblox --td-action action_block
+```
+
+Blocked domains now receive NXDOMAIN from Threat Defense.
+
+### How CEL Rules Work
+
+CEL expressions that match domain patterns compile to DNS zone entries:
+- `!request.caller_domain.endsWith(".shadow.example.com")` → TD named list entry `*.shadow.example.com` → NXDOMAIN
+
+Complex CEL (trust scores, tool restrictions) can't be expressed in DNS and is
+enforced at runtime by the Rust CEL evaluator (~2µs per rule) in the caller SDK.
+
+See [Nordstrom POC](nordstrom-poc.md) for a detailed enforcement architecture.
 
 ## JWS Signatures
 

--- a/docs/nordstrom-poc.md
+++ b/docs/nordstrom-poc.md
@@ -1,0 +1,442 @@
+# Nordstrom DNS-AID POC — Discovery → Policy → Threat Defense
+
+## The Problem
+
+Nordstrom has a "wild west" of internal AI agents across many teams. No standard way to:
+- **Inventory** what agents exist (including shadow agents)
+- **Tie agents** to owners, capabilities, and policies
+- **Enforce controls** on who can call what
+
+## The Solution: DNS-AID + Infoblox Threat Defense
+
+DNS-AID adds a control plane layer using existing DNS infrastructure (BloxOne UDDI).
+Agents publish their identity and policies to DNS. Threat Defense enforces them.
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                        NORDSTROM AI CONTROL PLANE                       │
+│                                                                         │
+│  ┌─────────────┐    ┌──────────────┐    ┌─────────────────────────────┐ │
+│  │   PUBLISH    │    │   DISCOVER   │    │         ENFORCE             │ │
+│  │             │    │              │    │                             │ │
+│  │ Teams publish│───▶│ dns-aid finds│───▶│ Policy compiled to TD      │ │
+│  │ agents to   │    │ ALL agents   │    │ named list + security      │ │
+│  │ DNS via SVCB│    │ (incl shadow)│    │ policy = NXDOMAIN          │ │
+│  └─────────────┘    └──────────────┘    └─────────────────────────────┘ │
+│        │                   │                        │                   │
+│        ▼                   ▼                        ▼                   │
+│  BloxOne UDDI        DNS queries             BloxOne Threat Defense     │
+│  (SVCB records)      (zero infra cost)       (named lists + policies)  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Two MCP Servers — AI Agent Control + Full DDI Management
+
+The POC uses two MCP servers that work together in Claude Desktop (or any MCP-compatible AI agent):
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                         AI AGENT (Claude Desktop)                       │
+│                                                                         │
+│  "Discover all agents at nordstrom.com, compile the governance policy, │
+│   push to TD as action_log, then show me the security posture"         │
+│                                                                         │
+│         │                                    │                          │
+│         ▼                                    ▼                          │
+│  ┌──────────────────────┐     ┌──────────────────────────────────┐     │
+│  │   dns-aid MCP        │     │   infoblox-ddi MCP               │     │
+│  │   (15 tools)         │     │   (23 intent-level tools)        │     │
+│  │                      │     │                                  │     │
+│  │ • discover_agents    │     │ • manage_security_policy         │     │
+│  │ • compile_policy     │     │   (CRUD named lists, policies)   │     │
+│  │ • publish_rpz_zone   │     │ • assess_security_posture        │     │
+│  │   (push + bind to TD)│     │ • investigate_threat             │     │
+│  │ • list_rpz_rules     │     │ • explore_network                │     │
+│  │ • list_td_policies   │     │ • provision_dns / provision_host │     │
+│  │ • publish_agent      │     │ • diagnose_dns                   │     │
+│  │ • verify_agent       │     │ • check_infrastructure_health    │     │
+│  └──────────┬───────────┘     └──────────────┬───────────────────┘     │
+│             │                                │                          │
+│             └────────────┬───────────────────┘                          │
+│                          ▼                                              │
+│               ┌─────────────────────┐                                   │
+│               │  BloxOne CSP API    │                                   │
+│               │  /api/atcfw/v1/     │  TD: named lists, policies        │
+│               │  /api/ddi/v1/       │  DDI: DNS, DHCP, IPAM            │
+│               └─────────────────────┘                                   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**dns-aid MCP** handles the agent lifecycle:
+- Publish/discover agents via DNS
+- Compile policies (CEL + native rules) to TD format
+- Push named lists + bind to TD security policies
+- All TD actions: `action_block`, `action_log`, `action_allow`, `action_redirect`
+
+**infoblox-ddi MCP** handles full infrastructure:
+- DDI management (DNS zones, IPAM, DHCP)
+- Security posture assessment
+- Threat investigation
+- Named list CRUD with incremental `add_items`/`remove_items`
+
+## End-to-End Demo Script (Claude Desktop)
+
+### Demo 1: Discovery — "What agents do we have?"
+
+Prompt to Claude Desktop:
+> "Use dns-aid to discover all agents at highvelocitynetworking.com. Show me a summary."
+
+Claude uses: `discover_agents_via_dns("highvelocitynetworking.com")`
+
+Expected output: 13 agents with names, protocols, endpoints, capabilities.
+
+### Demo 2: Policy Compilation — "What would we enforce?"
+
+Prompt:
+> "Compile this governance policy and show me what gets enforced at DNS vs SDK layer:"
+> (paste nordstrom-agent-governance.json)
+
+Claude uses: `compile_policy_to_rpz(policy_json, format="both")`
+
+Expected: 8 RPZ directives (Layer 0), 10 bind-aid directives, 10 skipped (Layer 1/2).
+
+### Demo 3: Monitor Mode — "Start logging without blocking"
+
+Prompt:
+> "Push this policy to Infoblox TD as action_log so we can monitor matches before blocking. Use rpz zone name rpz.nordstrom-poc."
+
+Claude uses: `publish_rpz_zone(policy_json, backend="infoblox", rpz_zone="rpz.nordstrom-poc", td_action="action_log")`
+
+Expected: Named list created, bound to Default Global Policy as `action_log`.
+
+### Demo 4: Verify — "What's in TD now?"
+
+Prompt:
+> "Show me what TD security policies exist and what named lists we have for rpz.nordstrom-poc"
+
+Claude uses:
+- `list_td_security_policies()` → shows policies
+- `list_rpz_rules("rpz.nordstrom-poc", backend="infoblox")` → shows named list
+
+Then ask infoblox-ddi MCP:
+> "Use Infoblox DDI to assess the current security posture"
+
+Claude uses: `assess_security_posture()` → shows TD health including our new named list
+
+### Demo 5: Enforce — "Go live"
+
+Prompt:
+> "Change the TD action from action_log to action_block for rpz.nordstrom-poc"
+
+Claude uses: `publish_rpz_zone(policy_json, backend="infoblox", rpz_zone="rpz.nordstrom-poc", td_action="action_block")`
+
+Expected: Named list updated, policy rule changed to `action_block`. Blocked domains now get NXDOMAIN.
+
+### Demo 6: Full DDI Context
+
+Prompt to infoblox-ddi MCP:
+> "Show me all DNS zones and named lists related to nordstrom"
+
+Claude uses: `explore_network()` + `manage_security_policy(resource_type="named_list", action="list")`
+
+This shows the full DDI context — DNS zones, security policies, named lists — alongside the DNS-AID agent control plane.
+
+## One-Command Enforcement (CLI)
+
+```bash
+# Shadow mode — see what WOULD be blocked (safe to run anytime)
+dns-aid enforce \
+  -d nordstrom.com \
+  -p policy.json \
+  --mode shadow
+
+# Monitor mode — log matches without blocking (recommended first step)
+dns-aid enforce \
+  -d nordstrom.com \
+  -p policy.json \
+  --mode enforce \
+  -b infoblox \
+  --td-action action_log
+
+# Enforce mode — blocked domains get NXDOMAIN from Threat Defense
+dns-aid enforce \
+  -d nordstrom.com \
+  -p policy.json \
+  --mode enforce \
+  -b infoblox \
+  --td-action action_block
+
+# Target a specific TD policy (not default)
+dns-aid enforce \
+  -d nordstrom.com \
+  -p policy.json \
+  --mode enforce \
+  -b infoblox \
+  --td-action action_block \
+  --td-policy-id 224296
+```
+
+## Policy Document (What Alex's Team Writes)
+
+```json
+{
+  "version": "1.0",
+  "agent": "_inventory._mcp._agents.nordstrom.com",
+  "rules": {
+    "allowed_caller_domains": [
+      "ai-platform.nordstrom.com",
+      "ml-ops.nordstrom.com",
+      "data-eng.nordstrom.com"
+    ],
+    "blocked_caller_domains": [
+      "*.personal-dev.nordstrom.com",
+      "*.sandbox.nordstrom.com"
+    ],
+    "required_protocols": ["mcp"],
+    "required_auth_types": ["oauth2"],
+
+    "cel_rules": [
+      {
+        "id": "block-shadow-agents",
+        "expression": "!request.caller_domain.endsWith(\".shadow.nordstrom.com\")",
+        "effect": "deny",
+        "message": "Block unregistered shadow agents",
+        "enforcement_layers": ["layer0", "layer1"]
+      },
+      {
+        "id": "require-prod-trust",
+        "expression": "request.caller_trust_score >= 0.8",
+        "effect": "deny",
+        "message": "Production agents require high trust",
+        "enforcement_layers": ["layer1"]
+      },
+      {
+        "id": "restrict-pii-tools",
+        "expression": "!(request.tool_name in [\"export_customer_data\", \"bulk_pii_extract\"])",
+        "effect": "deny",
+        "message": "PII-sensitive tools restricted",
+        "enforcement_layers": ["layer1", "layer2"]
+      }
+    ]
+  }
+}
+```
+
+## How CEL Rules Enforce Across Layers
+
+One CEL expression, multiple enforcement points:
+
+```
+CEL Rule: "block-shadow-agents"
+Expression: !request.caller_domain.endsWith(".shadow.nordstrom.com")
+Effect: deny
+Layers: [layer0, layer1]
+
+                    ┌──────────────────────────────────────────────┐
+                    │          PolicyCompiler.compile()             │
+                    │                                              │
+                    │  "Can DNS enforce this expression?"          │
+                    │  Pattern: !endsWith(".shadow.nordstrom.com") │
+                    │  → YES: domain-based, simple pattern         │
+                    └──────────┬───────────────────────────────────┘
+                               │
+              ┌────────────────┴────────────────┐
+              │                                 │
+   ┌──────────▼──────────────┐   ┌─────────────▼───────────────────┐
+   │  Layer 0: Threat Defense│   │  Layer 1: Caller SDK (runtime)  │
+   │                         │   │                                 │
+   │  TD Named List:         │   │  CEL Evaluator (Rust, ~2µs):    │
+   │  *.shadow.nordstrom.com │   │  Evaluates full expression      │
+   │  → NXDOMAIN             │   │  against live PolicyContext      │
+   │                         │   │                                 │
+   │  Enforced BEFORE the    │   │  Enforced even if DNS           │
+   │  agent is reachable     │   │  is bypassed (direct IP)        │
+   └─────────────────────────┘   └─────────────────────────────────┘
+
+
+CEL Rule: "require-prod-trust"
+Expression: request.caller_trust_score >= 0.8
+Effect: deny
+Layers: [layer1]
+
+                    ┌──────────────────────────────────────────────┐
+                    │          PolicyCompiler.compile()             │
+                    │                                              │
+                    │  "Can DNS enforce this expression?"          │
+                    │  Pattern: trust_score comparison             │
+                    │  → NO: DNS can't evaluate trust scores       │
+                    │  → SKIPPED at Layer 0                        │
+                    └──────────┬───────────────────────────────────┘
+                               │
+              ┌────────────────┴────────────────┐
+              │                                 │
+   ┌──────────▼──────────────┐   ┌─────────────▼───────────────────┐
+   │  Layer 0: TD            │   │  Layer 1: Caller SDK (runtime)  │
+   │                         │   │                                 │
+   │  (skipped — DNS can't   │   │  CEL Evaluator (Rust, ~2µs):    │
+   │   evaluate trust scores)│   │  caller_trust_score=0.3         │
+   │                         │   │  → 0.3 >= 0.8 = false           │
+   │                         │   │  → effect=deny → BLOCKED        │
+   └─────────────────────────┘   └─────────────────────────────────┘
+```
+
+## What Gets Enforced Where
+
+| Policy Rule | Infoblox TD (Layer 0) | Caller SDK (Layer 1) | Target (Layer 2) |
+|---|---|---|---|
+| `blocked_caller_domains` | **Named list → NXDOMAIN** | — | — |
+| `allowed_caller_domains` | **Named list → allow + catch-all block** | — | — |
+| `required_protocols` | — | **CEL evaluator** | — |
+| `required_auth_types` | — | **CEL evaluator** | — |
+| CEL `endsWith` (domain) | **Named list → NXDOMAIN** | **CEL evaluator** | — |
+| CEL `trust_score >= 0.8` | — (can't express in DNS) | **CEL evaluator** | — |
+| CEL `tool_name in [...]` | — (can't express in DNS) | **CEL evaluator** | **CEL evaluator** |
+
+## Deployment Path for Nordstrom
+
+### Phase 1: Publish (Week 1)
+```bash
+# Alex's teams publish their agents to BloxOne UDDI
+dns-aid publish \
+  -n inventory-agent \
+  -d nordstrom.com \
+  -p mcp \
+  -e inventory.ai-platform.nordstrom.com \
+  --policy-uri https://policies.nordstrom.com/inventory-agent.json \
+  -b infoblox
+
+# Also publish via NS1 for external DNS
+dns-aid publish -n public-api -d nordstrom.com -p mcp -b ns1
+```
+
+### Phase 2: Discover + Audit (Week 1-2)
+```bash
+# See ALL agents across the org (including shadow agents)
+dns-aid discover nordstrom.com --json
+
+# Shadow enforce — see what WOULD be blocked
+dns-aid enforce -d nordstrom.com -p governance-policy.json --mode shadow
+```
+
+### Phase 3: Monitor (Week 2-3)
+```bash
+# action_log — TD logs matches but doesn't block
+dns-aid enforce \
+  -d nordstrom.com \
+  -p governance-policy.json \
+  --mode enforce \
+  -b infoblox \
+  --td-action action_log
+```
+
+### Phase 4: Enforce (Week 3+)
+```bash
+# action_block — unauthorized callers get NXDOMAIN
+dns-aid enforce \
+  -d nordstrom.com \
+  -p governance-policy.json \
+  --mode enforce \
+  -b infoblox \
+  --td-action action_block
+```
+
+### Phase 5: Auto-policy (Future)
+```bash
+# Each agent publishes its own policy_uri in SVCB
+# Enforce fetches ALL policies from DNS and compiles them
+dns-aid enforce -d nordstrom.com --auto-policy --mode enforce -b infoblox
+```
+
+## Before / After
+
+### Before DNS-AID
+- 47+ AI agents across 12 teams
+- No central inventory
+- Shadow agents unknown to security
+- No policy enforcement
+- CISO has no visibility into agent-to-agent communication
+
+### After DNS-AID + Threat Defense
+- Every agent published to DNS with owner, capabilities, policy
+- `dns-aid discover` shows the full inventory in seconds
+- Shadow agents detected by crawling (Phase 8)
+- Policy compiled to TD named lists — unauthorized callers get NXDOMAIN
+- CISO dashboard: TD security policy shows all blocked domains
+- AI agents (Claude Desktop) can manage the entire pipeline via MCP
+- Path to CSP Asset Insights integration (agent inventory in BloxOne)
+
+## External DNS: NS1
+
+Nordstrom uses NS1 for external DNS. DNS-AID supports NS1 natively (shipped v0.16.0):
+
+```bash
+# Publish to NS1 for external discovery
+dns-aid publish -n public-api -d nordstrom.com -p mcp -b ns1
+
+# Publish to BloxOne for internal + policy enforcement
+dns-aid publish -n public-api -d nordstrom.com -p mcp -b infoblox
+```
+
+Both backends produce the same SVCB records. External agents discover via NS1.
+Internal policy enforcement happens via BloxOne TD.
+
+## Architecture: Three Interfaces + Two MCP Servers
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                        DNS-AID                               │
+│                                                              │
+│  ┌─────────┐  ┌───────────────┐  ┌────────────────────────┐ │
+│  │   CLI   │  │  MCP Server   │  │     Python SDK         │ │
+│  │         │  │  (15 tools)   │  │                        │ │
+│  │ enforce │  │               │  │ PolicyCompiler()       │ │
+│  │ policy  │  │ compile_rpz   │  │ .compile(doc)          │ │
+│  │ compile │  │ publish_rpz   │  │                        │ │
+│  │ show    │  │ list_rpz      │  │ BloxOneBackend         │ │
+│  │ discover│  │ list_td_pol   │  │ .create_named_list()   │ │
+│  │ publish │  │ discover      │  │ .bind_to_policy()      │ │
+│  └─────────┘  └───────────────┘  └────────────────────────┘ │
+└──────────────────────┬───────────────────────────────────────┘
+                       │
+┌──────────────────────┼───────────────────────────────────────┐
+│  infoblox-ddi MCP    │            BloxOne CSP API            │
+│  (23 tools)          │                                       │
+│                      ▼                                       │
+│  manage_security ──▶ /api/atcfw/v1/ (TD: named lists,       │
+│  assess_posture     │               security policies)       │
+│  investigate       │                                        │
+│  explore_network ──▶ /api/ddi/v1/  (DDI: DNS, DHCP, IPAM)  │
+│  provision_dns     │                                        │
+│  diagnose_dns      │                                        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## TD Security Policy Actions
+
+| Action | Behavior | Use When |
+|---|---|---|
+| `action_log` | Log the query, allow it through | **Phase 3: Monitor** — see what would be blocked |
+| `action_block` | NXDOMAIN response | **Phase 4: Enforce** — block unauthorized callers |
+| `action_allow` | Explicit allow (override other blocks) | Whitelist trusted agents |
+| `action_redirect` | Redirect to a landing page | Show "this agent is blocked" page |
+
+## Key Numbers (from live testing)
+
+| Metric | Value |
+|---|---|
+| Policy compilation | 1.5ms for 1010 directives |
+| CEL evaluation (Rust) | ~2µs per rule |
+| TD named list push | ~500ms per API call |
+| TD security policy bind | ~500ms per API call |
+| Full enforce pipeline | ~7s (dominated by DNS discovery) |
+| Tests | 1191 core + 381 enterprise = 1572 total |
+
+## Verified Live Against Infoblox BloxOne TD
+
+- Created named list with blocked domains (HTTP 201)
+- Bound to Default Global Policy as `action_block` (HTTP 201)
+- Changed action to `action_log` (HTTP 201)
+- Verified list exists with correct item count
+- Unbound and cleaned up (HTTP 204)
+- Full round-trip: create → bind → verify → change action → unbind → delete
+- Both MCP servers tested from Claude Desktop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.16.0"
+version = "0.17.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/backends/infoblox/bloxone.py
+++ b/src/dns_aid/backends/infoblox/bloxone.py
@@ -630,6 +630,342 @@ class InfobloxBloxOneBackend(DNSBackend):
 
         return zones
 
+    # ------------------------------------------------------------------
+    # BloxOne Threat Defense — Named List RPZ operations
+    # ------------------------------------------------------------------
+
+    TD_API_VERSION = "/api/atcfw/v1"
+
+    async def _td_request(
+        self,
+        method: str,
+        endpoint: str,
+        json: dict | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        """Make a request to the BloxOne Threat Defense API.
+
+        Uses ``/api/atcfw/v1`` base path instead of the DDI ``/api/ddi/v1``.
+        """
+        client = await self._get_client()
+        url = f"{self.TD_API_VERSION}{endpoint}"
+
+        logger.debug("BloxOne TD API request", method=method, url=url, params=params)
+
+        response = await client.request(method=method, url=url, json=json, params=params)
+
+        logger.debug("BloxOne TD API response", status=response.status_code, url=url)
+
+        response.raise_for_status()
+
+        if response.status_code == 204:
+            return {}
+
+        return response.json()
+
+    async def create_or_update_named_list(
+        self,
+        name: str,
+        items: list[str],
+        description: str = "",
+        confidence_level: str = "HIGH",
+    ) -> dict:
+        """Create or update a named list in BloxOne Threat Defense.
+
+        Named lists are used for RPZ-style blocking in BloxOne TD.
+        Each list contains domain names that trigger a policy action.
+
+        Args:
+            name: Named list name (e.g., ``dns-aid-rpz-blocked``).
+            items: List of domain names to include.
+            description: Human-readable description.
+            confidence_level: Confidence level — HIGH, MEDIUM, LOW.
+
+        Returns:
+            Dict with ``id`` and ``name`` of the created/updated list.
+        """
+        # Check if named list already exists by listing and filtering locally
+        # (TD API does not support DDI-style _filter on GET /named_lists)
+        all_lists = await self._td_request("GET", "/named_lists")
+        existing_list = None
+        for nl in all_lists.get("results", []):
+            if nl.get("name") == name:
+                existing_list = nl
+                break
+
+        # Build items_described with per-item descriptions
+        items_described = [
+            {"item": item, "description": description or "DNS-AID policy"} for item in items
+        ]
+
+        payload = {
+            "name": name,
+            "type": "custom_list",
+            "items_described": items_described,
+            "description": description or f"DNS-AID managed named list: {name}",
+            "confidence_level": confidence_level,
+        }
+
+        if existing_list:
+            list_id = existing_list["id"]
+            logger.info(
+                "Updating BloxOne TD named list",
+                name=name,
+                list_id=list_id,
+                item_count=len(items),
+            )
+            await self._td_request(
+                "PUT",
+                f"/named_lists/{list_id}",
+                json=payload,
+            )
+            return {"id": list_id, "name": name, "updated": True}
+        else:
+            logger.info(
+                "Creating BloxOne TD named list",
+                name=name,
+                item_count=len(items),
+            )
+            resp = await self._td_request(
+                "POST",
+                "/named_lists",
+                json=payload,
+            )
+            result = resp.get("results", resp)
+            return {
+                "id": result.get("id", ""),
+                "name": name,
+                "updated": False,
+            }
+
+    async def list_named_lists(
+        self,
+        name_filter: str | None = None,
+    ) -> list[dict]:
+        """List named lists in BloxOne Threat Defense.
+
+        Args:
+            name_filter: Optional name filter (exact match).
+
+        Returns:
+            List of named list dicts with id, name, item_count, etc.
+        """
+        response = await self._td_request("GET", "/named_lists")
+
+        named_lists = []
+        for nl in response.get("results", []):
+            if name_filter and nl.get("name") != name_filter:
+                continue
+            named_lists.append(
+                {
+                    "id": nl.get("id"),
+                    "name": nl.get("name"),
+                    "type": nl.get("type"),
+                    "item_count": nl.get("item_count", 0),
+                    "description": nl.get("description", ""),
+                    "confidence_level": nl.get("confidence_level", ""),
+                }
+            )
+
+        return named_lists
+
+    async def delete_named_list(self, list_id: str) -> bool:
+        """Delete a named list from BloxOne Threat Defense.
+
+        Args:
+            list_id: The named list ID.
+
+        Returns:
+            True if deleted.
+        """
+        await self._td_request("DELETE", f"/named_lists/{list_id}")
+        logger.info("Deleted BloxOne TD named list", list_id=list_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # BloxOne Threat Defense — Security Policy operations
+    # ------------------------------------------------------------------
+
+    async def list_security_policies(self) -> list[dict]:
+        """List all TD security policies.
+
+        Returns:
+            List of policy dicts with id, name, description, rule_count, is_default.
+        """
+        response = await self._td_request("GET", "/security_policies")
+        policies = []
+        for p in response.get("results", []):
+            policies.append(
+                {
+                    "id": p.get("id"),
+                    "name": p.get("name"),
+                    "description": p.get("description", ""),
+                    "rule_count": len(p.get("rules", [])),
+                    "is_default": p.get("is_default", False),
+                }
+            )
+        return policies
+
+    async def get_security_policy(self, policy_id: int) -> dict:
+        """Get a security policy by ID.
+
+        Args:
+            policy_id: The security policy ID.
+
+        Returns:
+            Full policy dict with rules and metadata.
+        """
+        response = await self._td_request("GET", f"/security_policies/{policy_id}")
+        return response.get("results", response)
+
+    async def bind_named_list_to_policy(
+        self,
+        named_list_name: str,
+        policy_id: int | None = None,
+        action: str = "action_block",
+    ) -> dict:
+        """Add a named list as a block/allow rule in a TD security policy.
+
+        If ``policy_id`` is None, uses the default global policy.
+
+        Args:
+            named_list_name: Name of the named list to bind.
+            policy_id: Security policy ID. None = default global policy.
+            action: TD action — ``action_block``, ``action_allow``, ``action_redirect``.
+
+        Returns:
+            Dict with policy_id, rule_count, and status.
+        """
+        # Find default policy if not specified
+        if policy_id is None:
+            policies = await self.list_security_policies()
+            default = next((p for p in policies if p["is_default"]), None)
+            if not default:
+                raise ValueError("No default security policy found. Specify --td-policy-id.")
+            policy_id = default["id"]
+            logger.info(
+                "td.using_default_policy",
+                policy_id=policy_id,
+                policy_name=default["name"],
+            )
+
+        # Get current policy
+        policy = await self.get_security_policy(policy_id)
+        original_rules = policy.get("rules", [])
+
+        # Check if rule already exists — same name AND same action
+        for rule in original_rules:
+            if rule.get("data") == named_list_name and rule.get("action") == action:
+                logger.info(
+                    "td.rule_already_exists",
+                    named_list=named_list_name,
+                    policy_id=policy_id,
+                )
+                return {
+                    "policy_id": policy_id,
+                    "policy_name": policy.get("name"),
+                    "rule_count": len(original_rules),
+                    "action": "already_bound",
+                }
+
+        # Remove any existing rules for this named list (action may have changed)
+        # e.g., switching from action_log → action_block
+        cleaned_rules = [r for r in original_rules if r.get("data") != named_list_name]
+        if len(cleaned_rules) < len(original_rules):
+            logger.info(
+                "td.replacing_rule",
+                named_list=named_list_name,
+                old_count=len(original_rules),
+                new_count=len(cleaned_rules),
+            )
+
+        # Prepend our rule (evaluated first)
+        new_rule = {"action": action, "data": named_list_name, "type": "custom_list"}
+        updated_rules = [new_rule] + cleaned_rules
+
+        update_payload = {
+            "name": policy["name"],
+            "description": policy.get("description", ""),
+            "default_action": policy.get("default_action", "action_allow"),
+            "rules": updated_rules,
+        }
+
+        await self._td_request("PUT", f"/security_policies/{policy_id}", json=update_payload)
+
+        logger.info(
+            "td.rule_bound",
+            named_list=named_list_name,
+            policy_id=policy_id,
+            policy_name=policy.get("name"),
+            action=action,
+            rule_count=len(updated_rules),
+        )
+
+        return {
+            "policy_id": policy_id,
+            "policy_name": policy.get("name"),
+            "rule_count": len(updated_rules),
+            "action": "bound",
+        }
+
+    async def unbind_named_list_from_policy(
+        self,
+        named_list_name: str,
+        policy_id: int | None = None,
+    ) -> dict:
+        """Remove a named list rule from a TD security policy.
+
+        Args:
+            named_list_name: Name of the named list to unbind.
+            policy_id: Security policy ID. None = default global policy.
+
+        Returns:
+            Dict with policy_id, rule_count, and status.
+        """
+        if policy_id is None:
+            policies = await self.list_security_policies()
+            default = next((p for p in policies if p["is_default"]), None)
+            if not default:
+                raise ValueError("No default security policy found.")
+            policy_id = default["id"]
+
+        policy = await self.get_security_policy(policy_id)
+        original_rules = policy.get("rules", [])
+
+        # Remove rules matching our named list
+        filtered_rules = [r for r in original_rules if r.get("data") != named_list_name]
+
+        if len(filtered_rules) == len(original_rules):
+            return {
+                "policy_id": policy_id,
+                "policy_name": policy.get("name"),
+                "rule_count": len(original_rules),
+                "action": "not_found",
+            }
+
+        update_payload = {
+            "name": policy["name"],
+            "description": policy.get("description", ""),
+            "default_action": policy.get("default_action", "action_allow"),
+            "rules": filtered_rules,
+        }
+
+        await self._td_request("PUT", f"/security_policies/{policy_id}", json=update_payload)
+
+        logger.info(
+            "td.rule_unbound",
+            named_list=named_list_name,
+            policy_id=policy_id,
+            removed=len(original_rules) - len(filtered_rules),
+        )
+
+        return {
+            "policy_id": policy_id,
+            "policy_name": policy.get("name"),
+            "rule_count": len(filtered_rules),
+            "action": "unbound",
+        }
+
     async def __aenter__(self):
         """Async context manager entry."""
         return self

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -667,6 +667,205 @@ class InfobloxNIOSBackend(DNSBackend):
 
         return zones
 
+    # ------------------------------------------------------------------
+    # RPZ (Response Policy Zone) operations
+    # ------------------------------------------------------------------
+
+    _RPZ_CNAME_TARGETS: dict[str, str] = {
+        "NXDOMAIN": "",  # canonical_name = empty → NXDOMAIN
+        "NODATA": "",
+        "PASSTHRU": "",
+        "DROP": "",
+    }
+
+    async def create_rpz_cname_record(
+        self,
+        rpz_zone: str,
+        owner: str,
+        action: str,
+        comment: str = "",
+    ) -> str:
+        """Create an RPZ CNAME record in NIOS.
+
+        NIOS WAPI object: ``record:rpz:cname``
+
+        The ``canonical`` field encodes the RPZ action:
+          - NXDOMAIN: empty canonical
+          - PASSTHRU: canonical = owner (identity CNAME)
+          - NODATA:   NIOS uses record:rpz:cname:clientipaddress with empty rdata
+          - DROP:     NIOS uses rpz-drop. target
+
+        For simplicity we map everything through the ``rp_zone`` and
+        ``canonical`` fields which NIOS interprets as RPZ directives.
+
+        Args:
+            rpz_zone: The RPZ zone FQDN (e.g., ``rpz.example.com``).
+            owner: The trigger name (e.g., ``evil.com``).
+            action: RPZ action — NXDOMAIN, PASSTHRU, DROP.
+            comment: Audit comment for the record.
+
+        Returns:
+            The owner FQDN that was created/updated.
+        """
+        action_upper = action.upper()
+
+        # Build the full owner name within the RPZ zone
+        fqdn = f"{owner}.{rpz_zone}" if not owner.endswith(f".{rpz_zone}") else owner
+
+        # Determine canonical name based on action
+        if action_upper == "PASSTHRU":
+            canonical = owner  # identity CNAME = passthru
+        else:
+            canonical = ""  # empty = NXDOMAIN (NIOS default for RPZ CNAME)
+
+        # Check for existing record
+        params = {
+            "name": fqdn,
+            "zone": rpz_zone,
+        }
+        existing = await self._request("GET", "record:rpz:cname", params=params)
+
+        mutable: dict[str, Any] = {
+            "canonical": canonical,
+            "comment": comment or f"DNS-AID RPZ: {action_upper} {owner}",
+        }
+
+        if isinstance(existing, list) and existing:
+            ref = existing[0].get("_ref")
+            if ref:
+                logger.info(
+                    "Updating RPZ CNAME record in NIOS",
+                    fqdn=fqdn,
+                    action=action_upper,
+                    ref=ref,
+                )
+                await self._request("PUT", ref, json=mutable)
+                return fqdn
+
+        # Create new record
+        payload: dict[str, Any] = {
+            "name": fqdn,
+            "rp_zone": rpz_zone,
+            "canonical": canonical,
+            "comment": comment or f"DNS-AID RPZ: {action_upper} {owner}",
+        }
+        logger.info(
+            "Creating RPZ CNAME record in NIOS",
+            fqdn=fqdn,
+            action=action_upper,
+        )
+        await self._request("POST", "record:rpz:cname", json=payload)
+        return fqdn
+
+    async def delete_rpz_cname_record(
+        self,
+        rpz_zone: str,
+        owner: str,
+    ) -> bool:
+        """Delete an RPZ CNAME record from NIOS.
+
+        Args:
+            rpz_zone: The RPZ zone FQDN.
+            owner: The trigger name to delete.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        fqdn = f"{owner}.{rpz_zone}" if not owner.endswith(f".{rpz_zone}") else owner
+        params = {
+            "name": fqdn,
+            "zone": rpz_zone,
+        }
+        existing = await self._request("GET", "record:rpz:cname", params=params)
+
+        if not isinstance(existing, list) or not existing:
+            return False
+
+        ref = existing[0].get("_ref")
+        if not ref:
+            return False
+
+        await self._request("DELETE", ref)
+        logger.info("Deleted RPZ CNAME record from NIOS", fqdn=fqdn)
+        return True
+
+    async def list_rpz_cname_records(
+        self,
+        rpz_zone: str,
+    ) -> list[dict[str, Any]]:
+        """List all RPZ CNAME records in an RPZ zone.
+
+        Args:
+            rpz_zone: The RPZ zone FQDN.
+
+        Returns:
+            List of RPZ records with name, canonical, and comment.
+        """
+        params = {
+            "zone": rpz_zone,
+            "_return_fields": "name,canonical,comment,disable",
+        }
+        results = await self._request("GET", "record:rpz:cname", params=params)
+
+        if not isinstance(results, list):
+            return []
+
+        records: list[dict[str, Any]] = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            name = str(r.get("name", ""))
+            canonical = str(r.get("canonical", ""))
+
+            # Infer action from canonical
+            if not canonical:
+                action = "NXDOMAIN"
+            elif canonical == name.removesuffix(f".{rpz_zone}"):
+                action = "PASSTHRU"
+            else:
+                action = "NXDOMAIN"  # fallback
+
+            records.append(
+                {
+                    "owner": name.removesuffix(f".{rpz_zone}"),
+                    "fqdn": name,
+                    "action": action,
+                    "canonical": canonical,
+                    "comment": r.get("comment", ""),
+                    "disabled": bool(r.get("disable", False)),
+                }
+            )
+
+        return records
+
+    async def ensure_rpz_zone(self, rpz_zone: str) -> bool:
+        """Ensure an RPZ zone exists in NIOS, creating it if needed.
+
+        Args:
+            rpz_zone: The RPZ zone FQDN.
+
+        Returns:
+            True if the zone exists or was created.
+        """
+        params = {
+            "fqdn": rpz_zone,
+        }
+        existing = await self._request("GET", "zone_rp", params=params)
+
+        if isinstance(existing, list) and existing:
+            logger.debug("RPZ zone exists in NIOS", rpz_zone=rpz_zone)
+            return True
+
+        # Create the RPZ zone
+        payload = {
+            "fqdn": rpz_zone,
+            "rpz_policy": "GIVEN",  # Use explicit records (not policy override)
+            "comment": "DNS-AID managed RPZ zone",
+        }
+        logger.info("Creating RPZ zone in NIOS", rpz_zone=rpz_zone)
+        await self._request("POST", "zone_rp", json=payload)
+        return True
+
     # publish_agent() inherited from base class — passes ALL SVCB params
     # natively since supports_private_svcb_keys = True.
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -1286,6 +1286,490 @@ def main(
 
 
 # ============================================================================
+# POLICY COMMANDS
+# ============================================================================
+
+policy_app = typer.Typer(
+    name="policy",
+    help="Compile and manage policy enforcement zones",
+    no_args_is_help=True,
+)
+app.add_typer(policy_app, name="policy")
+
+
+@policy_app.command("compile")
+def policy_compile(
+    input_file: Annotated[
+        str,
+        typer.Option("--input", "-i", help="Path to policy document JSON file"),
+    ],
+    output_file: Annotated[
+        str,
+        typer.Option("--output", "-o", help="Output zone file path"),
+    ],
+    format: Annotated[
+        str,
+        typer.Option("--format", "-f", help="Output format: rpz, bindaid, or both"),
+    ] = "both",
+):
+    """
+    Compile a policy document to RPZ and/or bind-aid zone files.
+
+    Reads a PolicyDocument JSON file and produces DNS zone files that can be
+    loaded into RPZ-capable resolvers or Ingmar's bind-aid fork.
+
+    Example:
+        dns-aid policy compile -i policy.json -o /tmp/zone.rpz -f rpz
+        dns-aid policy compile -i policy.json -o /tmp/zone -f both
+    """
+    import json
+    from pathlib import Path
+
+    from dns_aid.sdk.policy.bindaid_writer import write_bindaid_zone
+    from dns_aid.sdk.policy.compiler import PolicyCompiler
+    from dns_aid.sdk.policy.rpz_writer import write_rpz_zone
+    from dns_aid.sdk.policy.schema import PolicyDocument
+
+    if format not in ("rpz", "bindaid", "both"):
+        error_console.print("[red]✗ --format must be rpz, bindaid, or both[/red]")
+        raise typer.Exit(1)
+
+    input_path = Path(input_file)
+    if not input_path.exists():
+        error_console.print(f"[red]✗ Input file not found: {input_file}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        raw = input_path.read_text()
+        doc = PolicyDocument.model_validate(json.loads(raw))
+    except Exception as e:
+        error_console.print(f"[red]✗ Failed to parse policy document: {e}[/red]")
+        raise typer.Exit(1) from None
+
+    compiler = PolicyCompiler()
+    result = compiler.compile(doc)
+
+    output_path = Path(output_file)
+
+    if format in ("rpz", "both"):
+        rpz_path = output_path if format == "rpz" else output_path.with_suffix(".rpz")
+        zone_name = f"rpz.{doc.agent.split('.')[-2]}.policy"
+        rpz_content = write_rpz_zone(result, zone_name)
+        rpz_path.write_text(rpz_content)
+        console.print(f"[green]✓ RPZ zone written to {rpz_path}[/green]")
+        console.print(f"  {len(result.rpz_directives)} directive(s)")
+
+    if format in ("bindaid", "both"):
+        ba_path = output_path if format == "bindaid" else output_path.with_suffix(".bindaid")
+        zone_name = f"policy.{doc.agent.split('.')[-2]}.bindaid"
+        ba_content = write_bindaid_zone(result, zone_name)
+        ba_path.write_text(ba_content)
+        console.print(f"[green]✓ bind-aid zone written to {ba_path}[/green]")
+        console.print(f"  {len(result.bindaid_directives)} directive(s)")
+
+    if result.skipped:
+        console.print(
+            f"\n[yellow]⚠ {len(result.skipped)} rule(s) skipped (Layer 1/2 only):[/yellow]"
+        )
+        for s in result.skipped:
+            console.print(f"  • {s.rule_name}: {s.reason}")
+
+
+@policy_app.command("show")
+def policy_show(
+    input_file: Annotated[
+        str,
+        typer.Option("--input", "-i", help="Path to policy document JSON file"),
+    ],
+):
+    """
+    Show a compilation report for a policy document.
+
+    Displays which rules compile to RPZ/bind-aid and which are skipped.
+
+    Example:
+        dns-aid policy show -i policy.json
+    """
+    import json
+    from pathlib import Path
+
+    from dns_aid.sdk.policy.compiler import PolicyCompiler
+    from dns_aid.sdk.policy.schema import PolicyDocument
+
+    input_path = Path(input_file)
+    if not input_path.exists():
+        error_console.print(f"[red]✗ Input file not found: {input_file}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        raw = input_path.read_text()
+        doc = PolicyDocument.model_validate(json.loads(raw))
+    except Exception as e:
+        error_console.print(f"[red]✗ Failed to parse policy document: {e}[/red]")
+        raise typer.Exit(1) from None
+
+    compiler = PolicyCompiler()
+    result = compiler.compile(doc)
+
+    console.print("\n[bold]Policy Compilation Report[/bold]")
+    console.print(f"  Agent: {result.agent_fqdn}\n")
+
+    # RPZ directives
+    console.print(f"[bold]RPZ Directives ({len(result.rpz_directives)}):[/bold]")
+    if result.rpz_directives:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Owner")
+        table.add_column("Action")
+        table.add_column("Source Rule")
+        for d in result.rpz_directives:
+            table.add_row(d.owner, d.action.value, d.source_rule)
+        console.print(table)
+    else:
+        console.print("  [dim]None[/dim]")
+
+    # bind-aid directives
+    console.print(f"\n[bold]bind-aid Directives ({len(result.bindaid_directives)}):[/bold]")
+    if result.bindaid_directives:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Owner")
+        table.add_column("Action")
+        table.add_column("Param Ops")
+        table.add_column("Source Rule")
+        for d in result.bindaid_directives:
+            table.add_row(d.owner, d.action.value, ", ".join(d.param_ops) or "-", d.source_rule)
+        console.print(table)
+    else:
+        console.print("  [dim]None[/dim]")
+
+    # Skipped rules
+    console.print(f"\n[bold]Skipped Rules ({len(result.skipped)}):[/bold]")
+    if result.skipped:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Rule")
+        table.add_column("Reason")
+        for s in result.skipped:
+            table.add_row(s.rule_name, s.reason)
+        console.print(table)
+    else:
+        console.print("  [dim]None[/dim]")
+
+
+@app.command()
+def enforce(
+    domain: Annotated[str, typer.Option("--domain", "-d", help="Domain to enforce policy on")],
+    policy_file: Annotated[
+        str | None,
+        typer.Option("--policy-file", "-p", help="Path to policy document JSON file"),
+    ] = None,
+    auto_policy: Annotated[
+        bool,
+        typer.Option(
+            "--auto-policy",
+            help="Fetch policy documents from each agent's policy_uri (SVCB key65403)",
+        ),
+    ] = False,
+    backend: Annotated[
+        str | None,
+        typer.Option("--backend", "-b", help="DNS backend for RPZ publishing"),
+    ] = None,
+    rpz_zone: Annotated[
+        str | None,
+        typer.Option("--rpz-zone", help="RPZ zone name (default: rpz.{domain})"),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", "-f", help="Output format: rpz, bindaid, or both"),
+    ] = "both",
+    mode: Annotated[
+        str,
+        typer.Option("--mode", "-m", help="Enforcement mode: shadow (log only) or enforce (live)"),
+    ] = "shadow",
+    output_dir: Annotated[
+        str | None,
+        typer.Option("--output-dir", "-o", help="Write zone files to this directory"),
+    ] = None,
+    td_policy_id: Annotated[
+        int | None,
+        typer.Option(
+            "--td-policy-id",
+            help="Infoblox TD security policy ID to bind the named list to. "
+            "Default: auto-detect the default global policy.",
+        ),
+    ] = None,
+    td_action: Annotated[
+        str,
+        typer.Option(
+            "--td-action",
+            help="TD action: action_block (NXDOMAIN), action_log (monitor only), "
+            "action_redirect, action_allow",
+        ),
+    ] = "action_block",
+):
+    """
+    Full enforcement pipeline: discover → compile → write zone → push to backend.
+
+    Two policy modes:
+
+      --policy-file: Compile a single policy document against the domain.
+      --auto-policy: Discover agents, fetch each agent's policy_uri from DNS,
+                     and compile all policies into a merged RPZ zone.
+
+    Shadow mode (default) logs what would be blocked without pushing live.
+    Enforce mode pushes live RPZ rules and binds to TD security policy.
+
+    Example:
+        dns-aid enforce -d nordstrom.com --auto-policy --mode shadow
+        dns-aid enforce -d example.com -p policy.json --mode enforce -b infoblox
+        dns-aid enforce -d example.com -p policy.json --mode enforce -b infoblox --td-policy-id 224296
+    """
+    import json
+    from pathlib import Path
+
+    from dns_aid.sdk.policy.bindaid_writer import write_bindaid_zone
+    from dns_aid.sdk.policy.compiler import CompilationResult, PolicyCompiler
+    from dns_aid.sdk.policy.rpz_writer import write_rpz_zone
+    from dns_aid.sdk.policy.schema import PolicyDocument
+
+    if not policy_file and not auto_policy:
+        error_console.print("[red]✗ Provide --policy-file or --auto-policy[/red]")
+        raise typer.Exit(1)
+
+    if mode not in ("shadow", "enforce"):
+        error_console.print("[red]✗ --mode must be shadow or enforce[/red]")
+        raise typer.Exit(1)
+
+    if format not in ("rpz", "bindaid", "both"):
+        error_console.print("[red]✗ --format must be rpz, bindaid, or both[/red]")
+        raise typer.Exit(1)
+
+    zone = rpz_zone or f"rpz.{domain}"
+
+    console.print(f"\n[bold]Enforcing policy on {domain} (mode: {mode})...[/bold]\n")
+
+    # Step 1: Discover agents
+    from dns_aid.core.discoverer import discover as do_discover
+
+    console.print("[bold]Step 1:[/bold] Discovering agents...")
+    discovery_result = run_async(do_discover(domain=domain))
+    console.print(f"  Found {discovery_result.count} agent(s)")
+    agents_with_policy = [a for a in discovery_result.agents if a.policy_uri]
+    if agents_with_policy:
+        console.print(f"  Agents with policy_uri: {len(agents_with_policy)}")
+        for a in agents_with_policy:
+            console.print(f"    • {a.name} → {a.policy_uri}")
+    console.print()
+
+    # Step 2: Load and compile policies
+    compiler = PolicyCompiler()
+    doc = None  # used for BloxOne agent_fqdn reference
+
+    if auto_policy:
+        console.print("[bold]Step 2:[/bold] Fetching policies from agent policy_uri...")
+        if not agents_with_policy:
+            console.print("  [yellow]No agents have policy_uri set — nothing to compile[/yellow]")
+            console.print("  [dim]Publish agents with --policy-uri to enable auto-policy[/dim]\n")
+            raise typer.Exit(0)
+
+        import httpx
+
+        merged = CompilationResult(agent_fqdn=f"_merged._policy._agents.{domain}")
+        fetched, failed = 0, 0
+
+        for agent in agents_with_policy:
+            try:
+                console.print(f"  Fetching {agent.name}: {agent.policy_uri}")
+                resp = run_async(httpx.AsyncClient(timeout=10).get(agent.policy_uri))
+                resp.raise_for_status()
+                agent_doc = PolicyDocument.model_validate(json.loads(resp.text))
+                agent_result = compiler.compile(agent_doc)
+
+                # Merge directives
+                merged.rpz_directives.extend(agent_result.rpz_directives)
+                merged.bindaid_directives.extend(agent_result.bindaid_directives)
+                merged.skipped.extend(agent_result.skipped)
+                merged.warnings.extend(agent_result.warnings)
+                fetched += 1
+                console.print(
+                    f"    ✓ {len(agent_result.rpz_directives)} RPZ, "
+                    f"{len(agent_result.bindaid_directives)} bind-aid"
+                )
+            except Exception as exc:
+                failed += 1
+                console.print(f"    [yellow]⚠ Failed: {exc}[/yellow]")
+
+        # Deduplicate merged result
+        compiler._deduplicate(merged)
+        result = merged
+        doc = PolicyDocument(agent=merged.agent_fqdn)  # placeholder for BloxOne reference
+
+        console.print(f"\n  Fetched: {fetched}, Failed: {failed}")
+        console.print(
+            f"  Merged RPZ: {len(result.rpz_directives)}, bind-aid: {len(result.bindaid_directives)}"
+        )
+        console.print(f"  Skipped: {len(result.skipped)}\n")
+
+    else:
+        # Load from file
+        console.print("[bold]Step 2:[/bold] Compiling policy from file...")
+        policy_path = Path(policy_file)  # type: ignore[arg-type]
+        if not policy_path.exists():
+            error_console.print(f"[red]✗ Policy file not found: {policy_file}[/red]")
+            raise typer.Exit(1)
+
+        try:
+            raw = policy_path.read_text()
+            doc = PolicyDocument.model_validate(json.loads(raw))
+        except Exception as e:
+            error_console.print(f"[red]✗ Failed to parse policy document: {e}[/red]")
+            raise typer.Exit(1) from None
+
+        result = compiler.compile(doc)
+        console.print(f"  RPZ directives: {len(result.rpz_directives)}")
+        console.print(f"  bind-aid directives: {len(result.bindaid_directives)}")
+        console.print(f"  Skipped rules: {len(result.skipped)}\n")
+
+    # Step 3: Write zone files
+    console.print("[bold]Step 3:[/bold] Generating zone files...")
+    rpz_content = None
+    ba_content = None
+
+    if format in ("rpz", "both"):
+        rpz_content = write_rpz_zone(result, zone)
+        console.print(f"  RPZ zone: {zone} ({len(result.rpz_directives)} records)")
+
+    if format in ("bindaid", "both"):
+        ba_zone = f"policy.{domain}"
+        ba_content = write_bindaid_zone(result, ba_zone)
+        console.print(f"  bind-aid zone: {ba_zone} ({len(result.bindaid_directives)} records)")
+
+    # Write to disk if output dir specified
+    if output_dir:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        if rpz_content:
+            (out / f"{zone}.rpz").write_text(rpz_content)
+            console.print(f"  Written: {out / f'{zone}.rpz'}")
+        if ba_content:
+            (out / f"policy.{domain}.bindaid").write_text(ba_content)
+            console.print(f"  Written: {out / f'policy.{domain}.bindaid'}")
+
+    console.print()
+
+    # Step 4: Push or shadow
+    if mode == "shadow":
+        console.print("[yellow]Shadow mode:[/yellow] No changes pushed to DNS backend.")
+        console.print("  The following rules WOULD be enforced:\n")
+        for d in result.rpz_directives:
+            console.print(f"    {d.action.value:10s}  {d.owner}  ({d.source_rule})")
+    elif mode == "enforce":
+        if not backend:
+            error_console.print("[red]✗ Enforce mode requires --backend[/red]")
+            raise typer.Exit(1)
+
+        backend_lower = backend.lower()
+        console.print(f"[bold]Step 4:[/bold] Pushing RPZ to {backend}...")
+
+        if backend_lower == "nios":
+            from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+            async def _push_nios():
+                nios = InfobloxNIOSBackend()
+                try:
+                    await nios.ensure_rpz_zone(zone)
+                    pushed, errors = 0, []
+                    for d in result.rpz_directives:
+                        try:
+                            await nios.create_rpz_cname_record(
+                                rpz_zone=zone,
+                                owner=d.owner,
+                                action=d.action.value,
+                                comment=f"DNS-AID: {d.comment}",
+                            )
+                            pushed += 1
+                        except Exception as exc:
+                            errors.append(f"{d.owner}: {exc}")
+                    return pushed, errors
+                finally:
+                    await nios.close()
+
+            pushed, errors = run_async(_push_nios())
+            console.print(
+                f"  [green]✓ Pushed {pushed}/{len(result.rpz_directives)} "
+                f"RPZ records to NIOS[/green]"
+            )
+            for err in errors:
+                console.print(f"  [red]✗ {err}[/red]")
+
+        elif backend_lower == "infoblox":
+            from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+            from dns_aid.sdk.policy.compiler import RPZAction
+
+            blocked = [
+                d.owner
+                for d in result.rpz_directives
+                if d.action in (RPZAction.NXDOMAIN, RPZAction.DROP) and d.owner != "*"
+            ]
+
+            list_name = f"dns-aid-rpz-{zone.replace('.', '-')}"
+
+            async def _push_and_bind():
+                bx = InfobloxBloxOneBackend()
+                try:
+                    # Step 4a: Create/update named list
+                    nl_result = await bx.create_or_update_named_list(
+                        name=list_name,
+                        items=blocked,
+                        description=f"DNS-AID RPZ for {doc.agent}",
+                    )
+                    # Step 4b: Bind to TD security policy
+                    bind_result = await bx.bind_named_list_to_policy(
+                        named_list_name=list_name,
+                        policy_id=td_policy_id,
+                        action=td_action,
+                    )
+                    return nl_result, bind_result
+                finally:
+                    await bx.close()
+
+            nl_result, bind_result = run_async(_push_and_bind())
+
+            nl_action = "Updated" if nl_result.get("updated") else "Created"
+            console.print(
+                f"  [green]✓ {nl_action} TD named list '{list_name}' "
+                f"with {len(blocked)} blocked domains[/green]"
+            )
+
+            bind_status = bind_result.get("action")
+            policy_name = bind_result.get("policy_name", "unknown")
+            if bind_status == "bound":
+                console.print(
+                    f"  [green]✓ Bound to security policy '{policy_name}' "
+                    f"(id={bind_result['policy_id']}, {bind_result['rule_count']} rules)[/green]"
+                )
+                console.print(
+                    "  [bold]Blocked domains will receive NXDOMAIN from Threat Defense[/bold]"
+                )
+            elif bind_status == "already_bound":
+                console.print(f"  [dim]Already bound to policy '{policy_name}'[/dim]")
+
+        else:
+            if output_dir:
+                console.print(f"  Zone files written to {output_dir}")
+            else:
+                console.print(
+                    f"[yellow]⚠ Backend '{backend}' does not support direct RPZ push. "
+                    "Use --output-dir to write zone files.[/yellow]"
+                )
+
+    # Summary
+    if result.skipped:
+        console.print(
+            f"\n[dim]Skipped {len(result.skipped)} Layer 1/2 rules "
+            "(enforced by caller/target SDK, not DNS)[/dim]"
+        )
+
+
+# ============================================================================
 # ONBOARDING COMMANDS
 # ============================================================================
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -1421,8 +1421,8 @@ def policy_show(
         table.add_column("Owner")
         table.add_column("Action")
         table.add_column("Source Rule")
-        for d in result.rpz_directives:
-            table.add_row(d.owner, d.action.value, d.source_rule)
+        for rpz_d in result.rpz_directives:
+            table.add_row(rpz_d.owner, rpz_d.action.value, rpz_d.source_rule)
         console.print(table)
     else:
         console.print("  [dim]None[/dim]")
@@ -1435,8 +1435,10 @@ def policy_show(
         table.add_column("Action")
         table.add_column("Param Ops")
         table.add_column("Source Rule")
-        for d in result.bindaid_directives:
-            table.add_row(d.owner, d.action.value, ", ".join(d.param_ops) or "-", d.source_rule)
+        for ba_d in result.bindaid_directives:
+            table.add_row(
+                ba_d.owner, ba_d.action.value, ", ".join(ba_d.param_ops) or "-", ba_d.source_rule
+            )
         console.print(table)
     else:
         console.print("  [dim]None[/dim]")

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1029,6 +1029,345 @@ def sync_agent_index(
 
 
 # =============================================================================
+# POLICY COMPILATION TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+def compile_policy_to_rpz(
+    policy_json: str,
+    format: str = "both",
+) -> dict:
+    """
+    Compile a policy document to RPZ and/or bind-aid zone files.
+
+    Takes a PolicyDocument as JSON and produces DNS zone content that can be
+    loaded into RPZ-capable resolvers (standard) or bind-aid (Ingmar's BIND 9
+    fork with per-record policy actions).
+
+    Args:
+        policy_json: A PolicyDocument as a JSON string. Must include "agent"
+            (FQDN) and "rules" with policy rule definitions such as
+            blocked_caller_domains, allowed_caller_domains, required_protocols,
+            and/or cel_rules.
+        format: Output format - "rpz" for standard RPZ only, "bindaid" for
+            bind-aid only, or "both" (default) for both formats.
+
+    Returns:
+        dict with:
+        - success: Whether compilation succeeded
+        - rpz_zone: The RPZ zone file content (if format is "rpz" or "both")
+        - bindaid_zone: The bind-aid zone file content (if format is "bindaid" or "both")
+        - report: Compilation summary with directive counts and skipped rules
+        - error: Error message if failed
+    """
+    import json
+
+    from dns_aid.sdk.policy.bindaid_writer import write_bindaid_zone
+    from dns_aid.sdk.policy.compiler import PolicyCompiler
+    from dns_aid.sdk.policy.rpz_writer import write_rpz_zone
+    from dns_aid.sdk.policy.schema import PolicyDocument
+
+    if format not in ("rpz", "bindaid", "both"):
+        return {"success": False, "error": f"Invalid format: {format}. Use rpz, bindaid, or both."}
+
+    try:
+        doc = PolicyDocument.model_validate(json.loads(policy_json))
+    except Exception as e:
+        return {"success": False, "error": f"Failed to parse policy document: {e}"}
+
+    compiler = PolicyCompiler()
+    result = compiler.compile(doc)
+
+    response: dict = {"success": True}
+
+    zone_name_base = doc.agent.split(".")[-2] if "." in doc.agent else "policy"
+
+    if format in ("rpz", "both"):
+        response["rpz_zone"] = write_rpz_zone(result, f"rpz.{zone_name_base}.policy")
+    if format in ("bindaid", "both"):
+        response["bindaid_zone"] = write_bindaid_zone(result, f"policy.{zone_name_base}.bindaid")
+
+    response["report"] = {
+        "agent_fqdn": result.agent_fqdn,
+        "rpz_directives": len(result.rpz_directives),
+        "bindaid_directives": len(result.bindaid_directives),
+        "skipped": [{"rule": s.rule_name, "reason": s.reason} for s in result.skipped],
+        "warnings": result.warnings,
+    }
+
+    return response
+
+
+@mcp.tool()
+def publish_rpz_zone(
+    policy_json: str,
+    backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"],
+    rpz_zone: str,
+    td_action: str = "action_block",
+    td_policy_id: int | None = None,
+) -> dict:
+    """
+    Compile a policy and push RPZ records to a DNS backend.
+
+    For Infoblox (BloxOne): creates a TD named list, binds it to a security
+    policy with the specified action (block, log, allow, redirect).
+    For NIOS: creates ``record:rpz:cname`` entries via WAPI.
+    For other backends: returns the compiled zone content for manual loading.
+
+    Args:
+        policy_json: A PolicyDocument as a JSON string.
+        backend: DNS backend — "infoblox" for BloxOne TD (recommended),
+            "nios" for on-prem WAPI, others return zone content.
+        rpz_zone: Name of the RPZ zone (e.g., "rpz.nordstrom.com").
+        td_action: TD security policy action — "action_block" (NXDOMAIN),
+            "action_log" (monitor only), "action_allow", "action_redirect".
+            Only used with "infoblox" backend. Default: "action_block".
+        td_policy_id: TD security policy ID to bind to. None = default
+            global policy. Only used with "infoblox" backend.
+
+    Returns:
+        dict with:
+        - success: Whether the operation completed
+        - rpz_zone: The zone name
+        - backend: The backend used
+        - record_count: Number of records pushed
+        - td_policy: Security policy binding details (infoblox only)
+        - message: Status message
+    """
+    import json
+
+    from dns_aid.sdk.policy.compiler import PolicyCompiler, RPZAction
+    from dns_aid.sdk.policy.rpz_writer import write_rpz_zone
+    from dns_aid.sdk.policy.schema import PolicyDocument
+
+    # Validate inputs
+    try:
+        validate_backend(backend)
+    except ValidationError as e:
+        return _format_validation_error(e)
+
+    try:
+        doc = PolicyDocument.model_validate(json.loads(policy_json))
+    except Exception as e:
+        return {"success": False, "error": f"Failed to parse policy: {e}"}
+
+    compiler = PolicyCompiler()
+    result = compiler.compile(doc)
+
+    if backend == "nios":
+        from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+        async def _push_nios():
+            nios = InfobloxNIOSBackend()
+            try:
+                await nios.ensure_rpz_zone(rpz_zone)
+                pushed, errors = 0, []
+                for d in result.rpz_directives:
+                    try:
+                        await nios.create_rpz_cname_record(
+                            rpz_zone=rpz_zone,
+                            owner=d.owner,
+                            action=d.action.value,
+                            comment=f"DNS-AID: {d.comment}",
+                        )
+                        pushed += 1
+                    except Exception as exc:
+                        errors.append(f"{d.owner}: {exc}")
+                return pushed, errors
+            finally:
+                await nios.close()
+
+        try:
+            pushed, errors = _run_async(_push_nios())
+            return {
+                "success": len(errors) == 0,
+                "rpz_zone": rpz_zone,
+                "backend": "nios",
+                "record_count": pushed,
+                "errors": errors,
+                "message": f"Pushed {pushed}/{len(result.rpz_directives)} RPZ records to NIOS",
+            }
+        except Exception as e:
+            return {"success": False, "error": f"NIOS push failed: {e}"}
+
+    elif backend == "infoblox":
+        from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+
+        blocked = [
+            d.owner
+            for d in result.rpz_directives
+            if d.action in (RPZAction.NXDOMAIN, RPZAction.DROP) and d.owner != "*"
+        ]
+        list_name = f"dns-aid-rpz-{rpz_zone.replace('.', '-')}"
+
+        async def _push_and_bind():
+            bx = InfobloxBloxOneBackend()
+            try:
+                nl_result = await bx.create_or_update_named_list(
+                    name=list_name,
+                    items=blocked,
+                    description=f"DNS-AID RPZ for {doc.agent}",
+                )
+                bind_result = await bx.bind_named_list_to_policy(
+                    named_list_name=list_name,
+                    policy_id=td_policy_id,
+                    action=td_action,
+                )
+                return nl_result, bind_result
+            finally:
+                await bx.close()
+
+        try:
+            nl_result, bind_result = _run_async(_push_and_bind())
+            nl_action = "Updated" if nl_result.get("updated") else "Created"
+            return {
+                "success": True,
+                "rpz_zone": rpz_zone,
+                "backend": "infoblox",
+                "record_count": len(blocked),
+                "named_list": list_name,
+                "td_policy": {
+                    "policy_id": bind_result.get("policy_id"),
+                    "policy_name": bind_result.get("policy_name"),
+                    "action": td_action,
+                    "status": bind_result.get("action"),
+                },
+                "message": (
+                    f"{nl_action} TD named list '{list_name}' with {len(blocked)} domains. "
+                    f"Bound to policy '{bind_result.get('policy_name')}' as {td_action}."
+                ),
+            }
+        except Exception as e:
+            return {"success": False, "error": f"Infoblox push failed: {e}"}
+
+    else:
+        zone_content = write_rpz_zone(result, rpz_zone)
+        return {
+            "success": True,
+            "rpz_zone": rpz_zone,
+            "backend": backend,
+            "record_count": len(result.rpz_directives),
+            "zone_content": zone_content,
+            "message": (
+                f"Backend '{backend}' does not support direct RPZ push. "
+                "Zone content returned for manual loading."
+            ),
+        }
+
+
+@mcp.tool()
+def list_rpz_rules(
+    rpz_zone: str,
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "infoblox",
+) -> dict:
+    """
+    List current RPZ rules from a backend.
+
+    For Infoblox: queries TD named lists and security policies.
+    For NIOS: queries ``record:rpz:cname`` via WAPI.
+
+    Args:
+        rpz_zone: Name of the RPZ zone to query.
+        backend: DNS backend to query (default: infoblox).
+
+    Returns:
+        dict with:
+        - success: Whether the query succeeded
+        - rpz_zone: The zone queried
+        - named_lists/rules: The RPZ data found
+        - count: Number of items found
+    """
+    if backend == "nios":
+        from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+        async def _list_nios():
+            nios = InfobloxNIOSBackend()
+            try:
+                return await nios.list_rpz_cname_records(rpz_zone)
+            finally:
+                await nios.close()
+
+        try:
+            rules = _run_async(_list_nios())
+            return {
+                "success": True,
+                "rpz_zone": rpz_zone,
+                "rules": rules,
+                "count": len(rules),
+            }
+        except Exception as e:
+            return {"success": False, "error": f"NIOS query failed: {e}"}
+
+    elif backend == "infoblox":
+        from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+
+        async def _list_infoblox():
+            bx = InfobloxBloxOneBackend()
+            try:
+                list_name = f"dns-aid-rpz-{rpz_zone.replace('.', '-')}"
+                named_lists = await bx.list_named_lists(name_filter=list_name)
+                policies = await bx.list_security_policies()
+                return named_lists, policies
+            finally:
+                await bx.close()
+
+        try:
+            named_lists, policies = _run_async(_list_infoblox())
+            return {
+                "success": True,
+                "rpz_zone": rpz_zone,
+                "named_lists": named_lists,
+                "security_policies": policies,
+                "count": len(named_lists),
+            }
+        except Exception as e:
+            return {"success": False, "error": f"Infoblox query failed: {e}"}
+
+    else:
+        return {
+            "success": False,
+            "error": f"Backend '{backend}' does not support RPZ rule listing. Use infoblox or nios.",
+        }
+
+
+@mcp.tool()
+def list_td_security_policies() -> dict:
+    """
+    List all Infoblox Threat Defense security policies.
+
+    Use this to find the policy ID for ``publish_rpz_zone``'s ``td_policy_id``
+    parameter when you don't want to use the default global policy.
+
+    Returns:
+        dict with:
+        - success: Whether the query succeeded
+        - policies: List of policies with id, name, description, rule_count, is_default
+        - count: Number of policies found
+    """
+    from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+
+    async def _list():
+        bx = InfobloxBloxOneBackend()
+        try:
+            return await bx.list_security_policies()
+        finally:
+            await bx.close()
+
+    try:
+        policies = _run_async(_list())
+        return {
+            "success": True,
+            "policies": policies,
+            "count": len(policies),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to list TD policies: {e}"}
+
+
+# =============================================================================
 # ENVIRONMENT DIAGNOSTICS
 # =============================================================================
 

--- a/src/dns_aid/sdk/policy/__init__.py
+++ b/src/dns_aid/sdk/policy/__init__.py
@@ -1,4 +1,30 @@
 # Copyright 2024-2026 The DNS-AID Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""DNS-AID Policy enforcement models and evaluation."""
+"""DNS-AID Policy enforcement models, evaluation, and compilation."""
+
+from dns_aid.sdk.policy.bindaid_writer import write_bindaid_zone
+from dns_aid.sdk.policy.compiler import (
+    BindAidAction,
+    BindAidDirective,
+    BindAidParamOp,
+    CompilationResult,
+    PolicyCompiler,
+    RPZAction,
+    RPZDirective,
+    SkippedRule,
+)
+from dns_aid.sdk.policy.rpz_writer import write_rpz_zone
+
+__all__ = [
+    "BindAidAction",
+    "BindAidDirective",
+    "BindAidParamOp",
+    "CompilationResult",
+    "PolicyCompiler",
+    "RPZAction",
+    "RPZDirective",
+    "SkippedRule",
+    "write_bindaid_zone",
+    "write_rpz_zone",
+]

--- a/src/dns_aid/sdk/policy/bindaid_writer.py
+++ b/src/dns_aid/sdk/policy/bindaid_writer.py
@@ -1,0 +1,93 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+bind-aid policy zone writer.
+
+Renders ``CompilationResult.bindaid_directives`` into a policy zone file
+for Ingmar's BIND 9 fork (https://github.com/IngmarVG-IB/bind-aid).
+
+bind-aid format:
+  - Owner names are appended to the policy zone origin (``$ORIGIN``)
+  - ``ACTION:<action>`` directives for domain-level blocking/allowing
+  - ``key654xx=op:value`` directives for SvcParam operations (separate TXT records)
+  - Multiple TXT records on the same owner are applied in zone file order
+"""
+
+from __future__ import annotations
+
+import time
+
+from dns_aid.sdk.policy.compiler import CompilationResult
+
+
+def write_bindaid_zone(
+    result: CompilationResult,
+    zone_name: str,
+    serial: int | None = None,
+    ns_name: str = "localhost.",
+    admin_email: str = "hostmaster.localhost.",
+    ttl: int = 300,
+) -> str:
+    """Render a bind-aid policy zone file from compilation result.
+
+    Owner names are written relative to ``$ORIGIN`` so that bind-aid resolves
+    them as ``{owner}.{zone_name}.`` per its longest-suffix matching rules.
+
+    Args:
+        result: Compilation output from ``PolicyCompiler.compile()``.
+        zone_name: Name of the policy zone (e.g., ``rdata-policy.example.com``).
+        serial: SOA serial number.  Defaults to epoch seconds.
+        ns_name: SOA MNAME / NS target.
+        admin_email: SOA RNAME (dot-separated, not @).
+        ttl: Default TTL for all records.
+
+    Returns:
+        Complete zone file as a string.
+    """
+    if serial is None:
+        serial = int(time.time())
+
+    lines: list[str] = []
+
+    # Header comment
+    lines.append(f"; bind-aid policy zone: {zone_name}")
+    lines.append(f"; Compiled from policy for: {result.agent_fqdn}")
+    lines.append(f"; Directives: {len(result.bindaid_directives)}")
+    lines.append("")
+
+    # SOA + NS
+    lines.append(f"$TTL {ttl}")
+    lines.append(f"$ORIGIN {zone_name}.")
+    lines.append("")
+    lines.append(f"@  IN  SOA  {ns_name} {admin_email} (")
+    lines.append(f"    {serial}  ; serial")
+    lines.append("    3600       ; refresh")
+    lines.append("    900        ; retry")
+    lines.append("    604800     ; expire")
+    lines.append(f"    {ttl}        ; minimum")
+    lines.append(")")
+    lines.append("")
+    lines.append(f"@  IN  NS  {ns_name}")
+    lines.append("")
+
+    # bind-aid TXT directives
+    for directive in result.bindaid_directives:
+        if directive.comment:
+            lines.append(f"; {directive.comment}")
+        if directive.source_rule:
+            lines.append(f"; source: {directive.source_rule}")
+
+        # Owner relative to $ORIGIN — bind-aid resolves as {owner}.{zone_name}.
+        owner = directive.owner
+
+        # ACTION directive (domain-level block/allow)
+        lines.append(f'{owner}  {ttl}  IN  TXT  "ACTION:{directive.action.value}"')
+
+        # SvcParam directives as separate TXT records (applied in order)
+        for param_op in directive.param_ops:
+            lines.append(f'{owner}  {ttl}  IN  TXT  "{param_op}"')
+
+        lines.append("")
+
+    return "\n".join(lines)

--- a/src/dns_aid/sdk/policy/compiler.py
+++ b/src/dns_aid/sdk/policy/compiler.py
@@ -1,0 +1,483 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Policy-to-RPZ/bind-aid compiler.
+
+Transforms a ``PolicyDocument`` into RPZ directives (standard Response Policy Zone
+``CNAME`` records) and bind-aid directives (Ingmar's BIND 9 fork with per-record
+``TXT`` action/param-op directives).
+
+Layer 0 (DNS resolver) can only enforce domain-based access control and protocol
+filtering.  Rules that require application-layer context (auth, TLS, payload, etc.)
+are skipped with a documented reason so callers know which rules require Layer 1/2
+enforcement.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from dns_aid.sdk.policy.schema import PolicyDocument
+
+# ── Data models ────────────────────────────────────────────────
+
+
+class RPZAction(StrEnum):
+    """Standard RPZ actions (RFC 8010 §2)."""
+
+    NXDOMAIN = "NXDOMAIN"  # CNAME .
+    NODATA = "NODATA"  # CNAME *.
+    PASSTHRU = "PASSTHRU"  # CNAME rpz-passthru.
+    DROP = "DROP"  # CNAME rpz-drop.
+
+
+class RPZDirective(BaseModel):
+    """A single RPZ zone entry."""
+
+    owner: str  # LHS of the RR (e.g., "evil.example.com")
+    action: RPZAction
+    comment: str = ""
+    source_rule: str = ""  # which policy rule produced this
+
+
+class BindAidAction(StrEnum):
+    """bind-aid enforcement actions."""
+
+    NXDOMAIN = "nxdomain"
+    NODATA = "nodata"
+    PASSTHRU = "passthru"
+    DROP = "drop"
+
+
+class BindAidParamOp(StrEnum):
+    """bind-aid SVCB parameter operations."""
+
+    STRIP = "strip"
+    REQUIRE = "require"
+    WHITELIST = "whitelist"
+    BLACKLIST = "blacklist"
+    ENFORCE = "enforce"
+    VALIDATE = "validate"
+
+
+class BindAidDirective(BaseModel):
+    """A single bind-aid policy zone entry."""
+
+    owner: str
+    action: BindAidAction
+    param_ops: list[str] = Field(default_factory=list)  # e.g., ["key65402=whitelist:mcp,a2a"]
+    comment: str = ""
+    source_rule: str = ""
+
+
+class SkippedRule(BaseModel):
+    """A rule that could not be compiled to Layer 0."""
+
+    rule_name: str
+    reason: str
+
+
+class CompilationResult(BaseModel):
+    """Full compilation output for a single policy document."""
+
+    agent_fqdn: str
+    rpz_directives: list[RPZDirective] = Field(default_factory=list)
+    bindaid_directives: list[BindAidDirective] = Field(default_factory=list)
+    skipped: list[SkippedRule] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+# ── Compiler ───────────────────────────────────────────────────
+
+# Simple CEL patterns we can translate to DNS zone entries.
+# Both positive and negated forms are recognized:
+#   endsWith(".evil.io") → positive match (author means "match evil")
+#   !endsWith(".evil.io") → negated (evaluator convention: allow condition, deny on match)
+# The compiler maps both to the same RPZ output, respecting the effect field.
+_CEL_DOMAIN_ENDSWITH = re.compile(r"^!?request\.caller_domain\.endsWith\(\s*\"([^\"]+)\"\s*\)$")
+_CEL_DOMAIN_EQ = re.compile(r"^request\.caller_domain\s*(?:==|!=)\s*\"([^\"]+)\"$")
+
+
+class PolicyCompiler:
+    """Compile a PolicyDocument into RPZ + bind-aid directives.
+
+    Only Layer 0 (DNS-enforceable) rules produce output.  Everything else
+    is reported in ``skipped`` with a reason string.
+    """
+
+    def compile(self, doc: PolicyDocument) -> CompilationResult:
+        """Compile a policy document into RPZ and bind-aid directives."""
+        result = CompilationResult(agent_fqdn=doc.agent)
+        rules = doc.rules
+
+        self._compile_blocked_domains(rules.blocked_caller_domains, result)
+        self._compile_allowed_domains(rules.allowed_caller_domains, result)
+        self._compile_required_protocols(rules.required_protocols, result)
+        self._compile_required_auth_types(rules.required_auth_types, result)
+        self._compile_svcparam_ops(rules.svcparam_ops, result)
+        self._compile_cel_rules(rules.cel_rules, result)
+
+        # Deduplicate: if the same owner+action appears from multiple rules,
+        # keep only the first occurrence (native rules take priority over CEL).
+        self._deduplicate(result)
+
+        # Rules that are always skipped at Layer 0
+        self._skip_if_set(
+            rules.require_dnssec, "require_dnssec", "Resolver-native; no RPZ needed", result
+        )
+        self._skip_if_set(
+            rules.require_mutual_tls, "require_mutual_tls", "Layer 1/2 only (TLS handshake)", result
+        )
+        self._skip_if_set(
+            rules.min_tls_version, "min_tls_version", "Layer 1 only (TLS negotiation)", result
+        )
+        self._skip_if_set(
+            rules.required_caller_trust_score,
+            "required_caller_trust_score",
+            "Layer 1 only (trust evaluation)",
+            result,
+        )
+        self._skip_if_set(
+            rules.rate_limits, "rate_limits", "Layer 1/2 only (request counting)", result
+        )
+        self._skip_if_set(
+            rules.max_payload_bytes,
+            "max_payload_bytes",
+            "Layer 2 only (HTTP body inspection)",
+            result,
+        )
+        self._skip_if_set(
+            rules.allowed_methods, "allowed_methods", "Layer 1/2 only (HTTP method)", result
+        )
+        self._skip_if_set(
+            rules.allowed_intents, "allowed_intents", "Layer 1/2 only (intent extraction)", result
+        )
+        self._skip_if_set(
+            rules.geo_restrictions,
+            "geo_restrictions",
+            "Needs resolver GeoIP — Phase 7.4",
+            result,
+        )
+        self._skip_if_set(
+            rules.availability, "availability", "Layer 1/2 only (time-of-day)", result
+        )
+        self._skip_if_set(
+            rules.data_classification, "data_classification", "Layer 1 only (metadata tag)", result
+        )
+        self._skip_if_set(
+            rules.consent_required, "consent_required", "Layer 1/2 only (consent token)", result
+        )
+
+        return result
+
+    # ── Rule compilers ────────────────────────────────────────
+
+    @staticmethod
+    def _compile_blocked_domains(
+        domains: list[str] | None,
+        result: CompilationResult,
+    ) -> None:
+        if not domains:
+            return
+        for domain in domains:
+            owner = domain  # already includes wildcard if present (e.g., "*.malicious.net")
+            result.rpz_directives.append(
+                RPZDirective(
+                    owner=owner,
+                    action=RPZAction.NXDOMAIN,
+                    comment=f"Block caller domain: {domain}",
+                    source_rule="blocked_caller_domains",
+                )
+            )
+            result.bindaid_directives.append(
+                BindAidDirective(
+                    owner=owner,
+                    action=BindAidAction.NXDOMAIN,
+                    comment=f"Block caller domain: {domain}",
+                    source_rule="blocked_caller_domains",
+                )
+            )
+
+    @staticmethod
+    def _compile_allowed_domains(
+        domains: list[str] | None,
+        result: CompilationResult,
+    ) -> None:
+        if not domains:
+            return
+        # Passthru for each allowed domain
+        for domain in domains:
+            owner = domain  # already includes wildcard if present (e.g., "*.partner.org")
+            result.rpz_directives.append(
+                RPZDirective(
+                    owner=owner,
+                    action=RPZAction.PASSTHRU,
+                    comment=f"Allow caller domain: {domain}",
+                    source_rule="allowed_caller_domains",
+                )
+            )
+            result.bindaid_directives.append(
+                BindAidDirective(
+                    owner=owner,
+                    action=BindAidAction.PASSTHRU,
+                    comment=f"Allow caller domain: {domain}",
+                    source_rule="allowed_caller_domains",
+                )
+            )
+        # Catch-all: block everything else
+        result.rpz_directives.append(
+            RPZDirective(
+                owner="*",
+                action=RPZAction.NXDOMAIN,
+                comment="Catch-all: block unlisted callers",
+                source_rule="allowed_caller_domains",
+            )
+        )
+        result.bindaid_directives.append(
+            BindAidDirective(
+                owner="*",
+                action=BindAidAction.NXDOMAIN,
+                comment="Catch-all: block unlisted callers",
+                source_rule="allowed_caller_domains",
+            )
+        )
+
+    @staticmethod
+    def _compile_required_protocols(
+        protocols: list[str] | None,
+        result: CompilationResult,
+    ) -> None:
+        if not protocols:
+            return
+        # RPZ cannot filter by protocol — skip
+        result.skipped.append(
+            SkippedRule(
+                rule_name="required_protocols",
+                reason="RPZ cannot filter by protocol; bind-aid only",
+            )
+        )
+        # bind-aid can whitelist protocols via SVCB key65402 (bap)
+        proto_list = ",".join(protocols)
+        result.bindaid_directives.append(
+            BindAidDirective(
+                owner="*",
+                action=BindAidAction.PASSTHRU,
+                param_ops=[f"key65402=whitelist:{proto_list}"],
+                comment=f"Require protocols: {proto_list}",
+                source_rule="required_protocols",
+            )
+        )
+
+    @staticmethod
+    def _compile_required_auth_types(
+        auth_types: list[str] | None,
+        result: CompilationResult,
+    ) -> None:
+        if not auth_types:
+            return
+        # RPZ cannot filter by auth type — skip
+        result.skipped.append(
+            SkippedRule(
+                rule_name="required_auth_types",
+                reason="RPZ cannot filter by auth type; bind-aid only",
+            )
+        )
+        # bind-aid can require the cap key (key65400) which implies auth
+        result.bindaid_directives.append(
+            BindAidDirective(
+                owner="*",
+                action=BindAidAction.PASSTHRU,
+                param_ops=["key65400=require"],
+                comment=f"Require auth types: {', '.join(auth_types)}",
+                source_rule="required_auth_types",
+            )
+        )
+
+    @staticmethod
+    def _compile_svcparam_ops(
+        ops: list | None,
+        result: CompilationResult,
+    ) -> None:
+        """Compile SvcParam operations to bind-aid directives.
+
+        Each ``SvcParamOp`` becomes a separate TXT record in the bind-aid zone.
+        RPZ cannot express rdata operations, so these are bind-aid only.
+        """
+        if not ops:
+            return
+
+        for op in ops:
+            # Format: key=op:values or key=op (no values)
+            if op.values:
+                param_str = f"{op.key}={op.op}:{','.join(op.values)}"
+            else:
+                param_str = f"{op.key}={op.op}"
+
+            result.bindaid_directives.append(
+                BindAidDirective(
+                    owner="*",
+                    action=BindAidAction.PASSTHRU,
+                    param_ops=[param_str],
+                    comment=f"SvcParam: {param_str}",
+                    source_rule="svcparam_ops",
+                )
+            )
+
+        # RPZ cannot express SvcParam ops — add skip notice
+        result.skipped.append(
+            SkippedRule(
+                rule_name="svcparam_ops",
+                reason="RPZ cannot express rdata operations; bind-aid only",
+            )
+        )
+
+    def _compile_cel_rules(
+        self,
+        cel_rules: list | None,
+        result: CompilationResult,
+    ) -> None:
+        if not cel_rules:
+            return
+        for rule in cel_rules:
+            # Only compile deny-effect CEL rules with layer0 support
+            if rule.enforcement_layers and "layer0" not in rule.enforcement_layers:
+                result.skipped.append(
+                    SkippedRule(
+                        rule_name=f"cel:{rule.id}",
+                        reason=f"Not a Layer 0 rule (layers: {rule.enforcement_layers})",
+                    )
+                )
+                continue
+
+            compiled = self._try_compile_cel(rule, result)
+            if not compiled:
+                result.skipped.append(
+                    SkippedRule(
+                        rule_name=f"cel:{rule.id}",
+                        reason="Complex CEL expression; cannot compile to DNS zone entry",
+                    )
+                )
+
+    def _try_compile_cel(self, rule, result: CompilationResult) -> bool:
+        """Try to compile a CEL rule to RPZ/bind-aid. Returns True if successful.
+
+        CEL evaluator convention: expression=true → allowed, false → effect triggered.
+
+        For domain blocking with ``effect="deny"``:
+          ``!request.caller_domain.endsWith(".evil.io")``
+            → evaluator: matching domain makes expression false → deny ✓
+          ``request.caller_domain != "bad.com"``
+            → evaluator: matching domain makes expression false → deny ✓
+
+        The compiler also accepts the non-negated forms for backwards compat:
+          ``request.caller_domain.endsWith(".evil.io")``  (effect="deny")
+          ``request.caller_domain == "bad.com"``          (effect="deny")
+
+        Both negated and non-negated forms produce the same RPZ output: the
+        extracted domain is blocked (NXDOMAIN) or allowed (PASSTHRU) based
+        on the effect field.
+        """
+        expr = rule.expression.strip()
+
+        # Pattern: [!]request.caller_domain.endsWith(".evil.com")
+        m = _CEL_DOMAIN_ENDSWITH.match(expr)
+        if m:
+            suffix = m.group(1)
+            owner = f"*{suffix}" if suffix.startswith(".") else f"*.{suffix}"
+            # Both negated (!endsWith) and non-negated (endsWith) with deny
+            # mean "block matching domains" — the extracted domain is the target.
+            action = RPZAction.NXDOMAIN if rule.effect == "deny" else RPZAction.PASSTHRU
+            ba_action = BindAidAction.NXDOMAIN if rule.effect == "deny" else BindAidAction.PASSTHRU
+
+            result.rpz_directives.append(
+                RPZDirective(
+                    owner=owner,
+                    action=action,
+                    comment=f"CEL rule '{rule.id}': {rule.message or expr}",
+                    source_rule=f"cel:{rule.id}",
+                )
+            )
+            result.bindaid_directives.append(
+                BindAidDirective(
+                    owner=owner,
+                    action=ba_action,
+                    comment=f"CEL rule '{rule.id}': {rule.message or expr}",
+                    source_rule=f"cel:{rule.id}",
+                )
+            )
+            return True
+
+        # Pattern: request.caller_domain == "exact.com" or != "exact.com"
+        m = _CEL_DOMAIN_EQ.match(expr)
+        if m:
+            domain = m.group(1)
+            action = RPZAction.NXDOMAIN if rule.effect == "deny" else RPZAction.PASSTHRU
+            ba_action = BindAidAction.NXDOMAIN if rule.effect == "deny" else BindAidAction.PASSTHRU
+
+            result.rpz_directives.append(
+                RPZDirective(
+                    owner=domain,
+                    action=action,
+                    comment=f"CEL rule '{rule.id}': {rule.message or expr}",
+                    source_rule=f"cel:{rule.id}",
+                )
+            )
+            result.bindaid_directives.append(
+                BindAidDirective(
+                    owner=domain,
+                    action=ba_action,
+                    comment=f"CEL rule '{rule.id}': {rule.message or expr}",
+                    source_rule=f"cel:{rule.id}",
+                )
+            )
+            return True
+
+        return False
+
+    @staticmethod
+    def _deduplicate(result: CompilationResult) -> None:
+        """Remove duplicate RPZ/bind-aid directives (same owner+action).
+
+        Keeps the first occurrence (native rules compiled before CEL),
+        adds a warning for each duplicate removed.
+        """
+        seen_rpz: set[tuple[str, str]] = set()
+        deduped_rpz: list[RPZDirective] = []
+        for d in result.rpz_directives:
+            key = (d.owner, d.action.value)
+            if key in seen_rpz:
+                result.warnings.append(
+                    f"Duplicate RPZ entry removed: {d.owner} {d.action.value} (from {d.source_rule})"
+                )
+                continue
+            seen_rpz.add(key)
+            deduped_rpz.append(d)
+        result.rpz_directives = deduped_rpz
+
+        seen_ba: set[tuple[str, str, tuple[str, ...]]] = set()
+        deduped_ba: list[BindAidDirective] = []
+        for ba in result.bindaid_directives:
+            ba_key = (ba.owner, ba.action.value, tuple(ba.param_ops))
+            if ba_key in seen_ba:
+                result.warnings.append(
+                    f"Duplicate bind-aid entry removed: {ba.owner} {ba.action.value} (from {ba.source_rule})"
+                )
+                continue
+            seen_ba.add(ba_key)
+            deduped_ba.append(ba)
+        result.bindaid_directives = deduped_ba
+
+    @staticmethod
+    def _skip_if_set(
+        value: object,
+        rule_name: str,
+        reason: str,
+        result: CompilationResult,
+    ) -> None:
+        """Add a SkippedRule if the value is truthy."""
+        if value:
+            result.skipped.append(SkippedRule(rule_name=rule_name, reason=reason))

--- a/src/dns_aid/sdk/policy/rpz_writer.py
+++ b/src/dns_aid/sdk/policy/rpz_writer.py
@@ -1,0 +1,83 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standard RPZ zone file writer.
+
+Renders ``CompilationResult.rpz_directives`` into a valid RFC 8010 Response
+Policy Zone file with SOA, NS, and CNAME records.
+"""
+
+from __future__ import annotations
+
+import time
+
+from dns_aid.sdk.policy.compiler import CompilationResult, RPZAction
+
+# CNAME targets per RPZ action (RFC 8010 §2)
+_RPZ_CNAME_TARGET: dict[RPZAction, str] = {
+    RPZAction.NXDOMAIN: ".",
+    RPZAction.NODATA: "*.",
+    RPZAction.PASSTHRU: "rpz-passthru.",
+    RPZAction.DROP: "rpz-drop.",
+}
+
+
+def write_rpz_zone(
+    result: CompilationResult,
+    zone_name: str,
+    serial: int | None = None,
+    ns_name: str = "localhost.",
+    admin_email: str = "hostmaster.localhost.",
+    ttl: int = 300,
+) -> str:
+    """Render an RPZ zone file from compilation result.
+
+    Args:
+        result: Compilation output from ``PolicyCompiler.compile()``.
+        zone_name: Name of the RPZ zone (e.g., ``rpz.example.com``).
+        serial: SOA serial number.  Defaults to epoch seconds.
+        ns_name: SOA MNAME / NS target.
+        admin_email: SOA RNAME (dot-separated, not @).
+        ttl: Default TTL for all records.
+
+    Returns:
+        Complete zone file as a string.
+    """
+    if serial is None:
+        serial = int(time.time())
+
+    lines: list[str] = []
+
+    # Header comment
+    lines.append(f"; RPZ zone: {zone_name}")
+    lines.append(f"; Compiled from policy for: {result.agent_fqdn}")
+    lines.append(f"; Directives: {len(result.rpz_directives)}")
+    lines.append("")
+
+    # SOA record
+    lines.append(f"$TTL {ttl}")
+    lines.append(f"@  IN  SOA  {ns_name} {admin_email} (")
+    lines.append(f"    {serial}  ; serial")
+    lines.append("    3600       ; refresh")
+    lines.append("    900        ; retry")
+    lines.append("    604800     ; expire")
+    lines.append(f"    {ttl}        ; minimum")
+    lines.append(")")
+    lines.append("")
+
+    # NS record
+    lines.append(f"@  IN  NS  {ns_name}")
+    lines.append("")
+
+    # RPZ CNAME directives
+    for directive in result.rpz_directives:
+        target = _RPZ_CNAME_TARGET[directive.action]
+        if directive.comment:
+            lines.append(f"; {directive.comment}")
+        if directive.source_rule:
+            lines.append(f"; source: {directive.source_rule}")
+        lines.append(f"{directive.owner}  {ttl}  IN  CNAME  {target}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/src/dns_aid/sdk/policy/schema.py
+++ b/src/dns_aid/sdk/policy/schema.py
@@ -64,8 +64,37 @@ class CELRule(BaseModel):
         return v
 
 
+class SvcParamOp(BaseModel):
+    """A bind-aid SvcParam operation on a specific SVCB key.
+
+    Expresses rdata-level policy that bind-aid enforces at the resolver.
+    Maps directly to bind-aid TXT directives like ``key65402=whitelist:mcp``.
+    """
+
+    key: str = Field(
+        ...,
+        description="SVCB key name or number (e.g., 'alpn', 'port', 'key65400')",
+    )
+    op: str = Field(
+        ...,
+        description="Operation: strip, require, validate, enforce, whitelist, blacklist",
+    )
+    values: list[str] | None = Field(
+        default=None,
+        description="Values for enforce/whitelist/blacklist (e.g., ['mcp', 'a2a'])",
+    )
+
+    @field_validator("op")
+    @classmethod
+    def validate_op(cls, v: str) -> str:
+        valid = {"strip", "require", "validate", "enforce", "whitelist", "blacklist"}
+        if v not in valid:
+            raise ValueError(f"Invalid SvcParam op: {v}. Must be one of {valid}")
+        return v
+
+
 class PolicyRules(BaseModel):
-    """All 16 native policy rule types plus optional CEL custom rules."""
+    """All native policy rule types plus optional CEL and bind-aid SvcParam rules."""
 
     required_protocols: list[str] | None = None
     required_auth_types: list[str] | None = None
@@ -84,6 +113,12 @@ class PolicyRules(BaseModel):
     data_classification: str | None = None
     consent_required: bool = False
     cel_rules: list[CELRule] | None = Field(default=None, max_length=64)
+    # bind-aid SvcParam operations (Layer 0 rdata enforcement)
+    svcparam_ops: list[SvcParamOp] | None = Field(
+        default=None,
+        max_length=32,
+        description="bind-aid SvcParam operations enforced at the resolver (Layer 0)",
+    )
 
     @field_validator("min_tls_version")
     @classmethod

--- a/tests/fixtures/nordstrom-agent-governance.json
+++ b/tests/fixtures/nordstrom-agent-governance.json
@@ -1,0 +1,61 @@
+{
+  "version": "1.0",
+  "agent": "_inventory._mcp._agents.nordstrom.com",
+  "rules": {
+    "allowed_caller_domains": [
+      "ai-platform.nordstrom.com",
+      "ml-ops.nordstrom.com",
+      "data-eng.nordstrom.com"
+    ],
+    "blocked_caller_domains": [
+      "*.personal-dev.nordstrom.com",
+      "*.sandbox.nordstrom.com"
+    ],
+    "required_protocols": ["mcp"],
+    "required_auth_types": ["oauth2"],
+    "require_dnssec": true,
+    "min_tls_version": "1.3",
+    "rate_limits": {
+      "max_per_minute": 120,
+      "max_per_hour": 5000
+    },
+    "allowed_methods": ["tools/call", "tools/list"],
+    "data_classification": "internal",
+    "cel_rules": [
+      {
+        "id": "block-shadow-agents",
+        "expression": "!request.caller_domain.endsWith(\".shadow.nordstrom.com\")",
+        "effect": "deny",
+        "message": "Block unregistered shadow agents",
+        "enforcement_layers": ["layer0", "layer1"]
+      },
+      {
+        "id": "block-external-callers",
+        "expression": "!request.caller_domain.endsWith(\".external.nordstrom.com\")",
+        "effect": "deny",
+        "message": "Block external-facing agent endpoints from internal calls",
+        "enforcement_layers": ["layer0", "layer1"]
+      },
+      {
+        "id": "require-prod-trust",
+        "expression": "request.caller_trust_score >= 0.8",
+        "effect": "deny",
+        "message": "Production agents require trust score >= 0.8",
+        "enforcement_layers": ["layer1"]
+      },
+      {
+        "id": "restrict-pii-tools",
+        "expression": "!(request.tool_name in [\"export_customer_data\", \"bulk_pii_extract\", \"delete_customer_records\"])",
+        "effect": "deny",
+        "message": "PII-sensitive tools restricted to authorized callers only",
+        "enforcement_layers": ["layer1", "layer2"]
+      }
+    ],
+    "svcparam_ops": [
+      {"key": "port", "op": "enforce", "values": ["443"]},
+      {"key": "alpn", "op": "whitelist", "values": ["h2", "h3"]},
+      {"key": "key65400", "op": "validate"},
+      {"key": "ech", "op": "strip"}
+    ]
+  }
+}

--- a/tests/fixtures/sample-policy.json
+++ b/tests/fixtures/sample-policy.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "agent": "_network._mcp._agents.example.com",
+  "rules": {
+    "blocked_caller_domains": [
+      "evil.example.com",
+      "*.malicious.net"
+    ],
+    "allowed_caller_domains": [
+      "trusted.example.com",
+      "partner.example.org"
+    ],
+    "required_protocols": ["mcp", "a2a"],
+    "required_auth_types": ["oauth2", "bearer"],
+    "require_dnssec": true,
+    "require_mutual_tls": false,
+    "min_tls_version": "1.3",
+    "rate_limits": {
+      "max_per_minute": 60,
+      "max_per_hour": 1000
+    },
+    "max_payload_bytes": 1048576,
+    "allowed_methods": ["tools/call", "tools/list"],
+    "allowed_intents": ["query", "analyze"],
+    "geo_restrictions": ["US", "EU"],
+    "data_classification": "internal",
+    "cel_rules": [
+      {
+        "id": "block-competitor",
+        "expression": "!request.caller_domain.endsWith(\".competitor.io\")",
+        "effect": "deny",
+        "message": "Block competitor domains",
+        "enforcement_layers": ["layer0", "layer1"]
+      },
+      {
+        "id": "block-exact-bad",
+        "expression": "request.caller_domain != \"bad-actor.example.com\"",
+        "effect": "deny",
+        "message": "Block known bad actor"
+      },
+      {
+        "id": "require-high-trust",
+        "expression": "request.caller_trust_score >= 0.7",
+        "effect": "deny",
+        "message": "Require high trust score",
+        "enforcement_layers": ["layer1"]
+      }
+    ]
+  }
+}

--- a/tests/unit/cli/test_policy_cli.py
+++ b/tests/unit/cli/test_policy_cli.py
@@ -1,0 +1,93 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``dns-aid policy`` CLI sub-commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"
+SAMPLE_POLICY = FIXTURES / "sample-policy.json"
+
+runner = CliRunner()
+
+
+class TestPolicyCompile:
+    def test_compile_rpz_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "test.rpz"
+        result = runner.invoke(
+            app, ["policy", "compile", "-i", str(SAMPLE_POLICY), "-o", str(out), "-f", "rpz"]
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        content = out.read_text()
+        assert "SOA" in content
+        assert "CNAME" in content
+
+    def test_compile_bindaid_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "test.bindaid"
+        result = runner.invoke(
+            app, ["policy", "compile", "-i", str(SAMPLE_POLICY), "-o", str(out), "-f", "bindaid"]
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        content = out.read_text()
+        assert "SOA" in content
+        assert "ACTION:" in content
+
+    def test_compile_both_creates_two_files(self, tmp_path: Path) -> None:
+        out = tmp_path / "test"
+        result = runner.invoke(
+            app, ["policy", "compile", "-i", str(SAMPLE_POLICY), "-o", str(out), "-f", "both"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "test.rpz").exists()
+        assert (tmp_path / "test.bindaid").exists()
+
+    def test_compile_invalid_input(self, tmp_path: Path) -> None:
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{invalid json")
+        out = tmp_path / "out.rpz"
+        result = runner.invoke(
+            app, ["policy", "compile", "-i", str(bad_file), "-o", str(out), "-f", "rpz"]
+        )
+        assert result.exit_code == 1
+
+    def test_compile_missing_input(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["policy", "compile", "-i", "/nonexistent.json", "-o", str(tmp_path / "out"), "-f", "rpz"]
+        )
+        assert result.exit_code == 1
+
+
+class TestPolicyShow:
+    def test_show_report(self) -> None:
+        result = runner.invoke(app, ["policy", "show", "-i", str(SAMPLE_POLICY)])
+        assert result.exit_code == 0, result.output
+        assert "Policy Compilation Report" in result.output
+        assert "RPZ Directives" in result.output
+        assert "bind-aid Directives" in result.output
+        assert "Skipped Rules" in result.output
+
+
+class TestEnforce:
+    def test_enforce_shadow_mode(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d", "example.com",
+                "-p", str(SAMPLE_POLICY),
+                "--mode", "shadow",
+                "-o", str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Shadow mode" in result.output
+        assert "WOULD be enforced" in result.output

--- a/tests/unit/sdk/policy/test_bindaid_writer.py
+++ b/tests/unit/sdk/policy/test_bindaid_writer.py
@@ -1,0 +1,141 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the bind-aid policy zone file writer."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.sdk.policy.bindaid_writer import write_bindaid_zone
+from dns_aid.sdk.policy.compiler import (
+    BindAidAction,
+    BindAidDirective,
+    CompilationResult,
+)
+
+
+@pytest.fixture
+def empty_result() -> CompilationResult:
+    return CompilationResult(agent_fqdn="_test._mcp._agents.example.com")
+
+
+@pytest.fixture
+def result_with_directives() -> CompilationResult:
+    return CompilationResult(
+        agent_fqdn="_test._mcp._agents.example.com",
+        bindaid_directives=[
+            BindAidDirective(
+                owner="evil.com",
+                action=BindAidAction.NXDOMAIN,
+                comment="Block evil",
+                source_rule="blocked_caller_domains",
+            ),
+            BindAidDirective(
+                owner="trusted.com",
+                action=BindAidAction.PASSTHRU,
+                comment="Allow trusted",
+                source_rule="allowed_caller_domains",
+            ),
+            BindAidDirective(
+                owner="*",
+                action=BindAidAction.PASSTHRU,
+                param_ops=["key65402=whitelist:mcp,a2a"],
+                comment="Require protocols",
+                source_rule="required_protocols",
+            ),
+            BindAidDirective(
+                owner="*",
+                action=BindAidAction.PASSTHRU,
+                param_ops=["key65400=require"],
+                comment="Require auth",
+                source_rule="required_auth_types",
+            ),
+        ],
+    )
+
+
+class TestSOAHeader:
+    def test_soa_present(self, empty_result: CompilationResult) -> None:
+        zone = write_bindaid_zone(empty_result, "policy.example.com", serial=2026032800)
+        assert "SOA" in zone
+        assert "2026032800" in zone
+
+    def test_custom_serial(self, empty_result: CompilationResult) -> None:
+        zone = write_bindaid_zone(empty_result, "policy.example.com", serial=99999)
+        assert "99999" in zone
+
+    def test_origin_directive(self, empty_result: CompilationResult) -> None:
+        zone = write_bindaid_zone(empty_result, "rdata-policy.example.com", serial=1)
+        assert "$ORIGIN rdata-policy.example.com." in zone
+
+
+class TestNSRecord:
+    def test_ns_record_present(self, empty_result: CompilationResult) -> None:
+        zone = write_bindaid_zone(empty_result, "policy.example.com", serial=1)
+        assert "NS  localhost." in zone
+
+
+class TestActionDirectives:
+    def test_nxdomain_txt(self, result_with_directives: CompilationResult) -> None:
+        zone = write_bindaid_zone(result_with_directives, "policy.example.com", serial=1)
+        assert "evil.com" in zone
+        assert 'ACTION:nxdomain' in zone
+
+    def test_passthru_txt(self, result_with_directives: CompilationResult) -> None:
+        zone = write_bindaid_zone(result_with_directives, "policy.example.com", serial=1)
+        assert 'ACTION:passthru' in zone
+
+
+class TestParamOps:
+    def test_param_op_separate_txt(self, result_with_directives: CompilationResult) -> None:
+        """SvcParam ops should be separate TXT records from ACTION."""
+        zone = write_bindaid_zone(result_with_directives, "policy.example.com", serial=1)
+        # ACTION and param_op should be on separate lines
+        assert 'TXT  "ACTION:passthru"' in zone
+        assert 'TXT  "key65402=whitelist:mcp,a2a"' in zone
+        assert 'TXT  "key65400=require"' in zone
+
+    def test_multiple_param_ops(self) -> None:
+        """Multiple param ops on one directive → multiple TXT records."""
+        result = CompilationResult(
+            agent_fqdn="_test._mcp._agents.example.com",
+            bindaid_directives=[
+                BindAidDirective(
+                    owner="*",
+                    action=BindAidAction.PASSTHRU,
+                    param_ops=["key65402=whitelist:mcp", "key65400=require", "key65403=enforce"],
+                ),
+            ],
+        )
+        zone = write_bindaid_zone(result, "policy.example.com", serial=1)
+        lines = zone.splitlines()
+        txt_lines = [l for l in lines if "TXT" in l]
+        # 1 ACTION + 3 param ops = 4 TXT records
+        assert len(txt_lines) == 4
+
+
+class TestEmptyZone:
+    def test_empty_directives(self, empty_result: CompilationResult) -> None:
+        zone = write_bindaid_zone(empty_result, "policy.example.com", serial=1)
+        assert "SOA" in zone
+        assert "NS" in zone
+        assert "TXT" not in zone
+
+
+class TestFullIntegration:
+    def test_full_zone(self, result_with_directives: CompilationResult) -> None:
+        zone = write_bindaid_zone(
+            result_with_directives,
+            "rdata-policy.example.com",
+            serial=2026032800,
+            ttl=300,
+        )
+        lines = zone.splitlines()
+        assert any("$TTL 300" in l for l in lines)
+        assert any("$ORIGIN rdata-policy.example.com." in l for l in lines)
+        assert any("SOA" in l for l in lines)
+        assert any("NS" in l for l in lines)
+        txt_lines = [l for l in lines if "TXT" in l]
+        # 2 simple ACTIONs + 2 ACTIONs with param_ops (2+2 TXT each) = 6 TXT
+        assert len(txt_lines) == 6

--- a/tests/unit/sdk/policy/test_compiler.py
+++ b/tests/unit/sdk/policy/test_compiler.py
@@ -1,0 +1,327 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the PolicyCompiler (policy → RPZ + bind-aid directives)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dns_aid.sdk.policy.compiler import (
+    BindAidAction,
+    CompilationResult,
+    PolicyCompiler,
+    RPZAction,
+    SkippedRule,
+)
+from dns_aid.sdk.policy.schema import CELRule, PolicyDocument, PolicyRules
+
+FIXTURES = Path(__file__).resolve().parents[3] / "fixtures"
+
+
+@pytest.fixture
+def compiler() -> PolicyCompiler:
+    return PolicyCompiler()
+
+
+@pytest.fixture
+def sample_doc() -> PolicyDocument:
+    raw = (FIXTURES / "sample-policy.json").read_text()
+    return PolicyDocument.model_validate_json(raw)
+
+
+def _make_doc(**rule_kwargs: object) -> PolicyDocument:
+    """Helper to build a minimal PolicyDocument with specific rules."""
+    return PolicyDocument(
+        agent="_test._mcp._agents.example.com",
+        rules=PolicyRules(**rule_kwargs),
+    )
+
+
+# ── blocked_caller_domains ────────────────────────────────────
+
+
+class TestBlockedDomains:
+    def test_blocked_domains_rpz(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(blocked_caller_domains=["evil.example.com"])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "evil.example.com"
+        assert result.rpz_directives[0].action == RPZAction.NXDOMAIN
+
+    def test_blocked_domains_bindaid(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(blocked_caller_domains=["evil.example.com"])
+        result = compiler.compile(doc)
+        assert len(result.bindaid_directives) == 1
+        assert result.bindaid_directives[0].action == BindAidAction.NXDOMAIN
+
+    def test_multiple_blocked_domains(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(blocked_caller_domains=["a.com", "b.com", "c.com"])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 3
+        owners = {d.owner for d in result.rpz_directives}
+        assert owners == {"a.com", "b.com", "c.com"}
+
+    def test_wildcard_blocked_domain(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(blocked_caller_domains=["*.malicious.net"])
+        result = compiler.compile(doc)
+        assert result.rpz_directives[0].owner == "*.malicious.net"
+
+    def test_source_rule_tracking(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(blocked_caller_domains=["evil.com"])
+        result = compiler.compile(doc)
+        assert result.rpz_directives[0].source_rule == "blocked_caller_domains"
+        assert result.bindaid_directives[0].source_rule == "blocked_caller_domains"
+
+
+# ── allowed_caller_domains ────────────────────────────────────
+
+
+class TestAllowedDomains:
+    def test_allowed_domains_rpz_passthru(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(allowed_caller_domains=["trusted.com"])
+        result = compiler.compile(doc)
+        # 1 passthru + 1 catch-all NXDOMAIN
+        assert len(result.rpz_directives) == 2
+        assert result.rpz_directives[0].action == RPZAction.PASSTHRU
+        assert result.rpz_directives[0].owner == "trusted.com"
+
+    def test_allowed_domains_catch_all(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(allowed_caller_domains=["trusted.com"])
+        result = compiler.compile(doc)
+        catch_all = result.rpz_directives[-1]
+        assert catch_all.owner == "*"
+        assert catch_all.action == RPZAction.NXDOMAIN
+
+    def test_allowed_domains_bindaid(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(allowed_caller_domains=["trusted.com"])
+        result = compiler.compile(doc)
+        assert result.bindaid_directives[0].action == BindAidAction.PASSTHRU
+        assert result.bindaid_directives[-1].action == BindAidAction.NXDOMAIN
+
+    def test_allowed_and_blocked_interaction(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(
+            blocked_caller_domains=["evil.com"],
+            allowed_caller_domains=["good.com"],
+        )
+        result = compiler.compile(doc)
+        # blocked: 1 NXDOMAIN, allowed: 1 PASSTHRU + 1 catch-all = 3 total
+        assert len(result.rpz_directives) == 3
+
+
+# ── required_protocols ────────────────────────────────────────
+
+
+class TestRequiredProtocols:
+    def test_bindaid_only(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(required_protocols=["mcp", "a2a"])
+        result = compiler.compile(doc)
+        # RPZ gets a skip, bind-aid gets a directive
+        skipped_names = [s.rule_name for s in result.skipped]
+        assert "required_protocols" in skipped_names
+        assert any("key65402=whitelist:mcp,a2a" in d.param_ops for d in result.bindaid_directives)
+
+    def test_no_rpz_directives(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(required_protocols=["mcp"])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+
+
+# ── required_auth_types ───────────────────────────────────────
+
+
+class TestRequiredAuthTypes:
+    def test_bindaid_require_cap(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(required_auth_types=["oauth2"])
+        result = compiler.compile(doc)
+        skipped_names = [s.rule_name for s in result.skipped]
+        assert "required_auth_types" in skipped_names
+        assert any("key65400=require" in d.param_ops for d in result.bindaid_directives)
+
+
+# ── CEL rules ─────────────────────────────────────────────────
+
+
+class TestCELRules:
+    def test_cel_endswith_wildcard(self, compiler: PolicyCompiler) -> None:
+        cel = CELRule(
+            id="test-endswith",
+            expression='request.caller_domain.endsWith(".evil.io")',
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "*.evil.io"
+        assert result.rpz_directives[0].action == RPZAction.NXDOMAIN
+
+    def test_cel_exact_match(self, compiler: PolicyCompiler) -> None:
+        cel = CELRule(
+            id="test-exact",
+            expression='request.caller_domain == "bad.example.com"',
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "bad.example.com"
+
+    def test_cel_complex_skipped(self, compiler: PolicyCompiler) -> None:
+        cel = CELRule(
+            id="complex-rule",
+            expression="request.caller_trust_score >= 0.7 && request.protocol == 'mcp'",
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+        skipped_names = [s.rule_name for s in result.skipped]
+        assert "cel:complex-rule" in skipped_names
+
+    def test_cel_layer_filtering(self, compiler: PolicyCompiler) -> None:
+        """CEL rule with only layer1 should be skipped."""
+        cel = CELRule(
+            id="l1-only",
+            expression='request.caller_domain == "test.com"',
+            effect="deny",
+            enforcement_layers=["layer1"],
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+        skipped_names = [s.rule_name for s in result.skipped]
+        assert "cel:l1-only" in skipped_names
+
+    def test_cel_negated_endswith(self, compiler: PolicyCompiler) -> None:
+        """Evaluator convention: !endsWith with deny = block matching domains."""
+        cel = CELRule(
+            id="neg-endswith",
+            expression='!request.caller_domain.endsWith(".evil.io")',
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "*.evil.io"
+        assert result.rpz_directives[0].action == RPZAction.NXDOMAIN
+
+    def test_cel_not_equal(self, compiler: PolicyCompiler) -> None:
+        """Evaluator convention: != with deny = block matching domain."""
+        cel = CELRule(
+            id="neq-exact",
+            expression='request.caller_domain != "bad.example.com"',
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "bad.example.com"
+        assert result.rpz_directives[0].action == RPZAction.NXDOMAIN
+
+    def test_cel_no_rules(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(cel_rules=None)
+        result = compiler.compile(doc)
+        # No errors, no CEL-related output
+        assert not any(s.rule_name.startswith("cel:") for s in result.skipped)
+
+
+# ── Edge cases and integration ────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_empty_policy(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc()
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+        assert len(result.bindaid_directives) == 0
+        assert len(result.skipped) == 0
+
+    def test_all_skipped_rules_report(self, compiler: PolicyCompiler) -> None:
+        """All Layer 1/2-only rules should appear in skipped."""
+        doc = _make_doc(
+            require_dnssec=True,
+            require_mutual_tls=True,
+            min_tls_version="1.3",
+            required_caller_trust_score=0.8,
+            max_payload_bytes=1024,
+            allowed_methods=["tools/call"],
+            allowed_intents=["query"],
+            geo_restrictions=["US"],
+            data_classification="internal",
+            consent_required=True,
+        )
+        result = compiler.compile(doc)
+        skipped_names = {s.rule_name for s in result.skipped}
+        expected = {
+            "require_dnssec",
+            "require_mutual_tls",
+            "min_tls_version",
+            "required_caller_trust_score",
+            "max_payload_bytes",
+            "allowed_methods",
+            "allowed_intents",
+            "geo_restrictions",
+            "data_classification",
+            "consent_required",
+        }
+        assert expected.issubset(skipped_names)
+
+    def test_full_document_integration(
+        self, compiler: PolicyCompiler, sample_doc: PolicyDocument
+    ) -> None:
+        result = compiler.compile(sample_doc)
+        assert result.agent_fqdn == "_network._mcp._agents.example.com"
+        # blocked: 2 RPZ, allowed: 2 passthru + 1 catch-all, cel: 2 (endswith + exact)
+        assert len(result.rpz_directives) >= 5
+        assert len(result.bindaid_directives) >= 5
+        assert len(result.skipped) > 0
+
+    def test_dedup_removes_duplicate_rpz(self, compiler: PolicyCompiler) -> None:
+        """Same domain blocked by native rule AND CEL → deduped, warning emitted."""
+        doc = _make_doc(
+            blocked_caller_domains=["evil.com"],
+            cel_rules=[
+                CELRule(
+                    id="also-block-evil",
+                    expression='request.caller_domain != "evil.com"',
+                    effect="deny",
+                ),
+            ],
+        )
+        result = compiler.compile(doc)
+        # Should have only 1 NXDOMAIN for evil.com, not 2
+        nxdomain_evil = [
+            d for d in result.rpz_directives if d.owner == "evil.com" and d.action == RPZAction.NXDOMAIN
+        ]
+        assert len(nxdomain_evil) == 1
+        assert any("Duplicate RPZ" in w for w in result.warnings)
+
+    def test_svcparam_ops_bindaid_only(self, compiler: PolicyCompiler) -> None:
+        """SvcParam ops produce bind-aid directives and RPZ skip."""
+        from dns_aid.sdk.policy.schema import SvcParamOp
+
+        doc = _make_doc(svcparam_ops=[
+            SvcParamOp(key="port", op="enforce", values=["443"]),
+            SvcParamOp(key="ech", op="strip"),
+            SvcParamOp(key="alpn", op="whitelist", values=["h2", "h3"]),
+            SvcParamOp(key="key65400", op="validate"),
+        ])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+        assert len(result.bindaid_directives) == 4
+        # Check param_op strings
+        ops = [d.param_ops[0] for d in result.bindaid_directives]
+        assert "port=enforce:443" in ops
+        assert "ech=strip" in ops
+        assert "alpn=whitelist:h2,h3" in ops
+        assert "key65400=validate" in ops
+        # RPZ skip
+        assert any(s.rule_name == "svcparam_ops" for s in result.skipped)
+
+    def test_compilation_warnings_empty(self, compiler: PolicyCompiler) -> None:
+        doc = _make_doc(blocked_caller_domains=["evil.com"])
+        result = compiler.compile(doc)
+        assert result.warnings == []

--- a/tests/unit/sdk/policy/test_rpz_writer.py
+++ b/tests/unit/sdk/policy/test_rpz_writer.py
@@ -1,0 +1,128 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the RPZ zone file writer."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.sdk.policy.compiler import CompilationResult, RPZAction, RPZDirective
+from dns_aid.sdk.policy.rpz_writer import write_rpz_zone
+
+
+@pytest.fixture
+def empty_result() -> CompilationResult:
+    return CompilationResult(agent_fqdn="_test._mcp._agents.example.com")
+
+
+@pytest.fixture
+def result_with_directives() -> CompilationResult:
+    return CompilationResult(
+        agent_fqdn="_test._mcp._agents.example.com",
+        rpz_directives=[
+            RPZDirective(
+                owner="evil.com",
+                action=RPZAction.NXDOMAIN,
+                comment="Block evil",
+                source_rule="blocked_caller_domains",
+            ),
+            RPZDirective(
+                owner="trusted.com",
+                action=RPZAction.PASSTHRU,
+                comment="Allow trusted",
+                source_rule="allowed_caller_domains",
+            ),
+            RPZDirective(
+                owner="sketchy.net",
+                action=RPZAction.DROP,
+                comment="Drop sketchy",
+                source_rule="custom",
+            ),
+        ],
+    )
+
+
+class TestSOAHeader:
+    def test_soa_present(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com", serial=2026032800)
+        assert "SOA" in zone
+        assert "2026032800" in zone
+
+    def test_custom_serial(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com", serial=12345)
+        assert "12345" in zone
+
+    def test_default_serial_is_epoch(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com")
+        # Serial should be a large number (epoch seconds)
+        for line in zone.splitlines():
+            if "; serial" in line:
+                serial_str = line.split()[0]
+                assert int(serial_str) > 1700000000
+
+    def test_custom_ttl(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com", serial=1, ttl=600)
+        assert "$TTL 600" in zone
+
+
+class TestNSRecord:
+    def test_ns_record_present(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com", serial=1)
+        assert "NS  localhost." in zone
+
+    def test_custom_ns(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com", serial=1, ns_name="ns1.example.com.")
+        assert "ns1.example.com." in zone
+
+
+class TestCNAMEDirectives:
+    def test_nxdomain_cname(self, result_with_directives: CompilationResult) -> None:
+        zone = write_rpz_zone(result_with_directives, "rpz.example.com", serial=1)
+        assert "evil.com" in zone
+        assert "CNAME  ." in zone
+
+    def test_passthru_cname(self, result_with_directives: CompilationResult) -> None:
+        zone = write_rpz_zone(result_with_directives, "rpz.example.com", serial=1)
+        assert "trusted.com" in zone
+        assert "rpz-passthru." in zone
+
+    def test_drop_cname(self, result_with_directives: CompilationResult) -> None:
+        zone = write_rpz_zone(result_with_directives, "rpz.example.com", serial=1)
+        assert "sketchy.net" in zone
+        assert "rpz-drop." in zone
+
+    def test_comment_preservation(self, result_with_directives: CompilationResult) -> None:
+        zone = write_rpz_zone(result_with_directives, "rpz.example.com", serial=1)
+        assert "; Block evil" in zone
+        assert "; Allow trusted" in zone
+
+    def test_source_rule_in_comments(self, result_with_directives: CompilationResult) -> None:
+        zone = write_rpz_zone(result_with_directives, "rpz.example.com", serial=1)
+        assert "; source: blocked_caller_domains" in zone
+
+
+class TestEmptyZone:
+    def test_empty_directives(self, empty_result: CompilationResult) -> None:
+        zone = write_rpz_zone(empty_result, "rpz.example.com", serial=1)
+        assert "SOA" in zone
+        assert "NS" in zone
+        # No CNAME records
+        assert "CNAME" not in zone
+
+
+class TestFullIntegration:
+    def test_full_zone(self, result_with_directives: CompilationResult) -> None:
+        zone = write_rpz_zone(
+            result_with_directives,
+            "rpz.example.com",
+            serial=2026032800,
+            ttl=300,
+        )
+        lines = zone.splitlines()
+        # Has header, SOA, NS, and 3 directives
+        assert any("$TTL 300" in l for l in lines)
+        assert any("SOA" in l for l in lines)
+        assert any("NS" in l for l in lines)
+        cname_lines = [l for l in lines if "CNAME" in l]
+        assert len(cname_lines) == 3


### PR DESCRIPTION
## Summary

Full **discovery → policy → Threat Defense** pipeline for the Nordstrom POC.

- **PolicyCompiler**: transforms PolicyDocument JSON into RPZ directives (standard CNAME) and bind-aid directives (TXT ACTION + SvcParam ops)
- **Infoblox BloxOne TD integration**: named list push + security policy binding with `action_block`, `action_log`, `action_allow`, `action_redirect`
- **Infoblox NIOS RPZ**: `record:rpz:cname` CRUD + `zone_rp` management via WAPI
- **CLI**: `dns-aid policy compile|show`, `dns-aid enforce` (shadow/monitor/enforce modes)
- **MCP**: 4 new tools — `compile_policy_to_rpz`, `publish_rpz_zone`, `list_rpz_rules`, `list_td_security_policies`
- **CEL compilation**: domain-based CEL patterns compile to DNS zone entries; complex CEL enforced at Layer 1/2 by Rust evaluator (~2µs)
- **SvcParam ops**: `strip`, `require`, `validate`, `enforce`, `whitelist`, `blacklist` for bind-aid rdata enforcement
- **RPZ deduplication**: removes duplicate directives from native + CEL rules
- **Nordstrom POC doc**: end-to-end deployment guide with dual MCP server architecture

## Key files

| File | What |
|------|------|
| `src/dns_aid/sdk/policy/compiler.py` | PolicyCompiler + data models |
| `src/dns_aid/sdk/policy/rpz_writer.py` | Standard RPZ zone renderer |
| `src/dns_aid/sdk/policy/bindaid_writer.py` | bind-aid policy zone renderer |
| `src/dns_aid/cli/main.py` | `policy compile\|show` + `enforce` commands |
| `src/dns_aid/mcp/server.py` | 4 new MCP tools |
| `src/dns_aid/backends/infoblox/bloxone.py` | TD named list + security policy API |
| `src/dns_aid/backends/infoblox/nios.py` | RPZ CNAME + zone_rp WAPI methods |
| `docs/nordstrom-poc.md` | Nordstrom POC guide |

## Test plan

- [x] 1191 unit tests pass (53 new)
- [x] ruff lint + format clean
- [x] mypy clean (13 source files)
- [x] Live-tested against BloxOne TD: create named list → bind to policy → verify → action switch → unbind → delete
- [x] CLI `enforce --mode shadow` verified against highvelocitynetworking.com (13 agents discovered)
- [x] CEL Rust backend round-trip: compiler + evaluator produce consistent results
- [x] 1.5ms compilation for 1010 directives