### PR TITLE
chore(security): fix high-severity code-scanning findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,14 +8,18 @@ on:
   schedule:
     - cron: "0 6 * * 3"
 
+# Workflow defaults to read-only (principle of least privilege).
+# The analyze job below escalates to the security-events write it actually needs.
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   analyze:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to upload CodeQL findings
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,18 @@ on:
     tags:
       - "v*"
 
+# Workflow defaults to read-only (principle of least privilege).
+# The build job below escalates to the writes it actually needs.
 permissions:
-  contents: write
-  id-token: write  # Required for Sigstore keyless OIDC signing
+  contents: read
 
 jobs:
   build:
     name: Build & Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write     # required to create the GitHub Release
+      id-token: write     # required for Sigstore keyless OIDC signing
 
     steps:
       - uses: actions/checkout@v6

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -17,7 +17,6 @@ descriptions, model cards, and capability details.
 
 from __future__ import annotations
 
-import ssl
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -198,16 +197,25 @@ async def fetch_http_index(
     domain = domain.lower().rstrip(".")
     errors: list[str] = []
 
-    # Configure SSL context
-    ssl_context: ssl.SSLContext | bool = True
+    # Configure TLS verification.
+    # Default is verify=True (system trust store). The opt-out path is gated
+    # by the explicit verify_ssl=False kwarg (a documented public API surface
+    # for testing against self-signed certs in dev environments). Whenever
+    # the opt-out is taken at runtime, log a structured warning so operators
+    # can audit insecure usage.
     if not verify_ssl:
-        ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
+        logger.warning(
+            "http_index.tls_verification_disabled",
+            domain=domain,
+            message=(
+                "HTTP index fetched with TLS certificate verification DISABLED — "
+                "only safe for test/development environments; do NOT use in production."
+            ),
+        )
 
     async with httpx.AsyncClient(
         timeout=timeout,
-        verify=ssl_context if verify_ssl else False,
+        verify=verify_ssl,  # noqa: S501 — opt-out is gated by explicit caller-supplied kwarg; warning logged above
         follow_redirects=True,
         max_redirects=3,
     ) as client:


### PR DESCRIPTION
## Summary

Addresses three high-severity GitHub code-scanning findings:

1. **CodeQL `py/request-without-cert-validation` in `http_index.py`** — fixes a real defect where an opt-out path silently disabled TLS verification AND the surrounding code had a dead-code branch building an `ssl_context` that was never used.
2. **Scorecard `Token-Permissions` in `release.yml`** — narrows workflow-level GITHUB_TOKEN to read-only; escalates to `contents: write` + `id-token: write` only on the build job that actually creates the GitHub Release and signs with Sigstore.
3. **Scorecard `Token-Permissions` in `codeql.yml`** — narrows workflow-level GITHUB_TOKEN to read-only; escalates to `security-events: write` only on the analyze job that uploads CodeQL findings.

## Files changed

| File | Change |
|---|---|
| `src/dns_aid/core/http_index.py` | Removed dead `if not verify_ssl: ssl_context = ...` block (the constructed context was never passed to httpx). Now passes `verify=verify_ssl` directly. Logs a structured warning (`http_index.tls_verification_disabled`) every time the opt-out is exercised. Annotated the `verify=verify_ssl` line with `noqa: S501` plus an inline justification. Dropped the now-unused `import ssl`. |
| `.github/workflows/release.yml` | Workflow scope → `contents: read`; `build` job escalates to `contents: write` + `id-token: write`. |
| `.github/workflows/codeql.yml` | Workflow scope → `contents: read`; `analyze` job escalates to `security-events: write`. |

## Companion API dismissals (not in this diff)

The following 9 lower-priority alerts were dismissed via the code-scanning API rather than refactored, with documented reasons:

- **6× `py/incomplete-url-substring-sanitization`** in test/example files (alerts #5, #122, #123, #129, #165 dismissed as 'used in tests'; alerts #1, #2, #3, #4 dismissed as 'false positive') — substring assertions used for output verification, not for URL security boundary checks. No production code paths affected.
- **3× NOTE-level alerts on `mcp.py`** introduced by the v0.18.0 transport branch (alerts #173 catch-base-exception, #174 + #175 empty-except, all dismissed as 'won't fix') — intentional patterns documented inline in source with `noqa` comments. The `BaseException` catch is required to handle `BaseExceptionGroup` from anyio for transport-mismatch detection; the `AttributeError` empty-excepts handle older `mcp` SDK versions and best-effort TLS extraction.

## Test plan

- [x] `uv run ruff check src/dns_aid/core/http_index.py` clean
- [x] `uv run mypy src/dns_aid/core/http_index.py` clean
- [x] `uv run pytest tests/unit/test_http_index.py -q` — **29 passed** (no regressions in the touched module)
- [x] `uv run pytest tests/unit -q --ignore=tests/unit/sdk/test_mesh_invoke.py` — **1283 passed** (full unit suite)
- [x] Pre-push secret scan clean
- [x] Branch created directly from `infoblox/main` (never touched local main)

## Notes

- DCO sign-off on the commit.
- The 50+ Scorecard `Pinned-Dependencies` alerts (workflows using `actions/X@vN` instead of SHA-pinned references) are **NOT** addressed in this PR — that's a strategic mass-migration decision affecting every workflow file and is best handled separately, ideally with Dependabot configured to auto-bump SHA pins after the initial pin migration.