### PR TITLE
release: v0.18.4 — README backend table accuracy + bundle ship of source sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.4] - 2026-04-25
+
+### Changed
+
+- **`README.md` DNS Backends table corrected and expanded.** Marked Infoblox NIOS as `✅ Production` (it had been listed as `🚧 Planned` despite being one of the most production-complete backends — 887 lines, 30 methods, full WAPI 2.13.7 integration). Added missing rows for **NS1** (now IBM Managed DNS) and **Google Cloud DNS**, both shipped as production backends. Added an "Install Extra" column showing the exact `pip install dns-aid[<extra>]` invocation for every backend. End-state: the README table now matches the actual `pyproject.toml` `[project.optional-dependencies]` declarations and the `src/dns_aid/backends/` directory.
+- **`src/dns_aid/cli/init.py`** — `dns-aid init` first-run welcome examples switched from a project lead's personal demo zone to `example.com`, so the first command a new user sees is generic and not vendor-specific.
+- **`src/dns_aid/mcp/server.py`** — MCP tool `domain` parameter docstring switched to `example.com` for the same reason. The docstring ships in the `.mcpb` bundle and surfaces in Claude Desktop's tool catalog.
+
+### Added
+
+- **PyPI `Programming Language :: Python :: 3.13` classifier.** CI already tests on 3.13 and the README badge declares 3.13 support; the PyPI Trove classifier list now reflects this so PyPI search and downstream tooling see the full version-support range.
+- **PyPI `[project.urls]`: Issues + Security entries.** PyPI surfaces these as labeled links in the project sidebar (`Issues = .../issues`, `Security = .../security/policy`).
+- **`CODEOWNERS` updated for two-maintainer reality.** Now distributes review responsibility between the two current maintainers per subsystem: core protocol engine and governance docs require both; `src/dns_aid/sdk/policy/` is led by the policy/standards maintainer.
+
+### Notes
+
+- No public API surface changes, no source code logic changes; all changes are docstrings, package metadata, examples, and ownership/governance.
+- 1267 unit tests pass on the bumped version. Manifest passes `npx @anthropic-ai/mcpb validate`.
+
 ## [0.18.3] - 2026-04-25
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,9 +6,14 @@ license: Apache-2.0
 repository-code: "https://github.com/infobloxopen/dns-aid-core"
 
 authors:
-  - name: "The DNS-AID Authors"
+  - family-names: Racic
+    given-names: Igor
+    affiliation: Infoblox
+  - family-names: Van Glabbeek
+    given-names: Ingmar
+    affiliation: Infoblox
 
-version: "0.18.3"
+version: "0.18.4"
 date-released: "2026-04-25"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -619,14 +619,16 @@ For per-provider environment configuration, see the [Getting Started Guide](docs
 
 DNS-AID supports multiple DNS backends:
 
-| Backend | Description | Status |
-|---------|-------------|--------|
-| Route 53 | AWS Route 53 | ✅ Production |
-| Infoblox UDDI | Infoblox Universal DDI (cloud) | ✅ Production |
-| DDNS | RFC 2136 Dynamic DNS (BIND, etc.) | ✅ Production |
-| Cloudflare | Cloudflare DNS | ✅ Production |
-| Mock | In-memory (testing) | ✅ Production |
-| NIOS | Infoblox NIOS (on-prem) | 🚧 Planned |
+| Backend | Description | Install Extra | Status |
+|---------|-------------|---------------|--------|
+| Route 53 | AWS Route 53 | `dns-aid[route53]` | ✅ Production |
+| Cloudflare | Cloudflare DNS | `dns-aid[cloudflare]` | ✅ Production |
+| NS1 | NS1 (now IBM) Managed DNS | `dns-aid[ns1]` | ✅ Production |
+| Google Cloud DNS | GCP Cloud DNS | `dns-aid[cloud-dns]` | ✅ Production |
+| Infoblox NIOS | Infoblox NIOS (on-prem WAPI) | `dns-aid[nios]` | ✅ Production |
+| Infoblox UDDI | Infoblox Universal DDI (cloud) | `dns-aid[infoblox]` | ✅ Production |
+| DDNS | RFC 2136 Dynamic DNS (BIND, etc.) | `dns-aid[ddns]` | ✅ Production |
+| Mock | In-memory (testing only) | (built-in) | ✅ Production |
 
 ### Route 53 Setup
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.4",
   "name": "dns-aid",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "DNS-based AI agent discovery. Publish, discover, and verify AI agents via DNS using SVCB records (RFC 9460). No central registry needed.",
   "license": "Apache-2.0",
   "privacy_policies": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.18.3"
+version = "0.18.4"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Patch release that:
1. Publishes the source-code-level sanitization from PR #97 (which was not yet on PyPI or in any `.mcpb` because PR #97 changed shipped artifacts but didn't bump the version)
2. Fixes a real documentation accuracy bug discovered in the fourth deep audit pass
3. Lists the two named maintainers in `CITATION.cff` for academic citation

## Changes

### Real fix: README DNS Backends table

| Before (wrong) | After (matches reality) |
|---|---|
| NIOS marked **🚧 Planned** | NIOS marked **✅ Production** — 887 LOC, 30 methods, full WAPI 2.13.7 integration |
| NS1 missing entirely | NS1 added (473 LOC) |
| Google Cloud DNS missing entirely | Cloud DNS added (340 LOC) |
| No install-extra hint | New "Install Extra" column showing `pip install dns-aid[<extra>]` per backend |

End-state: the README table now matches `src/dns_aid/backends/` and `pyproject.toml [project.optional-dependencies]`.

### `CITATION.cff` — actual author names

Replaced placeholder `name: "The DNS-AID Authors"` with the two current maintainers (Igor Racic, Ingmar Van Glabbeek; both Infoblox) so academic citations resolve to real people.

### Now in published artifacts (was on git after PR #97 but not in any release):

- `dns-aid init` first-run welcome uses `example.com` instead of personal demo zone
- MCP tool `domain` parameter docstring uses `example.com` (ships in `.mcpb` Claude Desktop catalog)
- PyPI Trove classifier: `Python :: 3.13` declared
- PyPI `[project.urls]`: Issues + Security entries
- CODEOWNERS distributes review responsibility across both current maintainers

### Version bump in lockstep

- `manifest.json`: 0.18.3 → 0.18.4
- `pyproject.toml`: 0.18.3 → 0.18.4
- `CITATION.cff`: 0.18.3 → 0.18.4
- `uv.lock`: regenerated

## Test plan

- [x] `npx @anthropic-ai/mcpb validate manifest.json` → passes
- [x] `npx @anthropic-ai/mcpb pack` → 102 files / 342 KB at v0.18.4
- [x] `uv run ruff check src/` → clean
- [x] `uv run ruff format --check src/` → 76 files already formatted
- [x] `uv run mypy src/dns_aid/` → no issues found in 76 source files
- [x] `uv run pytest tests/unit/sdk/policy/ tests/unit/cli/ tests/unit/mcp/` → 254 passed

No public API surface changes; no source code logic changes.

## After merge

Tag `v0.18.4` and push — release workflow handles wheel/sdist build, SBOM, Sigstore signatures, GitHub Release creation, and PyPI Trusted Publisher publish.