### PR TITLE
security: bump python-multipart to >=0.0.27 (CVE-2026-42561, v0.18.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.6] - 2026-05-08
+
+### Security
+
+- **`python-multipart` floor raised to `>=0.0.27`** in both `[project.optional-dependencies] api` and the `all` extra. Patches **CVE-2026-42561 / GHSA-pp6c-gr5w-3c5g** (high severity) — "Denial of Service via unbounded multipart part headers". Upstream fix landed in `python-multipart 0.0.27` (PR #267 "Add multipart header limits"). The previous floor (`>=0.0.26`) only covered CVE-2026-40347; the new floor supersedes it. `uv.lock` regenerated to pull the patched version. Closes Dependabot alert #11.
+
+### Notes
+
+- No public API surface changes; no source code logic changes.
+- PyPI users with fresh `pip install dns-aid` were already getting the patched version (since `>=0.0.26` resolves to latest). This release closes the gap for downstream consumers of this repo's `uv.lock` and prevents future lockfile regression.
+- 1267 unit tests pass on the bumped version.
+
 ## [0.18.5] - 2026-05-08
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.18.5"
+version: "0.18.6"
 date-released: "2026-05-08"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.18.5"
+version = "0.18.6"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -53,7 +53,7 @@ mcp = [
     # Direct floors on transitive deps pulled by `mcp` to close Dependabot alerts
     # (mcp's upstream constraints are looser than the patched versions need).
     "pyjwt>=2.12.0",            # CVE-2026-32597 (high) — accepts unknown 'crit' header
-    "python-multipart>=0.0.26", # CVE-2026-40347 (medium) — DoS via large preamble
+    "python-multipart>=0.0.27", # CVE-2026-42561 / GHSA-pp6c-gr5w-3c5g (high) — DoS via unbounded multipart headers; supersedes CVE-2026-40347
 ]
 route53 = [
     "boto3>=1.34.0",
@@ -126,7 +126,7 @@ all = [
     "uvicorn>=0.30.0",
     # Transitive floors via mcp (Dependabot)
     "pyjwt>=2.12.0",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
     # Backends: Route53, Cloudflare, NS1, Cloud DNS, Infoblox BloxOne, NIOS, DDNS
     "boto3>=1.34.0",
     "google-auth>=2.30.0",

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.18.5"
+version = "0.18.6"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -742,8 +742,8 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-multipart", marker = "extra == 'all'", specifier = ">=0.0.26" },
-    { name = "python-multipart", marker = "extra == 'mcp'", specifier = ">=0.0.26" },
+    { name = "python-multipart", marker = "extra == 'all'", specifier = ">=0.0.27" },
+    { name = "python-multipart", marker = "extra == 'mcp'", specifier = ">=0.0.27" },
     { name = "requests", marker = "extra == 'cloud-dns'", specifier = ">=2.33.0" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=13.0.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
@@ -1750,11 +1750,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Patches **CVE-2026-42561 / GHSA-pp6c-gr5w-3c5g** (high severity): _Denial of Service via unbounded multipart part headers_.

Closes Dependabot alert [#11](https://github.com/infobloxopen/dns-aid-core/security/dependabot/11).

## Upstream verification

The fix is confirmed in `python-multipart 0.0.27` against three independent sources:

| Source | Patched version |
|---|---|
| Dependabot alert #11 | `first_patched_version: 0.0.27` |
| Upstream advisory [GHSA-pp6c-gr5w-3c5g](https://github.com/Kludex/python-multipart/security/advisories/GHSA-pp6c-gr5w-3c5g) | `patched_versions: 0.0.27` |
| Upstream [`0.0.27` release notes](https://github.com/Kludex/python-multipart/releases/tag/0.0.27) | PR #267 _"Add multipart header limits"_ |

PyPI sdist for `0.0.27` shipped on `2026-04-27`, two days before the GHSA was published — standard responsible-disclosure cadence.

## Changes

- **`pyproject.toml`** — `python-multipart` floor raised from `>=0.0.26` → `>=0.0.27` in both:
  - `[project.optional-dependencies] api`
  - `[project.optional-dependencies] all`
- **`pyproject.toml`** — inline comment updated to reference the new CVE/GHSA; the prior `CVE-2026-40347` floor is **superseded** by 0.0.27's fix.
- **`pyproject.toml`** — `version` 0.18.5 → 0.18.6.
- **`CITATION.cff`** — version 0.18.5 → 0.18.6.
- **`uv.lock`** — regenerated; `python-multipart 0.0.26 → 0.0.27`.
- **`CHANGELOG.md`** — new `[0.18.6] - 2026-05-08` `### Security` entry.

## Impact

- **PyPI users (`pip install dns-aid`)**: already protected — `>=0.0.26` already resolves to the latest patched 0.0.27 from PyPI. This release **prevents future regression** by raising the floor.
- **Downstream `uv.lock` consumers** (DNS-AID workspace, forks, reproducible builds): **were vulnerable** until this PR; lockfile regen pulls them to 0.0.27.
- **No public API surface changes**, no source code logic changes.

## Test plan

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — 76 files formatted
- [x] `uv run mypy src/dns_aid/` — 76 source files, no issues
- [x] `uv run pytest tests/unit/` — 1267 passed