### PR TITLE
ci: expand CodeQL trigger to all branches (close Scorecard SASTID)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: ['**']  # all branches — closes Scorecard SASTID coverage gap
   pull_request:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary

Closes the Scorecard `SASTID` coverage gap (currently 25/28 commits scanned, score 9/10) by expanding the CodeQL `push` trigger from `branches: [main]` to `branches: ['**']`. Direct pushes to feature branches will now get a SAST scan immediately, instead of only when a PR is opened.

## Why

Scorecard counts a commit as "SAST-scanned" only if a SAST tool reported a check on that commit's SHA. Today CodeQL fires on:
- push to `main` (every commit on main is scanned)
- pull_request to `main` (PR head SHAs are scanned)
- weekly cron

That misses any commit pushed to a feature branch before a PR is opened against it. With multiple commits per branch and PRs being squashed/merged, intermediate commits go unscanned, dragging the SASTID score below 10.

## Change

```diff
 on:
   push:
-    branches: [main]
+    branches: ['**']  # all branches — closes Scorecard SASTID coverage gap
   pull_request:
     branches: [main]
   schedule:
     - cron: "0 6 * * 3"
```

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/codeql.yml"))'` → YAML valid
- [x] No source code or behavior changes
- [ ] CI on this PR triggers CodeQL on the feature branch — green is the proof

## After merge

Next Scorecard scan should report `SASTID` score 10/10 (all commits scanned) and the alert will close.