### PR TITLE
docs: align README/CONTRIBUTING/GOVERNANCE/docs with LF dual-track positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@
 
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation of the DNS-AID specification, developed at the IETF: [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+Reference implementation of the DNS-AID specification, developed at the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
+
+## Relationship to IETF
+
+The DNS-AID specification is being developed within the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
+This repository provides a reference implementation.
+
+This project does not define the specification. The IETF draft is authoritative.
 
 ## Scope of this Repository
 
@@ -1015,81 +1023,9 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
-## Background: Why DNS-AID?
+## Background and Comparison
 
-### vs Competing Proposals
-
-| Approach | Problem | DNS-AID Advantage |
-|----------|---------|-------------------|
-| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
-| **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
-| **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
-| **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
-| **NANDA (MIT)** | New P2P overlay network, new ops paradigm | Uses infrastructure your DNS team already operates |
-| **Web3 (ERC-8004)** | Gas fees, crypto wallets, enterprise-hostile | Free DNS queries, no blockchain complexity |
-| **ai.txt / llms.txt** | No integrity verification, free-form JSON | DNSSEC cryptographic verification, structured SVCB |
-
-### Feature Comparison
-
-| Feature | DNS-AID | Central Registry | ai.txt |
-|---------|---------|------------------|--------|
-| **Decentralized** | ✅ | ❌ | ✅ |
-| **Secure (DNSSEC)** | ✅ | Varies | ❌ |
-| **Sovereign** | ✅ | ❌ | ✅ |
-| **Standards-based** | ✅ (IETF) | ❌ | ❌ |
-| **Works with existing infra** | ✅ | ❌ | ✅ |
-
-### The Sovereignty Question
-
-> **Who controls agent discovery?**
-> - ANS: GoDaddy (US company as gatekeeper)
-> - AgentDNS: China Telecom (state-owned carrier)
-> - Web3: Ethereum Foundation
-> - **DNS-AID: You control your own domain**
->
-> DNS-AID preserves sovereignty. Organizations and nations maintain control over their own agent namespaces with no central authority that can block, censor, or surveil agent discovery.
-
-### Google's Agent Ecosystem
-
-Google is building a full-stack agent platform: **A2A** (communication), **UCP** (payments), and **Gemini/Search** (discovery). While A2A is an open protocol, discovery through Google surfaces means:
-- Google controls visibility (pay-to-rank)
-- Transaction fees via [UCP](https://developers.google.com/merchant/ucp)
-- Platform dependency for reach
-
-**DNS-AID complements A2A** by providing neutral, decentralized discovery — find agents anywhere, not just through Google.
-
-### Understanding the .agent Domain Approach
-
-The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-level domain through ICANN's [new gTLD program](https://newgtlds.icann.org/). Here's how the two approaches compare:
-
-**How .agent Domains Would Work:**
-1. Apply to ICANN for `.agent` gTLD (~$185,000 application fee)
-2. Wait 9-20 months for ICANN approval process
-3. Build registry infrastructure (Open Agent Registry, Inc.)
-4. Sell `.agent` domains through accredited registrars
-5. Users pay annual registration fees (~$15-50/year per domain)
-
-**How DNS-AID Works:**
-1. Use your existing domain (you already own `yourcompany.com`)
-2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
-3. Start discovering and being discovered immediately
-
-| Factor | .agent gTLD | DNS-AID |
-|--------|-------------|---------|
-| **Cost to publish** | ~$15-50/year domain fee | Free (use existing domain) |
-| **Time to start** | Months (gTLD launch + registration) | Minutes |
-| **Who controls discovery** | Registry operator | You (your domain) |
-| **Works today** | ❌ Pending ICANN approval | ✅ Works now |
-| **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
-| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
-
-**The Friendly Take:**
-
-Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
-
-DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
-
-*Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
+For background on how DNS-AID compares to other agent-discovery approaches (ANS, Google A2A+UCP, `.agent` gTLD, AgentDNS, NANDA, Web3, `ai.txt`) and "The Sovereignty Question", see [docs/positioning.md](docs/positioning.md). That content is non-normative — protocol positioning is determined at the IETF.
 
 ## Examples
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,11 @@
 # Security Policy
 
+## Scope
+
+This security policy covers vulnerabilities in this reference implementation.
+
+Protocol-level security considerations belong with the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
 ## Supported Versions
 
 | Version | Supported          |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -295,7 +295,7 @@ for agent in result.agents:
 
 ### verify()
 
-Verify DNS-AID records for an agent with security validation.
+Verify DNS-AID records as interpreted by this implementation, with security validation.
 
 ```python
 async def verify(fqdn: str) -> VerifyResult

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-01 protocol for
+This implementation follows the IETF draft-mozleywilliams-dnsop-dnsaid protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
 
 ## Relationship to IETF
@@ -192,9 +192,14 @@ that round-trip the same inputs through every surface.
    - Not found → endpoint_source = "http_index_fallback"
 ```
 
-### Future Enhancement: HTTP Index Fallback in DNS Mode
+## Future Enhancements (Non-Normative)
+
 These are implementation proposals and are not part of the current IETF draft.
+
 Items in this section may inform future versions of the specification but should not be treated as authoritative.
+
+### Future Enhancement: HTTP Index Fallback in DNS Mode
+
 Currently the two discovery modes are independent — pure DNS never consults the
 HTTP index and vice versa. Per the DNS-AID draft, the HTTP well-known endpoint
 is a complementary discovery mechanism. A future enhancement should add an

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -1,6 +1,6 @@
 # DNS-AID Demo Guide
 
-This guide demonstrates use of the DNS-AID reference implementation for agent discovery workflows. Perfect for conference calls, IETF presentations, and Linux Foundation demos.
+This guide demonstrates use of the DNS-AID reference implementation for agent discovery workflows. The underlying specification is developed at the IETF (https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 > **Version 0.6.0** - DNSSEC enforcement, DANE full certificate matching, Sigstore release signing, Route53/Cloudflare SVCB param demotion, JWS signatures for application-layer verification, Tier 1 Execution Telemetry SDK, and community rankings.
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,77 @@
+# DNS-AID: Background and Comparison
+
+> **Non-normative.** This document provides background context comparing the DNS-AID approach to other agent-discovery proposals. It describes positioning of the DNS-AID *specification* (developed at the IETF), not features specific to this reference implementation. The authoritative specification is the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
+## vs Competing Proposals
+
+| Approach | Problem | DNS-AID Advantage |
+|----------|---------|-------------------|
+| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
+| **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
+| **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
+| **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
+| **NANDA (MIT)** | New P2P overlay network, new ops paradigm | Uses infrastructure your DNS team already operates |
+| **Web3 (ERC-8004)** | Gas fees, crypto wallets, enterprise-hostile | Free DNS queries, no blockchain complexity |
+| **ai.txt / llms.txt** | No integrity verification, free-form JSON | DNSSEC cryptographic verification, structured SVCB |
+
+## Feature Comparison
+
+| Feature | DNS-AID | Central Registry | ai.txt |
+|---------|---------|------------------|--------|
+| **Decentralized** | ✅ | ❌ | ✅ |
+| **Secure (DNSSEC)** | ✅ | Varies | ❌ |
+| **Sovereign** | ✅ | ❌ | ✅ |
+| **Standards-based** | ✅ (IETF) | ❌ | ❌ |
+| **Works with existing infra** | ✅ | ❌ | ✅ |
+
+## The Sovereignty Question
+
+> **Who controls agent discovery?**
+> - ANS: GoDaddy (US company as gatekeeper)
+> - AgentDNS: China Telecom (state-owned carrier)
+> - Web3: Ethereum Foundation
+> - **DNS-AID: You control your own domain**
+>
+> DNS-AID preserves sovereignty. Organizations and nations maintain control over their own agent namespaces with no central authority that can block, censor, or surveil agent discovery.
+
+## Google's Agent Ecosystem
+
+Google is building a full-stack agent platform: **A2A** (communication), **UCP** (payments), and **Gemini/Search** (discovery). While A2A is an open protocol, discovery through Google surfaces means:
+- Google controls visibility (pay-to-rank)
+- Transaction fees via [UCP](https://developers.google.com/merchant/ucp)
+- Platform dependency for reach
+
+**DNS-AID complements A2A** by providing neutral, decentralized discovery — find agents anywhere, not just through Google.
+
+## Understanding the .agent Domain Approach
+
+The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-level domain through ICANN's [new gTLD program](https://newgtlds.icann.org/). Here's how the two approaches compare:
+
+**How .agent Domains Would Work:**
+1. Apply to ICANN for `.agent` gTLD (~$185,000 application fee)
+2. Wait 9-20 months for ICANN approval process
+3. Build registry infrastructure (Open Agent Registry, Inc.)
+4. Sell `.agent` domains through accredited registrars
+5. Users pay annual registration fees (~$15-50/year per domain)
+
+**How DNS-AID Works:**
+1. Use your existing domain (you already own `yourcompany.com`)
+2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
+3. Start discovering and being discovered immediately
+
+| Factor | .agent gTLD | DNS-AID |
+|--------|-------------|---------|
+| **Cost to publish** | ~$15-50/year domain fee | Free (use existing domain) |
+| **Time to start** | Months (gTLD launch + registration) | Minutes |
+| **Who controls discovery** | Registry operator | You (your domain) |
+| **Works today** | ❌ Pending ICANN approval | ✅ Works now |
+| **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
+| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
+
+**The Friendly Take:**
+
+Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
+
+DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
+
+*Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*


### PR DESCRIPTION
## Summary

Apply the **Part B repository-alignment edits** from the *DNS-AID: Linux Foundation Onboarding & Repository Alignment* plan — positioning this repo as a **reference implementation** distinct from the **IETF specification**, ahead of LF proposal submission.

**Docs-only.** No code, test, behavior, or API changes.

## Doc-prescribed change set

Every edit in this PR maps back to a numbered ask in the LF alignment plan.

| File | Plan IDs | Edits |
|---|---|---|
| `README.md` | B-R5, B-R6, B-R7, B-R8, B-R9 | Reframe opening line as `Reference implementation of the DNS-AID specification, developed at the IETF: …` (drops `-01` version pin); insert `## Relationship to IETF` and `## Scope of this Repository` after the project description; move `Why DNS-AID?` comparative content (vs ANS / A2A+UCP / `.agent` gTLD / AgentDNS / NANDA / Web3 / `ai.txt` / Sovereignty Question) to `docs/positioning.md` and replace in-README with a brief link; reframe the governance reference as implementation-ecosystem framing |
| `CONTRIBUTING.md` | B-C1, B-C2, B-C3 | Reframe LF sentence in opening paragraph; add `## Specification Alignment` and `## Experimental / Prototype Work` sections after Quick Start |
| `GOVERNANCE.md` | B-G1, B-G2, +typo | Replace opening paragraph to govern the reference implementation, not the protocol; add `## Scope` section; fix typo `Ivan Racic` → `Igor Racic` (line 19) |
| `SECURITY.md` | O4 | Add `## Scope` section: this policy covers implementation vulnerabilities; protocol-level security considerations belong with the IETF draft |
| `docs/api-reference.md` | B-A1, B-A2 | Add `## Relationship to IETF` at top; reframe phrases at lines 80, 160, 221: `using the DNS-AID protocol` → `using this implementation of the DNS-AID specification`; `Verify DNS-AID records` → `Verify DNS-AID records as interpreted by this implementation` |
| `docs/architecture.md` | B-D1, B-D2, B-D4, B-D5 | Add `## Relationship to IETF` at top; `DNS-AID implements the IETF draft` → `This implementation follows the IETF draft` (drops `-01` version pin); rename `### Resolution Priority` → `### Implementation Resolution Strategy`; add `## Future Enhancements (Non-Normative)` parent preamble before existing future-enhancement subsection |
| `docs/getting-started.md` | B-S1 | Add `## Relationship to IETF` after title |
| `docs/demo-guide.md` | B-M1 | Reframe first sentence as demonstrating the reference implementation |
| `docs/positioning.md` (new) | B-R8 destination | New file holding the moved comparative content with a non-normative disclaimer at top |

## Items intentionally out of scope (per the plan)

- **`CHANGELOG.md` historical entries** — plan says "historical entries can stand". Going forward, version-bump entries will distinguish implementation changes from spec-tracking changes.
- **`bandaid_` TXT-prefix carve-out** — plan flagged this as a "separate decision". Repo-wide grep `bandaid_` in `src/` returned **zero matches**; nothing to decide.
- **IETF draft cross-reference (X1)** — that's a change to the IETF draft itself (currently has `https://github.com/USER/REPO` placeholder); will land on the next `-02` revision via the draft co-authors.
- **Phase 0.1 internal alignment, 0.3 neutral GitHub org, 0.4 charter draft, Phases 1–3** — procedural / LF-staff / legal items, not repo edits.

## Verification

```
uv run ruff check src/             All checks passed
uv run ruff format --check src/    76 files already formatted
uv run mypy src/dns_aid/           Success: no issues found in 76 source files
uv run pytest tests/unit/ -x -q    1267 passed, 21 warnings in 4.75s
```

## Test plan

- [ ] CI passes (DCO, ruff, mypy, pytest, security, scorecard, codeql)
- [ ] Render-check `docs/positioning.md` and the new README sections on the PR's Files tab
- [ ] Confirm `Why DNS-AID?` content is preserved in `docs/positioning.md` (no information loss)
- [ ] Confirm `Ivan Racic` → `Igor Racic` typo fix in `GOVERNANCE.md`

## Source

`DNS-AID: Linux Foundation Onboarding & Repository Alignment` plan, Part B.