### PR TITLE
docs: LF readiness pass 2 — vendor neutrality, contributor disclosure, trademarks

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,14 @@ This file lists the current maintainers of the DNS-AID project. The project is a
 |------|--------|-------------|------|-------|
 | Igor Racic | [@iracic82](https://github.com/iracic82) | Infoblox | Project Lead | 2024-12 |
 
+## Active Contributors
+
+The following contributors have shipped substantive code or research that informs the implementation. Listing here does not confer maintainer rights or responsibilities — it acknowledges material contribution.
+
+| Name | GitHub | Affiliation | Contribution |
+|------|--------|-------------|--------------|
+| Ingmar Van Glabbeek | [@ivanglabbeek](https://github.com/ivanglabbeek) | Infoblox | bind-aid (BIND 9 fork integrating the DNS-AID policy layer at Layer 0); related design work on the Trust Engine and Governance phase |
+
 ## Desired Roles
 
 The project is looking for maintainers in the following areas:
@@ -47,6 +55,14 @@ DNS-AID is currently a **single-maintainer project** (bus factor = 1). This is a
 - An Infoblox employee + a community contributor on the maintainer list
 
 If you are interested in contributing in a maintainer capacity, please open a discussion at [dns-aid-core/discussions](https://github.com/infobloxopen/dns-aid-core/discussions) or contact the project lead directly.
+
+## Release process and namespace ownership
+
+For full transparency:
+
+- **PyPI publishing** — the `dns-aid` package on [PyPI](https://pypi.org/project/dns-aid/) is published exclusively via [PyPI Trusted Publisher OIDC](https://docs.pypi.org/trusted-publishers/) tied to this repository's `.github/workflows/release.yml`. No long-lived API tokens exist. Only commits that land on a `v*` tag in this repo can publish to PyPI.
+- **Release artifacts** — every wheel and sdist is signed with [Sigstore](https://www.sigstore.dev/) cosign keyless OIDC during the release workflow. SBOM (`sbom.json`) is generated via `cyclonedx-py` and signed alongside the artifacts.
+- **GitHub branch protection** — `main` requires 1 approving review and successful status checks. During the current single-maintainer phase, the project lead admin-merges with documented PR descriptions and mandatory CI as the gate. This will tighten to required external review once a second maintainer joins.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -29,22 +29,13 @@ DNS-AID enables AI agents to discover each other via DNS, using the internet's e
 - [Getting Started Guide](docs/getting-started.md)
 - [API Reference](docs/api-reference.md)
 
-## Agent Directory
+## Companion services
 
-Browse and discover DNS-AID published agents:
+The DNS-AID protocol is implementation-agnostic — it works against any DNS provider and any directory implementation. The library in this repository is sufficient on its own; the items below are independent, community-operated services that demonstrate what can be built on top of DNS-AID.
 
-🌐 **Web Directory:** [directory.velosecurity-ai.io](https://directory.velosecurity-ai.io)
-📚 **API Documentation:** [api.velosecurity-ai.io/api/v1/docs](https://api.velosecurity-ai.io/api/v1/docs)
+🌐 **Hosted Agent Directory** (operated by Infoblox): [directory.velosecurity-ai.io](https://directory.velosecurity-ai.io) — indexes DNS-AID agents discovered across public DNS, with full-text search, capability filtering, trust scoring, lifecycle/sunset tracking, and copy-paste configs for Claude Desktop / Cursor / the SDK. API docs at [api.velosecurity-ai.io/api/v1/docs](https://api.velosecurity-ai.io/api/v1/docs).
 
-The directory indexes agents discovered via DNS and provides:
-- **Search** - Find agents by name, domain, or capabilities (full-text search)
-- **Filter** - Filter by protocol, category, capabilities, and security score
-- **Connect** - Copy-paste config for Claude Desktop, Cursor, or SDK
-- **Metadata** - Transport, auth type, structured capabilities with action intents (v0.10.0+)
-- **Lifecycle** - Deprecated/sunset status and successor agent routing (v0.10.0+)
-- **Trust Scores** - Composite scoring from DNSSEC, telemetry reliability, and community usage
-- **Company Profiles** - Display company metadata (logo, website, description)
-- **Auto-crawl** - Agents indexed immediately after domain verification
+You are encouraged to run your own directory or telemetry backend — the indexer is a thin layer over the same DNS records this library publishes and discovers, and the SDK telemetry sink is configurable via `DNS_AID_SDK_HTTP_PUSH_URL` (off by default).
 
 ## Quick Start
 
@@ -106,7 +97,7 @@ for r in ranked:
 # Fetch community-wide rankings from telemetry API (v0.6.0+)
 from dns_aid.sdk import AgentClient, SDKConfig
 
-config = SDKConfig(telemetry_api_url="https://api.velosecurity-ai.io")
+config = SDKConfig(telemetry_api_url="https://api.example.com")
 async with AgentClient(config) as client:
     rankings = await client.fetch_rankings(limit=10)
     for r in rankings:
@@ -121,7 +112,7 @@ from dns_aid.sdk import AgentClient, SDKConfig
 config = SDKConfig(
     otel_enabled=True,         # Export to OpenTelemetry
     caller_id="my-app",
-    http_push_url="https://api.velosecurity-ai.io/api/v1/telemetry/signals",
+    http_push_url="https://api.example.com/v1/telemetry/signals",
 )
 
 async with AgentClient(config=config) as client:
@@ -241,18 +232,18 @@ DNS-AID also supports HTTP-based agent discovery for compatibility with ANS-styl
 
 ```bash
 # Fetch HTTP index directly
-curl https://index.aiagents.highvelocitynetworking.com/index-wellknown
+curl https://index.aiagents.example.com/index-wellknown
 
 # Fetch capability document for a specific agent
-curl https://index.aiagents.highvelocitynetworking.com/cap/booking-agent
+curl https://index.aiagents.example.com/cap/booking-agent
 
 # CLI with HTTP index
-dns-aid discover highvelocitynetworking.com --use-http-index
+dns-aid discover example.com --use-http-index
 ```
 
 ```python
 # Python with HTTP index
-agents = await dns_aid.discover("highvelocitynetworking.com", use_http_index=True)
+agents = await dns_aid.discover("example.com", use_http_index=True)
 ```
 
 | Discovery Method | When to Use |
@@ -323,7 +314,7 @@ Then Claude can discover and connect to AI agents:
 >
 > "Publish my chat agent to DNS at mycompany.com"
 >
-> "Discover agents at highvelocitynetworking.com and search for flights from SFO to JFK"
+> "Discover agents at example.com and search for flights from SFO to JFK"
 
 #### Live Demo
 
@@ -342,10 +333,10 @@ Try the live demo with Claude Desktop:
 
 Then ask Claude to discover and use the booking agent:
 
-> "Discover agents at highvelocitynetworking.com using HTTP index, find a booking agent, and search for flights from SFO to JFK on March 15th 2026"
+> "Discover agents at example.com using HTTP index, find a booking agent, and search for flights from SFO to JFK on March 15th 2026"
 
 Claude will:
-1. Call `discover_agents_via_dns` → finds booking-agent at `https://booking.highvelocitynetworking.com/mcp`
+1. Call `discover_agents_via_dns` → finds booking-agent at `https://booking.example.com/mcp`
 2. Call `list_agent_tools` → sees search_flights, get_flight_details, check_availability, create_reservation
 3. Call `call_agent_tool` → searches for flights and returns results
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,36 @@
+# Trademarks
+
+## DNS-AID
+
+"DNS-AID" is the project name for the reference implementation in this repository of the IETF draft `draft-mozleywilliams-dnsop-dnsaid`.
+
+The Apache License 2.0 ([LICENSE](LICENSE)) under which DNS-AID is released **does not** grant any rights to use the project's name or logos as trademarks. Apache License 2.0, Section 6 ("Trademarks") explicitly excludes trademark licenses from the grant.
+
+## Permitted uses
+
+Without prior written permission, you may:
+
+- Refer to the project by name in technical descriptions, documentation, blog posts, papers, talks, and similar contexts (nominative use), provided you do not imply endorsement, sponsorship, or affiliation.
+- State that your software is "compatible with DNS-AID" or "implements the DNS-AID reference protocol" if and only if it actually does so.
+- Distribute unmodified copies of this repository (binary or source) under the terms of the Apache License 2.0.
+
+## Uses requiring permission
+
+Without prior written permission, you may **not**:
+
+- Use "DNS-AID" or any confusingly similar name as the name of a forked or derivative project, product, or service.
+- Use "DNS-AID" in domain names, social media handles, or commercial marketing in a way that suggests endorsement by or affiliation with this project.
+- Use any DNS-AID logos or visual marks (current or future) without explicit permission from the project lead.
+
+## Linux Foundation context
+
+If DNS-AID is accepted into a Linux Foundation foundation, this trademark policy will be superseded by the LF foundation's standard trademark policy and any project-specific overlay. Until that point, the rules above apply.
+
+## Contact
+
+Questions about trademark usage: open a [GitHub Discussion](https://github.com/infobloxopen/dns-aid-core/discussions) or contact the project lead listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Other marks referenced in this project
+
+- "Infoblox" is a trademark of Infoblox Inc. Use of the Infoblox name in this repository is by permission of Infoblox in connection with the Infoblox NIOS / Universal DDI backend integrations and the project's organizational hosting.
+- "Anthropic", "Claude", "Cursor", "Cloudflare", "AWS", "Route 53", "Google Cloud DNS", "NS1", "IBM", "PyPI", and other third-party product or company names mentioned in this repository are the trademarks of their respective owners and are used here for descriptive interoperability purposes only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1365,7 +1365,7 @@ Restart Claude Desktop, then ask:
 - "Discover agents at example.com"
 - "Publish my agent to DNS"
 - "Send a message to the security-analyzer agent at ai.infoblox.com" *(uses discover-first flow)*
-- "What tools does the booking agent at highvelocitynetworking.com have?"
+- "What tools does the booking agent at example.com have?"
 
 ### MCP Agent Proxying
 

--- a/docs/mcp-directory-listing.md
+++ b/docs/mcp-directory-listing.md
@@ -14,7 +14,7 @@ Each works against live DNS records with no credentials required.
 
 ### Prompt 1: Discover agents at a domain
 
-> Discover what AI agents are published at highvelocitynetworking.com
+> Discover what AI agents are published at example.com
 
 Expected: Returns a list of agents with their names, protocols (MCP/A2A),
 endpoints, and capabilities. Demonstrates DNS-based agent discovery using
@@ -22,7 +22,7 @@ SVCB record queries.
 
 ### Prompt 2: Verify an agent's DNS security
 
-> Verify the DNS records for _network._mcp._agents.highvelocitynetworking.com
+> Verify the DNS records for _network._mcp._agents.example.com
 > and tell me if DNSSEC is valid
 
 Expected: Returns DNS record validation results including SVCB record
@@ -31,7 +31,7 @@ reachability, and a security score.
 
 ### Prompt 3: Diagnose the environment
 
-> Run DNS-AID environment diagnostics for the domain highvelocitynetworking.com
+> Run DNS-AID environment diagnostics for the domain example.com
 
 Expected: Returns a structured diagnostic report checking Python version,
 DNS resolution capability, backend configuration, and agent discovery


### PR DESCRIPTION
## Summary

Three concerns LF intake reviewers were likely to flag, addressed together since they all live in docs/governance. No source code changes, no version bump.

## 1. Vendor neutrality (`README.md`)

**Before:** the "Agent Directory" section pointed users at `velosecurity-ai.io` (an Infoblox commercial offering) without disclosure, and the SDK code examples hardcoded the same URL. This read as the OSS reference impl funneling users into a commercial product.

**After:**
- Renamed section to **"Companion services"**
- Explicit `(operated by Infoblox)` attribution on the hosted directory
- Clarified the protocol is implementation-agnostic and you can run your own directory or telemetry backend
- SDK code examples switched to neutral `example.com` placeholders
- The hosted directory URLs are retained as a genuine evaluation aid — the vendor relationship is now transparent rather than hidden

Also replaced `highvelocitynetworking.com` (project lead's personal demo zone) with `example.com` across CLI examples in README, `docs/getting-started.md`, and `docs/mcp-directory-listing.md` — same logic as the earlier nordstrom → example sanitization.

## 2. Active contributor acknowledgement (`MAINTAINERS.md`)

`git shortlog` shows two active Infoblox humans:
```
242  Igor Racic        <iracic82@gmail.com>     ← in MAINTAINERS
 14  Ingmar V.G.       <ivanglabbeek@infoblox.com>  ← was not listed
```

Added an **"Active Contributors"** section acknowledging Ingmar's bind-aid (BIND 9 fork integrating the DNS-AID policy layer) and Trust Engine work, **without claiming maintainer status** (that requires his explicit consent).

Added a **"Release process and namespace ownership"** subsection documenting:
- PyPI Trusted Publisher OIDC binding (no long-lived API tokens)
- Sigstore signing on every wheel/sdist
- Admin-merge reality during the single-maintainer phase (will tighten once a second maintainer joins)

Hidden gaps are now transparent disclosures.

## 3. Trademark policy (`TRADEMARKS.md`, new)

Apache 2.0 §6 explicitly excludes trademarks from the license grant. Added a standard policy stub aligned with LF mark-usage guidelines:
- Permitted nominative use (compatibility statements, technical references)
- Prohibited uses (forks named "DNS-AID", endorsement-implying marketing, logos)
- LF transition note (this policy is superseded once accepted)
- Third-party mark acknowledgement (Infoblox, Anthropic, Cloudflare, NS1/IBM, AWS, GCP, etc.)

## Verification

- [x] `uv run ruff check src/` → clean
- [x] `uv run ruff format --check src/` → 76 files already formatted
- [x] `uv run mypy src/dns_aid/` → no issues found in 76 source files
- [x] `npx @anthropic-ai/mcpb validate manifest.json` → passes
- [x] `grep velosecurity-ai.io README docs` → 1 result (the intentional disclosure with explicit attribution)
- [x] `grep highvelocitynetworking.com README docs` → 0 results

## Out of scope

- Adding Ingmar as Maintainer (requires his explicit consent — separate PR after that conversation)
- Enabling `enforce_admins: true` on branch protection (not realistic in single-maintainer phase; documented instead)