### PR TITLE
perf(discoverer): parallelize HTTP-index per-agent SVCB walks (v0.18.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.5] - 2026-05-08
+
+### Changed
+
+- **`src/dns_aid/core/discoverer.py`** — `_discover_via_http_index` now parallelizes per-agent SVCB walks the same way `_discover_agents_in_zone` does. Replaced the sequential `for http_agent in http_agents` loop with an `asyncio.Semaphore(20)` + `asyncio.gather(..., return_exceptions=True)` pattern, reusing the existing `_collect_agent_results` filter helper. End-state: HTTP-index-mode discovery completes in roughly `max(per-agent latency)` instead of `sum(per-agent latency)`, matching the latency profile of the DNS-zone-walk path. No behavior change for callers — every existing `TestDiscoverViaHttpIndex` case passes unchanged.
+
+### Notes
+
+- No public API surface changes; concurrency cap (20) intentionally matches the DNS-zone-walk ceiling so a single domain cannot fan out beyond what the existing path already permits.
+- 1267 unit tests pass on the bumped version.
+
 ## [0.18.4] - 2026-04-25
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.18.4"
-date-released: "2026-04-25"
+version: "0.18.5"
+date-released: "2026-05-08"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.18.4"
+version = "0.18.5"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -661,13 +661,21 @@ async def _discover_via_http_index(
         agent_count=len(http_agents),
     )
 
-    agents: list[AgentRecord] = []
-    for http_agent in http_agents:
-        agent = await _process_http_agent(http_agent, domain, protocol, name)
-        if agent:
-            agents.append(agent)
+    # Mirror the DNS-index path's concurrency pattern: cap fan-out with a
+    # Semaphore and dispatch via asyncio.gather. Per-agent processing is
+    # independent (each call does its own SVCB+cap+TXT chain), so the
+    # sequential for-loop here was a real performance asymmetry vs
+    # _discover_agents_in_zone — for N agents on cold DNS/HTTPS caches it
+    # multiplied latency by ~N. Same Semaphore(20) cap as the DNS path.
+    sem = asyncio.Semaphore(20)
 
-    return agents
+    async def _process_with_sem(ha: HttpIndexAgent) -> AgentRecord | None:
+        async with sem:
+            return await _process_http_agent(ha, domain, protocol, name)
+
+    tasks = [_process_with_sem(ha) for ha in http_agents]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return _collect_agent_results(results)
 
 
 def _http_agent_to_record(


### PR DESCRIPTION
## Summary

`_discover_via_http_index` was the only remaining sequential per-agent walk in the discovery pipeline. The DNS-zone-walk path (`_discover_agents_in_zone`) already fans out per-agent SVCB lookups under an `asyncio.Semaphore(20)` + `asyncio.gather(..., return_exceptions=True)`, so HTTP-index mode was leaking the full sum of per-agent latency to the caller while DNS-index mode paid only the max.

This PR closes that gap by reusing the exact same concurrency pattern (and the same `_collect_agent_results` filter helper) in the HTTP-index branch.

## Changes

**`src/dns_aid/core/discoverer.py`** — `_discover_via_http_index`
- Replaced the sequential `for http_agent in http_agents` loop with a `Semaphore(20)`-bounded `asyncio.gather` fan-out.
- Concurrency cap intentionally matches the DNS-zone-walk ceiling so a single domain cannot fan out beyond what the existing path already permits.
- No public API surface change. All `TestDiscoverViaHttpIndex` cases pass unchanged.

**Version bump**
- `pyproject.toml`: `0.18.4` → `0.18.5`
- `CITATION.cff`: version + `date-released: 2026-05-08`
- `CHANGELOG.md`: new `[0.18.5] - 2026-05-08` section

## Why now

Reviewer of the discovery flow (peer-review of Section 5.1.2) flagged sequential per-agent fetches in the HTTP-index path as a real perf bug worth a small patch. Verified against the code via Serena symbolic analysis, then mirrored the existing parallel pattern.

## Test plan

- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/`
- [x] `uv run mypy src/dns_aid/`
- [x] `uv run pytest tests/unit/ -x -q` — 1267 passed
- [x] `TestDiscoverViaHttpIndex` cases unchanged and green