### PR TITLE
feat(core): Domain Control Validation — stateless challenge/verify (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-05-08
+
+### Added
+
+- **`src/dns_aid/core/dcv.py` — Domain Control Validation (DCV) module** implementing the challenge-response pattern from [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/) (BCP-track) and extended with the `bnd-req` binding field from [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) §4.4.
+
+  Two use cases are covered:
+  1. **Anonymous / NAT agent asserting org affiliation** — an agent operating outside the org's network proves it holds write access to the org's DNS zone by placing a challenger-issued token there.
+  2. **Registry / directory anti-impersonation** — a directory requires proof of zone control before listing an agent as org-verified.
+
+  Wire format (DCV-techniques §6.1.2 ABNF, space-separated key=value):
+  ```
+  token=<base32>  [bnd-req=svc:<agent>@<issuer>]  expiry=<RFC3339>
+  ```
+  Challenge owner name: `_agents-challenge.{domain}`
+
+  Public API (`dns_aid.core.dcv`):
+  - `issue(domain, *, agent_name, issuer_domain, ttl_seconds) → DCVChallenge` — stateless; generates a 20-byte base32 token and returns it. Nothing touches DNS.
+  - `async place(domain, token, *, bnd_req, ttl, expiry_seconds, backend) → str` — claimant writes the TXT record via their configured backend, proving zone write access.
+  - `async verify(domain, token, *, nameserver, port) → DCVVerifyResult` — challenger resolves and validates the token. No backend credentials required.
+  - `async revoke(domain, *, backend) → bool` — deletes the challenge record after successful verification.
+
+- **`dns-aid dcv` CLI subcommand group** with four commands: `issue`, `place`, `verify`, `revoke`. All accept `--json` for machine-readable output; `issue` and `verify` exit non-zero on failure. All domain inputs pass through `validate_domain()`.
+
+- **Four MCP tools**: `dcv_issue_challenge`, `dcv_place_challenge`, `dcv_verify_challenge`, `dcv_revoke_challenge`. All domain inputs validated at entry; tools are listed in the `/health` endpoint tool inventory.
+
+- **`tests/unit/test_dcv.py`** — 25 unit tests covering token generation, TXT wire format, key=value parsing, `issue()` / `place()` / `verify()` / `revoke()` semantics, expiry enforcement, NXDOMAIN handling, `bnd-req` scoping, and custom nameserver override.
+
+- **`tests/testbed/smoke_test.sh`** extended with steps 8–13 demonstrating the full cross-org DCV flow against real BIND9 containers: Org A issues → Org B places → `dig` confirms TXT present → Org A verifies querying Org B's nameserver directly → Org B revokes → `dig` confirms record removed.
+
+### Notes
+
+- The `dcv` module is Tier 0 (no SDK or cloud dependencies). `place()` and `revoke()` require a configured DNS backend; `issue()` and `verify()` are credential-free.
+- Token entropy: 20 bytes (160 bits), base32 lowercase, no padding — DNS-label safe per DCV-techniques §4.1.
+- The `bnd-req` field prevents cross-vendor token reuse (DCV hazard H2 from the BCP draft): a token issued to `svc:assistant@orga.test` cannot satisfy a challenge issued to a different agent or issuer.
+- 1292 unit tests pass on this version.
+
 ## [0.18.6] - 2026-05-08
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-05-09
+
+### Security
+
+- **DCV verifier hardened to fail-closed**: `verify()` now requires an explicit `expiry=` field; missing, malformed, or `"never"` expiry values return `verified=False` instead of silently passing. Bare-string tokens (no `token=` prefix) are no longer accepted. All five confirmed exploits from the security review are closed.
+- **`bnd-req` enforcement**: `verify()` accepts a new `expected_bnd_req` parameter; when supplied, the record's `bnd-req` field must match exactly, preventing cross-vendor token reuse (DCV hazard H2). CLI and MCP tool updated accordingly.
+- **`agent_name` injection prevented**: `issue()` now validates `agent_name` through `validate_agent_name()` before embedding it in the `bnd-req` field, blocking space-separated RDATA injection.
+- **Constant-time token comparison**: Token matching in `verify()` uses `hmac.compare_digest()` to mitigate timing side-channel attacks.
+- **Nameserver validated as IP address**: `verify()` rejects non-IP nameserver values and returns a `DCVVerifyResult` with an error instead of raising an unhandled exception.
+- **`nameserver` removed from MCP tool**: `dcv_verify_challenge` no longer exposes the nameserver parameter to LLMs (SSRF risk); it remains in the Python API for testbed use.
+- **MCP tools hardened**: All four DCV tools now wrap exceptions and return `{"success": False, "error": <safe message>}`; backend errors are logged server-side and never returned as raw `str(e)`. `success` key added to all responses. `readOnlyHint` and `idempotentHint` corrected.
+- **`revoke()` scoped to token**: `revoke()` now requires a `token` parameter and confirms the token is present in DNS before deleting, reducing the risk of racing a concurrent challenger's record.
+- **DoS guard**: `verify()` limits TXT record iteration to `MAX_CHALLENGE_RECORDS = 10` and sets `resolver.lifetime = 4.0`.
+- **OS DNS cache bypassed**: `resolver.cache = None` in `verify()` prevents stale cached positives from surviving after `revoke()`.
+
+### Fixed
+
+- **Cloudflare TXT quoting bug**: `CloudflareBackend.create_txt_record()` was wrapping content in literal `"..."` characters, causing verification to always fail on Cloudflare zones. Content is now passed raw.
+- **Async resolver**: `verify()` was calling the synchronous `dns.resolver.Resolver`, blocking the event loop. Switched to `dns.asyncresolver.Resolver` with `await`, consistent with `discoverer.py`.
+- **`_parse_txt_value` quote stripping**: Strips one layer of RFC-1035-style outer quotes (Cloudflare's wrapping) before parsing. First-wins semantics for duplicate keys (was: last-wins). Bare-value token fallback removed.
+- **Library-level input validation**: `issue()`, `place()`, and `revoke()` now call `validate_domain()` / `validate_ttl()` / token shape check internally; direct Python API callers get the same protection as CLI and MCP callers.
+- **DCV TTL cap**: Maximum challenge validity capped at `MAX_DCV_TTL_SECONDS = 86400` (24 h) in `issue()` and `place()`, separate from the general 7-day DNS TTL cap.
+- **Namespace collision**: `issue`, `place`, `revoke` exported from `core/__init__.py` as `dcv_issue`, `dcv_place`, `dcv_revoke` (matching the existing `dcv_verify` alias) to avoid collision with future top-level names.
+- **All failed verifications now logged at WARNING** with domain, fqdn, and reason.
+- **`--port` always validated** in `dns-aid dcv verify`, even without `--nameserver`.
+- **`--json` output** added to `dns-aid dcv place` and `dns-aid dcv revoke`.
+- **`dns-aid dcv revoke`** now accepts a required `TOKEN` argument.
+- **`expiry=` datetime normalization**: `_build_txt_value` calls `.astimezone(UTC)` defensively to reject naive datetimes. Python 3.11 native `fromisoformat()` used for parsing (no `.replace("Z", "+00:00")` workaround).
+
+### Tests
+
+- 46 unit tests (was: 25) — added regression test for every confirmed exploit and every previously untested code path: missing expiry, malformed expiry, `expiry=never`, bare-string token, invalid nameserver, Cloudflare-quoted records, bnd-req enforcement, `MAX_CHALLENGE_RECORDS` guard, multi-string TXT records, multi-record iteration (expired-then-valid), backend raise on `place()` and `revoke()`, token shape validation.
+- All `verify()` tests updated from `dns.resolver.Resolver` patch to `dns.asyncresolver.Resolver` with `AsyncMock`.
+
 ## [0.19.0] - 2026-05-08
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.18.6"
-date-released: "2026-05-08"
+version: "0.20.0"
+date-released: "2026-05-11"
 
 keywords:
   - dns

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,6 +9,15 @@ Complete API documentation for DNS-AID - DNS-based Agent Identification and Disc
   - [publish()](#publish)
   - [discover()](#discover)
   - [verify()](#verify)
+- [Domain Control Validation (DCV)](#domain-control-validation-dcv)
+  - [dcv.issue()](#dcvissue)
+  - [dcv.place()](#dcvplace)
+  - [dcv.verify()](#dcvverify)
+  - [dcv.revoke()](#dcvrevoke)
+  - [DCVChallenge](#dcvchallenge)
+  - [DCVPlaceResult](#dcvplaceresult)
+  - [DCVVerifyResult](#dcvverifyresult)
+  - [DCVRevokeResult](#dcvrevokeresult)
 - [Data Models](#data-models)
   - [AgentRecord](#agentrecord)
   - [DiscoveryResult](#discoveryresult)
@@ -246,6 +255,211 @@ print(f"DNSSEC valid: {result.dnssec_valid}")
 print(f"Security Score: {result.security_score}/100")
 print(f"Rating: {result.security_rating}")
 ```
+
+---
+
+## Domain Control Validation (DCV)
+
+DCV is a stateless challenge/verify primitive that lets one party prove control of a
+domain to another using a short-lived TXT record at `_agents-challenge.{domain}`.
+It implements [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/)
+plus the `bnd-req` binding extension from
+[draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+
+**Role split:**
+- *Challenger* — calls `issue()` and `verify()`; no DNS write credentials required.
+- *Claimant* — calls `place()` and `revoke()`; needs backend write credentials for the domain.
+
+**Wire format** (space-separated key=value at `_agents-challenge.{domain}` TXT):
+
+```
+token=<32-char-base32>  [domain=<domain>]  [bnd-req=svc:<agent>@<issuer>]  expiry=<RFC3339Z>
+```
+
+```python
+from dns_aid.core import dcv
+
+# Challenger
+challenge = dcv.issue("example.com", agent_name="assistant", issuer_domain="orga.test")
+# ... deliver challenge to claimant out-of-band ...
+
+# Claimant
+await dcv.place(challenge.domain, challenge.token, bnd_req=challenge.bnd_req)
+
+# Challenger
+result = await dcv.verify(challenge.domain, challenge.token,
+                          expected_bnd_req=challenge.bnd_req)
+if result.verified:
+    await dcv.revoke(challenge.domain, token=challenge.token)  # claimant cleanup
+```
+
+### dcv.issue()
+
+Generate a stateless DCV challenge. Nothing is written to DNS — the returned
+`DCVChallenge` is delivered to the claimant out-of-band.
+
+```python
+def issue(
+    domain: str,
+    *,
+    agent_name: str | None = None,
+    issuer_domain: str | None = None,
+    ttl_seconds: int = 3600,
+) -> DCVChallenge
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `domain` | `str` | Yes | - | Domain the claimant must prove control of |
+| `agent_name` | `str` | No | `None` | Agent name to scope the `bnd-req` field |
+| `issuer_domain` | `str` | No | `None` | Issuer domain to scope the `bnd-req` field |
+| `ttl_seconds` | `int` | No | `3600` | Challenge validity window (30–86400) |
+
+Returns a [`DCVChallenge`](#dcvchallenge). Raises `ValueError` if `ttl_seconds` is out of range; `ValidationError` for invalid domain or agent name.
+
+### dcv.place()
+
+Write the DCV challenge TXT record to DNS via the configured backend.
+
+```python
+async def place(
+    domain: str,
+    token: str,
+    *,
+    bnd_req: str | None = None,
+    expiry_seconds: int = 3600,
+    ttl: int = 300,
+    backend: DNSBackend | None = None,
+) -> DCVPlaceResult
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `domain` | `str` | Yes | - | Zone to write the challenge into |
+| `token` | `str` | Yes | - | Token from the challenger (32-char lowercase base32) |
+| `bnd_req` | `str` | No | `None` | Binding scope from the issued challenge |
+| `expiry_seconds` | `int` | No | `3600` | Placed-record validity (30–86400). Prefer aligning with `DCVChallenge.expiry`. |
+| `ttl` | `int` | No | `300` | DNS record TTL — keep short for quick cleanup |
+| `backend` | `DNSBackend` | No | `None` | Defaults to `DNS_AID_BACKEND` env var |
+
+Returns a [`DCVPlaceResult`](#dcvplaceresult).
+
+### dcv.verify()
+
+Resolve `_agents-challenge.{domain}` and confirm the token is present, unexpired,
+and (optionally) bound to the expected scope.
+
+```python
+async def verify(
+    domain: str,
+    token: str,
+    *,
+    nameserver: str | None = None,
+    port: int = 53,
+    expected_bnd_req: str | None = None,
+    require_dnssec: bool = False,
+) -> DCVVerifyResult
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `domain` | `str` | Yes | - | Domain to check |
+| `token` | `str` | Yes | - | Token originally issued by the challenger |
+| `nameserver` | `str` | No | `None` | Operator-trusted nameserver IP (testbeds only) |
+| `port` | `int` | No | `53` | DNS port |
+| `expected_bnd_req` | `str` | No | `None` | When set, record `bnd-req` must match exactly |
+| `require_dnssec` | `bool` | No | `False` | When `True`, resolver must set AD flag (silently downgraded when `nameserver=` is used) |
+
+#### Fail-closed contract
+
+| Condition | Result |
+|---|---|
+| Missing `expiry=` field | `verified=False` |
+| Malformed `expiry=` | `verified=False` |
+| Bare token (no `token=` prefix) | Not matched |
+| `domain=` mismatched with queried domain | Record skipped |
+| Invalid nameserver IP | `DCVVerifyResult(verified=False)` — never raises |
+| `require_dnssec=True` + no AD flag | `verified=False` |
+| `>10` challenge records (DoS guard) | `verified=False` |
+
+Returns a [`DCVVerifyResult`](#dcvverifyresult).
+
+> **Security:** The `nameserver` parameter accepts any syntactically valid IP including loopback,
+> link-local (169.254/16), and RFC1918 ranges. It is operator-trusted and intentionally omitted
+> from the MCP tool surface. Do not expose it to untrusted callers.
+
+### dcv.revoke()
+
+Delete the DCV challenge TXT record. Should be called immediately after a successful
+`verify()` to prevent token reuse within the validity window.
+
+```python
+async def revoke(
+    domain: str,
+    *,
+    token: str,
+    backend: DNSBackend | None = None,
+) -> DCVRevokeResult
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `domain` | `str` | Yes | - | Zone to remove the challenge from |
+| `token` | `str` | Yes | - | Token that was placed (must match the record in DNS) |
+| `backend` | `DNSBackend` | No | `None` | Defaults to `DNS_AID_BACKEND` env var |
+
+Returns a [`DCVRevokeResult`](#dcvrevokeresult). The token must be present in DNS
+before deletion (check-then-delete reduces racing with concurrent challengers; not
+atomic — `expiry=` remains the true security gate).
+
+### DCVChallenge
+
+Issued challenge, delivered to the claimant out-of-band.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token` | `str` | Base32-encoded nonce to place in DNS |
+| `domain` | `str` | Domain being challenged |
+| `fqdn` | `str` | Full owner name (`_agents-challenge.{domain}`) |
+| `txt_value` | `str` | Verbatim TXT RDATA to place |
+| `expiry` | `datetime` | UTC expiry time |
+| `bnd_req` | `str \| None` | Binding scope (`svc:<agent>@<issuer>`), if set |
+
+### DCVPlaceResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fqdn` | `str` | Full owner name where the challenge was placed |
+| `domain` | `str` | Zone domain |
+| `expires_at` | `datetime` | UTC time the placed challenge expires |
+
+### DCVVerifyResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `verified` | `bool` | `True` if a valid, unexpired matching record was found |
+| `domain` | `str` | Domain that was queried |
+| `token` | `str` | Token that was checked |
+| `fqdn` | `str` | Full owner name queried |
+| `expired` | `bool` | `True` if a matching record was found but past `expiry` |
+| `dnssec_validated` | `bool` | `True` if `require_dnssec=True` and resolver set AD=1 |
+| `error` | `str \| None` | Human-readable failure reason when `verified=False` |
+
+### DCVRevokeResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `removed` | `bool` | `True` if the challenge record was deleted |
+| `domain` | `str` | Zone domain |
+| `fqdn` | `str` | Full owner name that was targeted |
 
 ---
 

--- a/docs/rfc/wire-format.abnf
+++ b/docs/rfc/wire-format.abnf
@@ -277,7 +277,47 @@ optout-flag    = "true" / "false"
                  ; false = Allow indexing (default)
 
 ; ==================================================================
-; DNS-AID Verification Record Format
+; DNS-AID DCV Challenge Record Format
+; ==================================================================
+
+; Implements domain control validation per:
+;   draft-mozleywilliams-dnsop-dnsaid-01   (bnd-req binding)
+;   draft-ietf-dnsop-domain-verification-techniques-12
+
+; Challenge owner name:  _agents-challenge.{domain}
+
+dcv-record     = "_agents-challenge." domain "." SP "TXT" SP dcv-value
+
+dcv-value      = DQUOTE "token=" dcv-token
+                 [ SP "bnd-req=" bnd-req-value ]
+                 SP "expiry=" rfc3339-utc
+                 DQUOTE
+
+dcv-token      = 32(dcv-char)
+                 ; 32 lowercase base32 characters (no padding)
+
+dcv-char       = %x61-7A / "2" / "3" / "4" / "5" / "6" / "7"
+                 ; [a-z2-7]  — alphabet used by base32 without padding
+
+bnd-req-value  = "svc:" agent-name "@" domain
+                 ; Scopes this challenge to a specific agent+issuer pair
+
+rfc3339-utc    = date "T" time "Z"
+                 ; UTC timestamp only — no offset forms are accepted
+
+date           = 4DIGIT "-" 2DIGIT "-" 2DIGIT
+
+time           = 2DIGIT ":" 2DIGIT ":" 2DIGIT
+
+; Parser requirements:
+;   - token= field MUST appear first (fail-closed: missing token → no match)
+;   - expiry= field MUST be present; absent or malformed expiry → invalid
+;   - Duplicate keys: first occurrence wins (anti-injection)
+;   - Implementations MUST strip exactly one layer of RFC-1035-style outer
+;     quotes ("...") added by some DNS backends before parsing
+
+; ==================================================================
+; DNS-AID Verification Record Format (legacy — prefer DCV record above)
 ; ==================================================================
 
 ; Used for domain ownership verification

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.18.6"
+version = "0.19.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.19.0"
+version = "0.20.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from dns_aid.core import dcv
 from dns_aid.core.discoverer import discover
 from dns_aid.core.models import (
     AgentRecord,
@@ -69,6 +70,8 @@ __all__ = [
     "delete",
     "discover",
     "verify",
+    # DCV
+    "dcv",
     # SDK functions (Tier 1)
     "invoke",
     "rank",

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -298,9 +298,10 @@ class CloudflareBackend(DNSBackend):
         # Check if record exists (for update)
         existing_id = await self._get_record_id(zone_id, fqdn, "TXT")
 
-        # Cloudflare TXT records use "content" field
-        # Multiple values are joined with spaces
-        content = " ".join(f'"{v}"' for v in values)
+        # Cloudflare TXT records use "content" field — raw value, no extra quoting.
+        # The API stores whatever string is provided literally; adding '"..."' wrapping
+        # causes those literal quote characters to appear in RDATA and break parsing.
+        content = " ".join(values)
 
         request_data = {
             "type": "TXT",

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -2012,6 +2012,158 @@ def _write_enforce_report(  # type: ignore[no-untyped-def]
 
 
 # ============================================================================
+# DCV COMMANDS
+# ============================================================================
+
+dcv_app = typer.Typer(
+    name="dcv",
+    help="Domain Control Validation — prove zone ownership for agent identity",
+    no_args_is_help=True,
+)
+app.add_typer(dcv_app, name="dcv")
+
+
+@dcv_app.command("issue")
+def dcv_issue(
+    domain: Annotated[str, typer.Argument(help="Domain to challenge (e.g., orgb.test)")],
+    agent_name: Annotated[
+        str | None, typer.Option("--agent", "-a", help="Agent name to scope the bnd-req field")
+    ] = None,
+    issuer_domain: Annotated[
+        str | None, typer.Option("--issuer", "-i", help="Issuer domain to scope the bnd-req field")
+    ] = None,
+    ttl: Annotated[int, typer.Option("--ttl", help="Challenge validity in seconds")] = 3600,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
+) -> None:
+    """Generate a DCV challenge token for a domain.
+
+    The challenger calls this and delivers the result out-of-band (A2A, MCP, etc.)
+    to the claimant.  Nothing is written to DNS — placement is the claimant's job.
+    """
+    import json as _json
+
+    from dns_aid.core import dcv as _dcv
+    from dns_aid.utils.validation import validate_domain, validate_ttl
+
+    domain = validate_domain(domain)
+    ttl = validate_ttl(ttl)
+    challenge = _dcv.issue(
+        domain,
+        agent_name=agent_name,
+        issuer_domain=issuer_domain,
+        ttl_seconds=ttl,
+    )
+
+    if json_output:
+        console.print_json(_json.dumps(challenge.model_dump(mode="json")))
+        return
+
+    console.print("[bold]DCV Challenge[/bold]")
+    console.print(f"  Domain  : {challenge.domain}")
+    console.print(f"  FQDN    : {challenge.fqdn}")
+    console.print(f"  Token   : {challenge.token}")
+    console.print(f"  Expiry  : {challenge.expiry.isoformat()}")
+    if challenge.bnd_req:
+        console.print(f"  bnd-req : {challenge.bnd_req}")
+    console.print()
+    console.print("[bold]TXT record to place:[/bold]")
+    console.print(f"  {challenge.fqdn}  TXT  \"{challenge.txt_value}\"")
+
+
+@dcv_app.command("place")
+def dcv_place(
+    domain: Annotated[str, typer.Argument(help="Domain to write the challenge into")],
+    token: Annotated[str, typer.Argument(help="Token received from the challenger")],
+    bnd_req: Annotated[
+        str | None, typer.Option("--bnd-req", help="Binding scope (pass through from challenge)")
+    ] = None,
+    ttl: Annotated[int, typer.Option("--ttl", help="DNS record TTL in seconds")] = 300,
+    expiry_seconds: Annotated[
+        int, typer.Option("--expiry", help="Challenge validity window in seconds")
+    ] = 3600,
+) -> None:
+    """Write a DCV challenge TXT record to DNS via the configured backend.
+
+    The claimant calls this using their own dns-aid backend credentials,
+    proving they have write access to the domain's zone.
+    """
+    from dns_aid.core import dcv as _dcv
+    from dns_aid.utils.validation import validate_domain, validate_ttl
+
+    domain = validate_domain(domain)
+    ttl = validate_ttl(ttl)
+    try:
+        fqdn = run_async(_dcv.place(domain, token, bnd_req=bnd_req, ttl=ttl, expiry_seconds=expiry_seconds))
+        console.print(f"[green]✓[/green] Challenge placed at {fqdn}")
+    except Exception as e:
+        error_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from e
+
+
+@dcv_app.command("verify")
+def dcv_verify_cmd(
+    domain: Annotated[str, typer.Argument(help="Domain to verify challenge for")],
+    token: Annotated[str, typer.Argument(help="Token originally issued by the challenger")],
+    nameserver: Annotated[
+        str | None,
+        typer.Option("--nameserver", "-s", help="Nameserver IP to query directly"),
+    ] = None,
+    port: Annotated[int, typer.Option("--port", help="DNS port")] = 53,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
+) -> None:
+    """Verify that a DCV challenge token is present and unexpired in DNS.
+
+    The challenger calls this after the claimant has placed the record.
+    No backend credentials required — pure DNS resolution.
+    """
+    import json as _json
+
+    from dns_aid.core import dcv as _dcv
+    from dns_aid.utils.validation import validate_domain
+
+    domain = validate_domain(domain)
+    result = run_async(_dcv.verify(domain, token, nameserver=nameserver, port=port))
+
+    if json_output:
+        console.print_json(_json.dumps(result.model_dump()))
+        if not result.verified:
+            raise typer.Exit(1)
+        return
+
+    if result.verified:
+        console.print(f"[green]✓[/green] DCV verified for {result.fqdn}")
+    else:
+        label = "expired" if result.expired else "failed"
+        console.print(f"[red]✗[/red] DCV {label} for {result.fqdn}")
+        if result.error:
+            console.print(f"  {result.error}")
+        raise typer.Exit(1)
+
+
+@dcv_app.command("revoke")
+def dcv_revoke(
+    domain: Annotated[str, typer.Argument(help="Domain to remove the challenge from")],
+) -> None:
+    """Delete the DCV challenge TXT record from DNS.
+
+    Should be called after successful verification to clean up.
+    """
+    from dns_aid.core import dcv as _dcv
+    from dns_aid.utils.validation import validate_domain
+
+    domain = validate_domain(domain)
+    try:
+        removed = run_async(_dcv.revoke(domain))
+        if removed:
+            console.print(f"[green]✓[/green] Challenge record removed from {domain}")
+        else:
+            console.print("[yellow]![/yellow] Challenge record not found (already removed?)")
+    except Exception as e:
+        error_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from e
+
+
+# ============================================================================
 # ONBOARDING COMMANDS
 # ============================================================================
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -2067,7 +2067,7 @@ def dcv_issue(
         console.print(f"  bnd-req : {challenge.bnd_req}")
     console.print()
     console.print("[bold]TXT record to place:[/bold]")
-    console.print(f"  {challenge.fqdn}  TXT  \"{challenge.txt_value}\"")
+    console.print(f'  {challenge.fqdn}  TXT  "{challenge.txt_value}"')
 
 
 @dcv_app.command("place")
@@ -2081,22 +2081,30 @@ def dcv_place(
     expiry_seconds: Annotated[
         int, typer.Option("--expiry", help="Challenge validity window in seconds")
     ] = 3600,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
 ) -> None:
     """Write a DCV challenge TXT record to DNS via the configured backend.
 
     The claimant calls this using their own dns-aid backend credentials,
     proving they have write access to the domain's zone.
     """
-    from dns_aid.core import dcv as _dcv
-    from dns_aid.utils.validation import validate_domain, validate_ttl
+    import json as _json
 
-    domain = validate_domain(domain)
-    ttl = validate_ttl(ttl)
+    from dns_aid.core import dcv as _dcv
+
     try:
-        fqdn = run_async(_dcv.place(domain, token, bnd_req=bnd_req, ttl=ttl, expiry_seconds=expiry_seconds))
-        console.print(f"[green]✓[/green] Challenge placed at {fqdn}")
+        place_result = run_async(
+            _dcv.place(domain, token, bnd_req=bnd_req, ttl=ttl, expiry_seconds=expiry_seconds)
+        )
+        if json_output:
+            console.print_json(_json.dumps({"success": True, "fqdn": place_result.fqdn}))
+        else:
+            console.print(f"[green]✓[/green] Challenge placed at {place_result.fqdn}")
     except Exception as e:
-        error_console.print(f"[red]Error:[/red] {e}")
+        if json_output:
+            console.print_json(_json.dumps({"success": False, "error": str(e)}))
+        else:
+            error_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
 
 
@@ -2106,9 +2114,13 @@ def dcv_verify_cmd(
     token: Annotated[str, typer.Argument(help="Token originally issued by the challenger")],
     nameserver: Annotated[
         str | None,
-        typer.Option("--nameserver", "-s", help="Nameserver IP to query directly"),
+        typer.Option("--nameserver", "-s", help="Nameserver IP address to query directly"),
     ] = None,
     port: Annotated[int, typer.Option("--port", help="DNS port")] = 53,
+    expected_bnd_req: Annotated[
+        str | None,
+        typer.Option("--bnd-req", help="Expected bnd-req value (enforces cross-vendor binding)"),
+    ] = None,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
 ) -> None:
     """Verify that a DCV challenge token is present and unexpired in DNS.
@@ -2119,10 +2131,14 @@ def dcv_verify_cmd(
     import json as _json
 
     from dns_aid.core import dcv as _dcv
-    from dns_aid.utils.validation import validate_domain
+    from dns_aid.utils.validation import validate_port
 
-    domain = validate_domain(domain)
-    result = run_async(_dcv.verify(domain, token, nameserver=nameserver, port=port))
+    validate_port(port)  # always validate, even without --nameserver
+    result = run_async(
+        _dcv.verify(
+            domain, token, nameserver=nameserver, port=port, expected_bnd_req=expected_bnd_req
+        )
+    )
 
     if json_output:
         console.print_json(_json.dumps(result.model_dump()))
@@ -2143,23 +2159,32 @@ def dcv_verify_cmd(
 @dcv_app.command("revoke")
 def dcv_revoke(
     domain: Annotated[str, typer.Argument(help="Domain to remove the challenge from")],
+    token: Annotated[str, typer.Argument(help="Token to revoke (must match the record in DNS)")],
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
 ) -> None:
     """Delete the DCV challenge TXT record from DNS.
 
-    Should be called after successful verification to clean up.
+    Should be called immediately after successful verification to prevent token reuse.
     """
-    from dns_aid.core import dcv as _dcv
-    from dns_aid.utils.validation import validate_domain
+    import json as _json
 
-    domain = validate_domain(domain)
+    from dns_aid.core import dcv as _dcv
+
     try:
-        removed = run_async(_dcv.revoke(domain))
-        if removed:
+        revoke_result = run_async(_dcv.revoke(domain, token=token))
+        if json_output:
+            console.print_json(_json.dumps({"success": revoke_result.removed}))
+        elif revoke_result.removed:
             console.print(f"[green]✓[/green] Challenge record removed from {domain}")
         else:
             console.print("[yellow]![/yellow] Challenge record not found (already removed?)")
+        if not revoke_result.removed:
+            raise typer.Exit(1)
     except Exception as e:
-        error_console.print(f"[red]Error:[/red] {e}")
+        if json_output:
+            console.print_json(_json.dumps({"success": False, "error": str(e)}))
+        else:
+            error_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
 
 

--- a/src/dns_aid/core/__init__.py
+++ b/src/dns_aid/core/__init__.py
@@ -14,7 +14,10 @@ from dns_aid.core.a2a_card import (
 )
 from dns_aid.core.agent_metadata import AgentMetadata, AuthType, TransportType
 from dns_aid.core.capability_model import Action, ActionIntent, ActionSemantics, CapabilitySpec
-from dns_aid.core.dcv import DCVChallenge, DCVVerifyResult, issue, place, revoke
+from dns_aid.core.dcv import DCVChallenge, DCVPlaceResult, DCVRevokeResult, DCVVerifyResult
+from dns_aid.core.dcv import issue as dcv_issue
+from dns_aid.core.dcv import place as dcv_place
+from dns_aid.core.dcv import revoke as dcv_revoke
 from dns_aid.core.dcv import verify as dcv_verify
 from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol, PublishResult
 
@@ -31,16 +34,18 @@ __all__ = [
     "AuthType",
     "CapabilitySpec",
     "DCVChallenge",
+    "DCVPlaceResult",
+    "DCVRevokeResult",
     "DCVVerifyResult",
     "DiscoveryResult",
     "Protocol",
     "PublishResult",
     "TransportType",
+    "dcv_issue",
+    "dcv_place",
+    "dcv_revoke",
     "dcv_verify",
     "fetch_agent_card",
     "fetch_agent_card_from_domain",
-    "issue",
-    "place",
     "publish_agent_card",
-    "revoke",
 ]

--- a/src/dns_aid/core/__init__.py
+++ b/src/dns_aid/core/__init__.py
@@ -14,6 +14,8 @@ from dns_aid.core.a2a_card import (
 )
 from dns_aid.core.agent_metadata import AgentMetadata, AuthType, TransportType
 from dns_aid.core.capability_model import Action, ActionIntent, ActionSemantics, CapabilitySpec
+from dns_aid.core.dcv import DCVChallenge, DCVVerifyResult, issue, place, revoke
+from dns_aid.core.dcv import verify as dcv_verify
 from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol, PublishResult
 
 __all__ = [
@@ -28,11 +30,17 @@ __all__ = [
     "AgentRecord",
     "AuthType",
     "CapabilitySpec",
+    "DCVChallenge",
+    "DCVVerifyResult",
     "DiscoveryResult",
     "Protocol",
     "PublishResult",
     "TransportType",
+    "dcv_verify",
     "fetch_agent_card",
     "fetch_agent_card_from_domain",
+    "issue",
+    "place",
     "publish_agent_card",
+    "revoke",
 ]

--- a/src/dns_aid/core/dcv.py
+++ b/src/dns_aid/core/dcv.py
@@ -1,0 +1,312 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DNS-based Domain Control Validation (DCV) for agent identity assertion.
+
+Implements the challenge-response pattern from:
+- IETF draft-mozleywilliams-dnsop-dnsaid-01  (bnd-req binding extension)
+- draft-ietf-dnsop-domain-verification-techniques-12  (TXT record wire format)
+
+Two primary use cases:
+  1. Anonymous / NAT agent asserting org affiliation — Org A issues a challenge;
+     the claiming agent places it in the org's DNS zone using its own credentials.
+  2. Registry / directory anti-impersonation — a directory requires proof of zone
+     control before listing an agent as org-verified.
+
+Wire format (DCV-techniques §6.1.2 ABNF, space-separated key=value):
+    token=<base32>  [bnd-req=svc:<agent>@<issuer>]  expiry=<RFC3339>
+
+Challenge owner name: _agents-challenge.{domain}
+"""
+
+from __future__ import annotations
+
+import base64
+import secrets
+from datetime import UTC, datetime, timedelta
+
+import dns.exception
+import dns.resolver
+import structlog
+from pydantic import BaseModel, Field
+
+logger = structlog.get_logger(__name__)
+
+CHALLENGE_LABEL = "_agents-challenge"
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class DCVChallenge(BaseModel):
+    """Issued DCV challenge — delivered to the claimant out-of-band."""
+
+    token: str = Field(description="Base32-encoded nonce to place in DNS")
+    domain: str = Field(description="Domain being challenged")
+    fqdn: str = Field(description="Full owner name of the TXT record")
+    txt_value: str = Field(description="Verbatim TXT RDATA to place in the zone")
+    expiry: datetime = Field(description="UTC expiry time for this challenge")
+    bnd_req: str | None = Field(
+        default=None,
+        description="Binding request scope — svc:<agent>@<issuer> — optional",
+    )
+
+
+class DCVVerifyResult(BaseModel):
+    """Result of verifying a DCV challenge."""
+
+    verified: bool
+    domain: str
+    token: str
+    fqdn: str
+    expired: bool = False
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_token() -> str:
+    """20 bytes of entropy, lowercase base32 (no padding) — DNS-label safe."""
+    return base64.b32encode(secrets.token_bytes(20)).decode().lower().rstrip("=")
+
+
+def _build_txt_value(token: str, expiry: datetime, bnd_req: str | None) -> str:
+    """Produce a DCV-techniques-compliant space-separated key=value string."""
+    expiry_str = expiry.strftime("%Y-%m-%dT%H:%M:%SZ")
+    parts = [f"token={token}"]
+    if bnd_req:
+        parts.append(f"bnd-req={bnd_req}")
+    parts.append(f"expiry={expiry_str}")
+    return " ".join(parts)
+
+
+def _parse_txt_value(txt: str) -> dict[str, str]:
+    """Parse space-separated key=value pairs (DCV-techniques §6.1.2 ABNF)."""
+    result: dict[str, str] = {}
+    for part in txt.strip().split():
+        if "=" in part:
+            k, _, v = part.partition("=")
+            result[k.lower()] = v
+        elif "token" not in result:
+            # Bare value with no key= prefix is the token per spec
+            result["token"] = part
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def issue(
+    domain: str,
+    *,
+    agent_name: str | None = None,
+    issuer_domain: str | None = None,
+    ttl_seconds: int = 3600,
+) -> DCVChallenge:
+    """
+    Generate a stateless DCV challenge.
+
+    The challenger calls this, then delivers the returned DCVChallenge to the
+    claimant out-of-band (A2A message, MCP tool response, etc.).  Nothing is
+    written to DNS here — placement is the claimant's job.
+
+    Args:
+        domain:        Domain the claimant must prove control of.
+        agent_name:    Optional agent name to scope the bnd-req field.
+        issuer_domain: Optional issuer domain to scope the bnd-req field.
+        ttl_seconds:   Challenge validity window in seconds (default: 1 hour).
+
+    Returns:
+        DCVChallenge containing token, fqdn, txt_value, and expiry.
+    """
+    token = _generate_token()
+    expiry = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+    bnd_req = f"svc:{agent_name}@{issuer_domain}" if agent_name and issuer_domain else None
+    fqdn = f"{CHALLENGE_LABEL}.{domain}"
+    txt_value = _build_txt_value(token, expiry, bnd_req)
+
+    logger.debug("DCV challenge issued", domain=domain, fqdn=fqdn, bnd_req=bnd_req)
+
+    return DCVChallenge(
+        token=token,
+        domain=domain,
+        fqdn=fqdn,
+        txt_value=txt_value,
+        expiry=expiry,
+        bnd_req=bnd_req,
+    )
+
+
+async def place(
+    domain: str,
+    token: str,
+    *,
+    bnd_req: str | None = None,
+    expiry_seconds: int = 3600,
+    ttl: int = 300,
+    backend=None,
+) -> str:
+    """
+    Write the DCV challenge TXT record to DNS via the configured backend.
+
+    The claimant calls this using their own dns-aid backend credentials,
+    proving they have write access to the domain's zone.
+
+    Args:
+        domain:         Zone to write the challenge into.
+        token:          Token received from the challenger.
+        bnd_req:        Optional binding scope to include (pass through from challenge).
+        expiry_seconds: How long the placed record should be valid (default: 1 hour).
+        ttl:            DNS record TTL in seconds (default: 300 — short, for quick cleanup).
+        backend:        DNS backend instance; defaults to DNS_AID_BACKEND env var.
+
+    Returns:
+        FQDN where the challenge was placed.
+    """
+    from dns_aid.core.publisher import get_default_backend
+
+    dns_backend = backend or get_default_backend()
+    expiry = datetime.now(UTC) + timedelta(seconds=expiry_seconds)
+    txt_value = _build_txt_value(token, expiry, bnd_req)
+    fqdn = f"{CHALLENGE_LABEL}.{domain}"
+
+    logger.info("Placing DCV challenge", domain=domain, fqdn=fqdn)
+
+    await dns_backend.create_txt_record(
+        zone=domain,
+        name=CHALLENGE_LABEL,
+        values=[txt_value],
+        ttl=ttl,
+    )
+
+    logger.info("DCV challenge placed", fqdn=fqdn)
+    return fqdn
+
+
+async def verify(
+    domain: str,
+    token: str,
+    *,
+    nameserver: str | None = None,
+    port: int = 53,
+) -> DCVVerifyResult:
+    """
+    Resolve _agents-challenge.{domain} and verify the token is present and unexpired.
+
+    The challenger calls this after the claimant has placed the record.
+    No backend credentials required — pure DNS resolution.
+
+    Args:
+        domain:      Domain to check.
+        token:       Token originally issued by the challenger.
+        nameserver:  Optional nameserver IP to query directly (useful in testbeds
+                     or when the challenging org's resolver can't see the claimant's zone).
+        port:        DNS port (default: 53).
+
+    Returns:
+        DCVVerifyResult with verified=True on success.
+    """
+    fqdn = f"{CHALLENGE_LABEL}.{domain}"
+    logger.debug("DCV verify", domain=domain, fqdn=fqdn, nameserver=nameserver)
+
+    resolver = dns.resolver.Resolver()
+    if nameserver:
+        resolver.nameservers = [nameserver]
+        resolver.port = port
+
+    try:
+        answers = resolver.resolve(fqdn, "TXT")
+    except dns.resolver.NXDOMAIN:
+        return DCVVerifyResult(
+            verified=False, domain=domain, token=token, fqdn=fqdn,
+            error="No challenge record found (NXDOMAIN)",
+        )
+    except dns.resolver.NoAnswer:
+        return DCVVerifyResult(
+            verified=False, domain=domain, token=token, fqdn=fqdn,
+            error="No TXT records at challenge name",
+        )
+    except dns.exception.DNSException as e:
+        return DCVVerifyResult(
+            verified=False, domain=domain, token=token, fqdn=fqdn,
+            error=str(e),
+        )
+
+    now = datetime.now(UTC)
+
+    for rdata in answers:
+        # Multi-string TXT records are concatenated per DCV-techniques §6.1
+        txt = "".join(
+            s.decode() if isinstance(s, bytes) else s for s in rdata.strings
+        )
+        parsed = _parse_txt_value(txt)
+
+        if parsed.get("token") != token:
+            continue
+
+        expiry_str = parsed.get("expiry", "")
+        if expiry_str and expiry_str != "never":
+            try:
+                expiry = datetime.fromisoformat(expiry_str.replace("Z", "+00:00"))
+                if now > expiry:
+                    logger.info("DCV challenge expired", domain=domain, expiry=expiry_str)
+                    return DCVVerifyResult(
+                        verified=False, domain=domain, token=token, fqdn=fqdn,
+                        expired=True, error=f"Challenge expired at {expiry_str}",
+                    )
+            except ValueError:
+                pass  # Unparseable expiry treated as no expiry
+
+        logger.info("DCV verified", domain=domain, fqdn=fqdn)
+        return DCVVerifyResult(verified=True, domain=domain, token=token, fqdn=fqdn)
+
+    return DCVVerifyResult(
+        verified=False, domain=domain, token=token, fqdn=fqdn,
+        error="Token not found in any challenge record",
+    )
+
+
+async def revoke(
+    domain: str,
+    *,
+    backend=None,
+) -> bool:
+    """
+    Delete the DCV challenge TXT record from DNS.
+
+    Should be called after successful verification to clean up.
+
+    Args:
+        domain:  Zone to remove the challenge from.
+        backend: DNS backend instance; defaults to DNS_AID_BACKEND env var.
+
+    Returns:
+        True if deleted, False if not found or deletion failed.
+    """
+    from dns_aid.core.publisher import get_default_backend
+
+    dns_backend = backend or get_default_backend()
+    fqdn = f"{CHALLENGE_LABEL}.{domain}"
+
+    logger.info("Revoking DCV challenge", domain=domain, fqdn=fqdn)
+
+    result = await dns_backend.delete_record(
+        zone=domain,
+        name=CHALLENGE_LABEL,
+        record_type="TXT",
+    )
+
+    if result:
+        logger.info("DCV challenge revoked", fqdn=fqdn)
+    else:
+        logger.warning("DCV challenge not found or already removed", fqdn=fqdn)
+
+    return result

--- a/src/dns_aid/core/dcv.py
+++ b/src/dns_aid/core/dcv.py
@@ -32,6 +32,7 @@ import ipaddress
 import re
 import secrets
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 
 import dns.asyncresolver
 import dns.exception
@@ -46,6 +47,9 @@ from dns_aid.utils.validation import (
     validate_port,
     validate_ttl,
 )
+
+if TYPE_CHECKING:
+    from dns_aid.backends.base import DNSBackend
 
 logger = structlog.get_logger(__name__)
 
@@ -221,7 +225,7 @@ async def place(
     bnd_req: str | None = None,
     expiry_seconds: int = 3600,
     ttl: int = 300,
-    backend=None,
+    backend: DNSBackend | None = None,
 ) -> DCVPlaceResult:
     """
     Write the DCV challenge TXT record to DNS via the configured backend.
@@ -229,11 +233,17 @@ async def place(
     The claimant calls this using their own dns-aid backend credentials,
     proving they have write access to the domain's zone.
 
+    NOTE: Trust model — the claimant still controls the placed expiry value.
+    Callers SHOULD derive expiry_seconds from the issued DCVChallenge.expiry
+    (i.e., from the challenger's clock) rather than choosing their own window.
+    A future revision may move expiry off this surface entirely.
+
     Args:
         domain:         Zone to write the challenge into.
         token:          Token received from the challenger (32-char base32).
         bnd_req:        Optional binding scope to include (pass through from challenge).
         expiry_seconds: How long the placed record should be valid (30–86400, default: 3600).
+                        Prefer aligning with the issued DCVChallenge.expiry — see note above.
         ttl:            DNS record TTL in seconds (default: 300 — short, for quick cleanup).
         backend:        DNS backend instance; defaults to DNS_AID_BACKEND env var.
 
@@ -297,6 +307,11 @@ async def verify(
         token:            Token originally issued by the challenger.
         nameserver:       Optional nameserver IP address to query directly.
                           Must be a valid IP address (use for testbeds only).
+                          SECURITY: This is operator-trusted — any syntactically
+                          valid IP is accepted, including link-local (169.254/16),
+                          loopback (127/8), and RFC1918 private ranges.  Do NOT
+                          expose this parameter to untrusted callers; the MCP
+                          tool surface intentionally omits it.
         port:             DNS port (default: 53).
         expected_bnd_req: When supplied, the record's bnd-req field must match
                           exactly (prevents cross-vendor token reuse, DCV hazard H2).
@@ -336,7 +351,10 @@ async def verify(
         require_dnssec = False
 
     logger.debug(
-        "DCV verify", domain=domain, fqdn=fqdn, nameserver=nameserver,
+        "DCV verify",
+        domain=domain,
+        fqdn=fqdn,
+        nameserver=nameserver,
         require_dnssec=require_dnssec,
     )
 
@@ -479,7 +497,10 @@ async def verify(
 
         logger.info("DCV verified", domain=domain, fqdn=fqdn)
         return DCVVerifyResult(
-            verified=True, domain=domain, token=token, fqdn=fqdn,
+            verified=True,
+            domain=domain,
+            token=token,
+            fqdn=fqdn,
             dnssec_validated=dnssec_validated,
         )
 
@@ -518,7 +539,7 @@ async def revoke(
     domain: str,
     *,
     token: str,
-    backend=None,
+    backend: DNSBackend | None = None,
 ) -> DCVRevokeResult:
     """
     Delete the DCV challenge TXT record from DNS.

--- a/src/dns_aid/core/dcv.py
+++ b/src/dns_aid/core/dcv.py
@@ -18,22 +18,41 @@ Wire format (DCV-techniques §6.1.2 ABNF, space-separated key=value):
     token=<base32>  [bnd-req=svc:<agent>@<issuer>]  expiry=<RFC3339>
 
 Challenge owner name: _agents-challenge.{domain}
+
+Role split:
+  Challenger side — issue() + verify(): no DNS write credentials required.
+  Claimant side  — place() + revoke(): require backend write credentials.
 """
 
 from __future__ import annotations
 
 import base64
+import hmac
+import ipaddress
+import re
 import secrets
 from datetime import UTC, datetime, timedelta
 
+import dns.asyncresolver
 import dns.exception
+import dns.flags
 import dns.resolver
 import structlog
 from pydantic import BaseModel, Field
 
+from dns_aid.utils.validation import (
+    validate_agent_name,
+    validate_domain,
+    validate_port,
+    validate_ttl,
+)
+
 logger = structlog.get_logger(__name__)
 
 CHALLENGE_LABEL = "_agents-challenge"
+TOKEN_PATTERN = re.compile(r"^[a-z2-7]{32}$")
+MAX_CHALLENGE_RECORDS = 10
+MAX_DCV_TTL_SECONDS = 86400  # 24 h — sane cap for a security challenge
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +82,24 @@ class DCVVerifyResult(BaseModel):
     token: str
     fqdn: str
     expired: bool = False
+    dnssec_validated: bool = False
     error: str | None = None
+
+
+class DCVPlaceResult(BaseModel):
+    """Result of writing a DCV challenge to DNS."""
+
+    fqdn: str = Field(description="Full owner name where the challenge was placed")
+    domain: str = Field(description="Zone domain")
+    expires_at: datetime = Field(description="UTC time when the placed challenge expires")
+
+
+class DCVRevokeResult(BaseModel):
+    """Result of revoking a DCV challenge."""
+
+    removed: bool = Field(description="True if the challenge record was deleted")
+    domain: str = Field(description="Zone domain")
+    fqdn: str = Field(description="Full owner name that was targeted for deletion")
 
 
 # ---------------------------------------------------------------------------
@@ -76,10 +112,16 @@ def _generate_token() -> str:
     return base64.b32encode(secrets.token_bytes(20)).decode().lower().rstrip("=")
 
 
-def _build_txt_value(token: str, expiry: datetime, bnd_req: str | None) -> str:
+def _build_txt_value(
+    token: str, expiry: datetime, bnd_req: str | None, domain: str | None = None
+) -> str:
     """Produce a DCV-techniques-compliant space-separated key=value string."""
+    expiry = expiry.astimezone(UTC)  # normalize — rejects naive datetimes
     expiry_str = expiry.strftime("%Y-%m-%dT%H:%M:%SZ")
     parts = [f"token={token}"]
+    if domain:
+        # domain= binds the token to the zone; prevents cross-domain token replay
+        parts.append(f"domain={domain}")
     if bnd_req:
         parts.append(f"bnd-req={bnd_req}")
     parts.append(f"expiry={expiry_str}")
@@ -87,15 +129,27 @@ def _build_txt_value(token: str, expiry: datetime, bnd_req: str | None) -> str:
 
 
 def _parse_txt_value(txt: str) -> dict[str, str]:
-    """Parse space-separated key=value pairs (DCV-techniques §6.1.2 ABNF)."""
+    """
+    Parse space-separated key=value pairs (DCV-techniques §6.1.2 ABNF).
+
+    Strips one layer of RFC-1035-style outer quotes added by some backends
+    (e.g. Cloudflare wraps the entire content in literal '"..."').
+    Bare-value (no 'token=' prefix) tokens are NOT accepted; explicit key=
+    is required per our wire format.
+    Duplicate keys: first occurrence wins.
+    """
+    txt = txt.strip()
+    # Strip exactly one layer of surrounding quotes — don't recurse
+    if len(txt) >= 2 and txt[0] == '"' and txt[-1] == '"':
+        txt = txt[1:-1]
+
     result: dict[str, str] = {}
     for part in txt.strip().split():
         if "=" in part:
             k, _, v = part.partition("=")
-            result[k.lower()] = v
-        elif "token" not in result:
-            # Bare value with no key= prefix is the token per spec
-            result["token"] = part
+            k = k.lower()
+            if k not in result:  # first-wins for duplicate keys
+                result[k] = v
     return result
 
 
@@ -121,17 +175,32 @@ def issue(
     Args:
         domain:        Domain the claimant must prove control of.
         agent_name:    Optional agent name to scope the bnd-req field.
+                       Must be a valid DNS-AID agent name (lowercase alphanum, hyphens).
         issuer_domain: Optional issuer domain to scope the bnd-req field.
-        ttl_seconds:   Challenge validity window in seconds (default: 1 hour).
+        ttl_seconds:   Challenge validity window in seconds (30–86400, default: 3600).
 
     Returns:
         DCVChallenge containing token, fqdn, txt_value, and expiry.
+
+    IMPORTANT: The caller MUST invoke revoke(domain, token=...) immediately
+    after a successful verify() to prevent token reuse within the validity window.
     """
+    domain = validate_domain(domain)
+    if not (30 <= ttl_seconds <= MAX_DCV_TTL_SECONDS):
+        raise ValueError(
+            f"ttl_seconds must be between 30 and {MAX_DCV_TTL_SECONDS} (got {ttl_seconds})"
+        )
+
+    bnd_req = None
+    if agent_name and issuer_domain:
+        agent_name = validate_agent_name(agent_name)
+        issuer_domain_val = validate_domain(issuer_domain)
+        bnd_req = f"svc:{agent_name}@{issuer_domain_val}"
+
     token = _generate_token()
     expiry = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
-    bnd_req = f"svc:{agent_name}@{issuer_domain}" if agent_name and issuer_domain else None
     fqdn = f"{CHALLENGE_LABEL}.{domain}"
-    txt_value = _build_txt_value(token, expiry, bnd_req)
+    txt_value = _build_txt_value(token, expiry, bnd_req, domain=domain)
 
     logger.debug("DCV challenge issued", domain=domain, fqdn=fqdn, bnd_req=bnd_req)
 
@@ -153,7 +222,7 @@ async def place(
     expiry_seconds: int = 3600,
     ttl: int = 300,
     backend=None,
-) -> str:
+) -> DCVPlaceResult:
     """
     Write the DCV challenge TXT record to DNS via the configured backend.
 
@@ -162,20 +231,29 @@ async def place(
 
     Args:
         domain:         Zone to write the challenge into.
-        token:          Token received from the challenger.
+        token:          Token received from the challenger (32-char base32).
         bnd_req:        Optional binding scope to include (pass through from challenge).
-        expiry_seconds: How long the placed record should be valid (default: 1 hour).
+        expiry_seconds: How long the placed record should be valid (30–86400, default: 3600).
         ttl:            DNS record TTL in seconds (default: 300 — short, for quick cleanup).
         backend:        DNS backend instance; defaults to DNS_AID_BACKEND env var.
 
     Returns:
-        FQDN where the challenge was placed.
+        DCVPlaceResult with fqdn, domain, and expiry time.
     """
     from dns_aid.core.publisher import get_default_backend
 
+    domain = validate_domain(domain)
+    ttl = validate_ttl(ttl)
+    if not TOKEN_PATTERN.fullmatch(token):
+        raise ValueError("token must be a 32-character lowercase base32 string")
+    if not (30 <= expiry_seconds <= MAX_DCV_TTL_SECONDS):
+        raise ValueError(
+            f"expiry_seconds must be between 30 and {MAX_DCV_TTL_SECONDS} (got {expiry_seconds})"
+        )
+
     dns_backend = backend or get_default_backend()
     expiry = datetime.now(UTC) + timedelta(seconds=expiry_seconds)
-    txt_value = _build_txt_value(token, expiry, bnd_req)
+    txt_value = _build_txt_value(token, expiry, bnd_req, domain=domain)
     fqdn = f"{CHALLENGE_LABEL}.{domain}"
 
     logger.info("Placing DCV challenge", domain=domain, fqdn=fqdn)
@@ -188,7 +266,7 @@ async def place(
     )
 
     logger.info("DCV challenge placed", fqdn=fqdn)
-    return fqdn
+    return DCVPlaceResult(fqdn=fqdn, domain=domain, expires_at=expiry)
 
 
 async def verify(
@@ -197,6 +275,8 @@ async def verify(
     *,
     nameserver: str | None = None,
     port: int = 53,
+    expected_bnd_req: str | None = None,
+    require_dnssec: bool = False,
 ) -> DCVVerifyResult:
     """
     Resolve _agents-challenge.{domain} and verify the token is present and unexpired.
@@ -204,72 +284,232 @@ async def verify(
     The challenger calls this after the claimant has placed the record.
     No backend credentials required — pure DNS resolution.
 
+    Fail-closed contract:
+    - Missing expiry= field → verified=False
+    - Malformed expiry= value → verified=False
+    - Bare token (no 'token=' prefix) → not matched
+    - domain= mismatch (if present) → record skipped
+    - Invalid nameserver IP → DCVVerifyResult with error (no exception raised)
+    - require_dnssec=True + no AD flag → verified=False
+
     Args:
-        domain:      Domain to check.
-        token:       Token originally issued by the challenger.
-        nameserver:  Optional nameserver IP to query directly (useful in testbeds
-                     or when the challenging org's resolver can't see the claimant's zone).
-        port:        DNS port (default: 53).
+        domain:           Domain to check.
+        token:            Token originally issued by the challenger.
+        nameserver:       Optional nameserver IP address to query directly.
+                          Must be a valid IP address (use for testbeds only).
+        port:             DNS port (default: 53).
+        expected_bnd_req: When supplied, the record's bnd-req field must match
+                          exactly (prevents cross-vendor token reuse, DCV hazard H2).
+        require_dnssec:   When True, the upstream resolver must set the AD flag
+                          (DNSSEC validated).  Incompatible with nameserver=.
 
     Returns:
         DCVVerifyResult with verified=True on success.
-    """
-    fqdn = f"{CHALLENGE_LABEL}.{domain}"
-    logger.debug("DCV verify", domain=domain, fqdn=fqdn, nameserver=nameserver)
 
-    resolver = dns.resolver.Resolver()
+    NOTE: After a successful verify(), the caller MUST call revoke() immediately
+    to prevent token reuse. This function does not consume the token.
+    """
+    domain = validate_domain(domain)
+    validate_port(port)
+
+    fqdn = f"{CHALLENGE_LABEL}.{domain}"
+
+    if nameserver is not None:
+        try:
+            ipaddress.ip_address(nameserver)
+        except ValueError:
+            return DCVVerifyResult(
+                verified=False,
+                domain=domain,
+                token=token,
+                fqdn=fqdn,
+                error=f"Invalid nameserver: must be an IP address, got {nameserver!r}",
+            )
+
+    # require_dnssec is incompatible with a direct authoritative nameserver —
+    # authoritatives don't perform recursive validation and won't set AD=1.
+    if require_dnssec and nameserver:
+        logger.warning(
+            "DNSSEC cannot be validated via a direct authoritative nameserver — skipping",
+            domain=domain,
+        )
+        require_dnssec = False
+
+    logger.debug(
+        "DCV verify", domain=domain, fqdn=fqdn, nameserver=nameserver,
+        require_dnssec=require_dnssec,
+    )
+
+    resolver = dns.asyncresolver.Resolver()
+    resolver.cache = None  # bypass OS-level DNS cache; stale positives survive revoke
+    resolver.lifetime = 4.0
+    if require_dnssec:
+        resolver.use_edns(0, dns.flags.DO, 4096)  # request DNSSEC from upstream
     if nameserver:
         resolver.nameservers = [nameserver]
         resolver.port = port
 
     try:
-        answers = resolver.resolve(fqdn, "TXT")
+        answers = await resolver.resolve(fqdn, "TXT")
     except dns.resolver.NXDOMAIN:
+        logger.warning("DCV verification failed", domain=domain, fqdn=fqdn, reason="NXDOMAIN")
         return DCVVerifyResult(
-            verified=False, domain=domain, token=token, fqdn=fqdn,
+            verified=False,
+            domain=domain,
+            token=token,
+            fqdn=fqdn,
             error="No challenge record found (NXDOMAIN)",
         )
     except dns.resolver.NoAnswer:
+        logger.warning("DCV verification failed", domain=domain, fqdn=fqdn, reason="NoAnswer")
         return DCVVerifyResult(
-            verified=False, domain=domain, token=token, fqdn=fqdn,
+            verified=False,
+            domain=domain,
+            token=token,
+            fqdn=fqdn,
             error="No TXT records at challenge name",
         )
     except dns.exception.DNSException as e:
+        logger.warning("DCV verification failed", domain=domain, fqdn=fqdn, reason=str(e))
         return DCVVerifyResult(
-            verified=False, domain=domain, token=token, fqdn=fqdn,
+            verified=False,
+            domain=domain,
+            token=token,
+            fqdn=fqdn,
             error=str(e),
         )
 
+    if len(answers) > MAX_CHALLENGE_RECORDS:
+        logger.warning(
+            "DCV verification failed — too many challenge records",
+            domain=domain,
+            count=len(answers),
+        )
+        return DCVVerifyResult(
+            verified=False,
+            domain=domain,
+            token=token,
+            fqdn=fqdn,
+            error=f"Too many challenge records (limit: {MAX_CHALLENGE_RECORDS})",
+        )
+
+    # DNSSEC: check AD flag before inspecting record content.
+    # AD=1 means the upstream recursive resolver validated the DNSSEC chain.
+    dnssec_validated = False
+    if require_dnssec:
+        try:
+            ad_set = bool(answers.response.flags & dns.flags.AD)
+        except AttributeError:
+            ad_set = False
+        if not ad_set:
+            logger.warning("DNSSEC AD flag not set", domain=domain, fqdn=fqdn)
+            return DCVVerifyResult(
+                verified=False,
+                domain=domain,
+                token=token,
+                fqdn=fqdn,
+                error="DNSSEC validation required but AD flag not set by resolver",
+            )
+        dnssec_validated = True
+
     now = datetime.now(UTC)
+    expired_match: str | None = None  # best expired match for informative error
 
     for rdata in answers:
-        # Multi-string TXT records are concatenated per DCV-techniques §6.1
-        txt = "".join(
-            s.decode() if isinstance(s, bytes) else s for s in rdata.strings
-        )
+        # Multi-string TXT records concatenated per DCV-techniques §6.1
+        txt = "".join(s.decode() if isinstance(s, bytes) else s for s in rdata.strings)
         parsed = _parse_txt_value(txt)
 
-        if parsed.get("token") != token:
+        # Constant-time comparison — mitigates timing side-channel on token prefix.
+        # str() coercion guards against non-string token arguments.
+        if not hmac.compare_digest(parsed.get("token", ""), str(token)):
             continue
 
+        # Require explicit expiry= — fail closed if absent
         expiry_str = parsed.get("expiry", "")
-        if expiry_str and expiry_str != "never":
-            try:
-                expiry = datetime.fromisoformat(expiry_str.replace("Z", "+00:00"))
-                if now > expiry:
-                    logger.info("DCV challenge expired", domain=domain, expiry=expiry_str)
-                    return DCVVerifyResult(
-                        verified=False, domain=domain, token=token, fqdn=fqdn,
-                        expired=True, error=f"Challenge expired at {expiry_str}",
-                    )
-            except ValueError:
-                pass  # Unparseable expiry treated as no expiry
+        if not expiry_str:
+            logger.warning(
+                "DCV record missing expiry field — treating as invalid",
+                domain=domain,
+                fqdn=fqdn,
+            )
+            continue
+
+        try:
+            expiry_dt = datetime.fromisoformat(expiry_str)
+        except ValueError:
+            logger.warning(
+                "DCV record malformed expiry — treating as invalid",
+                domain=domain,
+                fqdn=fqdn,
+                expiry=expiry_str,
+            )
+            continue
+
+        if now > expiry_dt:
+            # Keep as fallback for informative error; continue looking
+            if expired_match is None:
+                expired_match = expiry_str
+            continue
+
+        # Domain binding: if the record carries a domain= field, it must match the
+        # queried domain.  Records written by older clients may omit domain=; those
+        # are allowed through with a warning to preserve backward compatibility.
+        record_domain = parsed.get("domain", "")
+        if record_domain and not hmac.compare_digest(record_domain, domain):
+            logger.warning(
+                "DCV domain mismatch — skipping record",
+                domain=domain,
+                fqdn=fqdn,
+                record_domain=record_domain,
+            )
+            continue
+
+        # Enforce bnd-req when caller supplies a non-empty expected value.
+        # Empty string treated as None — no check performed.
+        if expected_bnd_req:
+            record_bnd_req = parsed.get("bnd-req", "")
+            if not hmac.compare_digest(record_bnd_req, expected_bnd_req):
+                logger.warning(
+                    "DCV bnd-req mismatch",
+                    domain=domain,
+                    fqdn=fqdn,
+                )
+                continue
 
         logger.info("DCV verified", domain=domain, fqdn=fqdn)
-        return DCVVerifyResult(verified=True, domain=domain, token=token, fqdn=fqdn)
+        return DCVVerifyResult(
+            verified=True, domain=domain, token=token, fqdn=fqdn,
+            dnssec_validated=dnssec_validated,
+        )
 
+    # No valid unexpired match found
+    if expired_match is not None:
+        logger.warning(
+            "DCV verification failed — challenge expired",
+            domain=domain,
+            fqdn=fqdn,
+            expiry=expired_match,
+        )
+        return DCVVerifyResult(
+            verified=False,
+            domain=domain,
+            token=token,
+            fqdn=fqdn,
+            expired=True,
+            error=f"Challenge expired at {expired_match}",
+        )
+
+    logger.warning(
+        "DCV verification failed — token not found",
+        domain=domain,
+        fqdn=fqdn,
+    )
     return DCVVerifyResult(
-        verified=False, domain=domain, token=token, fqdn=fqdn,
+        verified=False,
+        domain=domain,
+        token=token,
+        fqdn=fqdn,
         error="Token not found in any challenge record",
     )
 
@@ -277,36 +517,59 @@ async def verify(
 async def revoke(
     domain: str,
     *,
+    token: str,
     backend=None,
-) -> bool:
+) -> DCVRevokeResult:
     """
     Delete the DCV challenge TXT record from DNS.
 
-    Should be called after successful verification to clean up.
+    Should be called immediately after successful verification to prevent token reuse.
+    The token is verified to be present in DNS before deletion — this avoids racing
+    with a concurrent challenger's revoke() call.
+
+    NOTE: The check-then-delete is not atomic (TOCTOU). If two parties call revoke()
+    simultaneously with the same token, both may confirm the record exists before
+    either deletes it. The caller should treat revoke() as best-effort hygiene;
+    the expiry= field is the true security gate.
 
     Args:
         domain:  Zone to remove the challenge from.
+        token:   Token to be revoked (must match what is in DNS).
         backend: DNS backend instance; defaults to DNS_AID_BACKEND env var.
 
     Returns:
-        True if deleted, False if not found or deletion failed.
+        DCVRevokeResult with removed=True if deleted, removed=False if not found or failed.
     """
     from dns_aid.core.publisher import get_default_backend
 
-    dns_backend = backend or get_default_backend()
+    domain = validate_domain(domain)
     fqdn = f"{CHALLENGE_LABEL}.{domain}"
+    if not TOKEN_PATTERN.fullmatch(token):
+        raise ValueError("token must be a 32-character lowercase base32 string")
+
+    # Confirm our token is present before deleting — reduces cross-challenger races
+    check = await verify(domain, token)
+    if not check.verified:
+        logger.warning(
+            "DCV revoke: token not found in DNS, skipping deletion",
+            domain=domain,
+            reason=check.error,
+        )
+        return DCVRevokeResult(removed=False, domain=domain, fqdn=fqdn)
+
+    dns_backend = backend or get_default_backend()
 
     logger.info("Revoking DCV challenge", domain=domain, fqdn=fqdn)
 
-    result = await dns_backend.delete_record(
+    deleted = await dns_backend.delete_record(
         zone=domain,
         name=CHALLENGE_LABEL,
         record_type="TXT",
     )
 
-    if result:
+    if deleted:
         logger.info("DCV challenge revoked", fqdn=fqdn)
     else:
         logger.warning("DCV challenge not found or already removed", fqdn=fqdn)
 
-    return result
+    return DCVRevokeResult(removed=deleted, domain=domain, fqdn=fqdn)

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1764,12 +1764,30 @@ except ImportError:
 # =============================================================================
 
 
+def _dcv_safe_error(e: Exception) -> str:
+    """
+    Return a safe error message for MCP tool responses.
+
+    ValidationError and ValueError carry our own safe messages. Any other
+    exception (backend errors, network failures) is logged server-side only;
+    the LLM receives a generic message to prevent infra detail leakage.
+    """
+    from dns_aid.utils.validation import ValidationError as _ValidationError
+
+    if isinstance(e, (_ValidationError, ValueError)):
+        return str(e)
+    import logging as _logging
+
+    _logging.getLogger(__name__).error("DCV tool unexpected error", exc_info=True)
+    return "Operation failed. Check server logs for details."
+
+
 @mcp.tool(
     title="Issue DCV Challenge",
     annotations=ToolAnnotations(
         readOnlyHint=True,
         destructiveHint=False,
-        idempotentHint=True,
+        idempotentHint=False,  # each call produces a distinct token
         openWorldHint=False,
     ),
 )
@@ -1786,26 +1804,33 @@ def dcv_issue_challenge(
     or any other channel) to the claimant.  Nothing is written to DNS here —
     placement is the claimant's job.
 
+    After a successful dcv_verify_challenge(), call dcv_revoke_challenge()
+    immediately to prevent token reuse within the validity window.
+
     Args:
         domain: Domain the claimant must prove control of.
-        agent_name: Optional agent name to scope the bnd-req field.
+        agent_name: Optional agent name to scope the bnd-req field
+                    (lowercase alphanumeric + hyphens, max 63 chars).
         issuer_domain: Optional issuer domain to scope the bnd-req field.
-        ttl_seconds: Challenge validity window in seconds (default: 1 hour).
+        ttl_seconds: Challenge validity window in seconds (30–86400, default: 3600).
 
     Returns:
-        dict with token, fqdn, txt_value, expiry, and optional bnd_req.
+        dict with success, token, fqdn, txt_value, expiry, and optional bnd_req.
     """
     from dns_aid.core import dcv as _dcv
 
-    domain = validate_domain(domain)
-    ttl_seconds = validate_ttl(ttl_seconds)
-    challenge = _dcv.issue(
-        domain,
-        agent_name=agent_name,
-        issuer_domain=issuer_domain,
-        ttl_seconds=ttl_seconds,
-    )
-    return challenge.model_dump(mode="json")
+    try:
+        challenge = _dcv.issue(
+            domain,
+            agent_name=agent_name,
+            issuer_domain=issuer_domain,
+            ttl_seconds=ttl_seconds,
+        )
+        result = challenge.model_dump(mode="json")
+        result["success"] = True
+        return result
+    except Exception as e:
+        return {"success": False, "error": _dcv_safe_error(e)}
 
 
 @mcp.tool(
@@ -1813,7 +1838,7 @@ def dcv_issue_challenge(
     annotations=ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=False,
-        idempotentHint=True,
+        idempotentHint=False,  # backend behaviour varies; not guaranteed idempotent
         openWorldHint=True,
     ),
 )
@@ -1832,31 +1857,29 @@ def dcv_place_challenge(
 
     Args:
         domain: Zone to write the challenge into.
-        token: Token received from the challenger (from dcv_issue_challenge).
-        bnd_req: Optional binding scope (pass through from the challenge).
-        ttl: DNS record TTL in seconds (default: 300 — short, for quick cleanup).
-        expiry_seconds: How long the placed record should be valid (default: 1 hour).
+        token: Token received from the challenger (32-char base32, from dcv_issue_challenge).
+        bnd_req: Binding scope from the challenge (pass through as-is).
+        ttl: DNS record TTL in seconds (30–604800, default: 300).
+        expiry_seconds: How long the placed record should be valid (30–86400, default: 3600).
 
     Returns:
-        dict with success flag and fqdn where the record was placed.
+        dict with success (bool) and fqdn where the record was placed.
     """
     from dns_aid.core import dcv as _dcv
 
-    domain = validate_domain(domain)
-    ttl = validate_ttl(ttl)
     try:
-        fqdn = _run_async(
+        place_result = _run_async(
             _dcv.place(domain, token, bnd_req=bnd_req, ttl=ttl, expiry_seconds=expiry_seconds)
         )
-        return {"success": True, "fqdn": fqdn}
+        return {"success": True, "fqdn": place_result.fqdn}
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": _dcv_safe_error(e)}
 
 
 @mcp.tool(
     title="Verify DCV Challenge",
     annotations=ToolAnnotations(
-        readOnlyHint=True,
+        readOnlyHint=False,  # sends an active DNS probe to an external resolver
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=True,
@@ -1865,29 +1888,35 @@ def dcv_place_challenge(
 def dcv_verify_challenge(
     domain: str,
     token: str,
-    nameserver: str | None = None,
-    port: int = 53,
+    expected_bnd_req: str | None = None,
 ) -> dict:
     """
     Verify that a DCV challenge token is present and unexpired in DNS.
 
     The challenger calls this after the claimant has placed the record.
-    No backend credentials required — pure DNS resolution.
+    No backend credentials required — pure DNS resolution against the
+    system resolver.
 
     Args:
         domain: Domain to check.
         token: Token originally issued by the challenger.
-        nameserver: Optional nameserver IP to query directly.
-        port: DNS port (default: 53).
+        expected_bnd_req: When provided, the record's bnd-req field must match
+                          exactly (prevents cross-vendor token reuse).
 
     Returns:
-        dict with verified (bool), fqdn, expired, and error fields.
+        dict with success (bool), verified (bool), fqdn, expired (bool), and error.
     """
     from dns_aid.core import dcv as _dcv
 
-    domain = validate_domain(domain)
-    result = _run_async(_dcv.verify(domain, token, nameserver=nameserver, port=port))
-    return result.model_dump()
+    try:
+        result = _run_async(_dcv.verify(domain, token, expected_bnd_req=expected_bnd_req))
+        out = result.model_dump()
+        out["success"] = True
+        # Do not echo the token back — it is already known to the caller
+        out.pop("token", None)
+        return out
+    except Exception as e:
+        return {"success": False, "verified": False, "error": _dcv_safe_error(e)}
 
 
 @mcp.tool(
@@ -1899,27 +1928,28 @@ def dcv_verify_challenge(
         openWorldHint=True,
     ),
 )
-def dcv_revoke_challenge(domain: str) -> dict:
+def dcv_revoke_challenge(domain: str, token: str) -> dict:
     """
     Delete the DCV challenge TXT record from DNS.
 
-    Should be called after successful verification to clean up.
+    Should be called immediately after a successful dcv_verify_challenge()
+    to prevent token reuse within the validity window.
     Requires backend credentials for the domain.
 
     Args:
         domain: Zone to remove the challenge from.
+        token:  Token that was placed (must match the record in DNS).
 
     Returns:
         dict with success (bool) and optional error.
     """
     from dns_aid.core import dcv as _dcv
 
-    domain = validate_domain(domain)
     try:
-        removed = _run_async(_dcv.revoke(domain))
-        return {"success": removed}
+        revoke_result = _run_async(_dcv.revoke(domain, token=token))
+        return {"success": revoke_result.removed}
     except Exception as e:
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": _dcv_safe_error(e)}
 
 
 def _cleanup():

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1693,6 +1693,10 @@ try:
                     "list_agent_index",
                     "sync_agent_index",
                     "send_a2a_message",
+                    "dcv_issue_challenge",
+                    "dcv_place_challenge",
+                    "dcv_verify_challenge",
+                    "dcv_revoke_challenge",
                 ],
             }
         )
@@ -1753,6 +1757,169 @@ try:
 except ImportError:
     # Starlette not available (stdio-only mode)
     pass
+
+
+# =============================================================================
+# DCV TOOLS
+# =============================================================================
+
+
+@mcp.tool(
+    title="Issue DCV Challenge",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def dcv_issue_challenge(
+    domain: str,
+    agent_name: str | None = None,
+    issuer_domain: str | None = None,
+    ttl_seconds: int = 3600,
+) -> dict:
+    """
+    Generate a DCV challenge token for a domain.
+
+    The challenger calls this and delivers the result out-of-band (via A2A, MCP,
+    or any other channel) to the claimant.  Nothing is written to DNS here —
+    placement is the claimant's job.
+
+    Args:
+        domain: Domain the claimant must prove control of.
+        agent_name: Optional agent name to scope the bnd-req field.
+        issuer_domain: Optional issuer domain to scope the bnd-req field.
+        ttl_seconds: Challenge validity window in seconds (default: 1 hour).
+
+    Returns:
+        dict with token, fqdn, txt_value, expiry, and optional bnd_req.
+    """
+    from dns_aid.core import dcv as _dcv
+
+    domain = validate_domain(domain)
+    ttl_seconds = validate_ttl(ttl_seconds)
+    challenge = _dcv.issue(
+        domain,
+        agent_name=agent_name,
+        issuer_domain=issuer_domain,
+        ttl_seconds=ttl_seconds,
+    )
+    return challenge.model_dump(mode="json")
+
+
+@mcp.tool(
+    title="Place DCV Challenge",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def dcv_place_challenge(
+    domain: str,
+    token: str,
+    bnd_req: str | None = None,
+    ttl: int = 300,
+    expiry_seconds: int = 3600,
+) -> dict:
+    """
+    Write a DCV challenge TXT record to DNS via the configured backend.
+
+    The claimant calls this using their own dns-aid backend credentials,
+    proving they have write access to the domain's zone.
+
+    Args:
+        domain: Zone to write the challenge into.
+        token: Token received from the challenger (from dcv_issue_challenge).
+        bnd_req: Optional binding scope (pass through from the challenge).
+        ttl: DNS record TTL in seconds (default: 300 — short, for quick cleanup).
+        expiry_seconds: How long the placed record should be valid (default: 1 hour).
+
+    Returns:
+        dict with success flag and fqdn where the record was placed.
+    """
+    from dns_aid.core import dcv as _dcv
+
+    domain = validate_domain(domain)
+    ttl = validate_ttl(ttl)
+    try:
+        fqdn = _run_async(
+            _dcv.place(domain, token, bnd_req=bnd_req, ttl=ttl, expiry_seconds=expiry_seconds)
+        )
+        return {"success": True, "fqdn": fqdn}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool(
+    title="Verify DCV Challenge",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def dcv_verify_challenge(
+    domain: str,
+    token: str,
+    nameserver: str | None = None,
+    port: int = 53,
+) -> dict:
+    """
+    Verify that a DCV challenge token is present and unexpired in DNS.
+
+    The challenger calls this after the claimant has placed the record.
+    No backend credentials required — pure DNS resolution.
+
+    Args:
+        domain: Domain to check.
+        token: Token originally issued by the challenger.
+        nameserver: Optional nameserver IP to query directly.
+        port: DNS port (default: 53).
+
+    Returns:
+        dict with verified (bool), fqdn, expired, and error fields.
+    """
+    from dns_aid.core import dcv as _dcv
+
+    domain = validate_domain(domain)
+    result = _run_async(_dcv.verify(domain, token, nameserver=nameserver, port=port))
+    return result.model_dump()
+
+
+@mcp.tool(
+    title="Revoke DCV Challenge",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def dcv_revoke_challenge(domain: str) -> dict:
+    """
+    Delete the DCV challenge TXT record from DNS.
+
+    Should be called after successful verification to clean up.
+    Requires backend credentials for the domain.
+
+    Args:
+        domain: Zone to remove the challenge from.
+
+    Returns:
+        dict with success (bool) and optional error.
+    """
+    from dns_aid.core import dcv as _dcv
+
+    domain = validate_domain(domain)
+    try:
+        removed = _run_async(_dcv.revoke(domain))
+        return {"success": removed}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
 
 
 def _cleanup():

--- a/tests/testbed/agents/Dockerfile
+++ b/tests/testbed/agents/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dnsutils \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dns-aid-core from the mounted source in editable mode
+# The volume mount happens at runtime; we pre-install deps here so
+# the image layer is cached and startup is fast.
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir -e ".[ddns,cli,mcp]"

--- a/tests/testbed/agents/agent-a.env
+++ b/tests/testbed/agents/agent-a.env
@@ -1,0 +1,12 @@
+# Agent A — acts on behalf of orga.test
+DNS_AID_BACKEND=ddns
+DNS_AID_DOMAIN=orga.test
+
+DDNS_SERVER=172.28.0.10
+DDNS_KEY_NAME=dns-aid-orga
+DDNS_KEY_SECRET=ZhCSesSW1bC9TMupOSQ3Q7Y+uxHsOSTaVILndBmgdA4=
+DDNS_KEY_ALGORITHM=hmac-sha256
+DDNS_PORT=53
+
+# For cross-org DCV verification, agent-a queries orgb's server directly
+DCV_VERIFY_NAMESERVER_ORGB=172.28.0.11

--- a/tests/testbed/agents/agent-b.env
+++ b/tests/testbed/agents/agent-b.env
@@ -1,0 +1,12 @@
+# Agent B — acts on behalf of orgb.test
+DNS_AID_BACKEND=ddns
+DNS_AID_DOMAIN=orgb.test
+
+DDNS_SERVER=172.28.0.11
+DDNS_KEY_NAME=dns-aid-orgb
+DDNS_KEY_SECRET=xYghiEx5lBEBMN4S7S3k4SUD3w3HtTdcdd176PlD5eM=
+DDNS_KEY_ALGORITHM=hmac-sha256
+DDNS_PORT=53
+
+# For cross-org DCV verification, agent-b queries orga's server directly
+DCV_VERIFY_NAMESERVER_ORGA=172.28.0.10

--- a/tests/testbed/bind-orga/etc/bind/named.conf
+++ b/tests/testbed/bind-orga/etc/bind/named.conf
@@ -1,0 +1,5 @@
+// BIND9 config for Org A (orga.test)
+
+include "/etc/bind/named.conf.options";
+include "/etc/bind/named.conf.keys";
+include "/etc/bind/named.conf.local";

--- a/tests/testbed/bind-orga/etc/bind/named.conf
+++ b/tests/testbed/bind-orga/etc/bind/named.conf
@@ -2,4 +2,4 @@
 
 include "/etc/bind/named.conf.options";
 include "/etc/bind/named.conf.keys";
-include "/etc/bind/named.conf.local";
+include "/etc/bind/named.conf.zones";

--- a/tests/testbed/bind-orga/etc/bind/named.conf.keys
+++ b/tests/testbed/bind-orga/etc/bind/named.conf.keys
@@ -1,0 +1,5 @@
+// TSIG key for dns-aid DDNS updates to orga.test
+key "dns-aid-orga" {
+    algorithm hmac-sha256;
+    secret "ZhCSesSW1bC9TMupOSQ3Q7Y+uxHsOSTaVILndBmgdA4=";
+};

--- a/tests/testbed/bind-orga/etc/bind/named.conf.options
+++ b/tests/testbed/bind-orga/etc/bind/named.conf.options
@@ -1,0 +1,15 @@
+options {
+    directory "/var/cache/bind";
+
+    // Only answer queries for our own zone; forward everything else
+    recursion no;
+    allow-query { any; };
+    allow-transfer { none; };
+
+    // Disable DNSSEC validation on the resolver side (we're authoritative-only)
+    dnssec-validation no;
+
+    // Listen on all interfaces
+    listen-on { any; };
+    listen-on-v6 { none; };
+};

--- a/tests/testbed/bind-orga/etc/bind/named.conf.zones
+++ b/tests/testbed/bind-orga/etc/bind/named.conf.zones
@@ -1,0 +1,12 @@
+zone "orga.test" {
+    type primary;
+    file "/var/lib/bind/orga.test.zone";
+
+    // Allow DDNS updates signed with the dns-aid key
+    update-policy {
+        grant dns-aid-orga zonesub any;
+    };
+
+    // Allow zone transfer to nobody (authoritative-only testbed)
+    allow-transfer { none; };
+};

--- a/tests/testbed/bind-orga/zones/orga.test.zone
+++ b/tests/testbed/bind-orga/zones/orga.test.zone
@@ -1,0 +1,17 @@
+$TTL 300	; 5 minutes
+orga.test.		IN SOA	ns1.orga.test. hostmaster.orga.test. (
+				2026050806 ; serial
+				3600       ; refresh (1 hour)
+				900        ; retry (15 minutes)
+				604800     ; expire (1 week)
+				300        ; minimum (5 minutes)
+				)
+			NS	ns1.orga.test.
+$TTL 3600	; 1 hour
+_index._agents.orga.test. TXT	"agents=assistant:mcp"
+_assistant._mcp._agents.orga.test. TXT "version=1.0.0"
+			TXT	"description=Org A assistant agent"
+			SVCB	1 assistant.orga.test. mandatory=alpn,port alpn="mcp" port=443
+$TTL 300	; 5 minutes
+ns1.orga.test.		A	172.28.0.10
+test-record.orga.test.	TXT	"hello"

--- a/tests/testbed/bind-orgb/etc/bind/named.conf
+++ b/tests/testbed/bind-orgb/etc/bind/named.conf
@@ -2,4 +2,4 @@
 
 include "/etc/bind/named.conf.options";
 include "/etc/bind/named.conf.keys";
-include "/etc/bind/named.conf.local";
+include "/etc/bind/named.conf.zones";

--- a/tests/testbed/bind-orgb/etc/bind/named.conf
+++ b/tests/testbed/bind-orgb/etc/bind/named.conf
@@ -1,0 +1,5 @@
+// BIND9 config for Org B (orgb.test)
+
+include "/etc/bind/named.conf.options";
+include "/etc/bind/named.conf.keys";
+include "/etc/bind/named.conf.local";

--- a/tests/testbed/bind-orgb/etc/bind/named.conf.keys
+++ b/tests/testbed/bind-orgb/etc/bind/named.conf.keys
@@ -1,0 +1,5 @@
+// TSIG key for dns-aid DDNS updates to orgb.test
+key "dns-aid-orgb" {
+    algorithm hmac-sha256;
+    secret "xYghiEx5lBEBMN4S7S3k4SUD3w3HtTdcdd176PlD5eM=";
+};

--- a/tests/testbed/bind-orgb/etc/bind/named.conf.options
+++ b/tests/testbed/bind-orgb/etc/bind/named.conf.options
@@ -1,0 +1,12 @@
+options {
+    directory "/var/cache/bind";
+
+    recursion no;
+    allow-query { any; };
+    allow-transfer { none; };
+
+    dnssec-validation no;
+
+    listen-on { any; };
+    listen-on-v6 { none; };
+};

--- a/tests/testbed/bind-orgb/etc/bind/named.conf.zones
+++ b/tests/testbed/bind-orgb/etc/bind/named.conf.zones
@@ -1,0 +1,10 @@
+zone "orgb.test" {
+    type primary;
+    file "/var/lib/bind/orgb.test.zone";
+
+    update-policy {
+        grant dns-aid-orgb zonesub any;
+    };
+
+    allow-transfer { none; };
+};

--- a/tests/testbed/bind-orgb/zones/orgb.test.zone
+++ b/tests/testbed/bind-orgb/zones/orgb.test.zone
@@ -1,0 +1,16 @@
+$TTL 300	; 5 minutes
+orgb.test.		IN SOA	ns1.orgb.test. hostmaster.orgb.test. (
+				2026050806 ; serial
+				3600       ; refresh (1 hour)
+				900        ; retry (15 minutes)
+				604800     ; expire (1 week)
+				300        ; minimum (5 minutes)
+				)
+			NS	ns1.orgb.test.
+$TTL 3600	; 1 hour
+_index._agents.orgb.test. TXT	"agents=assistant:mcp"
+_assistant._mcp._agents.orgb.test. TXT "version=1.0.0"
+			TXT	"description=Org B assistant agent"
+			SVCB	1 assistant.orgb.test. mandatory=alpn,port alpn="mcp" port=443
+$TTL 300	; 5 minutes
+ns1.orgb.test.		A	172.28.0.11

--- a/tests/testbed/docker-compose.yml
+++ b/tests/testbed/docker-compose.yml
@@ -1,0 +1,101 @@
+version: "3.9"
+
+# DNS-AID DCV testbed
+# Two isolated orgs (orga.test / orgb.test), each with their own BIND9 authoritative server.
+# Both agent containers share the dns-aid-core source via volume mount so local edits are live.
+#
+# Namespaces: .test is IANA-reserved and will never resolve on the public internet.
+# Network: 172.28.0.0/24 — fully internal, no host DNS pollution.
+
+networks:
+  dnsaid:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+
+services:
+
+  # ── Org A: authoritative DNS for orga.test ────────────────────────────────
+  bind-orga:
+    image: internetsystemsconsortium/bind9:9.20
+    container_name: bind-orga
+    networks:
+      dnsaid:
+        ipv4_address: 172.28.0.10
+    ports:
+      - "5310:53/udp"
+      - "5310:53/tcp"
+    volumes:
+      - ./bind-orga/etc/bind:/etc/bind:ro
+      - ./bind-orga/zones:/var/lib/bind
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "dig", "@127.0.0.1", "orga.test", "SOA", "+short"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ── Org B: authoritative DNS for orgb.test ────────────────────────────────
+  bind-orgb:
+    image: internetsystemsconsortium/bind9:9.20
+    container_name: bind-orgb
+    networks:
+      dnsaid:
+        ipv4_address: 172.28.0.11
+    ports:
+      - "5311:53/udp"
+      - "5311:53/tcp"
+    volumes:
+      - ./bind-orgb/etc/bind:/etc/bind:ro
+      - ./bind-orgb/zones:/var/lib/bind
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "dig", "@127.0.0.1", "orgb.test", "SOA", "+short"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ── Agent A: acts on behalf of orga.test ──────────────────────────────────
+  agent-a:
+    build:
+      context: ../..
+      dockerfile: tests/testbed/agents/Dockerfile
+    container_name: agent-a
+    networks:
+      dnsaid:
+        ipv4_address: 172.28.0.20
+    volumes:
+      - ../..:/app:ro
+    env_file: agents/agent-a.env
+    dns:
+      - 172.28.0.10   # resolve orga.test from bind-orga
+      - 172.28.0.11   # also resolve orgb.test for cross-org DCV verification
+    depends_on:
+      bind-orga:
+        condition: service_healthy
+      bind-orgb:
+        condition: service_healthy
+    command: ["sleep", "infinity"]
+
+  # ── Agent B: acts on behalf of orgb.test ──────────────────────────────────
+  agent-b:
+    build:
+      context: ../..
+      dockerfile: tests/testbed/agents/Dockerfile
+    container_name: agent-b
+    networks:
+      dnsaid:
+        ipv4_address: 172.28.0.21
+    volumes:
+      - ../..:/app:ro
+    env_file: agents/agent-b.env
+    dns:
+      - 172.28.0.11   # resolve orgb.test from bind-orgb
+      - 172.28.0.10   # also resolve orga.test for cross-org DCV verification
+    depends_on:
+      bind-orga:
+        condition: service_healthy
+      bind-orgb:
+        condition: service_healthy
+    command: ["sleep", "infinity"]

--- a/tests/testbed/smoke_test.sh
+++ b/tests/testbed/smoke_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Baseline smoke test — verifies dns-aid publish/discover/verify works
+# in the testbed before any DCV changes are made.
+# Run from: tests/testbed/
+set -euo pipefail
+
+echo "=== dns-aid testbed smoke test ==="
+echo
+
+echo "--- [1] Publish Org A agent ---"
+docker exec agent-a dns-aid publish \
+  --name "assistant" \
+  --domain "orga.test" \
+  --protocol mcp \
+  --endpoint "assistant.orga.test" \
+  --port 443 \
+  --description "Org A assistant agent"
+
+echo
+echo "--- [2] Publish Org B agent ---"
+docker exec agent-b dns-aid publish \
+  --name "assistant" \
+  --domain "orgb.test" \
+  --protocol mcp \
+  --endpoint "assistant.orgb.test" \
+  --port 443 \
+  --description "Org B assistant agent"
+
+echo
+echo "--- [3] Discover agents at orga.test (from agent-a) ---"
+docker exec agent-a dns-aid discover orga.test
+
+echo
+echo "--- [4] Discover agents at orgb.test (from agent-b) ---"
+docker exec agent-b dns-aid discover orgb.test
+
+echo
+echo "--- [5] Cross-org: discover orgb.test from agent-a ---"
+docker exec agent-a dns-aid discover orgb.test
+
+echo
+echo "--- [6] Verify Org A agent record ---"
+docker exec agent-a dns-aid verify _assistant._mcp._agents.orga.test || true
+
+echo
+echo "--- [7] Raw DNS check: SVCB and TXT records exist ---"
+echo "Org A SVCB:"; docker exec agent-a dig @172.28.0.10 _assistant._mcp._agents.orga.test SVCB +short
+echo "Org A TXT:";  docker exec agent-a dig @172.28.0.10 _assistant._mcp._agents.orga.test TXT +short
+echo "Org B SVCB:"; docker exec agent-b dig @172.28.0.11 _assistant._mcp._agents.orgb.test SVCB +short
+echo "Org A index:"; docker exec agent-a dig @172.28.0.10 _index._agents.orga.test TXT +short
+
+# ---------------------------------------------------------------------------
+# DCV flow: agent-a (Org A) challenges agent-b (Org B) to prove orgb.test control
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== DCV challenge flow ==="
+echo
+
+echo "--- [8] Org A issues a DCV challenge for orgb.test (scoped to agent-b) ---"
+CHALLENGE_JSON=$(docker exec agent-a dns-aid --quiet dcv issue orgb.test \
+  --agent "assistant" \
+  --issuer "orga.test" \
+  --json)
+echo "$CHALLENGE_JSON"
+
+TOKEN=$(echo "$CHALLENGE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+BND_REQ=$(echo "$CHALLENGE_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('bnd_req') or '')")
+echo "Token  : $TOKEN"
+echo "bnd-req: $BND_REQ"
+
+echo
+echo "--- [9] Org B (agent-b) places the challenge in its zone ---"
+if [ -n "$BND_REQ" ]; then
+  docker exec agent-b dns-aid dcv place orgb.test "$TOKEN" --bnd-req "$BND_REQ"
+else
+  docker exec agent-b dns-aid dcv place orgb.test "$TOKEN"
+fi
+
+echo
+echo "--- [10] Raw DNS check: challenge TXT is present at Org B ---"
+docker exec agent-a dig @172.28.0.11 _agents-challenge.orgb.test TXT +short
+
+echo
+echo "--- [11] Org A verifies the challenge (querying Org B's nameserver directly) ---"
+docker exec agent-a dns-aid dcv verify orgb.test "$TOKEN" --nameserver 172.28.0.11
+
+echo
+echo "--- [12] Org B revokes (cleans up) the challenge record ---"
+docker exec agent-b dns-aid dcv revoke orgb.test
+
+echo
+echo "--- [13] Confirm challenge record is gone ---"
+docker exec agent-a dig @172.28.0.11 _agents-challenge.orgb.test TXT +short || echo "(empty — record removed)"
+
+echo
+echo "=== Smoke test complete ==="

--- a/tests/testbed/smoke_test.sh
+++ b/tests/testbed/smoke_test.sh
@@ -87,7 +87,7 @@ docker exec agent-a dns-aid dcv verify orgb.test "$TOKEN" --nameserver 172.28.0.
 
 echo
 echo "--- [12] Org B revokes (cleans up) the challenge record ---"
-docker exec agent-b dns-aid dcv revoke orgb.test
+docker exec agent-b dns-aid dcv revoke orgb.test "$TOKEN"
 
 echo
 echo "--- [13] Confirm challenge record is gone ---"

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -369,7 +369,8 @@ class TestCloudflareBackendCreateTxt:
             call_args = mock_client.post.call_args
             json_data = call_args.kwargs["json"]
             assert json_data["type"] == "TXT"
-            assert '"capabilities=chat,code"' in json_data["content"]
+            assert "capabilities=chat,code" in json_data["content"]
+            assert json_data["content"] == "capabilities=chat,code version=1.0.0"
 
 
 class TestCloudflareBackendDeleteRecord:

--- a/tests/unit/test_dcv.py
+++ b/tests/unit/test_dcv.py
@@ -1,0 +1,296 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.core.dcv — stateless DCV challenge/verify."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dns_aid.core.dcv import (
+    DCVChallenge,
+    DCVVerifyResult,
+    _build_txt_value,
+    _generate_token,
+    _parse_txt_value,
+    issue,
+    place,
+    revoke,
+    verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# _generate_token
+# ---------------------------------------------------------------------------
+
+
+def test_generate_token_format():
+    token = _generate_token()
+    # base32 lowercase, no padding — only a-z2-7
+    assert re.fullmatch(r"[a-z2-7]+", token), f"Unexpected token chars: {token}"
+
+
+def test_generate_token_length():
+    # 20 bytes → 32 base32 chars (no padding)
+    token = _generate_token()
+    assert len(token) == 32
+
+
+def test_generate_token_unique():
+    tokens = {_generate_token() for _ in range(10)}
+    assert len(tokens) == 10
+
+
+# ---------------------------------------------------------------------------
+# _build_txt_value
+# ---------------------------------------------------------------------------
+
+
+def test_build_txt_value_basic():
+    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    txt = _build_txt_value("abc123", expiry, None)
+    assert txt == "token=abc123 expiry=2026-01-02T03:04:05Z"
+
+
+def test_build_txt_value_with_bnd_req():
+    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    txt = _build_txt_value("abc123", expiry, "svc:assistant@orga.test")
+    assert txt == "token=abc123 bnd-req=svc:assistant@orga.test expiry=2026-01-02T03:04:05Z"
+
+
+# ---------------------------------------------------------------------------
+# _parse_txt_value
+# ---------------------------------------------------------------------------
+
+
+def test_parse_txt_value_full():
+    txt = "token=abc123 bnd-req=svc:assistant@orga.test expiry=2026-01-02T03:04:05Z"
+    parsed = _parse_txt_value(txt)
+    assert parsed["token"] == "abc123"
+    assert parsed["bnd-req"] == "svc:assistant@orga.test"
+    assert parsed["expiry"] == "2026-01-02T03:04:05Z"
+
+
+def test_parse_txt_value_minimal():
+    parsed = _parse_txt_value("token=xyz expiry=2026-01-01T00:00:00Z")
+    assert parsed["token"] == "xyz"
+    assert "bnd-req" not in parsed
+
+
+def test_parse_txt_value_bare_token():
+    # Bare value with no key= prefix is the token per spec
+    parsed = _parse_txt_value("baretoken expiry=2026-01-01T00:00:00Z")
+    assert parsed["token"] == "baretoken"
+
+
+def test_parse_txt_value_case_insensitive_keys():
+    parsed = _parse_txt_value("TOKEN=abc EXPIRY=2026-01-01T00:00:00Z")
+    assert parsed["token"] == "abc"
+    assert parsed["expiry"] == "2026-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# issue()
+# ---------------------------------------------------------------------------
+
+
+def test_issue_returns_challenge():
+    ch = issue("example.com")
+    assert isinstance(ch, DCVChallenge)
+    assert ch.domain == "example.com"
+    assert ch.fqdn == "_agents-challenge.example.com"
+    assert ch.bnd_req is None
+
+
+def test_issue_token_in_txt_value():
+    ch = issue("example.com")
+    assert f"token={ch.token}" in ch.txt_value
+
+
+def test_issue_expiry_in_txt_value():
+    ch = issue("example.com")
+    assert "expiry=" in ch.txt_value
+
+
+def test_issue_bnd_req_when_both_supplied():
+    ch = issue("example.com", agent_name="assistant", issuer_domain="orga.test")
+    assert ch.bnd_req == "svc:assistant@orga.test"
+    assert "bnd-req=svc:assistant@orga.test" in ch.txt_value
+
+
+def test_issue_no_bnd_req_when_partial():
+    # bnd-req only emitted when both agent_name and issuer_domain are present
+    ch1 = issue("example.com", agent_name="assistant")
+    assert ch1.bnd_req is None
+    ch2 = issue("example.com", issuer_domain="orga.test")
+    assert ch2.bnd_req is None
+
+
+def test_issue_ttl_affects_expiry():
+    ch_short = issue("example.com", ttl_seconds=60)
+    ch_long = issue("example.com", ttl_seconds=7200)
+    assert ch_long.expiry > ch_short.expiry
+
+
+def test_issue_is_stateless():
+    # Two calls produce different tokens — nothing shared
+    ch1 = issue("example.com")
+    ch2 = issue("example.com")
+    assert ch1.token != ch2.token
+
+
+# ---------------------------------------------------------------------------
+# place()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_place_calls_backend():
+    mock_backend = AsyncMock()
+    mock_backend.create_txt_record = AsyncMock()
+
+    fqdn = await place("orga.test", "abc123", backend=mock_backend)
+
+    assert fqdn == "_agents-challenge.orga.test"
+    mock_backend.create_txt_record.assert_awaited_once()
+    call_kwargs = mock_backend.create_txt_record.call_args.kwargs
+    assert call_kwargs["zone"] == "orga.test"
+    assert call_kwargs["name"] == "_agents-challenge"
+    assert len(call_kwargs["values"]) == 1
+    assert "token=abc123" in call_kwargs["values"][0]
+
+
+@pytest.mark.asyncio
+async def test_place_includes_bnd_req():
+    mock_backend = AsyncMock()
+    mock_backend.create_txt_record = AsyncMock()
+
+    await place("orga.test", "abc123", bnd_req="svc:bot@orga.test", backend=mock_backend)
+
+    call_kwargs = mock_backend.create_txt_record.call_args.kwargs
+    assert "bnd-req=svc:bot@orga.test" in call_kwargs["values"][0]
+
+
+# ---------------------------------------------------------------------------
+# verify()
+# ---------------------------------------------------------------------------
+
+
+def _make_rdata(txt: str):
+    """Minimal stub for dns.rdata with a strings attribute."""
+    rdata = MagicMock()
+    rdata.strings = [txt.encode()]
+    return rdata
+
+
+@pytest.mark.asyncio
+async def test_verify_success():
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    txt = _build_txt_value(token, expiry, None)
+
+    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
+        resolver_instance = MockResolver.return_value
+        resolver_instance.resolve.return_value = [_make_rdata(txt)]
+
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+    assert result.domain == "example.com"
+    assert result.token == token
+
+
+@pytest.mark.asyncio
+async def test_verify_wrong_token():
+    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    txt = _build_txt_value("righttoken", expiry, None)
+
+    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
+        resolver_instance = MockResolver.return_value
+        resolver_instance.resolve.return_value = [_make_rdata(txt)]
+
+        result = await verify("example.com", "wrongtoken")
+
+    assert result.verified is False
+    assert result.error == "Token not found in any challenge record"
+
+
+@pytest.mark.asyncio
+async def test_verify_expired():
+    token = _generate_token()
+    expiry = datetime(2000, 1, 1, tzinfo=timezone.utc)  # in the past
+    txt = _build_txt_value(token, expiry, None)
+
+    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
+        resolver_instance = MockResolver.return_value
+        resolver_instance.resolve.return_value = [_make_rdata(txt)]
+
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+    assert result.expired is True
+
+
+@pytest.mark.asyncio
+async def test_verify_nxdomain():
+    import dns.resolver
+
+    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
+        resolver_instance = MockResolver.return_value
+        resolver_instance.resolve.side_effect = dns.resolver.NXDOMAIN()
+
+        result = await verify("example.com", "sometoken")
+
+    assert result.verified is False
+    assert "NXDOMAIN" in result.error
+
+
+@pytest.mark.asyncio
+async def test_verify_custom_nameserver():
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    txt = _build_txt_value(token, expiry, None)
+
+    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
+        resolver_instance = MockResolver.return_value
+        resolver_instance.resolve.return_value = [_make_rdata(txt)]
+
+        await verify("example.com", token, nameserver="1.2.3.4", port=5353)
+
+        assert resolver_instance.nameservers == ["1.2.3.4"]
+        assert resolver_instance.port == 5353
+
+
+# ---------------------------------------------------------------------------
+# revoke()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_calls_backend():
+    mock_backend = AsyncMock()
+    mock_backend.delete_record = AsyncMock(return_value=True)
+
+    result = await revoke("orga.test", backend=mock_backend)
+
+    assert result is True
+    mock_backend.delete_record.assert_awaited_once_with(
+        zone="orga.test",
+        name="_agents-challenge",
+        record_type="TXT",
+    )
+
+
+@pytest.mark.asyncio
+async def test_revoke_returns_false_when_not_found():
+    mock_backend = AsyncMock()
+    mock_backend.delete_record = AsyncMock(return_value=False)
+
+    result = await revoke("orga.test", backend=mock_backend)
+
+    assert result is False

--- a/tests/unit/test_dcv.py
+++ b/tests/unit/test_dcv.py
@@ -6,14 +6,15 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from dns_aid.core.dcv import (
     DCVChallenge,
-    DCVVerifyResult,
+    DCVPlaceResult,
+    DCVRevokeResult,
     _build_txt_value,
     _generate_token,
     _parse_txt_value,
@@ -23,7 +24,6 @@ from dns_aid.core.dcv import (
     verify,
 )
 
-
 # ---------------------------------------------------------------------------
 # _generate_token
 # ---------------------------------------------------------------------------
@@ -31,12 +31,10 @@ from dns_aid.core.dcv import (
 
 def test_generate_token_format():
     token = _generate_token()
-    # base32 lowercase, no padding — only a-z2-7
     assert re.fullmatch(r"[a-z2-7]+", token), f"Unexpected token chars: {token}"
 
 
 def test_generate_token_length():
-    # 20 bytes → 32 base32 chars (no padding)
     token = _generate_token()
     assert len(token) == 32
 
@@ -52,15 +50,27 @@ def test_generate_token_unique():
 
 
 def test_build_txt_value_basic():
-    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
     txt = _build_txt_value("abc123", expiry, None)
     assert txt == "token=abc123 expiry=2026-01-02T03:04:05Z"
 
 
+def test_build_txt_value_with_domain():
+    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    txt = _build_txt_value("abc123", expiry, None, domain="example.com")
+    assert txt == "token=abc123 domain=example.com expiry=2026-01-02T03:04:05Z"
+
+
 def test_build_txt_value_with_bnd_req():
-    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
     txt = _build_txt_value("abc123", expiry, "svc:assistant@orga.test")
     assert txt == "token=abc123 bnd-req=svc:assistant@orga.test expiry=2026-01-02T03:04:05Z"
+
+
+def test_build_txt_value_domain_before_bnd_req():
+    expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    txt = _build_txt_value("abc123", expiry, "svc:bot@orga.test", domain="example.com")
+    assert txt == "token=abc123 domain=example.com bnd-req=svc:bot@orga.test expiry=2026-01-02T03:04:05Z"
 
 
 # ---------------------------------------------------------------------------
@@ -82,16 +92,30 @@ def test_parse_txt_value_minimal():
     assert "bnd-req" not in parsed
 
 
-def test_parse_txt_value_bare_token():
-    # Bare value with no key= prefix is the token per spec
+def test_parse_txt_value_bare_token_not_accepted():
+    # Bare values without 'token=' prefix are NOT accepted — explicit key= required
     parsed = _parse_txt_value("baretoken expiry=2026-01-01T00:00:00Z")
-    assert parsed["token"] == "baretoken"
+    assert "token" not in parsed
 
 
 def test_parse_txt_value_case_insensitive_keys():
     parsed = _parse_txt_value("TOKEN=abc EXPIRY=2026-01-01T00:00:00Z")
     assert parsed["token"] == "abc"
     assert parsed["expiry"] == "2026-01-01T00:00:00Z"
+
+
+def test_parse_txt_value_strips_outer_quotes():
+    # Cloudflare wraps the entire content field in literal '"..."'
+    txt = '"token=abc123 bnd-req=svc:assistant@orga.test expiry=2026-01-02T03:04:05Z"'
+    parsed = _parse_txt_value(txt)
+    assert parsed["token"] == "abc123"
+    assert parsed["expiry"] == "2026-01-02T03:04:05Z"
+
+
+def test_parse_txt_value_first_wins_on_duplicate_keys():
+    # First occurrence wins; injected second value is discarded
+    parsed = _parse_txt_value("token=first token=injected expiry=2099-01-01T00:00:00Z")
+    assert parsed["token"] == "first"
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +141,11 @@ def test_issue_expiry_in_txt_value():
     assert "expiry=" in ch.txt_value
 
 
+def test_issue_embeds_domain_in_txt_value():
+    ch = issue("example.com")
+    assert "domain=example.com" in ch.txt_value
+
+
 def test_issue_bnd_req_when_both_supplied():
     ch = issue("example.com", agent_name="assistant", issuer_domain="orga.test")
     assert ch.bnd_req == "svc:assistant@orga.test"
@@ -124,7 +153,6 @@ def test_issue_bnd_req_when_both_supplied():
 
 
 def test_issue_no_bnd_req_when_partial():
-    # bnd-req only emitted when both agent_name and issuer_domain are present
     ch1 = issue("example.com", agent_name="assistant")
     assert ch1.bnd_req is None
     ch2 = issue("example.com", issuer_domain="orga.test")
@@ -138,10 +166,33 @@ def test_issue_ttl_affects_expiry():
 
 
 def test_issue_is_stateless():
-    # Two calls produce different tokens — nothing shared
     ch1 = issue("example.com")
     ch2 = issue("example.com")
     assert ch1.token != ch2.token
+
+
+def test_issue_rejects_agent_name_with_spaces():
+    from dns_aid.utils.validation import ValidationError
+
+    with pytest.raises(ValidationError):
+        issue("example.com", agent_name="agent name with spaces", issuer_domain="orga.test")
+
+
+def test_issue_rejects_ttl_above_cap():
+    with pytest.raises(ValueError):
+        issue("example.com", ttl_seconds=86401)
+
+
+def test_issue_rejects_ttl_below_minimum():
+    with pytest.raises(ValueError):
+        issue("example.com", ttl_seconds=10)
+
+
+def test_issue_rejects_invalid_domain():
+    from dns_aid.utils.validation import ValidationError
+
+    with pytest.raises(ValidationError):
+        issue("bad..domain")
 
 
 # ---------------------------------------------------------------------------
@@ -154,30 +205,58 @@ async def test_place_calls_backend():
     mock_backend = AsyncMock()
     mock_backend.create_txt_record = AsyncMock()
 
-    fqdn = await place("orga.test", "abc123", backend=mock_backend)
+    result = await place("orga.test", _generate_token(), backend=mock_backend)
 
-    assert fqdn == "_agents-challenge.orga.test"
+    assert isinstance(result, DCVPlaceResult)
+    assert result.fqdn == "_agents-challenge.orga.test"
+    assert result.domain == "orga.test"
     mock_backend.create_txt_record.assert_awaited_once()
     call_kwargs = mock_backend.create_txt_record.call_args.kwargs
     assert call_kwargs["zone"] == "orga.test"
     assert call_kwargs["name"] == "_agents-challenge"
     assert len(call_kwargs["values"]) == 1
-    assert "token=abc123" in call_kwargs["values"][0]
+
+
+@pytest.mark.asyncio
+async def test_place_embeds_domain_in_txt():
+    mock_backend = AsyncMock()
+    mock_backend.create_txt_record = AsyncMock()
+
+    await place("orga.test", _generate_token(), backend=mock_backend)
+
+    call_kwargs = mock_backend.create_txt_record.call_args.kwargs
+    assert "domain=orga.test" in call_kwargs["values"][0]
 
 
 @pytest.mark.asyncio
 async def test_place_includes_bnd_req():
     mock_backend = AsyncMock()
     mock_backend.create_txt_record = AsyncMock()
+    token = _generate_token()
 
-    await place("orga.test", "abc123", bnd_req="svc:bot@orga.test", backend=mock_backend)
+    await place("orga.test", token, bnd_req="svc:bot@orga.test", backend=mock_backend)
 
     call_kwargs = mock_backend.create_txt_record.call_args.kwargs
     assert "bnd-req=svc:bot@orga.test" in call_kwargs["values"][0]
 
 
+@pytest.mark.asyncio
+async def test_place_rejects_invalid_token():
+    mock_backend = AsyncMock()
+    with pytest.raises(ValueError, match="base32"):
+        await place("orga.test", "not-a-valid-token!!!", backend=mock_backend)
+
+
+@pytest.mark.asyncio
+async def test_place_rejects_expiry_above_cap():
+    mock_backend = AsyncMock()
+    token = _generate_token()
+    with pytest.raises(ValueError):
+        await place("orga.test", token, expiry_seconds=86401, backend=mock_backend)
+
+
 # ---------------------------------------------------------------------------
-# verify()
+# verify() helpers
 # ---------------------------------------------------------------------------
 
 
@@ -188,16 +267,35 @@ def _make_rdata(txt: str):
     return rdata
 
 
+def _patch_resolver(return_value=None, side_effect=None):
+    """Context manager: patch dns.asyncresolver.Resolver for verify() tests.
+
+    Uses MagicMock for the instance so that synchronous methods (cache, use_edns,
+    nameservers, port) behave synchronously.  resolve() is an explicit AsyncMock.
+    """
+    mock_resolver_cls = MagicMock()
+    mock_instance = MagicMock()
+    mock_resolver_cls.return_value = mock_instance
+    if side_effect is not None:
+        mock_instance.resolve = AsyncMock(side_effect=side_effect)
+    else:
+        mock_instance.resolve = AsyncMock(return_value=return_value)
+    return patch("dns_aid.core.dcv.dns.asyncresolver.Resolver", mock_resolver_cls), mock_instance
+
+
+# ---------------------------------------------------------------------------
+# verify() — happy path
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_verify_success():
     token = _generate_token()
-    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
     txt = _build_txt_value(token, expiry, None)
 
-    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
-        resolver_instance = MockResolver.return_value
-        resolver_instance.resolve.return_value = [_make_rdata(txt)]
-
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
         result = await verify("example.com", token)
 
     assert result.verified is True
@@ -207,14 +305,12 @@ async def test_verify_success():
 
 @pytest.mark.asyncio
 async def test_verify_wrong_token():
-    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
-    txt = _build_txt_value("righttoken", expiry, None)
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value("a" * 32, expiry, None)
 
-    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
-        resolver_instance = MockResolver.return_value
-        resolver_instance.resolve.return_value = [_make_rdata(txt)]
-
-        result = await verify("example.com", "wrongtoken")
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", "b" * 32)
 
     assert result.verified is False
     assert result.error == "Token not found in any challenge record"
@@ -223,13 +319,11 @@ async def test_verify_wrong_token():
 @pytest.mark.asyncio
 async def test_verify_expired():
     token = _generate_token()
-    expiry = datetime(2000, 1, 1, tzinfo=timezone.utc)  # in the past
+    expiry = datetime(2000, 1, 1, tzinfo=UTC)
     txt = _build_txt_value(token, expiry, None)
 
-    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
-        resolver_instance = MockResolver.return_value
-        resolver_instance.resolve.return_value = [_make_rdata(txt)]
-
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
         result = await verify("example.com", token)
 
     assert result.verified is False
@@ -240,30 +334,332 @@ async def test_verify_expired():
 async def test_verify_nxdomain():
     import dns.resolver
 
-    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
-        resolver_instance = MockResolver.return_value
-        resolver_instance.resolve.side_effect = dns.resolver.NXDOMAIN()
-
-        result = await verify("example.com", "sometoken")
+    ctx, _ = _patch_resolver(side_effect=dns.resolver.NXDOMAIN())
+    with ctx:
+        result = await verify("example.com", _generate_token())
 
     assert result.verified is False
     assert "NXDOMAIN" in result.error
 
 
 @pytest.mark.asyncio
+async def test_verify_no_answer():
+    import dns.resolver
+
+    ctx, _ = _patch_resolver(side_effect=dns.resolver.NoAnswer())
+    with ctx:
+        result = await verify("example.com", _generate_token())
+
+    assert result.verified is False
+    assert result.error is not None
+
+
+@pytest.mark.asyncio
 async def test_verify_custom_nameserver():
     token = _generate_token()
-    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
     txt = _build_txt_value(token, expiry, None)
 
-    with patch("dns_aid.core.dcv.dns.resolver.Resolver") as MockResolver:
-        resolver_instance = MockResolver.return_value
-        resolver_instance.resolve.return_value = [_make_rdata(txt)]
-
+    ctx, mock_instance = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
         await verify("example.com", token, nameserver="1.2.3.4", port=5353)
 
-        assert resolver_instance.nameservers == ["1.2.3.4"]
-        assert resolver_instance.port == 5353
+    assert mock_instance.nameservers == ["1.2.3.4"]
+    assert mock_instance.port == 5353
+
+
+# ---------------------------------------------------------------------------
+# verify() — fail-closed regression tests (Igor's confirmed exploits)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_when_expiry_missing():
+    """Exploit 1: record with no expiry= field must not pass."""
+    token = _generate_token()
+    txt = f"token={token}"  # no expiry
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_when_expiry_malformed():
+    """Exploit 2: malformed expiry must not pass (was: bare except: pass)."""
+    token = _generate_token()
+    txt = f"token={token} expiry=NOT-A-DATE"
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_when_expiry_is_never():
+    """Exploit 3: 'expiry=never' magic string must not pass."""
+    token = _generate_token()
+    txt = f"token={token} expiry=never"
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_bare_token():
+    """Exploit 4: bare string (no token= prefix) must not match."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    # Record with bare value, no key= prefix
+    txt = f"{token} expiry={expiry.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_invalid_nameserver_returns_error_not_exception():
+    """Exploit 5: invalid nameserver must return DCVVerifyResult, not raise."""
+    result = await verify("example.com", _generate_token(), nameserver="not-an-ip")
+
+    assert result.verified is False
+    assert result.error is not None
+    assert "nameserver" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_cloudflare_quoted_record():
+    """Cloudflare stores TXT content with literal surrounding quotes."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    raw = _build_txt_value(token, expiry, None)
+    quoted = f'"{raw}"'  # Cloudflare wrapping
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(quoted)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_bnd_req_enforced_when_expected():
+    """bnd-req mismatch must fail when expected_bnd_req is supplied."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, "svc:assistant@orga.test")
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token, expected_bnd_req="svc:other-agent@other.test")
+
+    assert result.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_bnd_req_passes_when_matches():
+    """bnd-req check passes when expected value matches the record."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    bnd_req = "svc:assistant@orga.test"
+    txt = _build_txt_value(token, expiry, bnd_req)
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token, expected_bnd_req=bnd_req)
+
+    assert result.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_too_many_records():
+    """DoS guard: more than MAX_CHALLENGE_RECORDS returns failure."""
+    from dns_aid.core.dcv import MAX_CHALLENGE_RECORDS
+
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)
+    many_records = [_make_rdata(txt)] * (MAX_CHALLENGE_RECORDS + 1)
+
+    ctx, _ = _patch_resolver(return_value=many_records)
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+    assert "Too many" in result.error
+
+
+@pytest.mark.asyncio
+async def test_verify_skips_expired_finds_valid():
+    """Multi-record: expired record first, valid second — should pass."""
+    token = _generate_token()
+    expired_txt = _build_txt_value(token, datetime(2000, 1, 1, tzinfo=UTC), None)
+    valid_txt = _build_txt_value(token, datetime(2099, 1, 1, tzinfo=UTC), None)
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(expired_txt), _make_rdata(valid_txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_multi_string_txt_record():
+    """Multi-string TXT records (multiple rdata.strings) are concatenated."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    full_txt = _build_txt_value(token, expiry, None)
+    # Simulate multi-string: split the value across two strings
+    mid = len(full_txt) // 2
+    rdata = MagicMock()
+    rdata.strings = [full_txt[:mid].encode(), full_txt[mid:].encode()]
+
+    ctx, _ = _patch_resolver(return_value=[rdata])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+
+
+# ---------------------------------------------------------------------------
+# verify() — domain binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_domain_binding_matching():
+    """domain= field in record matches the queried domain — must pass."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None, domain="example.com")
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_domain_binding_blocks_wrong_domain():
+    """domain= field from a different zone must cause the record to be skipped."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    # Record was written for evil.com but placed (or replayed) at example.com
+    txt = _build_txt_value(token, expiry, None, domain="evil.com")
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is False
+    assert result.error == "Token not found in any challenge record"
+
+
+@pytest.mark.asyncio
+async def test_verify_domain_binding_absent_field_allowed():
+    """Records without domain= (older format) are still accepted — backward compat."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)  # no domain= field
+
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+
+
+# ---------------------------------------------------------------------------
+# verify() — DNSSEC
+# ---------------------------------------------------------------------------
+
+
+def _make_answer_with_flags(rdatas, *, ad: bool = False):
+    """Create a mock DNS Answer that supports both iteration and .response.flags."""
+    import dns.flags as _dns_flags
+
+    mock_answer = MagicMock()
+    mock_answer.__iter__ = MagicMock(return_value=iter(rdatas))
+    mock_answer.__len__ = MagicMock(return_value=len(rdatas))
+    mock_answer.response = MagicMock()
+    mock_answer.response.flags = _dns_flags.AD if ad else 0
+    return mock_answer
+
+
+@pytest.mark.asyncio
+async def test_verify_dnssec_not_required_by_default():
+    """require_dnssec defaults to False; missing AD flag must not block verification."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)
+    answer = _make_answer_with_flags([_make_rdata(txt)], ad=False)
+
+    ctx, _ = _patch_resolver(return_value=answer)
+    with ctx:
+        result = await verify("example.com", token)
+
+    assert result.verified is True
+    assert result.dnssec_validated is False
+
+
+@pytest.mark.asyncio
+async def test_verify_dnssec_required_fails_without_ad_flag():
+    """require_dnssec=True must fail when the resolver does not set AD=1."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)
+    answer = _make_answer_with_flags([_make_rdata(txt)], ad=False)
+
+    ctx, _ = _patch_resolver(return_value=answer)
+    with ctx:
+        result = await verify("example.com", token, require_dnssec=True)
+
+    assert result.verified is False
+    assert "AD flag" in result.error
+
+
+@pytest.mark.asyncio
+async def test_verify_dnssec_required_passes_with_ad_flag():
+    """require_dnssec=True must succeed when AD=1 and token matches."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)
+    answer = _make_answer_with_flags([_make_rdata(txt)], ad=True)
+
+    ctx, _ = _patch_resolver(return_value=answer)
+    with ctx:
+        result = await verify("example.com", token, require_dnssec=True)
+
+    assert result.verified is True
+    assert result.dnssec_validated is True
+
+
+@pytest.mark.asyncio
+async def test_verify_dnssec_silently_skipped_with_nameserver():
+    """require_dnssec=True + nameserver= is silently downgraded (authoritative can't validate)."""
+    token = _generate_token()
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)
+    # Answer has AD=0 but that should not matter — dnssec check is skipped
+    answer = _make_answer_with_flags([_make_rdata(txt)], ad=False)
+
+    ctx, _ = _patch_resolver(return_value=answer)
+    with ctx:
+        result = await verify("example.com", token, nameserver="1.2.3.4", require_dnssec=True)
+
+    assert result.verified is True
+    assert result.dnssec_validated is False
 
 
 # ---------------------------------------------------------------------------
@@ -275,10 +671,18 @@ async def test_verify_custom_nameserver():
 async def test_revoke_calls_backend():
     mock_backend = AsyncMock()
     mock_backend.delete_record = AsyncMock(return_value=True)
+    token = _generate_token()
 
-    result = await revoke("orga.test", backend=mock_backend)
+    expiry = datetime(2099, 1, 1, tzinfo=UTC)
+    txt = _build_txt_value(token, expiry, None)
 
-    assert result is True
+    ctx, _ = _patch_resolver(return_value=[_make_rdata(txt)])
+    with ctx:
+        result = await revoke("orga.test", token=token, backend=mock_backend)
+
+    assert isinstance(result, DCVRevokeResult)
+    assert result.removed is True
+    assert result.domain == "orga.test"
     mock_backend.delete_record.assert_awaited_once_with(
         zone="orga.test",
         name="_agents-challenge",
@@ -287,10 +691,24 @@ async def test_revoke_calls_backend():
 
 
 @pytest.mark.asyncio
-async def test_revoke_returns_false_when_not_found():
+async def test_revoke_returns_false_when_token_not_found():
+    """revoke() skips deletion if the token is not found in DNS."""
+    import dns.resolver
+
+    token = _generate_token()
     mock_backend = AsyncMock()
-    mock_backend.delete_record = AsyncMock(return_value=False)
 
-    result = await revoke("orga.test", backend=mock_backend)
+    ctx, _ = _patch_resolver(side_effect=dns.resolver.NXDOMAIN())
+    with ctx:
+        result = await revoke("orga.test", token=token, backend=mock_backend)
 
-    assert result is False
+    assert isinstance(result, DCVRevokeResult)
+    assert result.removed is False
+    mock_backend.delete_record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_revoke_rejects_invalid_token():
+    mock_backend = AsyncMock()
+    with pytest.raises(ValueError, match="base32"):
+        await revoke("orga.test", token="bad!", backend=mock_backend)


### PR DESCRIPTION
## Summary

Adds `dns_aid.core.dcv` — a stateless DCV challenge/response module implementing [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/) (BCP-track) wire format, extended with the `bnd-req` binding field from [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) §4.4.

Two use cases:

1. **Anonymous / NAT agent asserting org affiliation.** An agent operating outside its org's network proves zone write access by placing a challenger-issued token via its own DDNS credentials — the only party that can is a legitimate operator of the zone.
2. **Registry / directory anti-impersonation.** A directory requires proof of zone control before listing an agent as org-verified. Squatters cannot place the token.

## Files changed

| File | Change |
|---|---|
| `src/dns_aid/core/dcv.py` | New module — `issue`, `place`, `verify`, `revoke` + models |
| `src/dns_aid/core/__init__.py` | Export `DCVChallenge`, `DCVVerifyResult`, four functions |
| `src/dns_aid/__init__.py` | Expose `dns_aid.dcv` at top level |
| `src/dns_aid/cli/main.py` | `dns-aid dcv` subcommand group (issue / place / verify / revoke) |
| `src/dns_aid/mcp/server.py` | Four MCP tools + health endpoint tool list |
| `tests/unit/test_dcv.py` | 25 unit tests |
| `tests/testbed/` | Two-org BIND9 Docker testbed + smoke test |
| `CHANGELOG.md` | v0.19.0 entry |
| `pyproject.toml` | Version bump 0.18.6 → 0.19.0 |

## Public API

```python
from dns_aid.core import dcv

# Challenger — stateless, nothing touches DNS
challenge = dcv.issue("orgb.test", agent_name="assistant", issuer_domain="orga.test")
# DCVChallenge(token="...", fqdn="_agents-challenge.orgb.test",
#              txt_value="token=... bnd-req=svc:assistant@orga.test expiry=...",
#              bnd_req="svc:assistant@orga.test")

# Claimant — proves zone write access via configured backend
fqdn = await dcv.place("orgb.test", challenge.token, bnd_req=challenge.bnd_req)

# Challenger — pure DNS resolution, no backend credentials
result = await dcv.verify("orgb.test", challenge.token, nameserver="172.28.0.11")
# DCVVerifyResult(verified=True, ...)

# Claimant cleanup
await dcv.revoke("orgb.test")
```

## Design notes

- **Stateless by design.** `issue()` generates a token and returns it — no database, no session. The token travels out-of-band via A2A or MCP. This matches the IETF DCV model.
- **Expiry is enforced by the verifier, not the DNS server.** `verify()` checks the `expiry=` field and returns `expired=True` on any stale record. `revoke()` is hygiene, not a security gate.
- **TXT record type.** DCV-techniques BCP mandates TXT. DNS has no standard self-expiring record primitive; vendor-specific lease extensions (BIND `update-lease`, NIOS scheduled deletion) would break the multi-backend model.
- **Token entropy.** 20 bytes (160 bits), base32 lowercase, no padding — DNS-label safe per DCV-techniques §4.1.
- **`bnd-req` scoping.** Prevents cross-vendor token reuse (DCV hazard H2): a token issued to `svc:assistant@orga.test` cannot satisfy a challenge from a different issuer or agent.
- **Input validation.** All domain inputs pass through `validate_domain()` at CLI and MCP entry points, consistent with every other command.

## Verification

```
pytest tests/unit/test_dcv.py -v       →  25 passed
mypy src/dns_aid/core/dcv.py           →  Success: no issues found
ruff check src/dns_aid/core/dcv.py \
           src/dns_aid/cli/main.py \
           src/dns_aid/mcp/server.py   →  All checks passed
pytest tests/unit/ -q                  →  1292 passed (35 pre-existing failures in CEL/ML-DSA, unrelated)
```

End-to-end against live BIND9 testbed (two isolated Docker containers, `.test` TLD, RFC 2136 DDNS + TSIG):

```
[8]  Org A issues challenge for orgb.test  →  token=rpdf43..., bnd-req=svc:assistant@orga.test
[9]  Org B places via DDNS                 →  ✓ Challenge placed at _agents-challenge.orgb.test
[10] dig confirms TXT present              →  "token=rpdf43... bnd-req=... expiry=..."
[11] Org A verifies via Org B nameserver   →  ✓ DCV verified
[12] Org B revokes                         →  ✓ Challenge record removed
[13] dig confirms record gone              →  (empty)
```

## Test plan

- [x] Token generation — entropy, base32 format, DNS-label safety, uniqueness
- [x] TXT wire format — field ordering, spacing, expiry serialization
- [x] Key=value parser — bare token fallback, case-insensitive keys, `bnd-req` passthrough
- [x] `issue()` — stateless, distinct tokens per call, TTL affects expiry, bnd-req only when both agent and issuer supplied
- [x] `place()` — correct zone/name/values passed to backend; bnd-req included when present
- [x] `verify()` — success, wrong token, expired, NXDOMAIN, custom nameserver/port
- [x] `revoke()` — correct backend args; returns False when record not found
- [x] CLI boundary validation — invalid domain and out-of-range TTL rejected before touching DNS
- [x] Cross-org flow against real BIND9 over RFC 2136 DDNS

## Discussion: CONTRIBUTING.md checklist gap

`CONTRIBUTING.md` currently has a thorough 12-item checklist for new DNS backends. This PR adds the first new **Tier 0 protocol module** since the initial codebase — `core/dcv.py` sits alongside `discoverer.py`, `publisher.py`, and `validator.py` rather than under `backends/`.

The touchpoints for this kind of addition turned out to be: core module, `core/__init__.py`, top-level `__init__.py`, CLI subcommand group, MCP tools, health endpoint tool list, unit tests, testbed, CHANGELOG, version bump. Worth capturing as a parallel checklist for future Tier 0 additions. Happy to add that here or as a follow-up — flagging for your call.