### PR TITLE
docs: LF sustainability disclosure + IETF draft name correction

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -34,7 +34,7 @@ DNS-AID is currently a **single-maintainer project** (bus factor = 1). This is a
 
 **Active mitigations**
 
-- **Public open standard** — DNS-AID is a reference implementation of an IETF draft (`draft-mozleywilliams-dnsop-bandaid`). The protocol is independent of any single implementation, so the standard remains viable even if this implementation pauses.
+- **Public open standard** — DNS-AID is a reference implementation of an IETF draft (`draft-mozleywilliams-dnsop-dnsaid`). The protocol is independent of any single implementation, so the standard remains viable even if this implementation pauses.
 - **Conservative architecture** — the codebase deliberately favors stdlib, well-known third-party libraries (`dnspython`, `httpx`), and standard DNS records (RFC 9460 SVCB, RFC 4033-4035 DNSSEC, RFC 6698 DANE) over bespoke abstractions. New maintainers should be productive in days, not months.
 - **Comprehensive automation** — CI runs lint, type-check, unit tests across Python 3.11/3.12/3.13, mock integration tests, CodeQL SAST, Bandit, OpenSSF Scorecard, dependency audit, SBOM generation, and Sigstore-signed releases on every PR. New contributors get fast, machine-checked feedback.
 - **DCO + SPDX** enforced on every commit — keeps provenance unambiguous as the contributor base grows.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,6 +28,26 @@ See [GOVERNANCE.md](GOVERNANCE.md) for the process. In brief:
 2. Be nominated by an existing maintainer
 3. Receive approval via Committer vote
 
+## Sustainability and Bus Factor
+
+DNS-AID is currently a **single-maintainer project** (bus factor = 1). This is acknowledged transparently as the project's most significant sustainability risk and is the reason `MAINTAINERS.md` lists the open roles above.
+
+**Active mitigations**
+
+- **Public open standard** — DNS-AID is a reference implementation of an IETF draft (`draft-mozleywilliams-dnsop-bandaid`). The protocol is independent of any single implementation, so the standard remains viable even if this implementation pauses.
+- **Conservative architecture** — the codebase deliberately favors stdlib, well-known third-party libraries (`dnspython`, `httpx`), and standard DNS records (RFC 9460 SVCB, RFC 4033-4035 DNSSEC, RFC 6698 DANE) over bespoke abstractions. New maintainers should be productive in days, not months.
+- **Comprehensive automation** — CI runs lint, type-check, unit tests across Python 3.11/3.12/3.13, mock integration tests, CodeQL SAST, Bandit, OpenSSF Scorecard, dependency audit, SBOM generation, and Sigstore-signed releases on every PR. New contributors get fast, machine-checked feedback.
+- **DCO + SPDX** enforced on every commit — keeps provenance unambiguous as the contributor base grows.
+- **Backed by Infoblox** — the project is hosted under the [`infobloxopen`](https://github.com/infobloxopen) organization. Infoblox provides the DNS expertise that motivated DNS-AID and has committed engineering time to its development.
+
+**Goals before LF graduation**
+
+- 2+ maintainers from at least 2 organizations
+- Documented succession process if the current maintainer becomes unavailable
+- An Infoblox employee + a community contributor on the maintainer list
+
+If you are interested in contributing in a maintainer capacity, please open a discussion at [dns-aid-core/discussions](https://github.com/infobloxopen/dns-aid-core/discussions) or contact the project lead directly.
+
 ## Contact
 
 - GitHub Issues: [dns-aid-core/issues](https://github.com/infobloxopen/dns-aid-core/issues)

--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,7 @@ This product includes software developed by Infoblox
 (https://www.infoblox.com/).
 
 This product is a reference implementation of the IETF draft:
-draft-mozleywilliams-dnsop-bandaid (DNS-AID).
+draft-mozleywilliams-dnsop-dnsaid (DNS-AID).
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation for [IETF draft-mozleywilliams-dnsop-bandaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/).
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
 
@@ -153,7 +153,7 @@ dns-aid publish \
     --transport streamable-http \
     --auth-type bearer
 
-# Publish with BANDAID custom SVCB parameters (v0.4.8+)
+# Publish with DNS-AID custom SVCB parameters (v0.4.8+)
 dns-aid publish \
     --name booking \
     --domain example.com \
@@ -357,7 +357,7 @@ _chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port
 _chat._a2a._agents.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
 ```
 
-**BANDAID Custom SVCB Parameters (v0.4.8+):** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
+**DNS-AID Custom SVCB Parameters (v0.4.8+):** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
 
 ```
 _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
@@ -376,7 +376,7 @@ _booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
 
 This allows any DNS client to discover agents without proprietary protocols or central registries.
 
-### Discovery Flow (BANDAID Draft Aligned)
+### Discovery Flow (DNS-AID Draft Aligned)
 
 ```
   Agent A                        DNS                           Agent B
@@ -719,23 +719,23 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
    )
    ```
 
-#### Infoblox UDDI Limitations & BANDAID Compliance
+#### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI SVCB records only support "alias mode" (priority 0) and do not
 > support SVC parameters (`alpn`, `port`, `mandatory`). This means **Infoblox UDDI is not fully
-> compliant with the [BANDAID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-bandaid/)**.
+> compliant with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)**.
 >
 > The draft requires ServiceMode SVCB records (priority > 0) with mandatory `alpn` and `port`
 > parameters. Infoblox UDDI's limitation is a platform constraint, not a DNS-AID limitation.
 
-| BANDAID Requirement | Route 53 | Infoblox UDDI |
+| DNS-AID Requirement | Route 53 | Infoblox UDDI |
 |---------------------|----------|---------------|
 | ServiceMode (priority > 0) | ✅ | ❌ |
 | `alpn` parameter | ✅ | ❌ |
 | `port` parameter | ✅ | ❌ |
 | `mandatory` key | ✅ | ❌ |
 
-**For full BANDAID compliance, use Route 53 or another RFC 9460-compliant DNS provider.**
+**For full DNS-AID compliance, use Route 53 or another RFC 9460-compliant DNS provider.**
 
 DNS-AID stores `alpn` and `port` in TXT records as a fallback for Infoblox UDDI, but this is
 a workaround and not standard-compliant for agent discovery.
@@ -815,7 +815,7 @@ DDNS (Dynamic DNS) is a universal backend that works with any DNS server support
 - **Universal**: Works with BIND, Windows DNS, PowerDNS, Knot, and any RFC 2136 server
 - **No vendor lock-in**: Standard protocol, no proprietary APIs
 - **On-premise friendly**: Perfect for enterprise internal DNS
-- **Full BANDAID compliance**: Supports ServiceMode SVCB with all parameters
+- **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
 ### Cloudflare Setup
 
@@ -883,7 +883,7 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **SVCB support**: Full RFC 9460 compliance with SVCB Type 64 records
 - **Global anycast**: Fast DNS resolution worldwide
 - **Simple API**: Well-documented REST API v4
-- **Full BANDAID compliance**: Supports ServiceMode SVCB with all parameters
+- **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
 ## Why DNS-AID?
 


### PR DESCRIPTION
## Summary

Two related docs/governance changes ahead of LF intake. Both touched only documentation files; no source code changes.

## Commit 1 — Sustainability and Bus Factor disclosure (`MAINTAINERS.md`)

LF reviewers will check `MAINTAINERS.md` to assess project resilience. Adds an explicit section that:

- Acknowledges single-maintainer status as the top sustainability risk
- Lists active mitigations (open standard, conservative architecture, comprehensive automation, DCO+SPDX provenance, Infoblox backing)
- States concrete goals before LF graduation (2+ maintainers from 2+ orgs, documented succession)
- Provides a clear contact path for prospective maintainers

Transparently disclosing the bus factor with concrete mitigations is the LF-recommended posture for young projects.

## Commit 2 — IETF draft name correction (`bandaid` → `dnsaid`)

The IETF draft was renamed from `draft-mozleywilliams-dnsop-bandaid` to `draft-mozleywilliams-dnsop-dnsaid` (current revision `-01`). Most of the codebase already uses the new name (see CHANGELOG entry for the full rename), but three files retained the old name:

- `README.md` — ~10 references including the prominent "Reference implementation for ..." link in the header, plus "DNS-AID Custom SVCB Parameters" and "DNS-AID compliance" sections
- `MAINTAINERS.md` — the IETF draft reference in the Sustainability section just added in commit 1
- `NOTICE` — the "reference implementation of the IETF draft" line

All three now point at the correct draft slug and revision: <https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/>

`CHANGELOG.md` line 421 (which historically documents the rename) is intentionally left as-is.

## Test plan

- [x] `grep -i bandaid README.md MAINTAINERS.md NOTICE` → no matches
- [x] `MAINTAINERS.md` markdown renders cleanly with the new section
- [x] No source code changes