### PR TITLE
docs: fix broken README doc links + promote Ingmar to Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,20 +1,13 @@
 # Maintainers
 
-This file lists the current maintainers of the DNS-AID project. The project is actively seeking additional maintainers to ensure long-term sustainability under the Linux Foundation.
+This file lists the current maintainers of the DNS-AID project. The project continues to recruit additional maintainers — see "Desired Roles" below — to broaden organizational diversity ahead of LF graduation.
 
 ## Current Maintainers
 
 | Name | GitHub | Affiliation | Role | Since |
 |------|--------|-------------|------|-------|
 | Igor Racic | [@iracic82](https://github.com/iracic82) | Infoblox | Project Lead | 2024-12 |
-
-## Active Contributors
-
-The following contributors have shipped substantive code or research that informs the implementation. Listing here does not confer maintainer rights or responsibilities — it acknowledges material contribution.
-
-| Name | GitHub | Affiliation | Contribution |
-|------|--------|-------------|--------------|
-| Ingmar Van Glabbeek | [@ivanglabbeek](https://github.com/ivanglabbeek) | Infoblox | bind-aid (BIND 9 fork integrating the DNS-AID policy layer at Layer 0); related design work on the Trust Engine and Governance phase |
+| Ingmar Van Glabbeek | [@ivanglabbeek](https://github.com/ivanglabbeek) | Infoblox | DNS Standards & Policy Layer Maintainer | 2026-04 |
 
 ## Desired Roles
 
@@ -38,7 +31,7 @@ See [GOVERNANCE.md](GOVERNANCE.md) for the process. In brief:
 
 ## Sustainability and Bus Factor
 
-DNS-AID is currently a **single-maintainer project** (bus factor = 1). This is acknowledged transparently as the project's most significant sustainability risk and is the reason `MAINTAINERS.md` lists the open roles above.
+DNS-AID currently has **two maintainers**, both Infoblox-affiliated (bus factor = 2 in headcount, 1 in organizational diversity). The remaining sustainability gap — single-organization maintainership — is acknowledged transparently and is the reason `MAINTAINERS.md` lists the open roles above.
 
 **Active mitigations**
 
@@ -50,9 +43,9 @@ DNS-AID is currently a **single-maintainer project** (bus factor = 1). This is a
 
 **Goals before LF graduation**
 
-- 2+ maintainers from at least 2 organizations
-- Documented succession process if the current maintainer becomes unavailable
-- An Infoblox employee + a community contributor on the maintainer list
+- An additional maintainer from a second organization (top priority)
+- Documented succession process for the project lead role
+- External (non-Infoblox) committer with merge rights on at least one subsystem
 
 If you are interested in contributing in a maintainer capacity, please open a discussion at [dns-aid-core/discussions](https://github.com/infobloxopen/dns-aid-core/discussions) or contact the project lead directly.
 
@@ -62,7 +55,7 @@ For full transparency:
 
 - **PyPI publishing** — the `dns-aid` package on [PyPI](https://pypi.org/project/dns-aid/) is published exclusively via [PyPI Trusted Publisher OIDC](https://docs.pypi.org/trusted-publishers/) tied to this repository's `.github/workflows/release.yml`. No long-lived API tokens exist. Only commits that land on a `v*` tag in this repo can publish to PyPI.
 - **Release artifacts** — every wheel and sdist is signed with [Sigstore](https://www.sigstore.dev/) cosign keyless OIDC during the release workflow. SBOM (`sbom.json`) is generated via `cyclonedx-py` and signed alongside the artifacts.
-- **GitHub branch protection** — `main` requires 1 approving review and successful status checks. During the current single-maintainer phase, the project lead admin-merges with documented PR descriptions and mandatory CI as the gate. This will tighten to required external review once a second maintainer joins.
+- **GitHub branch protection** — `main` requires 1 approving review and successful status checks. With two maintainers now in place, PRs are expected to be reviewed by the non-author maintainer; admin-merge remains available as a documented fallback for time-sensitive operational changes.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,16 @@ Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-01](https:/
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
 
-> **Doc Freshness:** Reviewed for DNS-AID v0.10.0 on March 2, 2026.
-
-> **New to DNS-AID?** Start with the [QuickStart](quickstart.md) for the fastest path, then use the [Getting Started Guide](docs/getting-started.md) for full setup and backend details.
+> **New to DNS-AID?** Start with the [Getting Started Guide](docs/getting-started.md) for install, first agent publication, and backend setup.
 
 ## Documentation
 
-- [QuickStart](quickstart.md)
-- [Installation Matrix](docs/install.md)
-- [Backend Minimum Config Snippets](docs/backend-config-snippets.md)
-- [CLI Command Matrix](docs/cli-command-matrix.md)
-- [Verify Scoring and High Verify Gates](docs/verify-scoring.md)
-- [Getting Started Guide](docs/getting-started.md)
-- [API Reference](docs/api-reference.md)
+- [Getting Started Guide](docs/getting-started.md) — install, first agent publication, backend setup
+- [API Reference](docs/api-reference.md) — Python SDK, CLI, and MCP server tool reference
+- [Architecture](docs/architecture.md) — protocol layers, metadata resolution, integration points
+- [Integrations](docs/integrations.md) — backend-specific setup notes
+- [Demo Guide](docs/demo-guide.md) — end-to-end walkthrough for talks and presentations
+- [Privacy Policy](PRIVACY.md) | [Security Policy](SECURITY.md) | [Trademarks](TRADEMARKS.md)
 
 ## Companion services
 
@@ -42,11 +39,14 @@ You are encouraged to run your own directory or telemetry backend — the indexe
 ### Install
 
 ```bash
-# Most common path: Core + CLI + MCP from GitHub
+# Install from PyPI
+pip install "dns-aid[cli,mcp]"
+
+# Or install the latest unreleased main from GitHub
 pip install "dns-aid[cli,mcp] @ git+https://github.com/infobloxopen/dns-aid-core.git"
 ```
 
-For the full install matrix (GitHub now vs PyPI status, monorepo, backend extras), see [docs/install.md](docs/install.md).
+For backend-specific extras (`route53`, `cloudflare`, `ns1`, `cloud_dns`, `infoblox`, `ddns`), see the [Getting Started Guide](docs/getting-started.md#install).
 
 ### Python Library
 
@@ -122,8 +122,6 @@ async with AgentClient(config=config) as client:
 ```
 
 ## CLI Usage
-
-See [CLI Command Matrix](docs/cli-command-matrix.md) for a concise table of commands, backend requirements, and examples.
 
 ```bash
 # Publish an agent to DNS
@@ -617,7 +615,7 @@ dns-aid-mcp  # Claude can now use DNS-AID tools
 
 ## DNS Backends
 
-For copy/paste minimum environment blocks by provider, see [Backend Minimum Config Snippets](docs/backend-config-snippets.md).
+For per-provider environment configuration, see the [Getting Started Guide](docs/getting-started.md) backend sections.
 
 DNS-AID supports multiple DNS backends:
 


### PR DESCRIPTION
## Summary

Two related findings from the deep LF readiness re-audit, fixed together since both are docs/governance.

## 1. README had 10 broken doc references to 5 files that never existed in git history

Bad first impression for any new visitor and a near-certain LF intake pushback. Files referenced but never authored:

| Phantom file | Referenced from README |
|---|---|
| `quickstart.md` | "New to DNS-AID?" banner + Documentation list |
| `docs/install.md` | Documentation list + Quick Start install section |
| `docs/backend-config-snippets.md` | Documentation list + DNS Backends section |
| `docs/cli-command-matrix.md` | Documentation list + CLI Usage section |
| `docs/verify-scoring.md` | Documentation list |

**Fix:** rewrote the Documentation section to list only docs that actually exist (`getting-started`, `api-reference`, `architecture`, `integrations`, `demo-guide`, plus the governance trio Privacy/Security/Trademarks). Pointed install/CLI/backend cross-refs at sections within `docs/getting-started.md` (which is comprehensive — 47 KB) instead of phantom files.

Also removed the stale **"Doc Freshness: Reviewed for DNS-AID v0.10.0 on March 2, 2026"** banner — we are at v0.18.3 today, and freshness banners are a maintenance trap that silently rot.

## 2. Promoted Ingmar Van Glabbeek to Maintainer (`MAINTAINERS.md`)

Reflects:
- Existing material contribution: bind-aid (BIND 9 fork integrating DNS-AID policy layer), Trust Engine design
- 14 commits in dns-aid-core and ongoing engagement
- Agreement to take maintainer responsibility on this codebase

**Bus factor: 1 → 2.** Updated:
- Promoted from "Active Contributors" → "Current Maintainers" (DNS Standards & Policy Layer Maintainer, 2026-04 onwards)
- Sustainability section now reflects bus factor = 2; remaining gap (single-organization, both Infoblox) called out as top recruitment goal before LF graduation
- Release process / branch protection paragraph: PRs now expected to be reviewed by the non-author maintainer, admin-merge documented as fallback

## Test plan

- [x] `grep` for each phantom filename → 0 hits in README
- [x] `grep "Doc Freshness"` → 0 hits
- [x] All remaining doc links in README point to files that exist
- [x] No source code changes