### PR TITLE
feat: MCP tool annotations + privacy policy for Anthropic directory listing (v0.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2026-04-14
+
+### Added
+- **MCP tool annotations** — all 15 MCP tools now declare `ToolAnnotations` with `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` hints per MCP spec. Helps clients (Claude Desktop, Cursor, etc.) determine permission levels for each tool. 9 tools marked read-only, 5 write (non-destructive), 1 destructive (`delete_agent_from_dns`).
+- **MCP tool titles** — all 15 tools include human-readable `title` parameter for directory listings (e.g., "Discover Agents via DNS", "Publish Agent to DNS").
+- **Privacy policy** (`PRIVACY.md`) — documents data handling for Anthropic MCP Directory submission. Covers DNS query routing, opt-in SDK telemetry, credential handling, and third-party backend interactions.
+- **Directory listing reference** (`docs/mcp-directory-listing.md`) — submission notes, demo prompts, and category/tag metadata for the Anthropic MCP Connector Directory.
+
 ## [0.17.1] - 2026-04-07
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.17.1"
-date-released: "2026-04-07"
+version: "0.17.2"
+date-released: "2026-04-14"
 
 keywords:
   - dns

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,89 @@
+# DNS-AID Privacy Policy
+
+**Effective Date:** April 14, 2026
+**Last Updated:** April 14, 2026
+
+## Overview
+
+DNS-AID is an open source toolkit for DNS-based AI agent discovery. This policy describes how the DNS-AID MCP server and CLI tools handle data.
+
+## What DNS-AID Does
+
+DNS-AID queries and publishes DNS records (SVCB, TXT) to enable AI agents to discover each other. It operates on public DNS infrastructure using standard protocols (RFC 9460, RFC 4033-4035).
+
+## Data Handling Summary
+
+- **No automatic telemetry.** The toolkit sends no usage data to any server by default.
+- **No analytics.** No tracking, metrics collection, or behavioral data is gathered.
+- **No user accounts.** DNS-AID has no user registration or authentication system.
+- **No conversation access.** The MCP server does not read, store, or access chat history, memory, conversation summaries, or uploaded files from the host AI application.
+
+## Data That Flows Through DNS-AID
+
+When you use DNS-AID tools, the following data is processed **locally on your machine**:
+
+| Operation | Data involved | Where it goes |
+|-----------|--------------|---------------|
+| `discover_agents` | Domain name you query | Public DNS resolvers (your configured DNS server) |
+| `verify_agent_dns` | Agent FQDN | Public DNS resolvers + DNSSEC validators |
+| `publish_agent_to_dns` | Agent name, endpoint, capabilities | Your configured DNS backend (Route53, Infoblox, Cloudflare, etc.) |
+| `delete_agent_from_dns` | Agent name, domain | Your configured DNS backend |
+| `compile_policy_to_rpz` | Policy JSON | Local only (no network calls) |
+| `diagnose_environment` | System config checks | Local only (no network calls) |
+| `list_agent_index` | Domain name | Your configured DNS backend |
+| `sync_agent_index` | Domain name | Your configured DNS backend |
+| `list_published_agents` | Domain name | Your configured DNS backend |
+| `list_rpz_rules` | RPZ zone name | Your configured DNS backend |
+| `list_td_security_policies` | None | Your configured Infoblox backend |
+
+## Agent Invocation Tools and Telemetry
+
+Three tools interact with external agent endpoints:
+
+| Operation | Data involved | Where it goes |
+|-----------|--------------|---------------|
+| `call_agent_tool` | Tool name, arguments | The target agent's MCP endpoint |
+| `list_agent_tools` | None | The target agent's MCP endpoint |
+| `send_a2a_message` | Message content | The target agent's A2A endpoint |
+
+These tools use the DNS-AID SDK which supports **opt-in telemetry**. Telemetry is **disabled by default** and is only activated when you explicitly set the `DNS_AID_SDK_HTTP_PUSH_URL` environment variable to a telemetry endpoint URL. When enabled, the SDK sends invocation signals (latency, status, agent FQDN) to the URL you specified via a fire-and-forget HTTP POST. No telemetry data is sent to DNS-AID maintainers or any third party unless you configure it to do so.
+
+Telemetry fields sent (when opted in): agent FQDN, endpoint, protocol, method, invocation latency, status (success/error/timeout), HTTP status code, response size, DNSSEC validation result, TLS version, auth type.
+
+## Credentials
+
+- DNS backend credentials (AWS keys, Infoblox API keys, Cloudflare tokens) are read from **your local environment variables or `.env` file**.
+- Credentials are never logged, cached beyond the current session, or transmitted anywhere other than the DNS backend you configured.
+- No credentials are sent to DNS-AID maintainers or any third party.
+
+## DNS Queries
+
+- DNS discovery queries go to **your system's configured DNS resolver** (e.g., your ISP, Google 8.8.8.8, Cloudflare 1.1.1.1).
+- DNS-AID does not operate its own DNS resolvers or proxy DNS traffic.
+- DNSSEC validation uses standard resolution chains through your resolver.
+
+## Third-Party Services
+
+DNS-AID interacts with third-party DNS providers **only when you explicitly configure a backend**:
+
+- **AWS Route 53** — governed by [AWS Privacy Policy](https://aws.amazon.com/privacy/)
+- **Cloudflare** — governed by [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/)
+- **Infoblox** — governed by [Infoblox Privacy Policy](https://www.infoblox.com/privacy-policy/)
+- **NS1 (IBM)** — governed by [IBM Privacy Policy](https://www.ibm.com/privacy)
+
+DNS-AID does not select or default to any third-party service. You choose your DNS backend.
+
+## Open Source
+
+DNS-AID is open source under the Apache License 2.0. You can inspect all code at:
+https://github.com/infobloxopen/dns-aid-core
+
+## Changes to This Policy
+
+Material changes to this policy will be documented in the project's release notes and CHANGELOG.
+
+## Contact
+
+- **GitHub Issues:** https://github.com/infobloxopen/dns-aid-core/issues
+- **Email:** iracic@infoblox.com
+- **IETF Draft:** draft-mozleywilliams-dnsop-dnsaid

--- a/docs/mcp-directory-listing.md
+++ b/docs/mcp-directory-listing.md
@@ -1,0 +1,50 @@
+# Anthropic MCP Directory — Submission Notes
+
+## Listing Description
+
+DNS-AID enables AI agents to discover and connect to other AI agents using DNS.
+Publish agents to DNS so others can find them, discover agents at any domain,
+and verify their DNS records and DNSSEC security — all using standard DNS
+infrastructure (RFC 9460 SVCB records).
+
+## Demo Prompts
+
+Use these three prompts with the DNS-AID MCP server to demonstrate core functionality.
+Each works against live DNS records with no credentials required.
+
+### Prompt 1: Discover agents at a domain
+
+> Discover what AI agents are published at highvelocitynetworking.com
+
+Expected: Returns a list of agents with their names, protocols (MCP/A2A),
+endpoints, and capabilities. Demonstrates DNS-based agent discovery using
+SVCB record queries.
+
+### Prompt 2: Verify an agent's DNS security
+
+> Verify the DNS records for _network._mcp._agents.highvelocitynetworking.com
+> and tell me if DNSSEC is valid
+
+Expected: Returns DNS record validation results including SVCB record
+existence, DNSSEC validation status, DANE/TLSA configuration, endpoint
+reachability, and a security score.
+
+### Prompt 3: Diagnose the environment
+
+> Run DNS-AID environment diagnostics for the domain highvelocitynetworking.com
+
+Expected: Returns a structured diagnostic report checking Python version,
+DNS resolution capability, backend configuration, and agent discovery
+against the specified domain. No credentials required for the diagnostic.
+
+## Category
+
+Developer Tools / Infrastructure / AI Agent Discovery
+
+## Tags
+
+dns, agent-discovery, mcp, a2a, svcb, dnssec, ai-agents, infrastructure
+
+## Privacy Policy URL
+
+https://github.com/infobloxopen/dns-aid-core/blob/main/PRIVACY.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.17.1"
+version = "0.17.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -57,6 +57,7 @@ structlog.configure(
 )
 
 from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.types import ToolAnnotations  # noqa: E402
 
 from dns_aid.utils.validation import (  # noqa: E402
     ValidationError,
@@ -211,7 +212,15 @@ def _format_validation_error(e: ValidationError) -> dict:
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Publish Agent to DNS",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def publish_agent_to_dns(
     name: str,
     domain: str,
@@ -387,7 +396,15 @@ def publish_agent_to_dns(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Discover Agents via DNS",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def discover_agents_via_dns(
     domain: str,
     protocol: Literal["mcp", "a2a"] | None = None,
@@ -512,7 +529,15 @@ def discover_agents_via_dns(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Call Agent Tool",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
 def call_agent_tool(
     endpoint: str,
     tool_name: str,
@@ -608,7 +633,15 @@ def call_agent_tool(
         return {"success": False, "error": str(e)}
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List Agent Tools",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def list_agent_tools(endpoint: str) -> dict:
     """
     List available tools on a discovered MCP agent.
@@ -647,7 +680,15 @@ def list_agent_tools(endpoint: str) -> dict:
         return {"success": False, "error": str(e)}
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Verify Agent DNS Records",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def verify_agent_dns(fqdn: str) -> dict:
     """
     Verify DNS-AID records for an agent.
@@ -705,7 +746,15 @@ def verify_agent_dns(fqdn: str) -> dict:
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List Published Agents",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def list_published_agents(
     domain: str,
     backend: Literal[
@@ -791,7 +840,15 @@ def list_published_agents(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Delete Agent from DNS",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def delete_agent_from_dns(
     name: str,
     domain: str,
@@ -887,7 +944,15 @@ def delete_agent_from_dns(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List Agent Index",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def list_agent_index(
     domain: str,
     backend: Literal[
@@ -950,7 +1015,15 @@ def list_agent_index(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Sync Agent Index",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def sync_agent_index(
     domain: str,
     backend: Literal[
@@ -1033,7 +1106,15 @@ def sync_agent_index(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Compile Policy to RPZ",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 def compile_policy_to_rpz(
     policy_json: str,
     format: str = "both",
@@ -1099,7 +1180,15 @@ def compile_policy_to_rpz(
     return response
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Publish RPZ Zone",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def publish_rpz_zone(
     policy_json: str,
     backend: Literal["route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"],
@@ -1256,7 +1345,15 @@ def publish_rpz_zone(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List RPZ Rules",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def list_rpz_rules(
     rpz_zone: str,
     backend: Literal[
@@ -1333,7 +1430,15 @@ def list_rpz_rules(
         }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List TD Security Policies",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
 def list_td_security_policies() -> dict:
     """
     List all Infoblox Threat Defense security policies.
@@ -1372,7 +1477,15 @@ def list_td_security_policies() -> dict:
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Diagnose Environment",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 def diagnose_environment(domain: str | None = None) -> dict:
     """
     Run DNS-AID environment diagnostics.
@@ -1406,7 +1519,15 @@ def diagnose_environment(domain: str | None = None) -> dict:
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Send A2A Message",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
 def send_a2a_message(
     message: str,
     endpoint: str | None = None,


### PR DESCRIPTION
## Summary
- Add `ToolAnnotations` to all 15 MCP tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` per MCP spec
- Add human-readable `title` to all 15 tools for directory display
- Add `PRIVACY.md` documenting data handling and opt-in telemetry
- Add `docs/mcp-directory-listing.md` with demo prompts and submission metadata
- Version bump 0.17.1 → 0.17.2

## Why
Anthropic MCP Connector Directory requires tool annotations and a privacy policy for listing. This prepares dns-aid-core for submission.

## Tool annotation summary
| Category | Tools | Count |
|---|---|---|
| Read-only | discover, verify, list_published, list_agent_tools, list_agent_index, list_rpz_rules, list_td_security_policies, diagnose_environment, compile_policy_to_rpz | 9 |
| Write (non-destructive) | publish_agent, call_agent_tool, sync_agent_index, publish_rpz_zone, send_a2a_message | 5 |
| Destructive | delete_agent_from_dns | 1 |

## Test plan
- [x] 1209 unit tests passing
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy type check clean
- [x] Secrets scan clean
- [x] Python syntax verification