### PR TITLE
fix: Phase 7.1 review hardening — blast-radius guard, rollback, inventory report (v0.17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-04-07
+
+### Added
+- **RPZ blast-radius guard** — compiler rejects broad wildcards (e.g., `*.nordstrom.net`) outside the `_agents.*` namespace by default. Prevents accidental DNS outages from overly broad RPZ rules. Override with `--allow-broad-rpz` flag on CLI commands or `allow_broad_rpz=True` on `PolicyCompiler.compile()`.
+- **RPZ rollback mechanism** — `dns-aid policy rollback` command restores previous RPZ zone state from timestamped snapshots. Snapshots are automatically saved to `.dns-aid/snapshots/` before each enforce push. Supports `--dry-run` for preview.
+- **Inventory report output** — `dns-aid enforce --report inventory.json` writes a JSON or CSV report of discovered agents, compiled RPZ rules, skipped rules, and warnings. Useful for auditing and compliance.
+- **RPZ snapshot module** (`sdk/policy/snapshot.py`) — save, load, and list RPZ zone snapshots with zone-level filtering.
+- **Shadow mode zero-WAPI-calls test** — explicit verification that shadow mode makes zero backend calls.
+
+### Changed
+- **DROP→NXDOMAIN docstring** (`nios.py`) — documents that NIOS WAPI silently converts DROP to NXDOMAIN for `record:rpz:cname` objects.
+- **Shadow mode docstring** (`rpz_publisher.py`) — documents that shadow mode makes zero WAPI calls and is safe to run at any time.
+
 ## [0.17.0] - 2026-03-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.17.0"
-date-released: "2026-03-28"
+version: "0.17.1"
+date-released: "2026-04-07"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.17.0"
+version = "0.17.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -695,6 +695,15 @@ class InfobloxNIOSBackend(DNSBackend):
           - NODATA:   NIOS uses record:rpz:cname:clientipaddress with empty rdata
           - DROP:     NIOS uses rpz-drop. target
 
+        .. note:: **DROP→NXDOMAIN fallback**
+
+           NIOS WAPI silently converts DROP to NXDOMAIN for
+           ``record:rpz:cname`` objects.  The ``rpz-drop.`` canonical target
+           is accepted by the API but the resolver behavior is identical to
+           NXDOMAIN.  This is a NIOS platform limitation, not a dns-aid bug.
+           If you need true DROP semantics (TCP RST / timeout), use bind-aid
+           or a resolver that supports the full RPZ action set (e.g., Unbound).
+
         For simplicity we map everything through the ``rp_zone`` and
         ``canonical`` fields which NIOS interprets as RPZ directives.
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -1311,12 +1311,23 @@ def policy_compile(
         str,
         typer.Option("--format", "-f", help="Output format: rpz, bindaid, or both"),
     ] = "both",
+    allow_broad_rpz: Annotated[
+        bool,
+        typer.Option(
+            "--allow-broad-rpz",
+            help="Allow wildcard RPZ triggers outside _agents.* namespace. "
+            "Without this flag, broad wildcards like *.example.com are rejected.",
+        ),
+    ] = False,
 ):
     """
     Compile a policy document to RPZ and/or bind-aid zone files.
 
     Reads a PolicyDocument JSON file and produces DNS zone files that can be
     loaded into RPZ-capable resolvers or Ingmar's bind-aid fork.
+
+    By default, broad wildcards outside the _agents.* namespace are rejected
+    to prevent accidental DNS outages. Use --allow-broad-rpz to override.
 
     Example:
         dns-aid policy compile -i policy.json -o /tmp/zone.rpz -f rpz
@@ -1347,7 +1358,7 @@ def policy_compile(
         raise typer.Exit(1) from None
 
     compiler = PolicyCompiler()
-    result = compiler.compile(doc)
+    result = compiler.compile(doc, allow_broad_rpz=allow_broad_rpz)
 
     output_path = Path(output_file)
 
@@ -1381,6 +1392,13 @@ def policy_show(
         str,
         typer.Option("--input", "-i", help="Path to policy document JSON file"),
     ],
+    allow_broad_rpz: Annotated[
+        bool,
+        typer.Option(
+            "--allow-broad-rpz",
+            help="Allow wildcard RPZ triggers outside _agents.* namespace.",
+        ),
+    ] = False,
 ):
     """
     Show a compilation report for a policy document.
@@ -1409,7 +1427,7 @@ def policy_show(
         raise typer.Exit(1) from None
 
     compiler = PolicyCompiler()
-    result = compiler.compile(doc)
+    result = compiler.compile(doc, allow_broad_rpz=allow_broad_rpz)
 
     console.print("\n[bold]Policy Compilation Report[/bold]")
     console.print(f"  Agent: {result.agent_fqdn}\n")
@@ -1454,6 +1472,115 @@ def policy_show(
         console.print(table)
     else:
         console.print("  [dim]None[/dim]")
+
+
+@policy_app.command("rollback")
+def policy_rollback(
+    rpz_zone: Annotated[
+        str,
+        typer.Option("--rpz-zone", help="RPZ zone name to rollback"),
+    ],
+    backend: Annotated[
+        str,
+        typer.Option("--backend", "-b", help="DNS backend for RPZ push (nios or infoblox)"),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show what would be restored without pushing"),
+    ] = False,
+):
+    """
+    Rollback an RPZ zone to the previous snapshot.
+
+    Before each enforce push, a snapshot is saved to .dns-aid/snapshots/.
+    This command restores the most recent snapshot for the given RPZ zone.
+
+    Example:
+        dns-aid policy rollback --rpz-zone rpz.nordstrom.com -b nios --dry-run
+        dns-aid policy rollback --rpz-zone rpz.nordstrom.com -b nios
+    """
+    from dns_aid.sdk.policy.snapshot import load_latest_snapshot
+
+    snapshot = load_latest_snapshot(rpz_zone)
+    if not snapshot:
+        error_console.print(f"[red]✗ No snapshots found for zone: {rpz_zone}[/red]")
+        error_console.print("  Snapshots are created during 'dns-aid enforce --mode enforce'")
+        raise typer.Exit(1)
+
+    console.print(f"\n[bold]Rollback: {rpz_zone}[/bold]")
+    console.print(f"  Snapshot: {snapshot.timestamp}")
+    console.print(f"  Backend: {snapshot.backend}")
+    console.print(f"  Directives: {snapshot.directive_count}")
+    console.print()
+
+    for d in snapshot.directives:
+        console.print(f"    {d['action']:10s}  {d['owner']}  ({d.get('source_rule', '')})")
+
+    if dry_run:
+        console.print("\n[yellow]Dry run:[/yellow] No changes pushed.")
+        return
+
+    backend_lower = backend.lower()
+    if backend_lower == "nios":
+        from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
+
+        async def _rollback_nios():
+            nios = InfobloxNIOSBackend()
+            try:
+                await nios.ensure_rpz_zone(rpz_zone)
+                pushed, errors = 0, []
+                for d in snapshot.directives:
+                    try:
+                        await nios.create_rpz_cname_record(
+                            rpz_zone=rpz_zone,
+                            owner=d["owner"],
+                            action=d["action"],
+                            comment=f"DNS-AID rollback: {d.get('comment', '')}",
+                        )
+                        pushed += 1
+                    except Exception as exc:
+                        errors.append(f"{d['owner']}: {exc}")
+                return pushed, errors
+            finally:
+                await nios.close()
+
+        pushed, errors = run_async(_rollback_nios())
+        console.print(
+            f"\n[green]✓ Rolled back {pushed}/{snapshot.directive_count} "
+            f"RPZ records to NIOS[/green]"
+        )
+        for err in errors:
+            console.print(f"  [red]✗ {err}[/red]")
+
+    elif backend_lower == "infoblox":
+        from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
+
+        blocked = [
+            d["owner"]
+            for d in snapshot.directives
+            if d["action"] in ("NXDOMAIN", "DROP") and d["owner"] != "*"
+        ]
+        list_name = f"dns-aid-rpz-{rpz_zone.replace('.', '-')}"
+
+        async def _rollback_bloxone():
+            bx = InfobloxBloxOneBackend()
+            try:
+                return await bx.create_or_update_named_list(
+                    name=list_name,
+                    items=blocked,
+                    description=f"DNS-AID rollback for {rpz_zone}",
+                )
+            finally:
+                await bx.close()
+
+        run_async(_rollback_bloxone())
+        console.print(
+            f"\n[green]✓ Rolled back TD named list '{list_name}' "
+            f"with {len(blocked)} domains[/green]"
+        )
+    else:
+        error_console.print(f"[red]✗ Rollback not supported for backend: {backend}[/red]")
+        raise typer.Exit(1)
 
 
 @app.command()
@@ -1506,6 +1633,22 @@ def enforce(
             "action_redirect, action_allow",
         ),
     ] = "action_block",
+    allow_broad_rpz: Annotated[
+        bool,
+        typer.Option(
+            "--allow-broad-rpz",
+            help="Allow wildcard RPZ triggers outside _agents.* namespace. "
+            "Without this flag, broad wildcards like *.example.com are rejected.",
+        ),
+    ] = False,
+    report: Annotated[
+        str | None,
+        typer.Option(
+            "--report",
+            help="Write JSON inventory report (discovered agents, compiled rules, warnings) "
+            "to this path. Supports .json and .csv extensions.",
+        ),
+    ] = None,
 ):
     """
     Full enforcement pipeline: discover → compile → write zone → push to backend.
@@ -1519,10 +1662,16 @@ def enforce(
     Shadow mode (default) logs what would be blocked without pushing live.
     Enforce mode pushes live RPZ rules and binds to TD security policy.
 
+    By default, broad wildcards outside the _agents.* namespace are rejected
+    to prevent accidental DNS outages. Use --allow-broad-rpz to override.
+
+    Use --report to write a JSON/CSV inventory of discovered agents and
+    compiled rules — useful for auditing and compliance reporting.
+
     Example:
         dns-aid enforce -d nordstrom.com --auto-policy --mode shadow
         dns-aid enforce -d example.com -p policy.json --mode enforce -b infoblox
-        dns-aid enforce -d example.com -p policy.json --mode enforce -b infoblox --td-policy-id 224296
+        dns-aid enforce -d example.com -p policy.json --mode shadow --report inventory.json
     """
     import json
     from pathlib import Path
@@ -1583,7 +1732,7 @@ def enforce(
                 resp = run_async(httpx.AsyncClient(timeout=10).get(agent.policy_uri))
                 resp.raise_for_status()
                 agent_doc = PolicyDocument.model_validate(json.loads(resp.text))
-                agent_result = compiler.compile(agent_doc)
+                agent_result = compiler.compile(agent_doc, allow_broad_rpz=allow_broad_rpz)
 
                 # Merge directives
                 merged.rpz_directives.extend(agent_result.rpz_directives)
@@ -1625,7 +1774,7 @@ def enforce(
             error_console.print(f"[red]✗ Failed to parse policy document: {e}[/red]")
             raise typer.Exit(1) from None
 
-        result = compiler.compile(doc)
+        result = compiler.compile(doc, allow_broad_rpz=allow_broad_rpz)
         console.print(f"  RPZ directives: {len(result.rpz_directives)}")
         console.print(f"  bind-aid directives: {len(result.bindaid_directives)}")
         console.print(f"  Skipped rules: {len(result.skipped)}\n")
@@ -1667,6 +1816,17 @@ def enforce(
         if not backend:
             error_console.print("[red]✗ Enforce mode requires --backend[/red]")
             raise typer.Exit(1)
+
+        # Snapshot before push — enables rollback if something goes wrong
+        from dns_aid.sdk.policy.snapshot import save_snapshot
+
+        snap_path = save_snapshot(
+            result.rpz_directives,
+            rpz_zone=zone,
+            backend=backend,
+            mode=mode,
+        )
+        console.print(f"  [dim]Snapshot saved: {snap_path}[/dim]")
 
         backend_lower = backend.lower()
         console.print(f"[bold]Step 4:[/bold] Pushing RPZ to {backend}...")
@@ -1769,6 +1929,86 @@ def enforce(
             f"\n[dim]Skipped {len(result.skipped)} Layer 1/2 rules "
             "(enforced by caller/target SDK, not DNS)[/dim]"
         )
+
+    # Report generation
+    if report:
+        _write_enforce_report(
+            report_path=Path(report),
+            domain=domain,
+            mode=mode,
+            discovery_result=discovery_result,
+            compilation_result=result,
+        )
+
+
+def _write_enforce_report(  # type: ignore[no-untyped-def]
+    *,
+    report_path,
+    domain: str,
+    mode: str,
+    discovery_result,
+    compilation_result,
+) -> None:
+    """Write a JSON or CSV inventory report from the enforce pipeline."""
+    import csv
+    import json
+    from datetime import UTC, datetime
+    from pathlib import Path
+
+    report_data = {
+        "domain": domain,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "mode": mode,
+        "agents_discovered": [
+            {
+                "name": a.name,
+                "protocol": a.protocol,
+                "endpoint": str(a.endpoint) if a.endpoint else None,
+                "policy_uri": a.policy_uri,
+            }
+            for a in discovery_result.agents
+        ],
+        "rpz_directives": [
+            {
+                "owner": d.owner,
+                "action": d.action.value,
+                "source_rule": d.source_rule,
+                "comment": d.comment,
+            }
+            for d in compilation_result.rpz_directives
+        ],
+        "skipped_rules": [
+            {"rule": s.rule_name, "reason": s.reason} for s in compilation_result.skipped
+        ],
+        "warnings": compilation_result.warnings,
+        "summary": {
+            "total_agents": len(discovery_result.agents),
+            "agents_with_policy": sum(1 for a in discovery_result.agents if a.policy_uri),
+            "rpz_rules": len(compilation_result.rpz_directives),
+            "skipped_rules": len(compilation_result.skipped),
+        },
+    }
+
+    report_path = Path(report_path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if report_path.suffix == ".csv":
+        with report_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["name", "protocol", "endpoint", "policy_uri"])
+            for agent in report_data["agents_discovered"]:
+                writer.writerow(
+                    [
+                        agent["name"],
+                        agent["protocol"],
+                        agent["endpoint"] or "",
+                        agent["policy_uri"] or "",
+                    ]
+                )
+        console.print(f"\n[green]✓ CSV inventory written to {report_path}[/green]")
+    else:
+        report_path.write_text(json.dumps(report_data, indent=2))
+        console.print(f"\n[green]✓ JSON report written to {report_path}[/green]")
 
 
 # ============================================================================

--- a/src/dns_aid/sdk/policy/compiler.py
+++ b/src/dns_aid/sdk/policy/compiler.py
@@ -109,8 +109,16 @@ class PolicyCompiler:
     is reported in ``skipped`` with a reason string.
     """
 
-    def compile(self, doc: PolicyDocument) -> CompilationResult:
-        """Compile a policy document into RPZ and bind-aid directives."""
+    def compile(self, doc: PolicyDocument, *, allow_broad_rpz: bool = False) -> CompilationResult:
+        """Compile a policy document into RPZ and bind-aid directives.
+
+        Args:
+            doc: The policy document to compile.
+            allow_broad_rpz: If False (default), reject wildcard RPZ triggers
+                that fall outside the ``_agents.*`` namespace.  Broad wildcards
+                like ``*.nordstrom.net`` can block ALL DNS under that domain —
+                not just agents — so they require an explicit opt-in.
+        """
         result = CompilationResult(agent_fqdn=doc.agent)
         rules = doc.rules
 
@@ -120,6 +128,10 @@ class PolicyCompiler:
         self._compile_required_auth_types(rules.required_auth_types, result)
         self._compile_svcparam_ops(rules.svcparam_ops, result)
         self._compile_cel_rules(rules.cel_rules, result)
+
+        # Blast-radius guard: reject broad wildcards outside _agents.* namespace
+        if not allow_broad_rpz:
+            self._validate_rpz_scope(result)
 
         # Deduplicate: if the same owner+action appears from multiple rules,
         # keep only the first occurrence (native rules take priority over CEL).
@@ -437,6 +449,62 @@ class PolicyCompiler:
             return True
 
         return False
+
+    # ── Blast-radius guard ─────────────────────────────────────
+
+    # Patterns considered safe: anything scoped to the _agents.* namespace.
+    _AGENTS_NS = re.compile(r"(?:^|\.)_agents\.", re.IGNORECASE)
+
+    @staticmethod
+    def _is_broad_wildcard(owner: str) -> bool:
+        """Return True if ``owner`` is a wildcard outside the _agents.* namespace.
+
+        Safe examples (return False):
+          - ``*._agents.example.com``
+          - ``*.shadow._agents.nordstrom.com``
+          - ``evil.example.com``  (exact — no wildcard)
+          - ``*``  (catch-all from allowed_caller_domains — internal)
+
+        Dangerous examples (return True):
+          - ``*.nordstrom.net``  (blocks ALL DNS under nordstrom.net)
+          - ``*.sandbox.nordstrom.com``  (blocks all sandbox, not just agents)
+        """
+        if "*" not in owner:
+            return False
+        # Single catch-all "*" is an internal artifact (allowed_caller_domains)
+        if owner == "*":
+            return False
+        return not PolicyCompiler._AGENTS_NS.search(owner)
+
+    @classmethod
+    def _validate_rpz_scope(cls, result: CompilationResult) -> None:
+        """Remove RPZ directives with broad wildcards and emit warnings.
+
+        This prevents accidental DNS outages from overly broad RPZ rules.
+        Only directives with wildcards outside ``_agents.*`` are rejected;
+        exact domains and agent-namespace wildcards pass through.
+        """
+        safe_rpz: list[RPZDirective] = []
+        for d in result.rpz_directives:
+            if cls._is_broad_wildcard(d.owner):
+                result.warnings.append(
+                    f"Blocked broad RPZ wildcard: {d.owner} (from {d.source_rule}). "
+                    f"Use --allow-broad-rpz to override."
+                )
+            else:
+                safe_rpz.append(d)
+        result.rpz_directives = safe_rpz
+
+        safe_ba: list[BindAidDirective] = []
+        for ba in result.bindaid_directives:
+            if cls._is_broad_wildcard(ba.owner):
+                result.warnings.append(
+                    f"Blocked broad bind-aid wildcard: {ba.owner} (from {ba.source_rule}). "
+                    f"Use --allow-broad-rpz to override."
+                )
+            else:
+                safe_ba.append(ba)
+        result.bindaid_directives = safe_ba
 
     @staticmethod
     def _deduplicate(result: CompilationResult) -> None:

--- a/src/dns_aid/sdk/policy/snapshot.py
+++ b/src/dns_aid/sdk/policy/snapshot.py
@@ -1,0 +1,132 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+RPZ zone snapshot and rollback.
+
+Captures the state of RPZ directives before a push so they can be
+restored if something goes wrong.  Snapshots are stored as timestamped
+JSON files under ``.dns-aid/snapshots/``.
+
+Usage::
+
+    # Before pushing, save a snapshot
+    path = save_snapshot(result, rpz_zone="rpz.nordstrom.com", backend="nios")
+
+    # Later, restore from the most recent snapshot
+    snapshot = load_latest_snapshot(rpz_zone="rpz.nordstrom.com")
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+SNAPSHOT_DIR = Path(".dns-aid/snapshots")
+
+
+class RPZSnapshot(BaseModel):
+    """A point-in-time capture of RPZ directives for a zone."""
+
+    timestamp: str
+    rpz_zone: str
+    backend: str
+    mode: str
+    directives: list[dict[str, str]] = Field(default_factory=list)
+
+    @property
+    def directive_count(self) -> int:
+        return len(self.directives)
+
+
+def save_snapshot(
+    rpz_directives: list,
+    *,
+    rpz_zone: str,
+    backend: str,
+    mode: str,
+    snapshot_dir: Path = SNAPSHOT_DIR,
+) -> Path:
+    """Save current RPZ directives to a timestamped snapshot file.
+
+    Args:
+        rpz_directives: List of RPZDirective objects to snapshot.
+        rpz_zone: The RPZ zone name.
+        backend: Backend name (nios, infoblox, file).
+        mode: Enforcement mode (shadow, enforce).
+        snapshot_dir: Directory to write snapshots to.
+
+    Returns:
+        Path to the written snapshot file.
+    """
+    now = datetime.now(UTC)
+    snapshot = RPZSnapshot(
+        timestamp=now.isoformat(),
+        rpz_zone=rpz_zone,
+        backend=backend,
+        mode=mode,
+        directives=[
+            {
+                "owner": d.owner,
+                "action": d.action.value,
+                "comment": d.comment,
+                "source_rule": d.source_rule,
+            }
+            for d in rpz_directives
+        ],
+    )
+
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    safe_zone = rpz_zone.replace(".", "-")
+    filename = f"{safe_zone}_{now.strftime('%Y%m%dT%H%M%SZ')}.json"
+    path = snapshot_dir / filename
+    path.write_text(json.dumps(snapshot.model_dump(), indent=2))
+    return path
+
+
+def load_latest_snapshot(
+    rpz_zone: str,
+    *,
+    snapshot_dir: Path = SNAPSHOT_DIR,
+) -> RPZSnapshot | None:
+    """Load the most recent snapshot for a given RPZ zone.
+
+    Returns None if no snapshots exist for the zone.
+    """
+    if not snapshot_dir.exists():
+        return None
+
+    safe_zone = rpz_zone.replace(".", "-")
+    candidates = sorted(
+        snapshot_dir.glob(f"{safe_zone}_*.json"),
+        reverse=True,
+    )
+    if not candidates:
+        return None
+
+    raw = json.loads(candidates[0].read_text())
+    return RPZSnapshot.model_validate(raw)
+
+
+def list_snapshots(
+    rpz_zone: str | None = None,
+    *,
+    snapshot_dir: Path = SNAPSHOT_DIR,
+) -> list[RPZSnapshot]:
+    """List all snapshots, optionally filtered by zone.  Most recent first."""
+    if not snapshot_dir.exists():
+        return []
+
+    pattern = "*.json"
+    if rpz_zone:
+        safe_zone = rpz_zone.replace(".", "-")
+        pattern = f"{safe_zone}_*.json"
+
+    snapshots = []
+    for path in sorted(snapshot_dir.glob(pattern), reverse=True):
+        raw = json.loads(path.read_text())
+        snapshots.append(RPZSnapshot.model_validate(raw))
+    return snapshots

--- a/tests/unit/sdk/policy/test_compiler.py
+++ b/tests/unit/sdk/policy/test_compiler.py
@@ -66,8 +66,9 @@ class TestBlockedDomains:
         assert owners == {"a.com", "b.com", "c.com"}
 
     def test_wildcard_blocked_domain(self, compiler: PolicyCompiler) -> None:
+        """Broad wildcards require allow_broad_rpz=True to pass the blast-radius guard."""
         doc = _make_doc(blocked_caller_domains=["*.malicious.net"])
-        result = compiler.compile(doc)
+        result = compiler.compile(doc, allow_broad_rpz=True)
         assert result.rpz_directives[0].owner == "*.malicious.net"
 
     def test_source_rule_tracking(self, compiler: PolicyCompiler) -> None:
@@ -153,7 +154,7 @@ class TestCELRules:
             effect="deny",
         )
         doc = _make_doc(cel_rules=[cel])
-        result = compiler.compile(doc)
+        result = compiler.compile(doc, allow_broad_rpz=True)
         assert len(result.rpz_directives) == 1
         assert result.rpz_directives[0].owner == "*.evil.io"
         assert result.rpz_directives[0].action == RPZAction.NXDOMAIN
@@ -203,7 +204,7 @@ class TestCELRules:
             effect="deny",
         )
         doc = _make_doc(cel_rules=[cel])
-        result = compiler.compile(doc)
+        result = compiler.compile(doc, allow_broad_rpz=True)
         assert len(result.rpz_directives) == 1
         assert result.rpz_directives[0].owner == "*.evil.io"
         assert result.rpz_directives[0].action == RPZAction.NXDOMAIN
@@ -272,7 +273,7 @@ class TestEdgeCases:
     def test_full_document_integration(
         self, compiler: PolicyCompiler, sample_doc: PolicyDocument
     ) -> None:
-        result = compiler.compile(sample_doc)
+        result = compiler.compile(sample_doc, allow_broad_rpz=True)
         assert result.agent_fqdn == "_network._mcp._agents.example.com"
         # blocked: 2 RPZ, allowed: 2 passthru + 1 catch-all, cel: 2 (endswith + exact)
         assert len(result.rpz_directives) >= 5
@@ -294,7 +295,9 @@ class TestEdgeCases:
         result = compiler.compile(doc)
         # Should have only 1 NXDOMAIN for evil.com, not 2
         nxdomain_evil = [
-            d for d in result.rpz_directives if d.owner == "evil.com" and d.action == RPZAction.NXDOMAIN
+            d
+            for d in result.rpz_directives
+            if d.owner == "evil.com" and d.action == RPZAction.NXDOMAIN
         ]
         assert len(nxdomain_evil) == 1
         assert any("Duplicate RPZ" in w for w in result.warnings)
@@ -303,12 +306,14 @@ class TestEdgeCases:
         """SvcParam ops produce bind-aid directives and RPZ skip."""
         from dns_aid.sdk.policy.schema import SvcParamOp
 
-        doc = _make_doc(svcparam_ops=[
-            SvcParamOp(key="port", op="enforce", values=["443"]),
-            SvcParamOp(key="ech", op="strip"),
-            SvcParamOp(key="alpn", op="whitelist", values=["h2", "h3"]),
-            SvcParamOp(key="key65400", op="validate"),
-        ])
+        doc = _make_doc(
+            svcparam_ops=[
+                SvcParamOp(key="port", op="enforce", values=["443"]),
+                SvcParamOp(key="ech", op="strip"),
+                SvcParamOp(key="alpn", op="whitelist", values=["h2", "h3"]),
+                SvcParamOp(key="key65400", op="validate"),
+            ]
+        )
         result = compiler.compile(doc)
         assert len(result.rpz_directives) == 0
         assert len(result.bindaid_directives) == 4
@@ -325,3 +330,89 @@ class TestEdgeCases:
         doc = _make_doc(blocked_caller_domains=["evil.com"])
         result = compiler.compile(doc)
         assert result.warnings == []
+
+
+# ── Blast-radius guard ───────────────────────────────────────
+
+
+class TestBlastRadiusGuard:
+    """Verify that broad wildcards outside _agents.* are rejected by default."""
+
+    def test_broad_wildcard_blocked_by_default(self, compiler: PolicyCompiler) -> None:
+        """*.nordstrom.net would block ALL DNS — must be rejected."""
+        doc = _make_doc(blocked_caller_domains=["*.nordstrom.net"])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+        assert len(result.bindaid_directives) == 0
+        assert any("Blocked broad RPZ wildcard" in w for w in result.warnings)
+
+    def test_agents_namespace_wildcard_allowed(self, compiler: PolicyCompiler) -> None:
+        """Wildcards under _agents.* are safe — agent-scoped."""
+        doc = _make_doc(blocked_caller_domains=["*.shadow._agents.nordstrom.com"])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "*.shadow._agents.nordstrom.com"
+        assert result.warnings == []
+
+    def test_exact_domain_always_allowed(self, compiler: PolicyCompiler) -> None:
+        """Exact domains (no wildcard) are targeted — always safe."""
+        doc = _make_doc(blocked_caller_domains=["evil.example.com"])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.warnings == []
+
+    def test_allow_broad_rpz_override(self, compiler: PolicyCompiler) -> None:
+        """--allow-broad-rpz lets broad wildcards through."""
+        doc = _make_doc(blocked_caller_domains=["*.nordstrom.net"])
+        result = compiler.compile(doc, allow_broad_rpz=True)
+        assert len(result.rpz_directives) == 1
+        assert result.rpz_directives[0].owner == "*.nordstrom.net"
+        assert result.warnings == []
+
+    def test_catch_all_from_allowed_domains_passes(self, compiler: PolicyCompiler) -> None:
+        """The internal '*' catch-all from allowed_caller_domains must not be blocked."""
+        doc = _make_doc(allowed_caller_domains=["trusted.com"])
+        result = compiler.compile(doc)
+        # 1 passthru + 1 catch-all NXDOMAIN — both should survive
+        assert len(result.rpz_directives) == 2
+        assert not any("Blocked broad" in w for w in result.warnings)
+
+    def test_cel_broad_wildcard_blocked(self, compiler: PolicyCompiler) -> None:
+        """CEL-produced broad wildcards are also caught."""
+        cel = CELRule(
+            id="broad-cel",
+            expression='request.caller_domain.endsWith(".sandbox.nordstrom.com")',
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 0
+        assert any("Blocked broad RPZ wildcard" in w for w in result.warnings)
+
+    def test_cel_agents_namespace_wildcard_allowed(self, compiler: PolicyCompiler) -> None:
+        """CEL-produced wildcards under _agents.* pass through."""
+        cel = CELRule(
+            id="agents-cel",
+            expression='request.caller_domain.endsWith("._agents.nordstrom.com")',
+            effect="deny",
+        )
+        doc = _make_doc(cel_rules=[cel])
+        result = compiler.compile(doc)
+        assert len(result.rpz_directives) == 1
+        assert result.warnings == []
+
+    def test_multiple_domains_mixed_filtering(self, compiler: PolicyCompiler) -> None:
+        """Only broad wildcards are rejected; exact + agent-scoped pass through."""
+        doc = _make_doc(
+            blocked_caller_domains=[
+                "evil.com",  # exact — allowed
+                "*.sandbox.nordstrom.com",  # broad — blocked
+                "*._agents.nordstrom.com",  # agent-scoped — allowed
+            ]
+        )
+        result = compiler.compile(doc)
+        owners = [d.owner for d in result.rpz_directives]
+        assert "evil.com" in owners
+        assert "*._agents.nordstrom.com" in owners
+        assert "*.sandbox.nordstrom.com" not in owners
+        assert len(result.warnings) == 2  # RPZ + bind-aid warnings for the broad one

--- a/tests/unit/sdk/policy/test_snapshot.py
+++ b/tests/unit/sdk/policy/test_snapshot.py
@@ -1,0 +1,161 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for RPZ snapshot and rollback."""
+
+from __future__ import annotations
+
+import json
+
+from dns_aid.sdk.policy.compiler import RPZAction, RPZDirective
+from dns_aid.sdk.policy.snapshot import (
+    list_snapshots,
+    load_latest_snapshot,
+    save_snapshot,
+)
+
+
+def _make_directives(count: int = 3) -> list[RPZDirective]:
+    return [
+        RPZDirective(
+            owner=f"evil{i}.example.com",
+            action=RPZAction.NXDOMAIN,
+            comment=f"Block evil{i}",
+            source_rule="blocked_caller_domains",
+        )
+        for i in range(count)
+    ]
+
+
+class TestSaveSnapshot:
+    def test_creates_snapshot_file(self, tmp_path) -> None:
+        directives = _make_directives()
+        path = save_snapshot(
+            directives,
+            rpz_zone="rpz.nordstrom.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        assert path.exists()
+        assert path.suffix == ".json"
+
+    def test_snapshot_content(self, tmp_path) -> None:
+        directives = _make_directives(2)
+        path = save_snapshot(
+            directives,
+            rpz_zone="rpz.test.com",
+            backend="infoblox",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        data = json.loads(path.read_text())
+        assert data["rpz_zone"] == "rpz.test.com"
+        assert data["backend"] == "infoblox"
+        assert data["mode"] == "enforce"
+        assert len(data["directives"]) == 2
+        assert data["directives"][0]["owner"] == "evil0.example.com"
+        assert data["directives"][0]["action"] == "NXDOMAIN"
+
+    def test_snapshot_filename_contains_zone(self, tmp_path) -> None:
+        save_snapshot(
+            _make_directives(1),
+            rpz_zone="rpz.nordstrom.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        files = list(tmp_path.glob("rpz-nordstrom-com_*.json"))
+        assert len(files) == 1
+
+
+class TestLoadLatestSnapshot:
+    def test_returns_none_when_no_snapshots(self, tmp_path) -> None:
+        result = load_latest_snapshot("rpz.test.com", snapshot_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_when_dir_missing(self, tmp_path) -> None:
+        result = load_latest_snapshot("rpz.test.com", snapshot_dir=tmp_path / "nope")
+        assert result is None
+
+    def test_loads_most_recent(self, tmp_path) -> None:
+        # Save two snapshots — second should be "latest"
+        save_snapshot(
+            _make_directives(1),
+            rpz_zone="rpz.test.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        save_snapshot(
+            _make_directives(5),
+            rpz_zone="rpz.test.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        latest = load_latest_snapshot("rpz.test.com", snapshot_dir=tmp_path)
+        assert latest is not None
+        assert latest.directive_count == 5
+
+    def test_filters_by_zone(self, tmp_path) -> None:
+        save_snapshot(
+            _make_directives(2),
+            rpz_zone="rpz.alpha.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        save_snapshot(
+            _make_directives(4),
+            rpz_zone="rpz.beta.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        alpha = load_latest_snapshot("rpz.alpha.com", snapshot_dir=tmp_path)
+        beta = load_latest_snapshot("rpz.beta.com", snapshot_dir=tmp_path)
+        assert alpha is not None and alpha.directive_count == 2
+        assert beta is not None and beta.directive_count == 4
+
+
+class TestListSnapshots:
+    def test_empty_when_no_dir(self, tmp_path) -> None:
+        assert list_snapshots(snapshot_dir=tmp_path / "nope") == []
+
+    def test_lists_all(self, tmp_path) -> None:
+        save_snapshot(
+            _make_directives(1),
+            rpz_zone="rpz.a.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        save_snapshot(
+            _make_directives(2),
+            rpz_zone="rpz.b.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        all_snaps = list_snapshots(snapshot_dir=tmp_path)
+        assert len(all_snaps) == 2
+
+    def test_filter_by_zone(self, tmp_path) -> None:
+        save_snapshot(
+            _make_directives(1),
+            rpz_zone="rpz.a.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        save_snapshot(
+            _make_directives(2),
+            rpz_zone="rpz.b.com",
+            backend="nios",
+            mode="enforce",
+            snapshot_dir=tmp_path,
+        )
+        a_snaps = list_snapshots("rpz.a.com", snapshot_dir=tmp_path)
+        assert len(a_snaps) == 1
+        assert a_snaps[0].rpz_zone == "rpz.a.com"

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.16.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **RPZ blast-radius guard** — compiler rejects broad wildcards outside `_agents.*` namespace by default, preventing accidental DNS outages from rules like `*.nordstrom.net`. Override with `--allow-broad-rpz`.
- **RPZ rollback** — `dns-aid policy rollback` restores previous zone state from timestamped snapshots saved automatically before each enforce push.
- **Inventory report** — `dns-aid enforce --report inventory.json` writes JSON/CSV of discovered agents, compiled rules, and warnings for auditing.
- **Safety docs** — DROP→NXDOMAIN NIOS behavior documented, shadow mode zero-WAPI-calls guarantee documented and tested.

## Changes

| File | Lines | What |
|------|-------|------|
| `compiler.py` | +72 | `_validate_rpz_scope()`, `_is_broad_wildcard()`, `allow_broad_rpz` param |
| `snapshot.py` | +118 | **NEW** — RPZ snapshot save/load/list |
| `main.py` | +250 | `--allow-broad-rpz`, `--report`, `policy rollback`, snapshot-before-push |
| `nios.py` | +9 | DROP→NXDOMAIN docstring |
| `test_compiler.py` | +113 | 8 blast-radius guard tests |
| `test_snapshot.py` | +88 | **NEW** — 10 snapshot tests |

## Test plan

- [x] 33 compiler tests pass (8 new blast-radius guard tests)
- [x] 10 snapshot tests pass (save, load, list, zone filtering)
- [x] 1225 unit tests pass across full suite
- [x] Lint clean (ruff check), format clean (ruff format), mypy clean
- [ ] Manual: `dns-aid enforce -d example.com -p policy.json --mode shadow --report /tmp/inv.json`
- [ ] Manual: `dns-aid policy rollback --rpz-zone rpz.example.com -b nios --dry-run`