### PR TITLE
docs+chore: third-pass LF audit fixes (sanitize source, add Python 3.13, CODEOWNERS)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,11 +5,14 @@
 #
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Default owners for everything
+# Default owners for everything (project lead reviews catchall)
 * @iracic82
 
-# Core protocol engine
-src/dns_aid/core/ @iracic82
+# Core protocol engine — both maintainers
+src/dns_aid/core/ @iracic82 @ivanglabbeek
+
+# Policy + standards layer — Ingmar leads
+src/dns_aid/sdk/policy/ @ivanglabbeek @iracic82
 
 # DNS backends
 src/dns_aid/backends/ @iracic82
@@ -20,7 +23,9 @@ src/dns_aid/mcp/ @iracic82
 # CLI
 src/dns_aid/cli/ @iracic82
 
-# CI/CD and governance
-.github/ @iracic82
-GOVERNANCE.md @iracic82
-SECURITY.md @iracic82
+# CI/CD and governance — both maintainers approve
+.github/ @iracic82 @ivanglabbeek
+GOVERNANCE.md @iracic82 @ivanglabbeek
+MAINTAINERS.md @iracic82 @ivanglabbeek
+SECURITY.md @iracic82 @ivanglabbeek
+TRADEMARKS.md @iracic82 @ivanglabbeek

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: Name Service (DNS)",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -155,6 +156,8 @@ Homepage = "https://github.com/infobloxopen/dns-aid-core"
 Documentation = "https://github.com/infobloxopen/dns-aid-core#readme"
 Repository = "https://github.com/infobloxopen/dns-aid-core"
 Changelog = "https://github.com/infobloxopen/dns-aid-core/blob/main/CHANGELOG.md"
+Issues = "https://github.com/infobloxopen/dns-aid-core/issues"
+Security = "https://github.com/infobloxopen/dns-aid-core/security/policy"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dns_aid"]

--- a/src/dns_aid/cli/init.py
+++ b/src/dns_aid/cli/init.py
@@ -25,9 +25,9 @@ def _discover_quickstart() -> None:
     """Show quickstart examples for discover-only usage."""
     console.print("\n[bold green]Discover-only mode — no backend needed![/bold green]\n")
     console.print("You can discover agents without any credentials:\n")
-    console.print("  [bold]dns-aid discover highvelocitynetworking.com[/bold]")
-    console.print("  [bold]dns-aid discover highvelocitynetworking.com --json[/bold]")
-    console.print("  [bold]dns-aid verify _network._mcp._agents.highvelocitynetworking.com[/bold]")
+    console.print("  [bold]dns-aid discover example.com[/bold]")
+    console.print("  [bold]dns-aid discover example.com --json[/bold]")
+    console.print("  [bold]dns-aid verify _network._mcp._agents.example.com[/bold]")
     console.print(
         "\nTo [bold]publish[/bold] agents, re-run [bold]dns-aid init[/bold] and choose a backend.\n"
     )

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -772,7 +772,7 @@ def list_published_agents(
     discover_agents_via_dns instead.
 
     Args:
-        domain: Domain you manage (e.g., "highvelocitynetworking.com").
+        domain: Domain you manage (e.g., "example.com").
         backend: DNS backend to use - requires matching API credentials configured.
 
     Returns:


### PR DESCRIPTION
## Summary

Four findings from a fresh deep audit of the post-PR-#96 state. None blocked prior LF readiness — these tighten the rough edges a careful reviewer would notice.

## Changes

### 1. Sanitize remaining `highvelocitynetworking.com` refs in **source code**

Earlier sanitization cleaned README and docs but missed two source spots that ship to end users:

| File | Why it mattered |
|---|---|
| `src/dns_aid/cli/init.py` (3 lines) | The `dns-aid init` first-run welcome printed three example commands using the project lead's personal demo zone. **Literally the first thing every new user sees.** |
| `src/dns_aid/mcp/server.py:775` | MCP tool docstring for the `domain` parameter referenced the same demo zone. **Ships in the `.mcpb` bundle** and surfaces in Claude Desktop's tool catalog. |

End state: zero `highvelocitynetworking.com` references anywhere in `src/` or `tests/`.

### 2. Add Python 3.13 to `pyproject.toml` classifiers

CI already tests on 3.11/3.12/3.13 and the README badge says 3.13, but the PyPI Trove classifier list still only declared 3.11 and 3.12 — PyPI search filters and downstream tooling were getting incomplete version-support info.

### 3. Add Issues + Security URLs to `pyproject.toml` `[project.urls]`

PyPI surfaces these URLs as labeled links in the project sidebar. Added:
```toml
Issues   = "https://github.com/infobloxopen/dns-aid-core/issues"
Security = "https://github.com/infobloxopen/dns-aid-core/security/policy"
```

### 4. Update CODEOWNERS for two-maintainer reality

PR #96 promoted Ingmar to Maintainer; CODEOWNERS still listed only `@iracic82` for everything.

| Path | Owners |
|---|---|
| Default catchall | `@iracic82` |
| `src/dns_aid/core/` | both maintainers |
| `src/dns_aid/sdk/policy/` (Ingmar's domain via bind-aid integration) | `@ivanglabbeek` primary, `@iracic82` secondary |
| `.github/`, GOVERNANCE, MAINTAINERS, SECURITY, TRADEMARKS | both maintainers |
| Backends, MCP, CLI | `@iracic82` (can widen as review bandwidth grows) |

## Test plan

- [x] `grep -rn highvelocitynetworking src/ tests/` → 0 matches
- [x] `uv run pytest tests/unit/cli/ tests/unit/mcp/` → 15 passed
- [x] No source code logic changes; only docstrings, classifiers, config, and ownership