### PR TITLE
chore: regenerate uv.lock for v0.18.5

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.18.4"
+version = "0.18.5"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Lockfile-only follow-up to v0.18.5 (PR #105 / tag `v0.18.5`).

The `pyproject.toml` version bump from `0.18.4` → `0.18.5` landed in PR #105 but the paired `uv.lock` regeneration was missed. This PR closes that gap so the workspace lockfile matches the published version, mirroring the v0.18.4 release commit pattern (which bundled `uv.lock | 2 +-`).

## Diff

Single-line change in `[[package]] dns-aid`:

```
-version = "0.18.4"
+version = "0.18.5"
```

No dependency graph changes — `uv lock` resolved 107 packages in 527ms with zero updates outside the workspace package itself.

## Test plan

- [x] `uv lock` clean (no transitive churn)
- [x] CI will run lint + tests + type check on this commit