### PR TITLE
feat(sdk): MCP Streamable HTTP transport with transparent legacy fallback (v0.18.0)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -96,9 +96,13 @@ jobs:
             --ignore-vuln CVE-2025-8869 \
             --ignore-vuln CVE-2026-1703 \
             --ignore-vuln CVE-2026-34073 \
-            --ignore-vuln CVE-2026-25645
+            --ignore-vuln CVE-2026-25645 \
+            --ignore-vuln CVE-2026-3219
         # CVE-2026-4539  pygments 2.19.2   — ReDoS in AdlLexer, local-only, no fix released
         # CVE-2025-8869  pip 25.2          — tar symlink traversal, mitigated by Python >=3.12 PEP 706
         # CVE-2026-1703  pip 25.2          — wheel path traversal, limited to install dir prefixes
         # CVE-2026-34073 cryptography 46.0.5 — name constraint bypass, uncommon topology, fix: 46.0.6
         # CVE-2026-25645 requests 2.32.5   — predictable temp path, only extract_zipped_paths(), fix: 2.33.0
+        # CVE-2026-3219  pip 26.0.1        — runner-image pip; affects the package manager only,
+        #                                    not the dns-aid runtime; no user-supplied input flows
+        #                                    through pip in CI; awaiting upstream pip fix

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ dmypy.json
 .env.local
 *.local
 
+# Credentials / tokens — NEVER commit these
+.mcpregistry_*
+*.token
+*_token
+*_secret
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ docs/demo-talking-points.md
 *.jnl
 .serena/
 coverage.xml
+
+# Speckit local working state (planning artifacts, never pushed)
+specs/
+.specify/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **MCP Streamable HTTP transport** (spec revision 2025-03-26 and later) — the SDK's MCP client now delegates transport to the official `mcp` Python SDK's `streamablehttp_client` and `ClientSession`, replacing the hand-rolled plain JSON-RPC POST. Modern MCP servers (AWS Bedrock AgentCore, Anthropic MCP Connector Directory listings, agentgateway-fronted servers, and other 2025-03-26+ spec-compliant targets) are now reachable end-to-end via `call_mcp_tool`, `list_mcp_tools`, and `AgentClient.invoke`.
+- **Transparent legacy transport fallback** — if a target server signals it does not support the modern transport (HTTP 405/406, refused initialize via JSON-RPC -32601), the handler automatically falls back to the legacy plain JSON-RPC POST path so on-premise and pre-2025-03-26 servers keep working. Fallback decisions are logged as structured warnings (`transport.legacy_fallback`) with endpoint, reason, and modern-attempt latency so operators can track which targets need migration.
+- **`dns_aid.sdk.auth._httpx_adapter`** — internal bridge that wraps existing `AuthHandler` implementations as `httpx.Auth` so they plug into the official MCP SDK without any handler-side changes. Bearer, OAuth2, mTLS, and API Key handlers continue to work unchanged.
+- **`dns_aid.sdk.protocols._mcp_telemetry`** — internal per-invocation telemetry capture using `httpx` event hooks. Records latency, TTFB, response size, cost headers, TLS version, status code, and response headers across both the modern and legacy transports.
+- **Public API surface contract test** (`tests/unit/sdk/test_public_api_contract.py`) — programmatic guard that asserts the signatures and return-type field sets of `MCPProtocolHandler.invoke`, `call_mcp_tool`, `list_mcp_tools`, `AgentClient.invoke`, `RawResponse`, `InvokeResult`, `InvocationStatus`, and `AuthHandler` are unchanged. Fails CI loudly on any unintentional drift.
+
+### Fixed
+- **`X-DNS-AID-Caller-Domain` header silent drop on the SDK code path** — the previous SDK transport built requests via `client.build_request(...)` with only `Content-Type` set; the dns-aid Layer 2 caller-identity header was added only on the legacy raw-httpx path and never on the SDK path. Layer 2 target middleware therefore could not enforce caller-identity-based policy for any user invoking through the SDK. The new transport propagates the header on every request in the session lifecycle (initialize handshake AND every subsequent tool call) on BOTH the modern and legacy fallback paths whenever `DNS_AID_CALLER_DOMAIN` is set. The header is omitted entirely (not sent as empty string) when the env var is unset or empty.
+- **Opaque HTTP 406 errors against modern MCP servers** — calls to modern Streamable HTTP MCP servers (AWS Bedrock AgentCore, agentgateway-fronted targets, Anthropic Connector Directory listings) previously failed with `HTTP 406: Not Acceptable` and no remediation hint, because the SDK was sending plain `Content-Type: application/json` without `Accept: application/json, text/event-stream`. The new transport handles content negotiation correctly via the official SDK; targets that still reject negotiation get a structured error message identifying the lifecycle phase that failed and naming the remediation (legacy fallback already attempted).
+- **Missing `[mcp]` extra produces a clear remediation message** — instead of an opaque `ImportError` at first use, the handler returns `RawResponse(success=False, error_type="ImportError", error_message="Missing 'mcp' extra: install dns-aid[mcp] ...")` so developers can self-serve fix the install.
+
+### Changed
+- **`dns_aid.core.invoke._invoke_raw_mcp` removed** — the legacy plain-POST helper was duplicate code after the unification; its behavior now lives inside `MCPProtocolHandler` as the transparent legacy fallback. The `_sdk_available` toggle no longer gates MCP (the modern path is always tried first; legacy fallback handles servers that need the old shape). The `_sdk_available` flag remains in place for the A2A no-SDK fallback path (out of scope for this change).
+- **Existing MCP unit tests** (`tests/unit/sdk/test_mcp_handler.py` plus the AgentClient/auth/top-level tests that mock MCP via `httpx.MockTransport`) now exercise the legacy fallback path via a shared `force_legacy_mcp_fallback` fixture in `tests/unit/sdk/conftest.py`. They continue to verify the legacy path's behavior unchanged. New unit coverage for the modern path lives at `tests/unit/sdk/protocols/test_mcp_streamable.py`, fallback decision logic at `tests/unit/sdk/protocols/test_mcp_fallback.py`, and error remediation messages at `tests/unit/sdk/protocols/test_mcp_errors.py`.
+
+### Notes
+- Public API surface preserved verbatim: `call_mcp_tool`, `list_mcp_tools`, `AgentClient.invoke`, `MCPProtocolHandler.invoke`, `RawResponse`, `InvocationResult`, `InvocationStatus`, `AuthHandler` all unchanged.
+- 1283 unit tests pass (mypy strict clean across 76 source files).
+
 ## [0.17.3] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.0] - 2026-04-25
 
 ### Added
 - **MCP Streamable HTTP transport** (spec revision 2025-03-26 and later) — the SDK's MCP client now delegates transport to the official `mcp` Python SDK's `streamablehttp_client` and `ClientSession`, replacing the hand-rolled plain JSON-RPC POST. Modern MCP servers (AWS Bedrock AgentCore, Anthropic MCP Connector Directory listings, agentgateway-fronted servers, and other 2025-03-26+ spec-compliant targets) are now reachable end-to-end via `call_mcp_tool`, `list_mcp_tools`, and `AgentClient.invoke`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ repository-code: "https://github.com/infobloxopen/dns-aid-core"
 authors:
   - name: "The DNS-AID Authors"
 
-version: "0.17.3"
-date-released: "2026-04-14"
+version: "0.18.0"
+date-released: "2026-04-25"
 
 keywords:
   - dns

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1122,9 +1122,20 @@ The SDK routes invocations through protocol-specific handlers:
 
 | Protocol | Handler | Wire Format |
 |----------|---------|-------------|
-| MCP | `MCPProtocolHandler` | JSON-RPC 2.0 (`tools/call`, `tools/list`) |
+| MCP | `MCPProtocolHandler` | MCP Streamable HTTP (modern, spec 2025-03-26+) for `tools/call` and `tools/list`, with transparent legacy plain JSON-RPC POST fallback when the target rejects the modern transport |
 | A2A | `A2AProtocolHandler` | JSON-RPC 2.0 for standard methods (`message/send`, `tasks/get`); generic payload for custom methods |
 | HTTPS | `HTTPSProtocolHandler` | HTTP POST with JSON body |
+
+**MCP Protocol Handler** delegates transport to the official `mcp` Python SDK
+(`mcp.client.streamable_http.streamablehttp_client` and `mcp.ClientSession`)
+for the modern path. The handler injects a per-invocation telemetry adapter
+(latency, TTFB, response size, cost headers, TLS version) and propagates the
+dns-aid `X-DNS-AID-Caller-Domain` header on every request when
+`DNS_AID_CALLER_DOMAIN` is set. On transport mismatch (HTTP 405/406, refused
+initialize via JSON-RPC -32601) the handler transparently falls back to the
+legacy plain JSON-RPC POST path; the fallback event is logged as a structured
+warning (`transport.legacy_fallback`) carrying the endpoint, the failure
+reason, and the modern attempt latency.
 
 **A2A Protocol Handler** automatically wraps standard A2A methods in a JSON-RPC 2.0 envelope:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,9 +215,17 @@ SDK invoke() → InvocationSignal
 
 | Protocol | Handler | Transport | Method Mapping |
 |----------|---------|-----------|----------------|
-| MCP | `MCPProtocolHandler` | JSON-RPC 2.0 / HTTPS | `tools/list`, `tools/call` |
+| MCP | `MCPProtocolHandler` | MCP Streamable HTTP (modern, spec 2025-03-26+) with transparent legacy plain JSON-RPC POST fallback | `tools/list`, `tools/call` |
 | A2A | `A2AProtocolHandler` | JSON-RPC 2.0 / HTTPS | `tasks/send`, `tasks/get` |
 | HTTPS | `HTTPSProtocolHandler` | REST / HTTPS | Method appended to URL path |
+
+The MCP handler delegates transport to the official `mcp` Python SDK's
+`streamablehttp_client`. When a target server signals incompatibility with the
+modern transport (HTTP 405/406, refused initialize via JSON-RPC -32601), the
+handler transparently falls back to the legacy plain JSON-RPC POST path so
+on-premise and pre-2025-03-26 servers keep working. Fallback events are logged
+as structured warnings (`transport.legacy_fallback`) so operators can track
+which targets need migration.
 
 ### Endpoint Path Resolution
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1056,21 +1056,38 @@ The discover-first flow:
 
 ### MCP Tool Calling
 
+DNS-AID's MCP client speaks the modern Streamable HTTP transport (spec
+revision 2025-03-26 and later) by default, so it works against AWS Bedrock
+AgentCore, Anthropic MCP Connector Directory listings, agentgateway-fronted
+servers, and any other modern MCP target. On-premise or older servers that
+only speak the legacy plain JSON-RPC POST transport are reached via a
+transparent fallback — no caller-side configuration required.
+
+If your target enforces Layer 2 caller-identity policy, set
+`DNS_AID_CALLER_DOMAIN` so the SDK propagates `X-DNS-AID-Caller-Domain` on
+every request. The header is omitted entirely when the env var is unset.
+
 ```python
+import os
 from dns_aid.core.invoke import call_mcp_tool, list_mcp_tools
 
-# List available tools on an MCP agent
+# Optional: identify the caller for Layer 2 policy enforcement
+os.environ["DNS_AID_CALLER_DOMAIN"] = "your-org.example.com"
+
+# List available tools on an MCP agent (modern transport, auto-fallback to legacy)
 tools_result = await list_mcp_tools("https://mcp.example.com/mcp")
 for tool in tools_result.data:
     print(f"  {tool['name']}: {tool.get('description', '')}")
 
-# Call a specific tool
+# Call a specific tool — credentials passed via the credentials kwarg
 result = await call_mcp_tool(
     "https://mcp.example.com/mcp",
     "search_flights",
     {"origin": "SFO", "destination": "JFK"},
+    credentials={"bearer_token": "your-bearer-token"},
 )
-print(result.data)  # Tool result
+print(result.data)         # Tool result
+print(result.telemetry)    # latency_ms, status, etc.
 ```
 
 ### Endpoint Resolution

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.4",
   "name": "dns-aid",
-  "version": "0.17.3",
+  "version": "0.18.0",
   "description": "DNS-based AI agent discovery. Publish, discover, and verify AI agents via DNS using SVCB records (RFC 9460). No central registry needed.",
   "author": {
     "name": "Infoblox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.17.3"
+version = "0.18.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/infobloxopen/dns-aid-core",
     "source": "github"
   },
-  "version": "0.17.3",
+  "version": "0.18.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "dns-aid",
-      "version": "0.17.3",
+      "version": "0.18.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/dns_aid/core/invoke.py
+++ b/src/dns_aid/core/invoke.py
@@ -446,67 +446,6 @@ async def _invoke_raw_a2a(endpoint: str, message: str, timeout: float) -> Invoke
         return InvokeResult(success=False, error=f"Unexpected error: {e}")
 
 
-async def _invoke_raw_mcp(
-    endpoint: str,
-    method: str,
-    params: dict | None,
-    timeout: float,
-) -> InvokeResult:
-    """Send an MCP JSON-RPC request via raw httpx (no telemetry)."""
-    url = normalize_endpoint(endpoint)
-
-    mcp_request = {
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params or {},
-        "id": 1,
-    }
-
-    try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            headers = {"Content-Type": "application/json"}
-            # Send caller domain in raw path for target-side policy (Layer 2)
-            import os
-
-            caller_domain = os.getenv("DNS_AID_CALLER_DOMAIN")
-            if caller_domain:
-                headers["X-DNS-AID-Caller-Domain"] = caller_domain
-            resp = await client.post(url, json=mcp_request, headers=headers)
-
-        if resp.status_code != 200:
-            return InvokeResult(
-                success=False,
-                error=f"HTTP {resp.status_code}: {resp.text[:200]}",
-            )
-
-        result = resp.json()
-
-        # Check for JSON-RPC error
-        if "error" in result:
-            rpc_error = result["error"]
-            msg = (
-                rpc_error.get("message", str(rpc_error))
-                if isinstance(rpc_error, dict)
-                else str(rpc_error)
-            )
-            return InvokeResult(success=False, error=msg)
-
-        return InvokeResult(success=True, data=result)
-
-    except httpx.TimeoutException:
-        return InvokeResult(
-            success=False,
-            error=f"Timeout connecting to {endpoint}",
-        )
-    except httpx.ConnectError as e:
-        return InvokeResult(
-            success=False,
-            error=f"Connection failed: {e}",
-        )
-    except Exception as e:
-        return InvokeResult(success=False, error=str(e))
-
-
 # ---------------------------------------------------------------------------
 # Agent card + discovery resolution
 # ---------------------------------------------------------------------------
@@ -759,27 +698,19 @@ async def call_mcp_tool(
     endpoint = await resolve_mcp_endpoint(endpoint)
     mcp_args = {"name": tool_name, "arguments": arguments or {}}
 
-    if _sdk_available:
-        result = await _invoke_via_sdk(
-            endpoint,
-            protocol="mcp",
-            method="tools/call",
-            arguments=mcp_args,
-            timeout=timeout,
-            caller_id=caller_id,
-            agent_record=agent_record,
-            credentials=credentials,
-            auth_type=auth_type,
-            auth_config=auth_config,
-            policy_uri=policy_uri,
-        )
-        return result
-
-    result = await _invoke_raw_mcp(endpoint, "tools/call", mcp_args, timeout)
-    # Post-process: extract content from raw JSON-RPC result
-    if result.success and isinstance(result.data, dict):
-        result.data = extract_mcp_content(result.data)
-    return result
+    return await _invoke_via_sdk(
+        endpoint,
+        protocol="mcp",
+        method="tools/call",
+        arguments=mcp_args,
+        timeout=timeout,
+        caller_id=caller_id,
+        agent_record=agent_record,
+        credentials=credentials,
+        auth_type=auth_type,
+        auth_config=auth_config,
+        policy_uri=policy_uri,
+    )
 
 
 async def list_mcp_tools(
@@ -812,32 +743,24 @@ async def list_mcp_tools(
     """
     endpoint = await resolve_mcp_endpoint(endpoint)
 
-    if _sdk_available:
-        result = await _invoke_via_sdk(
-            endpoint,
-            protocol="mcp",
-            method="tools/list",
-            arguments=None,
-            timeout=timeout,
-            caller_id=caller_id,
-            agent_record=agent_record,
-            credentials=credentials,
-            auth_type=auth_type,
-            auth_config=auth_config,
-            policy_uri=policy_uri,
-        )
-        # Normalize tools list from SDK response
-        if result.success:
-            data = result.data
-            if isinstance(data, dict):
-                result.data = data.get("tools", [])
-            elif not isinstance(data, list):
-                result.data = []
-        return result
-
-    result = await _invoke_raw_mcp(endpoint, "tools/list", {}, timeout)
-    # Extract tools list from raw JSON-RPC result
-    if result.success and isinstance(result.data, dict):
-        rpc_result = result.data.get("result", {})
-        result.data = rpc_result.get("tools", []) if isinstance(rpc_result, dict) else []
+    result = await _invoke_via_sdk(
+        endpoint,
+        protocol="mcp",
+        method="tools/list",
+        arguments=None,
+        timeout=timeout,
+        caller_id=caller_id,
+        agent_record=agent_record,
+        credentials=credentials,
+        auth_type=auth_type,
+        auth_config=auth_config,
+        policy_uri=policy_uri,
+    )
+    # Normalize tools list from SDK response
+    if result.success:
+        data = result.data
+        if isinstance(data, dict):
+            result.data = data.get("tools", [])
+        elif not isinstance(data, list):
+            result.data = []
     return result

--- a/src/dns_aid/sdk/auth/_httpx_adapter.py
+++ b/src/dns_aid/sdk/auth/_httpx_adapter.py
@@ -12,7 +12,6 @@ This adapter wraps the latter so it can be passed to the former.
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import ClassVar
 
 import httpx
 
@@ -22,7 +21,7 @@ from dns_aid.sdk.auth.base import AuthHandler
 class _DnsAidHttpxAuth(httpx.Auth):
     """Wrap a dns-aid ``AuthHandler`` so it satisfies the ``httpx.Auth`` protocol."""
 
-    requires_request_body: ClassVar[bool] = False
+    requires_request_body = False  # httpx.Auth instance attribute (overridden per-class)
 
     def __init__(self, handler: AuthHandler) -> None:
         self._handler = handler

--- a/src/dns_aid/sdk/auth/_httpx_adapter.py
+++ b/src/dns_aid/sdk/auth/_httpx_adapter.py
@@ -1,0 +1,48 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bridge dns-aid AuthHandler implementations to httpx.Auth.
+
+The official MCP Python SDK's `streamablehttp_client` accepts
+``auth: httpx.Auth | None``. dns-aid's existing AuthHandler interface
+(in ``base.py``) exposes an async ``apply(request)`` method instead.
+This adapter wraps the latter so it can be passed to the former.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import ClassVar
+
+import httpx
+
+from dns_aid.sdk.auth.base import AuthHandler
+
+
+class _DnsAidHttpxAuth(httpx.Auth):
+    """Wrap a dns-aid ``AuthHandler`` so it satisfies the ``httpx.Auth`` protocol."""
+
+    requires_request_body: ClassVar[bool] = False
+
+    def __init__(self, handler: AuthHandler) -> None:
+        self._handler = handler
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Apply credentials to *request* and yield it once.
+
+        dns-aid AuthHandlers are stateless per-request (no challenge/response
+        flow). A single yield is correct; httpx will not re-enter for retries.
+        """
+        request = await self._handler.apply(request)
+        yield request
+
+
+def to_httpx_auth(handler: AuthHandler | None) -> httpx.Auth | None:
+    """Convert a dns-aid ``AuthHandler`` (or ``None``) into an ``httpx.Auth``.
+
+    Returns ``None`` when *handler* is ``None`` so callers can pass the
+    result directly to ``streamablehttp_client(auth=...)``.
+    """
+    return _DnsAidHttpxAuth(handler) if handler is not None else None

--- a/src/dns_aid/sdk/protocols/_mcp_telemetry.py
+++ b/src/dns_aid/sdk/protocols/_mcp_telemetry.py
@@ -1,0 +1,139 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry capture for the MCP Streamable HTTP transport.
+
+The official MCP Python SDK exposes ``httpx_client_factory`` as the seam
+for replacing the underlying HTTP client. We pass a factory that creates
+an ``httpx.AsyncClient`` with event hooks attached, capturing the same
+signals dns-aid's existing ``RawResponse`` carries: TTFB, total latency,
+response size, cost headers, TLS version, status code, headers.
+
+Each ``streamablehttp_client`` invocation may issue multiple HTTP
+requests (initialize handshake, then one or more tool calls). The
+capture records the LAST request's signals — the tool call's response —
+matching the semantics of the previous one-shot transport.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+import httpx
+
+from mcp.shared._httpx_utils import McpHttpClientFactory
+
+
+@dataclass
+class _TelemetryCapture:
+    """Per-invocation transport-layer signal record.
+
+    Fields are populated by httpx event hooks during request/response
+    flow. Translated into the public ``RawResponse`` shape after the
+    session completes.
+    """
+
+    start_perf: float | None = None
+    ttfb_perf: float | None = None
+    total_perf: float | None = None
+    response_size_bytes: int = 0
+    cost_units: float | None = None
+    cost_currency: str | None = None
+    tls_version: str | None = None
+    http_status_code: int | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+
+    async def on_request(self, request: httpx.Request) -> None:
+        """httpx event hook: called when a request is about to be sent."""
+        self.start_perf = time.perf_counter()
+        # Reset per-request fields so the LAST request's signals win
+        self.ttfb_perf = None
+        self.total_perf = None
+        self.response_size_bytes = 0
+        self.cost_units = None
+        self.cost_currency = None
+        self.tls_version = None
+        self.http_status_code = None
+        self.headers = {}
+
+    async def on_response(self, response: httpx.Response) -> None:
+        """httpx event hook: called when response headers are received."""
+        now = time.perf_counter()
+        self.ttfb_perf = now
+        self.http_status_code = response.status_code
+        # Lowercase keys for case-insensitive lookup downstream
+        self.headers = {k.lower(): v for k, v in response.headers.items()}
+
+        cost_units_raw = self.headers.get("x-cost-units")
+        if cost_units_raw is not None:
+            try:
+                self.cost_units = float(cost_units_raw)
+            except (TypeError, ValueError):
+                self.cost_units = None
+
+        self.cost_currency = self.headers.get("x-cost-currency")
+
+        # Read response body to measure size and finalize total_perf.
+        # SSE streams are consumed by the SDK; this hook fires once headers
+        # arrive, so we cannot measure full body here for streaming responses.
+        # For non-streaming JSON responses, content is already buffered.
+        try:
+            self.response_size_bytes = len(response.content)
+        except (httpx.ResponseNotRead, RuntimeError):
+            # Streaming response — size will be tracked separately if needed.
+            self.response_size_bytes = 0
+
+        self.total_perf = time.perf_counter()
+
+        # TLS version extraction — best-effort, may not be available on all platforms.
+        try:
+            extensions = response.extensions
+            network_stream = extensions.get("network_stream") if extensions else None
+            if network_stream is not None:
+                ssl_object = network_stream.get_extra_info("ssl_object")
+                if ssl_object is not None:
+                    self.tls_version = ssl_object.version()
+        except (AttributeError, KeyError):
+            self.tls_version = None
+
+    @property
+    def invocation_latency_ms(self) -> float | None:
+        """Total latency in milliseconds, or None if not yet completed."""
+        if self.start_perf is None or self.total_perf is None:
+            return None
+        return (self.total_perf - self.start_perf) * 1000
+
+    @property
+    def ttfb_ms(self) -> float | None:
+        """Time to first byte in milliseconds, or None if not yet measured."""
+        if self.start_perf is None or self.ttfb_perf is None:
+            return None
+        return (self.ttfb_perf - self.start_perf) * 1000
+
+
+def _make_telemetry_factory(capture: _TelemetryCapture) -> McpHttpClientFactory:
+    """Build an ``httpx_client_factory`` that records signals into *capture*.
+
+    The returned factory matches the signature expected by
+    ``streamablehttp_client(httpx_client_factory=...)`` — see
+    ``mcp.shared._httpx_utils.create_mcp_http_client``.
+    """
+
+    def factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            headers=headers,
+            timeout=timeout if timeout is not None else httpx.Timeout(30.0),
+            auth=auth,
+            follow_redirects=True,
+            event_hooks={
+                "request": [capture.on_request],
+                "response": [capture.on_response],
+            },
+        )
+
+    return factory

--- a/src/dns_aid/sdk/protocols/_mcp_telemetry.py
+++ b/src/dns_aid/sdk/protocols/_mcp_telemetry.py
@@ -21,7 +21,6 @@ import time
 from dataclasses import dataclass, field
 
 import httpx
-
 from mcp.shared._httpx_utils import McpHttpClientFactory
 
 

--- a/src/dns_aid/sdk/protocols/mcp.py
+++ b/src/dns_aid/sdk/protocols/mcp.py
@@ -130,7 +130,7 @@ def _build_caller_headers() -> dict[str, str]:
     return {_CALLER_DOMAIN_HEADER: caller_domain}
 
 
-def _extract_call_tool_content(result: "CallToolResult") -> Any:
+def _extract_call_tool_content(result: CallToolResult) -> Any:
     """Extract the meaningful payload from a CallToolResult.
 
     MCP servers return tool output as a list of typed content blocks. The
@@ -161,7 +161,7 @@ def _extract_call_tool_content(result: "CallToolResult") -> Any:
     return [block.model_dump(mode="json") for block in content]
 
 
-def _extract_list_tools_payload(result: "ListToolsResult") -> dict[str, Any]:
+def _extract_list_tools_payload(result: ListToolsResult) -> dict[str, Any]:
     """Convert a typed ListToolsResult into the dict shape the SDK historically returned."""
     return {
         "tools": [
@@ -196,7 +196,7 @@ class MCPProtocolHandler(ProtocolHandler):
         method: str | None,
         arguments: dict[str, Any] | None,
         timeout: float,
-        auth_handler: "AuthHandler | None" = None,
+        auth_handler: AuthHandler | None = None,
     ) -> RawResponse:
         """Send an MCP request via the modern Streamable HTTP transport.
 
@@ -271,7 +271,7 @@ class MCPProtocolHandler(ProtocolHandler):
         mcp_method: str,
         mcp_arguments: dict[str, Any],
         timeout: float,
-        auth_handler: "AuthHandler | None",
+        auth_handler: AuthHandler | None,
         headers: dict[str, str],
         start: float,
     ) -> RawResponse:
@@ -279,33 +279,35 @@ class MCPProtocolHandler(ProtocolHandler):
         factory = _make_telemetry_factory(capture)
         auth = to_httpx_auth(auth_handler)
 
-        async with streamablehttp_client(
-            endpoint,
-            headers=headers if headers else None,
-            timeout=timeout,
-            httpx_client_factory=factory,
-            auth=auth,
-        ) as (read_stream, write_stream, _get_session_id):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
+        async with (  # noqa: SIM117 - keeping streams open across the inner session is required by the SDK contract
+            streamablehttp_client(
+                endpoint,
+                headers=headers if headers else None,
+                timeout=timeout,
+                httpx_client_factory=factory,
+                auth=auth,
+            ) as (read_stream, write_stream, _get_session_id),
+            ClientSession(read_stream, write_stream) as session,
+        ):
+            await session.initialize()
 
-                if mcp_method == "tools/list":
-                    list_result = await session.list_tools()
-                    data: Any = _extract_list_tools_payload(list_result)
-                    is_error = False
-                elif mcp_method == "tools/call":
-                    name = mcp_arguments.get("name", "")
-                    tool_args = mcp_arguments.get("arguments", {})
-                    call_result = await session.call_tool(name, tool_args)
-                    data = _extract_call_tool_content(call_result)
-                    is_error = call_result.isError
-                else:
-                    return RawResponse(
-                        success=False,
-                        status=InvocationStatus.ERROR,
-                        error_type="UnsupportedMethod",
-                        error_message=f"MCP method not supported by handler: {mcp_method}",
-                    )
+            if mcp_method == "tools/list":
+                list_result = await session.list_tools()
+                data: Any = _extract_list_tools_payload(list_result)
+                is_error = False
+            elif mcp_method == "tools/call":
+                name = mcp_arguments.get("name", "")
+                tool_args = mcp_arguments.get("arguments", {})
+                call_result = await session.call_tool(name, tool_args)
+                data = _extract_call_tool_content(call_result)
+                is_error = call_result.isError
+            else:
+                return RawResponse(
+                    success=False,
+                    status=InvocationStatus.ERROR,
+                    error_type="UnsupportedMethod",
+                    error_message=f"MCP method not supported by handler: {mcp_method}",
+                )
 
         # Compute end-to-end latency from invoke entry, not from session start.
         invocation_latency_ms = (time.perf_counter() - start) * 1000
@@ -351,7 +353,7 @@ class MCPProtocolHandler(ProtocolHandler):
         mcp_method: str,
         mcp_arguments: dict[str, Any],
         timeout: float,
-        auth_handler: "AuthHandler | None",
+        auth_handler: AuthHandler | None,
         headers: dict[str, str],
     ) -> RawResponse:
         """Send a single plain JSON-RPC 2.0 POST to *endpoint* — the legacy MCP transport.

--- a/src/dns_aid/sdk/protocols/mcp.py
+++ b/src/dns_aid/sdk/protocols/mcp.py
@@ -2,29 +2,188 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-MCP (Model Context Protocol) handler.
+MCP (Model Context Protocol) handler — modern Streamable HTTP transport.
 
-Implements JSON-RPC 2.0 over HTTPS for MCP agent invocation,
-with latency measurement and cost header extraction.
+Delegates the actual transport to the official MCP Python SDK
+(``mcp.client.streamable_http.streamablehttp_client``), wrapped in a thin
+dns-aid telemetry adapter and Layer 2 caller-identity injector. When the
+target server signals incompatibility with the modern transport, the
+handler transparently falls back to a plain JSON-RPC POST (the legacy
+transport) so on-premise and pre-2025-03-26 servers continue to work.
+
+The fallback decision is logged as a structured warning so operators can
+track which targets need migration.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
+import structlog
 
+from dns_aid.sdk.auth._httpx_adapter import to_httpx_auth
 from dns_aid.sdk.models import InvocationStatus
+from dns_aid.sdk.protocols._mcp_telemetry import _make_telemetry_factory, _TelemetryCapture
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
 
 if TYPE_CHECKING:
     from dns_aid.sdk.auth.base import AuthHandler
 
 
+_logger = structlog.get_logger(__name__)
+
+# Header used by dns-aid Layer 2 target middleware to identify the caller.
+_CALLER_DOMAIN_HEADER = "X-DNS-AID-Caller-Domain"
+_CALLER_DOMAIN_ENV_VAR = "DNS_AID_CALLER_DOMAIN"
+
+# Detect whether the official MCP SDK is importable at module load time.
+# Failure to import means the [mcp] extra is not installed; the handler
+# surfaces a clear remediation message instead of crashing at first use.
+try:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.shared.exceptions import McpError
+    from mcp.types import (
+        CallToolResult,
+        ListToolsResult,
+        TextContent,
+    )
+
+    _MCP_SDK_AVAILABLE = True
+    _MCP_IMPORT_ERROR: str | None = None
+except ImportError as exc:
+    _MCP_SDK_AVAILABLE = False
+    _MCP_IMPORT_ERROR = str(exc)
+
+
+_TransportClass = Literal["transport_mismatch", "real_failure"]
+
+
+def _classify_transport_failure(exc: BaseException) -> _TransportClass:
+    """Decide whether *exc* indicates a transport-protocol mismatch (fallback eligible)
+    or a real failure (auth/network/server) that should propagate as-is.
+
+    Transport mismatch: target server does not speak modern Streamable HTTP.
+    Triggers fallback to the legacy plain JSON-RPC POST path.
+
+    Real failure: target accepted the modern transport but the operation
+    itself failed for an orthogonal reason. No fallback — surface to caller.
+    """
+    # HTTP-level mismatch signals
+    if isinstance(exc, httpx.HTTPStatusError):
+        code = exc.response.status_code
+        if code in (405, 406):
+            return "transport_mismatch"
+        return "real_failure"
+
+    # ExceptionGroup may wrap inner causes (anyio raises these)
+    if isinstance(exc, BaseExceptionGroup):  # type: ignore[has-type]
+        for inner in exc.exceptions:
+            if _classify_transport_failure(inner) == "transport_mismatch":
+                return "transport_mismatch"
+        return "real_failure"
+
+    # MCP-level handshake refusal (server doesn't speak the protocol version we requested)
+    if _MCP_SDK_AVAILABLE and isinstance(exc, McpError):
+        # JSON-RPC -32601 = Method not found (e.g., server doesn't implement initialize)
+        try:
+            code = exc.error.code  # type: ignore[attr-defined]
+            if code == -32601:
+                return "transport_mismatch"
+        except AttributeError:
+            pass
+        return "real_failure"
+
+    # Treat connection-level rejection as transport mismatch ONLY when the modern
+    # transport itself raised it during negotiation (server closed the connection
+    # rather than completing the handshake). Generic ConnectError is a real failure.
+    return "real_failure"
+
+
+def _classify_failure_reason(exc: BaseException) -> str:
+    """Human-readable fallback reason for the structured warning log."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"http_{exc.response.status_code}"
+    if isinstance(exc, BaseExceptionGroup):  # type: ignore[has-type]
+        for inner in exc.exceptions:
+            return _classify_failure_reason(inner)
+    if _MCP_SDK_AVAILABLE and isinstance(exc, McpError):
+        return "initialize_refused"
+    return type(exc).__name__
+
+
+def _build_caller_headers() -> dict[str, str]:
+    """Return the dns-aid metadata headers to attach to every MCP request.
+
+    Currently only ``X-DNS-AID-Caller-Domain`` (Layer 2 caller identity).
+    Returns an empty dict when ``DNS_AID_CALLER_DOMAIN`` is unset OR set to
+    an empty string — the header is omitted entirely (NOT sent as empty
+    value), per the spec acceptance scenarios.
+    """
+    caller_domain = os.environ.get(_CALLER_DOMAIN_ENV_VAR, "").strip()
+    if not caller_domain:
+        return {}
+    return {_CALLER_DOMAIN_HEADER: caller_domain}
+
+
+def _extract_call_tool_content(result: "CallToolResult") -> Any:
+    """Extract the meaningful payload from a CallToolResult.
+
+    MCP servers return tool output as a list of typed content blocks. The
+    convention dns-aid has historically followed is:
+      - Take the first content block
+      - If it's a TextContent, attempt JSON-decode the text; fall back to raw text
+      - Otherwise return the raw content list
+
+    Preserves backwards compatibility with the previous ``_extract_mcp_content``
+    behavior that operated on dict-shaped JSON-RPC results.
+    """
+    content = result.content
+    if not content:
+        # Some tools may carry structured output instead of content blocks.
+        if result.structuredContent is not None:
+            return result.structuredContent
+        return None
+
+    first = content[0]
+    if isinstance(first, TextContent):
+        text = first.text or ""
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return text
+
+    # Non-text content (image, resource, etc.) — return as serialised dict list.
+    return [block.model_dump(mode="json") for block in content]
+
+
+def _extract_list_tools_payload(result: "ListToolsResult") -> dict[str, Any]:
+    """Convert a typed ListToolsResult into the dict shape the SDK historically returned."""
+    return {
+        "tools": [
+            {
+                "name": tool.name,
+                "description": tool.description or "",
+                "inputSchema": tool.inputSchema,
+            }
+            for tool in result.tools
+        ],
+        "nextCursor": result.nextCursor,
+    }
+
+
 class MCPProtocolHandler(ProtocolHandler):
-    """Handles MCP JSON-RPC 2.0 invocations over HTTPS."""
+    """Handles MCP invocations over the modern Streamable HTTP transport.
+
+    Falls back to the legacy plain JSON-RPC POST transport when the target
+    server rejects the modern transport (HTTP 406, refused initialize,
+    missing session-id support). The fallback is transparent to callers;
+    the only observable difference is a structured warning log entry.
+    """
 
     @property
     def protocol_name(self) -> str:
@@ -35,118 +194,249 @@ class MCPProtocolHandler(ProtocolHandler):
         client: httpx.AsyncClient,
         endpoint: str,
         method: str | None,
-        arguments: dict | None,
+        arguments: dict[str, Any] | None,
         timeout: float,
-        auth_handler: AuthHandler | None = None,
+        auth_handler: "AuthHandler | None" = None,
     ) -> RawResponse:
-        """
-        Send a JSON-RPC 2.0 request to an MCP agent.
+        """Send an MCP request via the modern Streamable HTTP transport.
 
-        The MCP protocol uses JSON-RPC with methods like:
-        - "tools/list" — enumerate available tools
-        - "tools/call" — call a specific tool (arguments.name + arguments.arguments)
-
+        The ``client`` parameter (a shared httpx.AsyncClient from AgentClient)
+        is intentionally NOT used by the modern transport — the official SDK
+        owns its own client built by ``httpx_client_factory``. The shared
+        client is reserved for the legacy fallback path so existing
+        connection pooling continues to work there.
         """
+        if not _MCP_SDK_AVAILABLE:
+            return RawResponse(
+                success=False,
+                status=InvocationStatus.ERROR,
+                error_type="ImportError",
+                error_message=(
+                    "Missing 'mcp' extra: install dns-aid[mcp] to use modern "
+                    f"MCP transport. Original error: {_MCP_IMPORT_ERROR}"
+                ),
+            )
+
         mcp_method = method or "tools/list"
-        params = arguments or {}
+        mcp_arguments = arguments or {}
+        headers = _build_caller_headers()
 
+        start = time.perf_counter()
+
+        # ── Modern Streamable HTTP path ──────────────────────────────────
+        try:
+            return await self._invoke_via_streamable_http(
+                endpoint=endpoint,
+                mcp_method=mcp_method,
+                mcp_arguments=mcp_arguments,
+                timeout=timeout,
+                auth_handler=auth_handler,
+                headers=headers,
+                start=start,
+            )
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            elapsed = (time.perf_counter() - start) * 1000
+            return _build_failure_response(exc, elapsed)
+        except BaseException as exc:  # noqa: BLE001 - we classify and re-raise via fallback if not transport_mismatch
+            classification = _classify_transport_failure(exc)
+            if classification != "transport_mismatch":
+                elapsed = (time.perf_counter() - start) * 1000
+                return _build_failure_response(exc, elapsed)
+
+            # ── Transparent fallback to legacy plain JSON-RPC POST ──────
+            reason = _classify_failure_reason(exc)
+            modern_attempt_ms = (time.perf_counter() - start) * 1000
+            _logger.warning(
+                "transport.legacy_fallback",
+                endpoint=endpoint,
+                reason=reason,
+                latency_ms_modern_attempt=round(modern_attempt_ms, 2),
+            )
+            return await self._invoke_via_legacy_fallback(
+                client=client,
+                endpoint=endpoint,
+                mcp_method=mcp_method,
+                mcp_arguments=mcp_arguments,
+                timeout=timeout,
+                auth_handler=auth_handler,
+                headers=headers,
+            )
+
+    # ── Modern path implementation ──────────────────────────────────────
+
+    async def _invoke_via_streamable_http(
+        self,
+        *,
+        endpoint: str,
+        mcp_method: str,
+        mcp_arguments: dict[str, Any],
+        timeout: float,
+        auth_handler: "AuthHandler | None",
+        headers: dict[str, str],
+        start: float,
+    ) -> RawResponse:
+        capture = _TelemetryCapture()
+        factory = _make_telemetry_factory(capture)
+        auth = to_httpx_auth(auth_handler)
+
+        async with streamablehttp_client(
+            endpoint,
+            headers=headers if headers else None,
+            timeout=timeout,
+            httpx_client_factory=factory,
+            auth=auth,
+        ) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                if mcp_method == "tools/list":
+                    list_result = await session.list_tools()
+                    data: Any = _extract_list_tools_payload(list_result)
+                    is_error = False
+                elif mcp_method == "tools/call":
+                    name = mcp_arguments.get("name", "")
+                    tool_args = mcp_arguments.get("arguments", {})
+                    call_result = await session.call_tool(name, tool_args)
+                    data = _extract_call_tool_content(call_result)
+                    is_error = call_result.isError
+                else:
+                    return RawResponse(
+                        success=False,
+                        status=InvocationStatus.ERROR,
+                        error_type="UnsupportedMethod",
+                        error_message=f"MCP method not supported by handler: {mcp_method}",
+                    )
+
+        # Compute end-to-end latency from invoke entry, not from session start.
+        invocation_latency_ms = (time.perf_counter() - start) * 1000
+
+        if is_error:
+            return RawResponse(
+                success=False,
+                status=InvocationStatus.ERROR,
+                data=data,
+                http_status_code=capture.http_status_code,
+                error_type="ToolError",
+                error_message=str(data) if data is not None else "tool returned isError=True",
+                invocation_latency_ms=invocation_latency_ms,
+                ttfb_ms=capture.ttfb_ms,
+                response_size_bytes=capture.response_size_bytes,
+                cost_units=capture.cost_units,
+                cost_currency=capture.cost_currency,
+                tls_version=capture.tls_version,
+                headers=capture.headers,
+            )
+
+        return RawResponse(
+            success=True,
+            status=InvocationStatus.SUCCESS,
+            data=data,
+            http_status_code=capture.http_status_code,
+            invocation_latency_ms=invocation_latency_ms,
+            ttfb_ms=capture.ttfb_ms,
+            response_size_bytes=capture.response_size_bytes,
+            cost_units=capture.cost_units,
+            cost_currency=capture.cost_currency,
+            tls_version=capture.tls_version,
+            headers=capture.headers,
+        )
+
+    # ── Legacy fallback path ────────────────────────────────────────────
+
+    async def _invoke_via_legacy_fallback(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        endpoint: str,
+        mcp_method: str,
+        mcp_arguments: dict[str, Any],
+        timeout: float,
+        auth_handler: "AuthHandler | None",
+        headers: dict[str, str],
+    ) -> RawResponse:
+        """Send a single plain JSON-RPC 2.0 POST to *endpoint* — the legacy MCP transport.
+
+        This is the same code path the previous (pre-streamable) MCPProtocolHandler used,
+        retained exclusively as the fallback for servers that do not speak the modern
+        Streamable HTTP transport. The dns-aid caller-identity header is propagated
+        the same way it is in the modern path so Layer 2 policy enforcement keeps
+        working consistently across both transports.
+        """
         rpc_request = {
             "jsonrpc": "2.0",
             "method": mcp_method,
-            "params": params,
+            "params": mcp_arguments,
             "id": 1,
         }
 
-        start = time.perf_counter()
-        ttfb_ms: float | None = None
+        request_headers = {"Content-Type": "application/json"}
+        request_headers.update(headers)  # invariant: caller-domain header propagates
 
+        start = time.perf_counter()
         try:
             request = client.build_request(
                 "POST",
                 endpoint,
                 json=rpc_request,
-                headers={"Content-Type": "application/json"},
+                headers=request_headers,
                 timeout=timeout,
             )
-            if auth_handler:
+            if auth_handler is not None:
                 request = await auth_handler.apply(request)
             response = await client.send(request)
             ttfb_ms = (time.perf_counter() - start) * 1000
-            invocation_latency_ms = ttfb_ms  # For simple request/response, TTFB ~ total
+            invocation_latency_ms = ttfb_ms
+        except httpx.TimeoutException as exc:
+            elapsed = (time.perf_counter() - start) * 1000
+            return _build_failure_response(exc, elapsed)
+        except httpx.ConnectError as exc:
+            elapsed = (time.perf_counter() - start) * 1000
+            return _build_failure_response(exc, elapsed)
+        except httpx.HTTPError as exc:
+            elapsed = (time.perf_counter() - start) * 1000
+            return _build_failure_response(exc, elapsed)
 
-        except httpx.TimeoutException:
-            elapsed = (time.perf_counter() - start) * 1000
-            return RawResponse(
-                success=False,
-                status=InvocationStatus.TIMEOUT,
-                error_type="TimeoutError",
-                error_message=f"Timeout after {timeout}s connecting to {endpoint}",
-                invocation_latency_ms=elapsed,
-            )
-        except httpx.ConnectError as e:
-            elapsed = (time.perf_counter() - start) * 1000
-            return RawResponse(
-                success=False,
-                status=InvocationStatus.REFUSED,
-                error_type="ConnectError",
-                error_message=str(e),
-                invocation_latency_ms=elapsed,
-            )
-        except httpx.HTTPError as e:
-            elapsed = (time.perf_counter() - start) * 1000
-            return RawResponse(
-                success=False,
-                status=InvocationStatus.ERROR,
-                error_type=type(e).__name__,
-                error_message=str(e),
-                invocation_latency_ms=elapsed,
-            )
-
-        # Extract cost from response headers (convention: X-Cost-Units, X-Cost-Currency)
         cost_units = _parse_float_header(response.headers, "x-cost-units")
         cost_currency = response.headers.get("x-cost-currency")
-
-        # Extract TLS version
         tls_version = _extract_tls_version(response)
-
-        # Response size
         response_size_bytes = len(response.content)
+        response_headers = {k.lower(): v for k, v in response.headers.items()}
 
-        # Parse HTTP error status
         if response.status_code != 200:
             return RawResponse(
                 success=False,
                 status=InvocationStatus.ERROR,
                 http_status_code=response.status_code,
                 error_type="HTTPError",
-                error_message=f"HTTP {response.status_code}: {response.text[:200]}",
+                error_message=(
+                    f"HTTP {response.status_code} from legacy fallback (modern transport "
+                    f"already failed): {response.text[:200]}"
+                ),
                 invocation_latency_ms=invocation_latency_ms,
                 ttfb_ms=ttfb_ms,
                 response_size_bytes=response_size_bytes,
                 cost_units=cost_units,
                 cost_currency=cost_currency,
                 tls_version=tls_version,
-                headers=dict(response.headers),
+                headers=response_headers,
             )
 
-        # Parse JSON-RPC response
         try:
             result = response.json()
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError as exc:
             return RawResponse(
                 success=False,
                 status=InvocationStatus.ERROR,
                 http_status_code=200,
                 error_type="JSONDecodeError",
-                error_message=f"Invalid JSON response: {e}",
+                error_message=f"Invalid JSON response from legacy fallback: {exc}",
                 invocation_latency_ms=invocation_latency_ms,
                 ttfb_ms=ttfb_ms,
                 response_size_bytes=response_size_bytes,
                 tls_version=tls_version,
-                headers=dict(response.headers),
+                headers=response_headers,
             )
 
-        # Check for JSON-RPC error
         if "error" in result:
             rpc_error = result["error"]
             return RawResponse(
@@ -155,19 +445,19 @@ class MCPProtocolHandler(ProtocolHandler):
                 data=rpc_error,
                 http_status_code=200,
                 error_type="RPCError",
-                error_message=rpc_error.get("message", str(rpc_error)),
+                error_message=rpc_error.get("message", str(rpc_error))
+                if isinstance(rpc_error, dict)
+                else str(rpc_error),
                 invocation_latency_ms=invocation_latency_ms,
                 ttfb_ms=ttfb_ms,
                 response_size_bytes=response_size_bytes,
                 cost_units=cost_units,
                 cost_currency=cost_currency,
                 tls_version=tls_version,
-                headers=dict(response.headers),
+                headers=response_headers,
             )
 
-        # Extract content from MCP response
-        data = _extract_mcp_content(result)
-
+        data = _extract_legacy_dict_content(result)
         return RawResponse(
             success=True,
             status=InvocationStatus.SUCCESS,
@@ -179,20 +469,52 @@ class MCPProtocolHandler(ProtocolHandler):
             cost_units=cost_units,
             cost_currency=cost_currency,
             tls_version=tls_version,
-            headers=dict(response.headers),
+            headers=response_headers,
         )
 
 
-def _extract_mcp_content(result: dict) -> dict | str | list | None:
-    """Extract meaningful content from MCP JSON-RPC result."""
+# ── Helpers (module-private, retained for backward compatibility with tests) ──
+
+
+def _build_failure_response(exc: BaseException, elapsed_ms: float) -> RawResponse:
+    if isinstance(exc, httpx.TimeoutException):
+        return RawResponse(
+            success=False,
+            status=InvocationStatus.TIMEOUT,
+            error_type="TimeoutError",
+            error_message=str(exc) or "Request timed out",
+            invocation_latency_ms=elapsed_ms,
+        )
+    if isinstance(exc, httpx.ConnectError):
+        return RawResponse(
+            success=False,
+            status=InvocationStatus.REFUSED,
+            error_type="ConnectError",
+            error_message=str(exc),
+            invocation_latency_ms=elapsed_ms,
+        )
+    return RawResponse(
+        success=False,
+        status=InvocationStatus.ERROR,
+        error_type=type(exc).__name__,
+        error_message=str(exc),
+        invocation_latency_ms=elapsed_ms,
+    )
+
+
+def _extract_legacy_dict_content(result: dict[str, Any]) -> Any:
+    """Extract content from a legacy plain-JSON-RPC MCP result dict.
+
+    Preserves the behavior of the pre-streamable transport for servers that
+    still respond with the dict-shaped result.
+    """
     rpc_result = result.get("result")
     if rpc_result is None:
         return None
 
-    # MCP content array pattern
     content = rpc_result.get("content") if isinstance(rpc_result, dict) else None
     if content and isinstance(content, list) and len(content) > 0:
-        text = content[0].get("text", "")
+        text = content[0].get("text", "") if isinstance(content[0], dict) else ""
         try:
             return json.loads(text)
         except (json.JSONDecodeError, TypeError):
@@ -201,8 +523,11 @@ def _extract_mcp_content(result: dict) -> dict | str | list | None:
     return rpc_result
 
 
+# Public alias retained for any external callers that imported this name.
+_extract_mcp_content = _extract_legacy_dict_content
+
+
 def _parse_float_header(headers: httpx.Headers, name: str) -> float | None:
-    """Parse a float value from a response header."""
     value = headers.get(name)
     if value is None:
         return None
@@ -213,13 +538,20 @@ def _parse_float_header(headers: httpx.Headers, name: str) -> float | None:
 
 
 def _extract_tls_version(response: httpx.Response) -> str | None:
-    """Extract TLS version from the response's underlying connection, if available."""
+    """Best-effort TLS version extraction from a completed httpx response."""
     try:
+        extensions = response.extensions
+        network_stream = extensions.get("network_stream") if extensions else None
+        if network_stream is not None:
+            ssl_object = network_stream.get_extra_info("ssl_object")
+            if ssl_object is not None:
+                return ssl_object.version()
+        # Fallback: probe the underlying stream the way the previous impl did
         stream = response.stream
         if hasattr(stream, "_stream") and hasattr(stream._stream, "get_extra_info"):
             ssl_object = stream._stream.get_extra_info("ssl_object")
             if ssl_object:
                 return ssl_object.version()
-    except Exception:
+    except (AttributeError, KeyError):
         pass
     return None

--- a/tests/unit/core/test_invoke.py
+++ b/tests/unit/core/test_invoke.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -15,16 +14,12 @@ from dns_aid.core.invoke import (
     InvokeResult,
     _build_agent_record_from_endpoint,
     _invoke_raw_a2a,
-    _invoke_raw_mcp,
     build_a2a_message_params,
-    call_mcp_tool,
     extract_a2a_response_text,
     extract_mcp_content,
-    list_mcp_tools,
     normalize_endpoint,
     send_a2a_message,
 )
-
 
 # ---------------------------------------------------------------------------
 # Pure utility tests
@@ -65,7 +60,12 @@ class TestExtractA2AResponseText:
         data = {
             "result": {
                 "artifacts": [
-                    {"parts": [{"kind": "text", "text": "Hello"}, {"kind": "text", "text": "World"}]}
+                    {
+                        "parts": [
+                            {"kind": "text", "text": "Hello"},
+                            {"kind": "text", "text": "World"},
+                        ]
+                    }
                 ]
             }
         }
@@ -184,47 +184,17 @@ class TestInvokeRawA2A:
         assert "403" in result.error
 
 
-class TestInvokeRawMCP:
-    @pytest.mark.asyncio
-    async def test_success(self):
-        mock_response = httpx.Response(
-            200,
-            json={"result": {"content": [{"text": "ok"}]}},
-            request=httpx.Request("POST", "https://mcp.example.com"),
-        )
-
-        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
-            mock_client = AsyncMock()
-            mock_client.post.return_value = mock_response
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            result = await _invoke_raw_mcp("https://mcp.example.com", "tools/list", {}, 30.0)
-
-        assert result.success is True
-
-    @pytest.mark.asyncio
-    async def test_jsonrpc_error(self):
-        mock_response = httpx.Response(
-            200,
-            json={"error": {"code": -32601, "message": "Method not found"}},
-            request=httpx.Request("POST", "https://mcp.example.com"),
-        )
-
-        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
-            mock_client = AsyncMock()
-            mock_client.post.return_value = mock_response
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            result = await _invoke_raw_mcp("https://mcp.example.com", "tools/call", {}, 30.0)
-
-        assert result.success is False
-        assert "Method not found" in result.error
+# NOTE: TestInvokeRawMCP and TestCallMCPToolNoSDK / TestListMCPToolsNoSDK were
+# removed when MCP transport was unified onto the modern Streamable HTTP path
+# (feature 001-mcp-streamable-http). The legacy `_invoke_raw_mcp` helper has
+# been deleted; the _sdk_available toggle no longer gates MCP. Modern transport
+# behavior is covered by tests/unit/sdk/protocols/test_mcp_streamable.py and
+# legacy fallback by tests/unit/sdk/test_mcp_handler.py.
 
 
 # ---------------------------------------------------------------------------
-# Public API tests (SDK disabled path)
+# Public API tests (A2A no-SDK path retained — A2A is out of scope for the
+# transport unification; its raw helper still exists.)
 # ---------------------------------------------------------------------------
 
 
@@ -233,7 +203,9 @@ class TestSendA2AMessageNoSDK:
     async def test_extracts_response_text(self):
         mock_response = httpx.Response(
             200,
-            json={"result": {"artifacts": [{"parts": [{"kind": "text", "text": "I am an agent"}]}]}},
+            json={
+                "result": {"artifacts": [{"parts": [{"kind": "text", "text": "I am an agent"}]}]}
+            },
             request=httpx.Request("POST", "https://a.example.com"),
         )
 
@@ -252,53 +224,10 @@ class TestSendA2AMessageNoSDK:
         assert result.data["response_text"] == "I am an agent"
 
 
-class TestCallMCPToolNoSDK:
-    @pytest.mark.asyncio
-    async def test_extracts_content(self):
-        mock_response = httpx.Response(
-            200,
-            json={"result": {"content": [{"text": json.dumps({"status": "ok"})}]}},
-            request=httpx.Request("POST", "https://m.example.com"),
-        )
-
-        with (
-            patch("dns_aid.core.invoke._sdk_available", False),
-            patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient,
-        ):
-            mock_client = AsyncMock()
-            mock_client.post.return_value = mock_response
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            result = await call_mcp_tool("https://m.example.com", "analyze", {"x": 1})
-
-        assert result.success is True
-        assert result.data == {"status": "ok"}
-
-
-class TestListMCPToolsNoSDK:
-    @pytest.mark.asyncio
-    async def test_extracts_tools_list(self):
-        mock_response = httpx.Response(
-            200,
-            json={"result": {"tools": [{"name": "t1", "description": "Tool 1"}]}},
-            request=httpx.Request("POST", "https://m.example.com"),
-        )
-
-        with (
-            patch("dns_aid.core.invoke._sdk_available", False),
-            patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient,
-        ):
-            mock_client = AsyncMock()
-            mock_client.post.return_value = mock_response
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            result = await list_mcp_tools("https://m.example.com")
-
-        assert result.success is True
-        assert len(result.data) == 1
-        assert result.data[0]["name"] == "t1"
+# NOTE: TestCallMCPToolNoSDK / TestListMCPToolsNoSDK removed alongside the
+# deletion of `_invoke_raw_mcp` and the `_sdk_available` toggle gating MCP.
+# Coverage of the modern path lives in tests/unit/sdk/protocols/test_mcp_streamable.py
+# and the legacy fallback in tests/unit/sdk/test_mcp_handler.py.
 
 
 class TestInvokeResult:

--- a/tests/unit/sdk/auth/test_client_auth.py
+++ b/tests/unit/sdk/auth/test_client_auth.py
@@ -14,6 +14,13 @@ from dns_aid.sdk.auth.simple import BearerAuthHandler
 from dns_aid.sdk.client import AgentClient
 
 
+@pytest.fixture(autouse=True)
+def _autouse_legacy_fallback(force_legacy_mcp_fallback: None) -> None:
+    """All MCP integration tests in this module use httpx.MockTransport,
+    which exercises the legacy plain JSON-RPC POST path (now reached via
+    transparent fallback from the modern Streamable HTTP transport)."""
+
+
 def _make_agent(
     auth_type: str | None = None,
     auth_config: dict | None = None,

--- a/tests/unit/sdk/auth/test_httpx_adapter.py
+++ b/tests/unit/sdk/auth/test_httpx_adapter.py
@@ -1,0 +1,79 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the dns-aid AuthHandler -> httpx.Auth adapter."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from dns_aid.sdk.auth._httpx_adapter import _DnsAidHttpxAuth, to_httpx_auth
+from dns_aid.sdk.auth.base import AuthHandler
+
+
+class _RecordingHandler(AuthHandler):
+    """Test double that records calls and stamps a header."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.last_request: httpx.Request | None = None
+
+    @property
+    def auth_type(self) -> str:
+        return "test-recording"
+
+    async def apply(self, request: httpx.Request) -> httpx.Request:
+        self.call_count += 1
+        self.last_request = request
+        request.headers["X-Test-Auth"] = "applied"
+        return request
+
+
+def test_to_httpx_auth_returns_none_for_none_handler() -> None:
+    assert to_httpx_auth(None) is None
+
+
+def test_to_httpx_auth_wraps_real_handler() -> None:
+    handler = _RecordingHandler()
+    adapter = to_httpx_auth(handler)
+    assert isinstance(adapter, httpx.Auth)
+    assert isinstance(adapter, _DnsAidHttpxAuth)
+
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_invokes_apply_exactly_once() -> None:
+    handler = _RecordingHandler()
+    adapter = _DnsAidHttpxAuth(handler)
+
+    request = httpx.Request("POST", "https://example.com/mcp")
+
+    flow = adapter.async_auth_flow(request)
+    yielded = await flow.__anext__()
+
+    assert handler.call_count == 1
+    assert yielded is request
+
+    # The flow should terminate after a single yield (no challenge/response loop).
+    with pytest.raises(StopAsyncIteration):
+        await flow.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_propagates_request_modifications() -> None:
+    handler = _RecordingHandler()
+    adapter = _DnsAidHttpxAuth(handler)
+
+    request = httpx.Request("GET", "https://example.com/mcp")
+    assert "X-Test-Auth" not in request.headers
+
+    flow = adapter.async_auth_flow(request)
+    yielded = await flow.__anext__()
+
+    assert yielded.headers.get("X-Test-Auth") == "applied"
+    assert handler.last_request is yielded
+
+
+def test_requires_request_body_is_false() -> None:
+    """httpx.Auth contract: handlers that don't read the body must declare so."""
+    assert _DnsAidHttpxAuth.requires_request_body is False

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -5,10 +5,45 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from dns_aid.core.models import AgentRecord, Protocol
 from dns_aid.sdk._config import SDKConfig
+
+
+class _ModernTransportRejected:
+    """Async context manager whose __aenter__ raises HTTP 406."""
+
+    async def __aenter__(self):  # type: ignore[no-untyped-def]
+        raise httpx.HTTPStatusError(
+            "modern transport rejected (simulated 406)",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(406),
+        )
+
+    async def __aexit__(self, *exc):  # type: ignore[no-untyped-def]
+        return False
+
+
+@pytest.fixture
+def force_legacy_mcp_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the MCP handler to take the legacy fallback path on every call.
+
+    Patches ``streamablehttp_client`` in ``dns_aid.sdk.protocols.mcp`` so
+    that any attempt to use the modern Streamable HTTP transport raises
+    HTTP 406 — which the handler classifies as a transport mismatch and
+    falls back to the legacy plain JSON-RPC POST path.
+
+    Use this fixture in any test that mocks MCP behavior with
+    ``httpx.MockTransport`` (which simulates the legacy POST path), so the
+    test continues to verify the legacy semantic now that it is reached
+    via fallback rather than as the primary transport.
+    """
+    monkeypatch.setattr(
+        "dns_aid.sdk.protocols.mcp.streamablehttp_client",
+        lambda *args, **kwargs: _ModernTransportRejected(),
+    )
 
 
 @pytest.fixture

--- a/tests/unit/sdk/protocols/test_mcp_errors.py
+++ b/tests/unit/sdk/protocols/test_mcp_errors.py
@@ -1,0 +1,208 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the MCP transport error remediation messages (US3).
+
+These tests verify that error paths surface clear, actionable messages
+instead of opaque stack traces or HTTP 406 with no remediation hint.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from dns_aid.sdk.models import InvocationStatus
+from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
+
+
+@pytest.fixture
+def handler() -> MCPProtocolHandler:
+    return MCPProtocolHandler()
+
+
+def _install_modern_failure(monkeypatch: pytest.MonkeyPatch, exc: BaseException) -> None:
+    class _Raiser:
+        async def __aenter__(self):
+            raise exc
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    monkeypatch.setattr(
+        "dns_aid.sdk.protocols.mcp.streamablehttp_client",
+        lambda *a, **k: _Raiser(),
+    )
+
+
+def _install_legacy_failure(transport_fn) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(transport_fn))
+
+
+@pytest.mark.asyncio
+async def test_missing_mcp_extra_returns_clear_remediation(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the [mcp] extra is not installed, surface a clear install message."""
+    import dns_aid.sdk.protocols.mcp as mcp_module
+
+    monkeypatch.setattr(mcp_module, "_MCP_SDK_AVAILABLE", False)
+    monkeypatch.setattr(mcp_module, "_MCP_IMPORT_ERROR", "No module named 'mcp'")
+
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is False
+    assert raw.status == InvocationStatus.ERROR
+    assert raw.error_type == "ImportError"
+    assert "dns-aid[mcp]" in (raw.error_message or "")
+    assert "Missing 'mcp' extra" in (raw.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_double_transport_failure_includes_legacy_context(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Modern path 406 + legacy path 406 → error names the legacy fallback context."""
+    _install_modern_failure(
+        monkeypatch,
+        httpx.HTTPStatusError(
+            "modern 406",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(406),
+        ),
+    )
+
+    def legacy_also_fails(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(406, text="legacy also rejected")
+
+    async with _install_legacy_failure(legacy_also_fails) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is False
+    assert raw.status == InvocationStatus.ERROR
+    assert raw.http_status_code == 406
+    msg = raw.error_message or ""
+    # Message must indicate this came through the legacy fallback (modern already failed)
+    assert "legacy fallback" in msg.lower()
+    assert "406" in msg
+
+
+@pytest.mark.asyncio
+async def test_initialize_refused_classified_as_transport_mismatch(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A server that refuses initialize via -32601 should still try legacy fallback."""
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    _install_modern_failure(
+        monkeypatch,
+        McpError(ErrorData(code=-32601, message="Method not found: initialize")),
+    )
+
+    def legacy_succeeds(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "result": {"content": [{"type": "text", "text": '{"ok": true}'}]},
+                "id": 1,
+            },
+        )
+
+    async with _install_legacy_failure(legacy_succeeds) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is True
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_clear_error(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 401 from the modern path must NOT trigger fallback, must surface clearly."""
+    _install_modern_failure(
+        monkeypatch,
+        httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(401),
+        ),
+    )
+
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is False
+    assert raw.status == InvocationStatus.ERROR
+    msg = (raw.error_message or "").lower()
+    # Must NOT suggest a transport remediation (auth ≠ transport problem)
+    assert "transport" not in msg or "401" in msg
+    # Must surface the underlying status
+    assert "401" in (raw.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_method_returns_clear_error(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown method passed to handler should surface a clear ERROR."""
+    # Stub modern path so it succeeds (we want to exercise the method dispatch branch)
+    from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock, MagicMock
+
+    @asynccontextmanager
+    async def fake_streamable(*args, **kwargs):
+        factory = kwargs.get("httpx_client_factory")
+        if factory is not None:
+            client = factory(headers=None, timeout=None, auth=None)
+            await client.aclose()
+        yield (MagicMock(), MagicMock(), lambda: "session-x")
+
+    @asynccontextmanager
+    async def fake_session(rs, ws):
+        session = MagicMock()
+        session.initialize = AsyncMock(return_value=MagicMock())
+        yield session
+
+    monkeypatch.setattr("dns_aid.sdk.protocols.mcp.streamablehttp_client", fake_streamable)
+    monkeypatch.setattr("dns_aid.sdk.protocols.mcp.ClientSession", fake_session)
+
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="unknown/weird-method",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is False
+    assert raw.status == InvocationStatus.ERROR
+    assert raw.error_type == "UnsupportedMethod"
+    assert "unknown/weird-method" in (raw.error_message or "")

--- a/tests/unit/sdk/protocols/test_mcp_fallback.py
+++ b/tests/unit/sdk/protocols/test_mcp_fallback.py
@@ -1,0 +1,361 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the MCP transport fallback decision logic.
+
+The handler tries the modern Streamable HTTP transport first. On
+"transport mismatch" failures (HTTP 405/406, refused initialize via
+JSON-RPC -32601, BaseExceptionGroup wrapping any of the above) it
+transparently falls back to the legacy plain JSON-RPC POST path. On
+"real failures" (auth, network timeout, connection refused, server
+errors, tool errors) it must NOT fall back — the failure propagates
+to the caller as RawResponse(success=False).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from dns_aid.sdk.models import InvocationStatus
+from dns_aid.sdk.protocols.mcp import (
+    MCPProtocolHandler,
+    _classify_failure_reason,
+    _classify_transport_failure,
+)
+
+
+@pytest.fixture
+def handler() -> MCPProtocolHandler:
+    return MCPProtocolHandler()
+
+
+def _legacy_response(payload: dict | None = None) -> httpx.Response:
+    body = payload or {
+        "jsonrpc": "2.0",
+        "result": {"content": [{"type": "text", "text": json.dumps({"ok": True})}]},
+        "id": 1,
+    }
+    return httpx.Response(200, json=body)
+
+
+def _make_legacy_client_with_capture(headers_capture: dict) -> httpx.AsyncClient:
+    """Return an AsyncClient whose MockTransport captures the request headers."""
+
+    def transport_fn(request: httpx.Request) -> httpx.Response:
+        headers_capture.update(dict(request.headers))
+        return _legacy_response()
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(transport_fn))
+
+
+def _install_modern_failure(monkeypatch: pytest.MonkeyPatch, exc: BaseException) -> None:
+    """Patch streamablehttp_client to raise *exc* on entry."""
+
+    class _Raiser:
+        async def __aenter__(self):
+            raise exc
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    monkeypatch.setattr(
+        "dns_aid.sdk.protocols.mcp.streamablehttp_client",
+        lambda *a, **k: _Raiser(),
+    )
+
+
+# ── Classification unit tests (no handler involvement) ───────────────────
+
+
+def test_classify_http_406_is_transport_mismatch() -> None:
+    exc = httpx.HTTPStatusError(
+        "406",
+        request=httpx.Request("POST", "https://x"),
+        response=httpx.Response(406),
+    )
+    assert _classify_transport_failure(exc) == "transport_mismatch"
+
+
+def test_classify_http_405_is_transport_mismatch() -> None:
+    exc = httpx.HTTPStatusError(
+        "405",
+        request=httpx.Request("POST", "https://x"),
+        response=httpx.Response(405),
+    )
+    assert _classify_transport_failure(exc) == "transport_mismatch"
+
+
+def test_classify_http_500_is_real_failure() -> None:
+    exc = httpx.HTTPStatusError(
+        "500",
+        request=httpx.Request("POST", "https://x"),
+        response=httpx.Response(500),
+    )
+    assert _classify_transport_failure(exc) == "real_failure"
+
+
+def test_classify_http_401_is_real_failure() -> None:
+    exc = httpx.HTTPStatusError(
+        "401",
+        request=httpx.Request("POST", "https://x"),
+        response=httpx.Response(401),
+    )
+    assert _classify_transport_failure(exc) == "real_failure"
+
+
+def test_classify_connect_error_is_real_failure() -> None:
+    assert _classify_transport_failure(httpx.ConnectError("nope")) == "real_failure"
+
+
+def test_classify_timeout_is_real_failure() -> None:
+    assert _classify_transport_failure(httpx.ReadTimeout("slow")) == "real_failure"
+
+
+def test_classify_mcp_method_not_found_is_transport_mismatch() -> None:
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    exc = McpError(ErrorData(code=-32601, message="Method not found"))
+    assert _classify_transport_failure(exc) == "transport_mismatch"
+
+
+def test_classify_mcp_other_error_is_real_failure() -> None:
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    exc = McpError(ErrorData(code=-32000, message="Server error"))
+    assert _classify_transport_failure(exc) == "real_failure"
+
+
+def test_classify_exception_group_with_inner_transport_mismatch() -> None:
+    inner_406 = httpx.HTTPStatusError(
+        "406",
+        request=httpx.Request("POST", "https://x"),
+        response=httpx.Response(406),
+    )
+    group = BaseExceptionGroup("group", [inner_406])
+    assert _classify_transport_failure(group) == "transport_mismatch"
+
+
+def test_classify_failure_reason_http() -> None:
+    exc = httpx.HTTPStatusError(
+        "406",
+        request=httpx.Request("POST", "https://x"),
+        response=httpx.Response(406),
+    )
+    assert _classify_failure_reason(exc) == "http_406"
+
+
+def test_classify_failure_reason_initialize_refused() -> None:
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    exc = McpError(ErrorData(code=-32601, message="Method not found"))
+    assert _classify_failure_reason(exc) == "initialize_refused"
+
+
+# ── Handler-level fallback behavior tests ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fallback_fires_on_http_406(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    _install_modern_failure(
+        monkeypatch,
+        httpx.HTTPStatusError(
+            "modern transport rejected",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(406),
+        ),
+    )
+
+    headers_capture: dict = {}
+    async with _make_legacy_client_with_capture(headers_capture) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is True
+    assert raw.status == InvocationStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_fallback_fires_on_initialize_refused(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    _install_modern_failure(
+        monkeypatch,
+        McpError(ErrorData(code=-32601, message="Method not found")),
+    )
+
+    headers_capture: dict = {}
+    async with _make_legacy_client_with_capture(headers_capture) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is True
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_on_auth_failure(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_modern_failure(
+        monkeypatch,
+        httpx.HTTPStatusError(
+            "401",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(401),
+        ),
+    )
+
+    # Legacy path response would succeed if invoked, so a successful raw
+    # response means the fallback fired (which it must NOT for 401).
+    fallback_invoked = {"called": False}
+
+    def transport_fn(request: httpx.Request) -> httpx.Response:
+        fallback_invoked["called"] = True
+        return _legacy_response()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(transport_fn)) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert fallback_invoked["called"] is False, "Fallback must NOT fire on 401"
+    assert raw.success is False
+    assert raw.status == InvocationStatus.ERROR
+    assert "401" in (raw.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_on_network_timeout(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_modern_failure(monkeypatch, httpx.ReadTimeout("Read timed out"))
+
+    fallback_invoked = {"called": False}
+
+    def transport_fn(request: httpx.Request) -> httpx.Response:
+        fallback_invoked["called"] = True
+        return _legacy_response()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(transport_fn)) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert fallback_invoked["called"] is False, "Fallback must NOT fire on timeout"
+    assert raw.success is False
+    assert raw.status == InvocationStatus.TIMEOUT
+    assert raw.error_type == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_on_connect_error(
+    handler: MCPProtocolHandler, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_modern_failure(monkeypatch, httpx.ConnectError("Connection refused"))
+
+    fallback_invoked = {"called": False}
+
+    def transport_fn(request: httpx.Request) -> httpx.Response:
+        fallback_invoked["called"] = True
+        return _legacy_response()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(transport_fn)) as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert fallback_invoked["called"] is False, "Fallback must NOT fire on ConnectError"
+    assert raw.success is False
+    assert raw.status == InvocationStatus.REFUSED
+
+
+# ── US2: Caller-domain header propagated on the fallback path too ────────
+
+
+@pytest.mark.asyncio
+async def test_caller_domain_header_propagated_in_fallback(
+    handler: MCPProtocolHandler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DNS_AID_CALLER_DOMAIN", "fallback.example.com")
+    _install_modern_failure(
+        monkeypatch,
+        httpx.HTTPStatusError(
+            "406",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(406),
+        ),
+    )
+
+    headers_capture: dict = {}
+    async with _make_legacy_client_with_capture(headers_capture) as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    # httpx lowercases header keys
+    assert headers_capture.get("x-dns-aid-caller-domain") == "fallback.example.com"
+
+
+@pytest.mark.asyncio
+async def test_no_caller_domain_header_in_fallback_when_env_unset(
+    handler: MCPProtocolHandler,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DNS_AID_CALLER_DOMAIN", raising=False)
+    _install_modern_failure(
+        monkeypatch,
+        httpx.HTTPStatusError(
+            "406",
+            request=httpx.Request("POST", "https://example.com/mcp"),
+            response=httpx.Response(406),
+        ),
+    )
+
+    headers_capture: dict = {}
+    async with _make_legacy_client_with_capture(headers_capture) as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert "x-dns-aid-caller-domain" not in headers_capture

--- a/tests/unit/sdk/protocols/test_mcp_streamable.py
+++ b/tests/unit/sdk/protocols/test_mcp_streamable.py
@@ -1,0 +1,450 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the MCP Streamable HTTP transport (modern path).
+
+These tests verify the handler's behavior when the modern Streamable HTTP
+transport succeeds. For the legacy fallback path's behavior see
+``tests/unit/sdk/test_mcp_handler.py``. For the fallback DECISION logic
+see ``tests/unit/sdk/protocols/test_mcp_fallback.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from dns_aid.sdk.models import InvocationStatus
+from dns_aid.sdk.protocols.mcp import _CALLER_DOMAIN_HEADER, MCPProtocolHandler
+
+
+def _build_call_tool_result(payload: Any, *, is_error: bool = False) -> Any:
+    """Build a CallToolResult-like object matching what the official SDK returns."""
+    from mcp.types import CallToolResult, TextContent
+
+    text = json.dumps(payload) if not isinstance(payload, str) else payload
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        isError=is_error,
+    )
+
+
+def _build_list_tools_result(tool_names: list[str]) -> Any:
+    """Build a ListToolsResult with the named tools (minimal schema)."""
+    from mcp.types import ListToolsResult, Tool
+
+    tools = [
+        Tool(
+            name=name,
+            description=f"{name} tool",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        )
+        for name in tool_names
+    ]
+    return ListToolsResult(tools=tools, nextCursor=None)
+
+
+@pytest.fixture
+def streamable_client_factory(monkeypatch: pytest.MonkeyPatch):
+    """Returns a callable that installs a fake streamablehttp_client + ClientSession.
+
+    Tests use this to inject the typed result they want the session to return,
+    plus a hook to inspect the headers/auth that were passed.
+    """
+    captured: dict[str, Any] = {}
+
+    def _install(
+        *,
+        call_tool_result: Any = None,
+        list_tools_result: Any = None,
+        on_initialize=None,
+    ) -> dict[str, Any]:
+        @asynccontextmanager
+        async def fake_streamable(*args, **kwargs):
+            captured["url"] = args[0] if args else kwargs.get("url")
+            captured["headers"] = kwargs.get("headers")
+            captured["auth"] = kwargs.get("auth")
+            captured["timeout"] = kwargs.get("timeout")
+            factory = kwargs.get("httpx_client_factory")
+            captured["factory"] = factory
+            # Simulate one HTTP request through the telemetry factory so
+            # event hooks fire and capture signals.
+            if factory is not None:
+                client = factory(headers=kwargs.get("headers"), timeout=None, auth=None)
+                request = httpx.Request("POST", captured["url"] or "https://example.com/mcp")
+                response = httpx.Response(
+                    200,
+                    request=request,
+                    headers={"x-cost-units": "0.05", "x-cost-currency": "USD"},
+                    content=b'{"result":"ok"}',
+                )
+                # Trigger hooks manually since we are not actually sending
+                for hook in client.event_hooks.get("request", []):
+                    await hook(request)
+                for hook in client.event_hooks.get("response", []):
+                    await hook(response)
+                await client.aclose()
+
+            yield (MagicMock(), MagicMock(), lambda: "session-123")
+
+        @asynccontextmanager
+        async def fake_session(read_stream, write_stream):
+            session = MagicMock()
+            session.initialize = AsyncMock(
+                return_value=on_initialize() if on_initialize else MagicMock()
+            )
+            session.call_tool = AsyncMock(return_value=call_tool_result)
+            session.list_tools = AsyncMock(return_value=list_tools_result)
+            yield session
+
+        monkeypatch.setattr(
+            "dns_aid.sdk.protocols.mcp.streamablehttp_client",
+            fake_streamable,
+        )
+        monkeypatch.setattr(
+            "dns_aid.sdk.protocols.mcp.ClientSession",
+            fake_session,
+        )
+        return captured
+
+    return _install
+
+
+@pytest.fixture
+def handler() -> MCPProtocolHandler:
+    return MCPProtocolHandler()
+
+
+# ── US1: Modern transport happy path ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_modern_transport_tools_call_happy_path(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"result": "pong"}),
+    )
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {"host": "1.1.1.1"}},
+            timeout=5.0,
+        )
+
+    assert raw.success is True
+    assert raw.status == InvocationStatus.SUCCESS
+    assert raw.data == {"result": "pong"}
+
+
+@pytest.mark.asyncio
+async def test_modern_transport_tools_list_happy_path(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    streamable_client_factory(
+        list_tools_result=_build_list_tools_result(["ping", "traceroute"]),
+    )
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/list",
+            arguments=None,
+            timeout=5.0,
+        )
+
+    assert raw.success is True
+    assert isinstance(raw.data, dict)
+    tools_payload = raw.data["tools"]
+    assert [t["name"] for t in tools_payload] == ["ping", "traceroute"]
+
+
+@pytest.mark.asyncio
+async def test_telemetry_signals_populated_on_modern_path(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+        )
+
+    assert raw.invocation_latency_ms is not None
+    assert raw.invocation_latency_ms > 0
+    assert raw.ttfb_ms is not None
+    assert raw.response_size_bytes is not None
+    assert raw.response_size_bytes > 0
+    assert raw.http_status_code == 200
+    assert raw.headers is not None
+
+
+@pytest.mark.asyncio
+async def test_cost_headers_propagated_on_modern_path(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+        )
+
+    assert raw.cost_units == 0.05
+    assert raw.cost_currency == "USD"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_modern_invocations_correlate(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    """asyncio.gather of N invocations all complete with their expected results."""
+    # Each invocation sees its own streamable_client_factory installation,
+    # so we need a session-scoped fake that can return distinct results per call.
+    # Use a counter-based mock.
+    counter = {"n": 0}
+    payloads = ["alpha", "beta", "gamma", "delta", "epsilon"]
+
+    @asynccontextmanager
+    async def fake_streamable(*args, **kwargs):
+        factory = kwargs.get("httpx_client_factory")
+        if factory is not None:
+            client = factory(headers=kwargs.get("headers"), timeout=None, auth=None)
+            request = httpx.Request("POST", args[0])
+            response = httpx.Response(200, request=request, content=b"{}")
+            for hook in client.event_hooks.get("request", []):
+                await hook(request)
+            for hook in client.event_hooks.get("response", []):
+                await hook(response)
+            await client.aclose()
+        yield (MagicMock(), MagicMock(), lambda: f"session-{counter['n']}")
+
+    @asynccontextmanager
+    async def fake_session(rs, ws):
+        session = MagicMock()
+        session.initialize = AsyncMock(return_value=MagicMock())
+        idx = counter["n"]
+        counter["n"] += 1
+        session.call_tool = AsyncMock(
+            return_value=_build_call_tool_result({"index": idx, "payload": payloads[idx]})
+        )
+        yield session
+
+    import dns_aid.sdk.protocols.mcp as mcp_module
+
+    original_streamable = mcp_module.streamablehttp_client
+    original_session = mcp_module.ClientSession
+    mcp_module.streamablehttp_client = fake_streamable
+    mcp_module.ClientSession = fake_session
+    try:
+        async with httpx.AsyncClient() as client:
+            results = await asyncio.gather(
+                *[
+                    handler.invoke(
+                        client=client,
+                        endpoint="https://mcp.example.com/mcp",
+                        method="tools/call",
+                        arguments={"name": "ping", "arguments": {}},
+                        timeout=5.0,
+                    )
+                    for _ in payloads
+                ]
+            )
+    finally:
+        mcp_module.streamablehttp_client = original_streamable
+        mcp_module.ClientSession = original_session
+
+    assert len(results) == len(payloads)
+    indices = sorted(r.data["index"] for r in results)
+    assert indices == [0, 1, 2, 3, 4]
+    for r in results:
+        assert r.success is True
+    assert counter["n"] == len(payloads)
+
+
+# ── US1: Tool error reported as failure ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tool_is_error_flag_marks_response_unsuccessful(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"error": "tool failed"}, is_error=True),
+    )
+    async with httpx.AsyncClient() as client:
+        raw = await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "broken", "arguments": {}},
+            timeout=5.0,
+        )
+
+    assert raw.success is False
+    assert raw.status == InvocationStatus.ERROR
+    assert raw.error_type == "ToolError"
+
+
+# ── US2: Caller-identity header propagation ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_caller_domain_header_set_when_env_var_present(
+    handler: MCPProtocolHandler,
+    streamable_client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DNS_AID_CALLER_DOMAIN", "test.example.com")
+    captured = streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+
+    async with httpx.AsyncClient() as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+        )
+
+    assert captured["headers"] is not None
+    assert captured["headers"][_CALLER_DOMAIN_HEADER] == "test.example.com"
+
+
+@pytest.mark.asyncio
+async def test_caller_domain_header_omitted_when_env_var_unset(
+    handler: MCPProtocolHandler,
+    streamable_client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DNS_AID_CALLER_DOMAIN", raising=False)
+    captured = streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+
+    async with httpx.AsyncClient() as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+        )
+
+    # Header omitted entirely (None or absent), NOT sent as empty string
+    assert captured["headers"] is None or _CALLER_DOMAIN_HEADER not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_caller_domain_header_omitted_when_env_var_empty(
+    handler: MCPProtocolHandler,
+    streamable_client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DNS_AID_CALLER_DOMAIN", "")
+    captured = streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+
+    async with httpx.AsyncClient() as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+        )
+
+    assert captured["headers"] is None or _CALLER_DOMAIN_HEADER not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_caller_domain_header_strips_whitespace(
+    handler: MCPProtocolHandler,
+    streamable_client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DNS_AID_CALLER_DOMAIN", "  whitespace.example.com  ")
+    captured = streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+
+    async with httpx.AsyncClient() as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+        )
+
+    assert captured["headers"][_CALLER_DOMAIN_HEADER] == "whitespace.example.com"
+
+
+# ── US1: Auth handler propagation ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auth_handler_passed_through_as_httpx_auth(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    from dns_aid.sdk.auth.simple import BearerAuthHandler
+
+    auth = BearerAuthHandler(token="test-token-abc")
+    captured = streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+
+    async with httpx.AsyncClient() as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+            auth_handler=auth,
+        )
+
+    assert captured["auth"] is not None
+    assert isinstance(captured["auth"], httpx.Auth)
+
+
+@pytest.mark.asyncio
+async def test_no_auth_handler_passes_none_to_streamable_client(
+    handler: MCPProtocolHandler, streamable_client_factory
+) -> None:
+    captured = streamable_client_factory(
+        call_tool_result=_build_call_tool_result({"ok": True}),
+    )
+
+    async with httpx.AsyncClient() as client:
+        await handler.invoke(
+            client=client,
+            endpoint="https://mcp.example.com/mcp",
+            method="tools/call",
+            arguments={"name": "ping", "arguments": {}},
+            timeout=5.0,
+            auth_handler=None,
+        )
+
+    assert captured["auth"] is None

--- a/tests/unit/sdk/protocols/test_mcp_telemetry.py
+++ b/tests/unit/sdk/protocols/test_mcp_telemetry.py
@@ -1,0 +1,219 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the MCP transport telemetry capture (event-hook based)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from dns_aid.sdk.protocols._mcp_telemetry import (
+    _make_telemetry_factory,
+    _TelemetryCapture,
+)
+
+
+@pytest.mark.asyncio
+async def test_request_hook_records_start_time() -> None:
+    capture = _TelemetryCapture()
+    request = httpx.Request("POST", "https://example.com/mcp")
+
+    assert capture.start_perf is None
+    await capture.on_request(request)
+    assert capture.start_perf is not None
+    assert capture.start_perf > 0
+
+
+@pytest.mark.asyncio
+async def test_request_hook_resets_per_request_fields() -> None:
+    capture = _TelemetryCapture(
+        ttfb_perf=1.0,
+        total_perf=2.0,
+        response_size_bytes=100,
+        cost_units=0.5,
+        cost_currency="USD",
+        tls_version="TLSv1.2",
+        http_status_code=500,
+        headers={"old-key": "old-value"},
+    )
+    request = httpx.Request("POST", "https://example.com/mcp")
+
+    await capture.on_request(request)
+
+    assert capture.ttfb_perf is None
+    assert capture.total_perf is None
+    assert capture.response_size_bytes == 0
+    assert capture.cost_units is None
+    assert capture.cost_currency is None
+    assert capture.tls_version is None
+    assert capture.http_status_code is None
+    assert capture.headers == {}
+
+
+@pytest.mark.asyncio
+async def test_response_hook_records_status_and_headers() -> None:
+    capture = _TelemetryCapture(start_perf=0.0)
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(
+        200,
+        request=request,
+        headers={"Content-Type": "application/json", "Server": "nginx"},
+        content=b'{"result": "ok"}',
+    )
+
+    await capture.on_response(response)
+
+    assert capture.http_status_code == 200
+    # Headers stored with lowercased keys
+    assert capture.headers["content-type"] == "application/json"
+    assert capture.headers["server"] == "nginx"
+    assert capture.ttfb_perf is not None
+    assert capture.total_perf is not None
+    assert capture.response_size_bytes == len(b'{"result": "ok"}')
+
+
+@pytest.mark.asyncio
+async def test_response_hook_parses_cost_headers() -> None:
+    capture = _TelemetryCapture(start_perf=0.0)
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(
+        200,
+        request=request,
+        headers={"X-Cost-Units": "0.05", "X-Cost-Currency": "USD"},
+        content=b"{}",
+    )
+
+    await capture.on_response(response)
+
+    assert capture.cost_units == 0.05
+    assert capture.cost_currency == "USD"
+
+
+@pytest.mark.asyncio
+async def test_response_hook_handles_missing_cost_headers() -> None:
+    capture = _TelemetryCapture(start_perf=0.0)
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(200, request=request, content=b"{}")
+
+    await capture.on_response(response)
+
+    assert capture.cost_units is None
+    assert capture.cost_currency is None
+
+
+@pytest.mark.asyncio
+async def test_response_hook_handles_malformed_cost_units() -> None:
+    capture = _TelemetryCapture(start_perf=0.0)
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(
+        200,
+        request=request,
+        headers={"X-Cost-Units": "not-a-number"},
+        content=b"{}",
+    )
+
+    await capture.on_response(response)
+
+    assert capture.cost_units is None
+
+
+@pytest.mark.asyncio
+async def test_response_hook_extracts_tls_version_when_available() -> None:
+    """Verify TLS version extraction works when network_stream extension exposes ssl_object."""
+    capture = _TelemetryCapture(start_perf=0.0)
+    request = httpx.Request("POST", "https://example.com/mcp")
+
+    ssl_object = MagicMock()
+    ssl_object.version.return_value = "TLSv1.3"
+    network_stream = MagicMock()
+    network_stream.get_extra_info.return_value = ssl_object
+
+    response = httpx.Response(200, request=request, content=b"{}")
+    response.extensions["network_stream"] = network_stream
+
+    await capture.on_response(response)
+
+    assert capture.tls_version == "TLSv1.3"
+    network_stream.get_extra_info.assert_called_once_with("ssl_object")
+
+
+@pytest.mark.asyncio
+async def test_response_hook_handles_missing_tls_info_gracefully() -> None:
+    capture = _TelemetryCapture(start_perf=0.0)
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(200, request=request, content=b"{}")
+    # No network_stream extension set.
+
+    await capture.on_response(response)
+
+    assert capture.tls_version is None
+
+
+@pytest.mark.asyncio
+async def test_invocation_latency_ms_computed_after_full_lifecycle() -> None:
+    capture = _TelemetryCapture()
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(200, request=request, content=b"{}")
+
+    assert capture.invocation_latency_ms is None
+
+    await capture.on_request(request)
+    await capture.on_response(response)
+
+    latency = capture.invocation_latency_ms
+    assert latency is not None
+    assert latency >= 0
+
+
+@pytest.mark.asyncio
+async def test_ttfb_ms_computed_after_response_headers_received() -> None:
+    capture = _TelemetryCapture()
+    request = httpx.Request("POST", "https://example.com/mcp")
+    response = httpx.Response(200, request=request, content=b"{}")
+
+    assert capture.ttfb_ms is None
+
+    await capture.on_request(request)
+    await capture.on_response(response)
+
+    ttfb = capture.ttfb_ms
+    assert ttfb is not None
+    assert ttfb >= 0
+
+
+def test_make_telemetry_factory_returns_async_client() -> None:
+    capture = _TelemetryCapture()
+    factory = _make_telemetry_factory(capture)
+
+    client = factory(headers=None, timeout=None, auth=None)
+    assert isinstance(client, httpx.AsyncClient)
+
+
+def test_factory_attaches_event_hooks_for_capture() -> None:
+    capture = _TelemetryCapture()
+    factory = _make_telemetry_factory(capture)
+
+    client = factory(headers={"X-Test": "1"}, timeout=httpx.Timeout(5.0), auth=None)
+
+    request_hooks = client.event_hooks.get("request", [])
+    response_hooks = client.event_hooks.get("response", [])
+    assert capture.on_request in request_hooks
+    assert capture.on_response in response_hooks
+
+
+def test_factory_propagates_headers_and_auth() -> None:
+    capture = _TelemetryCapture()
+    factory = _make_telemetry_factory(capture)
+
+    auth = MagicMock(spec=httpx.Auth)
+    client = factory(
+        headers={"X-Caller": "test.example.com"},
+        timeout=httpx.Timeout(10.0),
+        auth=auth,
+    )
+
+    assert client.headers.get("x-caller") == "test.example.com"
+    assert client.auth is auth

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -22,6 +22,14 @@ def config() -> SDKConfig:
     return SDKConfig(timeout_seconds=5.0, caller_id="test-agent")
 
 
+@pytest.fixture(autouse=True)
+def _autouse_legacy_fallback(force_legacy_mcp_fallback: None) -> None:
+    """MCP tests in this module use httpx.MockTransport which simulates the
+    legacy plain JSON-RPC POST path. Force fallback so they continue to verify
+    that path's behavior. Non-MCP tests are unaffected (the patch is a no-op
+    for them)."""
+
+
 class TestAgentClient:
     @pytest.mark.asyncio
     async def test_context_manager(self, config: SDKConfig) -> None:

--- a/tests/unit/sdk/test_mcp_handler.py
+++ b/tests/unit/sdk/test_mcp_handler.py
@@ -1,7 +1,18 @@
 # Copyright 2024-2026 The DNS-AID Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for MCP protocol handler."""
+"""Tests for the MCP protocol handler — legacy fallback transport.
+
+These tests exercise the LEGACY plain JSON-RPC POST path that the handler
+falls back to when a server rejects the modern Streamable HTTP transport.
+The autouse fixture below forces every test to take the fallback path by
+making the modern transport raise an HTTP 406 (transport mismatch).
+
+For tests of the modern Streamable HTTP path, see
+``tests/unit/sdk/protocols/test_mcp_streamable.py``.
+For tests of the fallback DECISION logic, see
+``tests/unit/sdk/protocols/test_mcp_fallback.py``.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +23,15 @@ import pytest
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
+
+
+@pytest.fixture(autouse=True)
+def _autouse_legacy_fallback(force_legacy_mcp_fallback: None) -> None:
+    """All tests in this module exercise the legacy fallback path.
+
+    Reuses the shared ``force_legacy_mcp_fallback`` fixture from
+    ``tests/unit/sdk/conftest.py``.
+    """
 
 
 @pytest.fixture

--- a/tests/unit/sdk/test_public_api_contract.py
+++ b/tests/unit/sdk/test_public_api_contract.py
@@ -1,0 +1,194 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public API surface contract test.
+
+Asserts that the public function signatures and return-type field sets
+that this feature COMMITS to preserve (per
+``specs/001-mcp-streamable-http/contracts/mcp-protocol-handler.md``)
+have not drifted. If anyone changes one of these signatures the test
+fails loudly so the contract document and any downstream callers can
+be updated together.
+
+Run this test directly to see the recorded contract:
+    pytest tests/unit/sdk/test_public_api_contract.py -v
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from typing import Any
+
+
+def _signature_param_names(fn: Any) -> list[str]:
+    return list(inspect.signature(fn).parameters.keys())
+
+
+def _signature_param_kinds(fn: Any) -> list[tuple[str, str]]:
+    """Return [(name, kind)] tuples — kind is e.g. POSITIONAL_OR_KEYWORD, KEYWORD_ONLY."""
+    return [(name, p.kind.name) for name, p in inspect.signature(fn).parameters.items()]
+
+
+# ── 1. MCPProtocolHandler.invoke ──────────────────────────────────────────
+
+
+def test_mcp_protocol_handler_invoke_signature_unchanged() -> None:
+    from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
+
+    expected = ["self", "client", "endpoint", "method", "arguments", "timeout", "auth_handler"]
+    assert _signature_param_names(MCPProtocolHandler.invoke) == expected
+
+
+def test_mcp_protocol_handler_protocol_name_returns_mcp() -> None:
+    from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
+
+    handler = MCPProtocolHandler()
+    assert handler.protocol_name == "mcp"
+
+
+# ── 2. RawResponse field set ──────────────────────────────────────────────
+
+
+def test_raw_response_field_set_unchanged() -> None:
+    from dns_aid.sdk.protocols.base import RawResponse
+
+    expected_fields = {
+        "success",
+        "status",
+        "data",
+        "http_status_code",
+        "error_type",
+        "error_message",
+        "invocation_latency_ms",
+        "ttfb_ms",
+        "response_size_bytes",
+        "cost_units",
+        "cost_currency",
+        "tls_version",
+        "headers",
+    }
+    actual_fields = {f.name for f in dataclasses.fields(RawResponse)}
+    assert actual_fields == expected_fields, (
+        f"RawResponse fields changed.\nAdded: {actual_fields - expected_fields}\n"
+        f"Removed: {expected_fields - actual_fields}"
+    )
+
+
+# ── 3. call_mcp_tool ──────────────────────────────────────────────────────
+
+
+def test_call_mcp_tool_signature_unchanged() -> None:
+    from dns_aid.core.invoke import call_mcp_tool
+
+    expected = [
+        "endpoint",
+        "tool_name",
+        "arguments",
+        "timeout",
+        "caller_id",
+        "credentials",
+        "agent_record",
+        "auth_type",
+        "auth_config",
+        "policy_uri",
+    ]
+    assert _signature_param_names(call_mcp_tool) == expected
+
+
+def test_call_mcp_tool_keyword_only_params_preserved() -> None:
+    from dns_aid.core.invoke import call_mcp_tool
+
+    kinds = dict(_signature_param_kinds(call_mcp_tool))
+    # Per the contract, all non-positional fields are keyword-only
+    for kw_only in (
+        "timeout",
+        "caller_id",
+        "credentials",
+        "agent_record",
+        "auth_type",
+        "auth_config",
+        "policy_uri",
+    ):
+        assert kinds[kw_only] == "KEYWORD_ONLY", (
+            f"{kw_only} must remain keyword-only (was {kinds[kw_only]})"
+        )
+
+
+# ── 4. list_mcp_tools ─────────────────────────────────────────────────────
+
+
+def test_list_mcp_tools_signature_unchanged() -> None:
+    from dns_aid.core.invoke import list_mcp_tools
+
+    expected = [
+        "endpoint",
+        "timeout",
+        "caller_id",
+        "credentials",
+        "agent_record",
+        "auth_type",
+        "auth_config",
+        "policy_uri",
+    ]
+    assert _signature_param_names(list_mcp_tools) == expected
+
+
+# ── 5. AgentClient.invoke ─────────────────────────────────────────────────
+
+
+def test_agent_client_invoke_signature_unchanged() -> None:
+    from dns_aid.sdk.client import AgentClient
+
+    expected = [
+        "self",
+        "agent",
+        "method",
+        "arguments",
+        "timeout",
+        "credentials",
+        "auth_handler",
+    ]
+    assert _signature_param_names(AgentClient.invoke) == expected
+
+
+# ── 6. AuthHandler interface ──────────────────────────────────────────────
+
+
+def test_auth_handler_protocol_unchanged() -> None:
+    from dns_aid.sdk.auth.base import AuthHandler
+
+    # AuthHandler is an ABC with `apply` and `auth_type`
+    assert hasattr(AuthHandler, "apply")
+    assert hasattr(AuthHandler, "auth_type")
+
+    apply_sig = _signature_param_names(AuthHandler.apply)
+    assert apply_sig == ["self", "request"]
+
+
+# ── 7. InvocationStatus enum values preserved ────────────────────────────
+
+
+def test_invocation_status_values_preserved() -> None:
+    from dns_aid.sdk.models import InvocationStatus
+
+    expected_values = {"SUCCESS", "TIMEOUT", "REFUSED", "ERROR"}
+    actual_values = {member.name for member in InvocationStatus}
+    # New values may be added (not breaking) but existing ones must remain
+    assert expected_values.issubset(actual_values), (
+        f"Expected InvocationStatus members removed: {expected_values - actual_values}"
+    )
+
+
+# ── 8. InvokeResult shape ─────────────────────────────────────────────────
+
+
+def test_invoke_result_field_set_unchanged() -> None:
+    from dns_aid.core.invoke import InvokeResult
+
+    expected_fields = {"success", "data", "error", "telemetry"}
+    actual_fields = {f.name for f in dataclasses.fields(InvokeResult)}
+    assert actual_fields == expected_fields, (
+        f"InvokeResult fields changed.\nAdded: {actual_fields - expected_fields}\n"
+        f"Removed: {expected_fields - actual_fields}"
+    )

--- a/tests/unit/sdk/test_top_level_api.py
+++ b/tests/unit/sdk/test_top_level_api.py
@@ -13,6 +13,12 @@ import pytest
 from dns_aid.core.models import AgentRecord, Protocol
 
 
+@pytest.fixture(autouse=True)
+def _autouse_legacy_fallback(force_legacy_mcp_fallback: None) -> None:
+    """Top-level MCP invocations in this module use httpx.MockTransport,
+    exercising the legacy plain JSON-RPC POST path via fallback."""
+
+
 class TestTopLevelInvoke:
     @pytest.mark.asyncio
     async def test_invoke_one_liner(self, sample_mcp_agent: AgentRecord) -> None:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -261,8 +261,8 @@ class TestBuildAgentRecordFromEndpoint:
         assert agent.endpoint_override == "https://mcp.example.com/mcp"
 
     def test_protocol_mapping(self):
-        from dns_aid.core.models import Protocol
         from dns_aid.core.invoke import _build_agent_record_from_endpoint
+        from dns_aid.core.models import Protocol
 
         mcp_agent = _build_agent_record_from_endpoint("https://host.com", protocol="mcp")
         assert mcp_agent.protocol == Protocol.MCP
@@ -289,12 +289,10 @@ class TestBuildAgentRecordFromEndpoint:
 
 
 class TestSDKAvailabilityFlag:
-    """Test that _sdk_available flag is set."""
-
-    def test_sdk_flag_is_boolean(self):
-        from dns_aid.core.invoke import _sdk_available
-
-        assert isinstance(_sdk_available, bool)
+    """The _sdk_available flag was removed when MCP transport was unified onto
+    the modern Streamable HTTP path (feature 001-mcp-streamable-http). The MCP
+    SDK is now a hard requirement for the MCP path; the [mcp] extra controls it.
+    """
 
     def test_call_agent_tool_registered(self):
         """Test call_agent_tool is registered as an MCP tool."""

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.17.1"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Replaces the dns-aid SDK's hand-rolled JSON-RPC POST with the official MCP Python SDK's `streamablehttp_client` and `ClientSession`, so the SDK now speaks the modern MCP Streamable HTTP transport (spec revision 2025-03-26 and later). Modern targets — AWS Bedrock AgentCore, Anthropic MCP Connector Directory listings, agentgateway-fronted servers — are now reachable end-to-end. Legacy on-premise servers are reached via a transparent fallback that fires only when the modern transport is rejected (HTTP 405/406, refused initialize via JSON-RPC -32601). Bumps version 0.17.3 → 0.18.0.

## Why

The previous transport sent only `Content-Type: application/json` with no `Accept: application/json, text/event-stream`, no `initialize` handshake, no `Mcp-Session-Id` continuity, and no SSE response handling. Any modern MCP server rejected the SDK with HTTP 406, leaving the project's "works NOW" mission claim unsupportable against the production MCP ecosystem.

A second silent defect surfaced during analysis: the SDK fast path was silently dropping the `X-DNS-AID-Caller-Domain` header, breaking Layer 2 caller-identity policy enforcement for any user on the SDK code path. Both issues are fixed in this PR.

## What changed

### Behavior

- **Modern Streamable HTTP transport** is the default. Modern targets work end-to-end with full session lifecycle (initialize handshake, server-issued session id continuity, SSE response stream parsing, unique JSON-RPC request ids).
- **Transparent legacy fallback** handles on-premise / pre-2025-03-26 servers. Triggers only on transport-mismatch failures (HTTP 405/406, JSON-RPC -32601 from initialize). Does NOT trigger on auth failures, network timeouts, server errors, or tool errors. Each fallback emits a structured `transport.legacy_fallback` warning carrying the endpoint, the failure reason, and the modern-attempt latency.
- **`X-DNS-AID-Caller-Domain` header propagated correctly** on both transport paths whenever `DNS_AID_CALLER_DOMAIN` is set; omitted entirely (not sent as empty string) when unset.
- **Missing `[mcp]` extra produces a clear remediation message** instead of an opaque ImportError at first use.

### Architecture

- New internal `_DnsAidHttpxAuth` adapter (`src/dns_aid/sdk/auth/_httpx_adapter.py`) bridges existing `AuthHandler` implementations (Bearer, OAuth2, mTLS, API Key) to the `httpx.Auth` shape the official SDK consumes — no auth-handler changes required.
- New internal `_TelemetryCapture` (`src/dns_aid/sdk/protocols/_mcp_telemetry.py`) uses `httpx` event hooks via the SDK's `httpx_client_factory` extension point to capture latency, TTFB, response size, cost headers, TLS version, and HTTP status across both transports.
- `_invoke_raw_mcp` in `core/invoke.py` deleted along with the `_sdk_available` toggle on the MCP path — it was duplicate dead code after the unification. Net cleanup: −150 LOC. The `_sdk_available` toggle remains for the A2A no-SDK fallback path (out of scope).

### Public API

Preserved verbatim. `call_mcp_tool`, `list_mcp_tools`, `AgentClient.invoke`, `MCPProtocolHandler.invoke`, `RawResponse`, `InvocationResult`, `InvocationStatus`, and the `AuthHandler` ABC all unchanged. A new `tests/unit/sdk/test_public_api_contract.py` programmatically asserts these surfaces have not drifted — fails CI loudly on any unintentional change.

## Files changed

| File | Change |
|---|---|
| `src/dns_aid/sdk/protocols/mcp.py` | Rewritten — modern transport + transparent legacy fallback + telemetry + caller-domain header + clear error messages (~470 LOC) |
| `src/dns_aid/sdk/protocols/_mcp_telemetry.py` | NEW — `_TelemetryCapture` + `_make_telemetry_factory` (~140 LOC) |
| `src/dns_aid/sdk/auth/_httpx_adapter.py` | NEW — `_DnsAidHttpxAuth` + `to_httpx_auth` (~50 LOC) |
| `src/dns_aid/core/invoke.py` | `_invoke_raw_mcp` deleted, MCP `_sdk_available` toggle removed (~−150 LOC) |
| `tests/unit/sdk/protocols/test_mcp_streamable.py` | NEW — 12 tests (modern path, telemetry, caller-domain, auth) |
| `tests/unit/sdk/protocols/test_mcp_fallback.py` | NEW — 18 tests (classification + handler-level fallback decisions) |
| `tests/unit/sdk/protocols/test_mcp_errors.py` | NEW — 5 tests (US3 remediation messages) |
| `tests/unit/sdk/protocols/test_mcp_telemetry.py` | NEW — 13 tests (event-hook capture mechanics) |
| `tests/unit/sdk/auth/test_httpx_adapter.py` | NEW — 5 tests (auth bridge) |
| `tests/unit/sdk/test_public_api_contract.py` | NEW — 10 tests (programmatic API surface guard) |
| `tests/unit/sdk/conftest.py` | New shared `force_legacy_mcp_fallback` fixture |
| `tests/unit/sdk/test_mcp_handler.py`, `test_client.py`, `test_top_level_api.py`, `auth/test_client_auth.py` | Autouse fixtures wiring existing tests to the legacy fallback path so they continue to verify it |
| `tests/unit/core/test_invoke.py`, `tests/unit/test_mcp_server.py` | Dead-code tests removed with explanatory inline notes |
| `.gitignore` | Adds credential-token patterns + speckit local working state (`specs/`, `.specify/`) |
| `docs/architecture.md`, `docs/api-reference.md`, `docs/getting-started.md` | Refresh — name the modern transport, document the fallback, show telemetry + credentials kwarg |
| `CHANGELOG.md` | `[0.18.0]` entry detailing every behavior change |
| `pyproject.toml`, `CITATION.cff`, `server.json`, `manifest.json`, `uv.lock` | Version 0.17.3 → 0.18.0; CITATION.cff date-released 2026-04-25 |

## Test plan

- [x] **1283 unit tests pass** locally (`uv run pytest tests/unit -q --ignore=tests/unit/sdk/test_mesh_invoke.py`) — 40 net new tests (foundational + US1 + US2 + US3 + contract + fallback), 5 dead-code tests removed.
- [x] **mypy strict clean** across 76 source files (`uv run mypy src/dns_aid/`).
- [x] **ruff check + format clean** on every touched file.
- [x] **Pre-push secret scan clean** across the 9-commit branch diff. `.mcpregistry_*_token` and `.env*` confirmed gitignored, never staged.
- [x] **Live validation against `mcp.highvelocitynetworking.com`** (production target):
  - Modern Streamable HTTP transport reaches the target end-to-end.
  - 401 from missing-bearer-token correctly classified as a real failure (NO false fallback to legacy) and surfaced cleanly.
  - p95 sequential-call latency ~174ms over 20 calls (transport + TLS handshake + initialize attempt round-trip).
  - **60.1 RPS** at 50 concurrent invocations on a single `AgentClient` (exceeds the SC-006 target of 50 RPS).
  - **Zero cross-contamination** across 50 concurrent invocations — every call got its correctly-correlated index back.
- [x] **Public API surface contract diff test** (`test_public_api_contract.py`) — passes 10/10; signatures and field sets of `MCPProtocolHandler.invoke`, `call_mcp_tool`, `list_mcp_tools`, `AgentClient.invoke`, `RawResponse`, `InvokeResult`, `InvocationStatus`, `AuthHandler` are unchanged.
- [x] **Backwards-compat regression**: existing AgentClient/auth/top-level/handler tests now exercise the legacy fallback path via the shared `force_legacy_mcp_fallback` fixture; all preserved behaviors continue to pass.

## Notes

- Version bump (0.17.3 → 0.18.0) ships in this PR rather than a follow-up — the change is a single coherent transport upgrade, so feature, tests, docs, and version live together for cleanest release atomicity.
- Public API surface preserved verbatim — existing callers require zero code changes.
- The fallback path uses the same legacy plain JSON-RPC POST shape the previous transport implemented; no behavior change for legacy-only servers.
- DCO sign-off on every commit.