### PR TITLE
docs(readme): fix broken badges + point all URLs at infobloxopen/dns-aid-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # DNS-AID
 
-[![CI](https://github.com/iracic82/DNS-AID/actions/workflows/ci.yml/badge.svg)](https://github.com/iracic82/DNS-AID/actions/workflows/ci.yml)
-[![Security](https://img.shields.io/badge/security-bandit%20%2B%20semgrep-green)](https://github.com/iracic82/DNS-AID/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-77%25-green)](https://github.com/iracic82/DNS-AID/actions/workflows/ci.yml)
+[![CI](https://github.com/infobloxopen/dns-aid-core/actions/workflows/ci.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/ci.yml)
+[![Security](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml)
+[![CodeQL](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/infobloxopen/dns-aid-core/badge)](https://scorecard.dev/viewer/?uri=github.com/infobloxopen/dns-aid-core)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
+[![PyPI](https://img.shields.io/pypi/v/dns-aid)](https://pypi.org/project/dns-aid/)
 
 **DNS-based Agent Identification and Discovery**
 
@@ -976,7 +978,7 @@ python examples/demo_full.py
 
 ```bash
 # Clone the repo
-git clone https://github.com/iracic82/DNS-AID.git
+git clone https://github.com/infobloxopen/dns-aid-core.git
 cd DNS-AID
 
 # Install all workspace packages (requires uv)


### PR DESCRIPTION
## Summary

The README header badges still pointed at the **pre-split monorepo** (`github.com/iracic82/DNS-AID`), which is why the CI badge rendered "failing" red and clicking it opened the wrong repo. Cleanup ahead of LF filing.

## Before / After

| Badge | Before | After |
|---|---|---|
| CI | `iracic82/DNS-AID` (failing red, wrong repo) | `infobloxopen/dns-aid-core` (live status) |
| Security | Static "bandit + semgrep" → wrong repo | **Live** `security.yml` workflow status |
| **CodeQL** | (missing) | **New** — live `codeql.yml` status |
| **OpenSSF Scorecard** | (missing) | **New** — live `api.securityscorecards.dev` score |
| Coverage | Hardcoded "77%" → wrong repo | **Removed** (no Codecov/Coveralls integration; the number had no provenance) |
| License | Apache-2.0 | unchanged |
| Python | "3.11 \| 3.12" | "3.11 \| 3.12 \| 3.13" (CI matrix tests 3.13) |
| **PyPI** | (missing) | **New** — live published version |

Also fixed: the `git clone` example URL in the install instructions.

## Why ship this now

LF reviewers form a first impression from the README header. Stale badges and a "failing" CI signal — even when the actual CI is green — kill credibility immediately.

## Test plan

- [x] `grep iracic82 README.md` → no matches
- [x] All badge URLs return valid SVG (verified by visiting the URLs)
- [x] No source code changes