### PR TITLE
docs(readme): add OpenSSF Best Practices passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Security](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml)
 [![CodeQL](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/infobloxopen/dns-aid-core/badge)](https://scorecard.dev/viewer/?uri=github.com/infobloxopen/dns-aid-core)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12651/badge)](https://www.bestpractices.dev/projects/12651)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
 [![PyPI](https://img.shields.io/pypi/v/dns-aid)](https://pypi.org/project/dns-aid/)


### PR DESCRIPTION
## Summary

Project earned the **OpenSSF Best Practices passing-tier badge** (project ID `12651`) on 2026-04-25. Adds the badge to the README header alongside the existing OpenSSF Scorecard badge.

🛡️ **Badge URL:** https://www.bestpractices.dev/projects/12651  
**Status:** passing

## Coverage

All MUST/SHOULD/SUGGESTED criteria across the Baseline series sections passed:

| Section | Score |
|---|---|
| Basics | 13/13 |
| Change Control | 9/9 |
| Reporting | 8/8 |
| Quality | 13/13 |
| Security | 16/16 |
| Analysis | 8/8 |

## Why this matters

The OpenSSF Best Practices badge is a recognized industry signal of software supply-chain hygiene. Linux Foundation intake reviewers look for it as evidence that the project meets baseline open-source security and governance practices.

## Test plan

- [x] Markdown renders cleanly with the new badge
- [x] No code changes