### PR TITLE
feat(sdk): SDK search wrapper — Path A filters + Path B directory search (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,131 @@ All notable changes to DNS-AID will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-05-11
+
+> SDK Search Wrapper — extends the SDK with two coherent search surfaces: in-memory
+> filters on Path A `discover()` for already-fetched agents, and a new opt-in Path B
+> `AgentClient.search()` for cross-domain queries against a configured directory backend.
+
+### Added
+
+#### Path B (new) — cross-domain search via opt-in directory backend
+
+- **`AgentClient.search(...)` method**: GET `{directory_api_url}/api/v1/search` and return a typed
+  `SearchResponse`. Supports filters `q`, `protocol`, `domain`, `capabilities`, `min_security_score`,
+  `verified_only`, `intent`, `auth_type`, `transport`, `realm`, `limit`, `offset`. Maps every
+  failure mode to a typed exception so callers can dispatch on `DirectoryConfigError`,
+  `DirectoryAuthError`, `DirectoryRateLimitedError`, `DirectoryUnavailableError`.
+- **New typed models** in `dns_aid.sdk.search`:
+  - `SearchResponse` — query echo, ranked results, pagination state, `has_more` /
+    `next_offset` helpers.
+  - `SearchResult` — agent + relevance score + trust attestation + optional provenance.
+  - `TrustAttestation` — `security_score` / `trust_score` / `popularity_score` /
+    `trust_tier` / `safety_status` / per-signal verification flags
+    (`dnssec_valid` / `dane_valid` / `svcb_valid` / `endpoint_reachable` /
+    `protocol_verified`) / `threat_flags` / `breakdown` / `badges`.
+  - `Provenance` — `discovery_level`, `first_seen`, `last_seen`, `last_verified`,
+    `company`. All faithful mirrors of the directory's
+    `dns_aid_directory.api.schemas.AgentResponse` flat shape.
+- **`dns-aid search` CLI subcommand**: every Path B filter as a flag with
+  human-readable + `--json` output, exit codes per BSD `sysexits.h` (75 transient,
+  77 auth, 78 config).
+- **`search_agents` MCP tool**: structured `success: true/false` envelope (never raises
+  to the transport); error classes `directory_not_configured`,
+  `directory_unavailable`, `directory_rate_limited`, `directory_auth_failed`,
+  `invalid_arguments` map 1:1 with SDK exceptions.
+- **Wire-shape adapter** (`dns_aid.sdk.client._adapt_search_payload`): translates the
+  directory's flat `AgentResponse` into the SDK's typed nested objects. Lifts trust +
+  provenance signals, derives `target_host` from `endpoint_url`, splits comma-separated
+  `bap` strings into lists, strips explicit nulls so Pydantic defaults apply. Localizes
+  every wire-shape quirk in one place — directory schema drift only requires updating
+  this helper.
+- **`SDKConfig.directory_api_url`** field + `DNS_AID_SDK_DIRECTORY_API_URL` env var.
+  Existing `telemetry_api_url` continues to work as a deprecation alias and emits one
+  `DeprecationWarning` per process; when both are set, `directory_api_url` wins.
+- **`SDKConfig.resolved_directory_url`** property — single source of truth that
+  `search()`, `fetch_rankings()`, and the telemetry signal push all read from.
+
+#### Path A (extension) — in-memory filters on already-fetched agents
+
+- **`discover(...)` filter kwargs** (all keyword-only, all default `None`/`False`,
+  no behavior change for existing callers): `capabilities`, `capabilities_any`,
+  `auth_type`, `intent`, `transport`, `realm`, `min_dnssec`, `text_match`,
+  `require_signed`, `require_signature_algorithm`. Implementation in
+  `dns_aid.core.filters.apply_filters` — pure-function predicates over already-enriched
+  `AgentRecord` lists. Path A's per-domain agent set is small (<50 typical), so
+  list-comprehension filtering is the right tool over a query language or DSL.
+- **`dns-aid discover` CLI flags** for every filter kwarg: `--capabilities`,
+  `--capabilities-any`, `--auth-type`, `--intent`, `--transport`, `--realm`,
+  `--min-dnssec`, `--text-match`, `--require-signed`, `--require-signature-algorithm`.
+- **`discover_agents_via_dns` MCP tool** extended with the same filter args.
+- **AgentRecord fields**: `dnssec_validated: bool`, `signature_verified: bool | None`,
+  `signature_algorithm: str | None` populated by the discoverer's existing JWS
+  verification path so the new `--require-signed` and `--min-dnssec` filters have a
+  record-level signal to evaluate.
+
+#### Composition pattern (zero-trust)
+
+- **`search()` (Path B) → `discover(domain, name=, require_signed=True)` (Path A)**:
+  documented in API reference and demonstrated end-to-end against the live
+  `api.velosecurity-ai.io` + `highvelocitynetworking.com` fixtures. Path B is opt-in
+  convenience; Path A re-verification is the authoritative trust gate.
+
+### Changed
+
+- **`dns-aid discover --name X`** now case-insensitive (DNS labels are case-insensitive
+  per RFC 1035). Previously a no-op when used without `--protocol` because the substrate
+  fall-through would full-zone-walk and the post-filter never ran. Both bugs fixed.
+- **`SearchResponse.query`** is `str | None` (the directory's echoed `q` string), not
+  a structured object. The previously-planned `SearchQuery` echo class was removed —
+  the directory just echoes a string.
+- **`SearchResult.score`** drops the `<= 1.0` ceiling. Directory uses raw scores
+  (e.g. 39.2) — no client-side normalization.
+
+### Security
+
+- **`validate_fetch_url` rejects URLs with userinfo** (`https://user:pass@host`).
+  Prevents accidental credential leaks via logs / error messages. New
+  `redact_url_for_log` helper in `dns_aid.utils.url_safety` for defense-in-depth on
+  any code path that logs the raw user-supplied URL.
+- **`AgentClient.search()` disables HTTP redirects** (`follow_redirects=False`).
+  Closes a redirect-based SSRF: without this guard, a directory returning
+  `Location: https://internal.local` would have bypassed the SSRF check on the
+  initial URL. 3xx responses now surface as `DirectoryUnavailableError(UnexpectedRedirect)`.
+- **Response size guard** in `AgentClient.search()`: caps response body at 10 MiB.
+  A misbehaving directory (forgot pagination, returned an oversized page) is rejected
+  with `DirectoryUnavailableError(ResponseTooLarge)` before reaching the JSON parser.
+- **`AgentClient.search()` skip-and-log adapter**: directory records lacking a
+  derivable `target_host` (no `endpoint_url`, no pre-set `target_host`) are dropped
+  rather than synthesized. The SDK never invents endpoint data a caller might invoke.
+  Drops are logged at WARN with full agent identity (`fqdn`, `name`, `domain`); the
+  `total` field is adjusted so paginators stay arithmetically consistent.
+
+### Deferred
+
+- **SDK auth on outbound directory calls** — `search()`, `fetch_rankings()`, and the
+  telemetry signal push currently make anonymous requests. Phase 5.6's `AuthHandler`
+  infrastructure is not yet wired into directory-side calls. Tracked in
+  `docs/impl/phase-5.6.1-sdk-directory-auth.md` in the main DNS-AID repo. The live
+  directory at `api.velosecurity-ai.io` does not currently require auth, so this is
+  non-blocking; landing it before private/internal-tenant search filters (per
+  Phase 10) becomes a hard requirement.
+- **Path B JWS / signature filtering** — directory does not yet expose per-agent
+  `sig` / `key_algorithms` columns. Out of scope for this slice; Path A
+  `--require-signed` is fully functional today.
+
+### Notes
+
+- 1484 unit + parity + integration tests pass on this branch.
+- `mypy` clean across 79 source files; ruff + ruff-format clean on all touched
+  files; `bandit` reports 0 new findings.
+- Live integration verified end-to-end against `https://api.velosecurity-ai.io/api/v1/search`
+  and the `highvelocitynetworking.com` Route 53 zone — SDK / CLI / MCP / Path B → Path A
+  composition all green.
+- Backwards compatibility preserved: every existing `discover()`, `dns-aid discover`,
+  and `discover_agents_via_dns` MCP-tool caller produces identical results when no
+  new filter kwargs are passed.
+
 ## [0.18.6] - 2026-05-08
 
 ### Security

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.18.6"
-date-released: "2026-05-08"
+version: "0.19.0"
+date-released: "2026-05-11"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ await dns_aid.publish(
     capabilities=["chat", "code-review"]
 )
 
-# Discover agents at a domain (pure DNS - default)
+# Discover agents at a domain (Path A: DNS substrate)
 agents = await dns_aid.discover("example.com")
 for agent in agents:
     print(f"{agent.name}: {agent.endpoint_url}")
@@ -70,9 +70,57 @@ for agent in agents:
 # Discover via HTTP index (ANS-compatible, richer metadata)
 agents = await dns_aid.discover("example.com", use_http_index=True)
 
+# Filtered discovery — pure-Python predicates over the in-memory result (v0.19.0+)
+result = await dns_aid.discover(
+    "example.com",
+    capabilities=["payment-processing"],
+    auth_type="oauth2",
+    realm="prod",
+    require_signed=True,
+    require_signature_algorithm=["ES256", "Ed25519"],
+)
+
 # Verify an agent's DNS records
 result = await dns_aid.verify("_my-agent._mcp._agents.example.com")
 print(f"Security Score: {result.security_score}/100")
+```
+
+### Path B: cross-domain search via opt-in directory (v0.19.0+)
+
+When you don't yet know which domain hosts the agent you want, query a configured
+directory backend for ranked candidates with pre-computed trust signals:
+
+```python
+from dns_aid.sdk import AgentClient, SDKConfig
+
+# directory_api_url can also be set via DNS_AID_SDK_DIRECTORY_API_URL env var.
+config = SDKConfig(directory_api_url="https://api.example.com")
+
+async with AgentClient(config=config) as client:
+    response = await client.search(
+        q="payment processing",
+        protocol="mcp",
+        capabilities=["payment-processing"],
+        min_security_score=70,
+        verified_only=True,
+    )
+    for r in response.results:
+        print(f"{r.score:.2f}  {r.agent.fqdn}  T{r.trust.trust_tier}")
+```
+
+**Zero-trust composition**: Path B → Path A re-verify before invoking. Directory is
+opt-in convenience; DNS substrate is the authoritative trust gate.
+
+```python
+async with AgentClient(config=config) as client:
+    response = await client.search(q="fraud detection", min_security_score=70)
+    for candidate in response.results:
+        verified = await dns_aid.discover(
+            candidate.agent.domain,
+            name=candidate.agent.name,
+            require_signed=True,
+        )
+        # Invoke only when DNS substrate confirms the directory's claim.
 ```
 
 ### SDK: Invoke Agents & Capture Telemetry (v0.6.0+)
@@ -159,8 +207,18 @@ dns-aid publish \
 # Discover agents at a domain (pure DNS - default)
 dns-aid discover example.com
 
-# Discover with filters
+# Discover with substrate filters
 dns-aid discover example.com --protocol mcp --name chat
+
+# Discover with in-memory filters (v0.19.0+)
+dns-aid discover example.com \
+    --capabilities payment-processing --capabilities fraud-detection \
+    --auth-type oauth2 --realm prod \
+    --require-signed --require-signature-algorithm ES256
+
+# Cross-domain search via configured directory backend (v0.19.0+)
+export DNS_AID_SDK_DIRECTORY_API_URL=https://api.example.com
+dns-aid search "payment processing" --protocol mcp --min-security-score 70
 
 # Discover via HTTP index (ANS-compatible, richer metadata)
 dns-aid discover example.com --use-http-index

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,6 +40,9 @@ Complete API documentation for DNS-AID - DNS-based Agent Identification and Disc
 - [SDK: Invocation & Telemetry](#sdk-invocation--telemetry)
   - [AgentClient](#agentclient)
   - [SDKConfig](#sdkconfig)
+  - [AgentClient.search() — Path B cross-domain search (v0.19.0+)](#agentclientsearch--path-b-cross-domain-search-v0190)
+  - [SearchResponse / SearchResult / TrustAttestation / Provenance (v0.19.0+)](#searchresponse--searchresult--trustattestation--provenance-v0190)
+  - [Directory exceptions (v0.19.0+)](#directory-exceptions-v0190)
   - [InvocationResult](#invocationresult)
   - [InvocationSignal](#invocationsignal)
   - [Ranking](#ranking)
@@ -157,7 +160,7 @@ else:
 
 ### discover()
 
-Discover AI agents at a domain using DNS-AID protocol.
+Discover AI agents at a domain using DNS-AID protocol (Path A — DNS substrate).
 
 ```python
 async def discover(
@@ -166,18 +169,55 @@ async def discover(
     name: str | None = None,
     require_dnssec: bool = False,
     use_http_index: bool = False,
+    enrich_endpoints: bool = True,
+    verify_signatures: bool = False,
+    *,
+    # Path A in-memory filter kwargs (v0.19.0+)
+    capabilities: list[str] | None = None,
+    capabilities_any: list[str] | None = None,
+    auth_type: str | None = None,
+    intent: str | None = None,
+    transport: str | None = None,
+    realm: str | None = None,
+    min_dnssec: bool = False,
+    text_match: str | None = None,
+    require_signed: bool = False,
+    require_signature_algorithm: list[str] | None = None,
 ) -> DiscoveryResult
 ```
 
 #### Parameters
 
+**Substrate parameters:**
+
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `domain` | `str` | Yes | - | Domain to search for agents |
 | `protocol` | `str \| Protocol` | No | `None` | Filter by protocol (None for all) |
-| `name` | `str` | No | `None` | Filter by specific agent name |
+| `name` | `str` | No | `None` | Filter by specific agent name (case-insensitive per RFC 1035) |
 | `require_dnssec` | `bool` | No | `False` | Require DNSSEC validation |
 | `use_http_index` | `bool` | No | `False` | Use HTTP index endpoint instead of DNS-only discovery |
+| `enrich_endpoints` | `bool` | No | `True` | Fetch cap docs / agent cards to enrich AgentRecords |
+| `verify_signatures` | `bool` | No | `False` | Fetch JWKS and verify per-agent JWS signatures |
+
+**Filter kwargs (v0.19.0+, all keyword-only, all default no-op):**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `capabilities` | `list[str] \| None` | All-of capability match — every entry must be present on the agent. Empty list = no-match (explicit). |
+| `capabilities_any` | `list[str] \| None` | Any-of capability match — at least one entry must be present. Empty list = no-match. |
+| `auth_type` | `str \| None` | Case-insensitive exact match against `agent.auth_type`. |
+| `intent` | `str \| None` | Match against `agent.category`; falls back to substring match across capabilities. |
+| `transport` | `str \| None` | Match against the agent's protocol identifier (Path A surfaces protocol, not wire transport). |
+| `realm` | `str \| None` | Exact match against `agent.realm`. |
+| `min_dnssec` | `bool` | When `True`, only records whose DNS response was DNSSEC-validated pass. |
+| `text_match` | `str \| None` | Case-insensitive substring match across `description`, `use_cases`, and `capabilities`. Empty string raises `ValueError`. |
+| `require_signed` | `bool` | When `True`, only records whose JWS signature verified pass. Auto-enables `verify_signatures=True`. |
+| `require_signature_algorithm` | `list[str] \| None` | Restrict `require_signed` matches to records whose verified algorithm is in this allow-list. Requires `require_signed=True`. |
+
+All filter predicates compose with logical AND. None / `False` means "no constraint".
+When every filter is unset, the input list is returned unchanged with no allocation
+(no-op fast path keeps existing callers free of overhead).
 
 #### Discovery Methods
 
@@ -189,6 +229,13 @@ async def discover(
 #### Returns
 
 `DiscoveryResult` - Contains list of discovered agents and query metadata.
+
+#### Raises
+
+- `ValueError` — `text_match` is an empty string, or `require_signature_algorithm`
+  is set without `require_signed=True`.
+- `DNSSECError` — `require_dnssec=True` but the domain's response is not
+  authenticated.
 
 #### Example
 
@@ -206,6 +253,21 @@ result = await discover("example.com", protocol="mcp", name="chat")
 
 # Discover via HTTP index (ANS-compatible, richer metadata)
 result = await discover("example.com", use_http_index=True)
+
+# Filter by capabilities + auth type (v0.19.0+)
+result = await discover(
+    "example.com",
+    capabilities=["payment-processing", "fraud-detection"],
+    auth_type="oauth2",
+    realm="prod",
+)
+
+# Trust-gated discovery: only signed agents with allow-listed algorithms
+result = await discover(
+    "example.com",
+    require_signed=True,
+    require_signature_algorithm=["ES256", "Ed25519"],
+)
 
 for agent in result.agents:
     print(f"{agent.name}: {agent.endpoint_url}")
@@ -1223,7 +1285,8 @@ config = SDKConfig(
     otel_endpoint=None,          # OTLP endpoint URL
     otel_export_format="otlp",   # "otlp" or "console"
     http_push_url=None,          # POST signals to remote telemetry API
-    telemetry_api_url=None,      # Base URL for fetch_rankings() queries
+    directory_api_url=None,      # Base URL for AgentClient.search() and fetch_rankings()
+    telemetry_api_url=None,      # Deprecated alias for directory_api_url
 )
 
 # Or from environment variables:
@@ -1241,7 +1304,185 @@ config = SDKConfig.from_env()
 | `DNS_AID_SDK_OTEL_ENABLED` | false | Enable OpenTelemetry |
 | `DNS_AID_SDK_OTEL_ENDPOINT` | None | OTLP collector URL |
 | `DNS_AID_SDK_HTTP_PUSH_URL` | None | POST signals to this URL |
-| `DNS_AID_SDK_TELEMETRY_API_URL` | None | Base URL for fetch_rankings() queries |
+| `DNS_AID_SDK_DIRECTORY_API_URL` | None | Base URL for `AgentClient.search()` + `fetch_rankings()` (v0.19.0+) |
+| `DNS_AID_SDK_TELEMETRY_API_URL` | None | Deprecated alias for `DNS_AID_SDK_DIRECTORY_API_URL` |
+
+The `resolved_directory_url` property returns `directory_api_url` when set, falling
+back to `telemetry_api_url` for backwards compatibility. Using the legacy alias
+emits a `DeprecationWarning` once per process.
+
+---
+
+### AgentClient.search() — Path B cross-domain search (v0.19.0+)
+
+```python
+async def search(
+    self,
+    q: str | None = None,
+    *,
+    protocol: Literal["mcp", "a2a", "https"] | None = None,
+    domain: str | None = None,
+    capabilities: list[str] | None = None,
+    min_security_score: int | None = None,
+    verified_only: bool = False,
+    intent: str | None = None,
+    auth_type: str | None = None,
+    transport: str | None = None,
+    realm: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> SearchResponse
+```
+
+Issues `GET {directory_api_url}/api/v1/search` and returns a typed `SearchResponse`.
+Path B is **opt-in**: invoking `search()` without `directory_api_url` configured
+raises `DirectoryConfigError` immediately, before any network work.
+
+#### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `q` | `str \| None` | `None` | Free-text query, or `None` for browse-all-with-filters mode. |
+| `protocol` | `Literal["mcp","a2a","https"] \| None` | `None` | Restrict to a protocol. |
+| `domain` | `str \| None` | `None` | Restrict to a single domain. |
+| `capabilities` | `list[str] \| None` | `None` | All-of capability match. |
+| `min_security_score` | `int \| None` | `None` | Minimum security score (0–100). |
+| `verified_only` | `bool` | `False` | Restrict to DCV-verified domains. |
+| `intent` | `str \| None` | `None` | Action intent filter (`query` / `command` / `transaction` / `subscription`). |
+| `auth_type` | `str \| None` | `None` | Auth type filter. |
+| `transport` | `str \| None` | `None` | Transport filter (`streamable-http`, `https`, `sse`, `stdio`). |
+| `realm` | `str \| None` | `None` | Multi-tenant realm filter. |
+| `limit` | `int` | `20` | Page size, 1–10000. |
+| `offset` | `int` | `0` | Pagination offset. |
+
+#### Returns
+
+`SearchResponse` — query echo, ranked results, pagination state.
+
+#### Raises
+
+- `DirectoryConfigError` — `directory_api_url` not configured.
+- `DirectoryAuthError` — Directory rejected credentials (HTTP 401/403).
+- `DirectoryRateLimitedError` — Directory rate-limited (HTTP 429); the
+  `retry_after_seconds` detail mirrors the `Retry-After` header.
+- `DirectoryUnavailableError` — Transient: connect refused, timeout, 5xx, 404,
+  unexpected redirect, oversized response, or response shape the SDK can't validate.
+- `RuntimeError` — Client not in an async context manager.
+
+#### Example
+
+```python
+from dns_aid.sdk import AgentClient, SDKConfig
+
+async with AgentClient(config=SDKConfig.from_env()) as client:
+    response = await client.search(
+        "payment processing",
+        protocol="mcp",
+        capabilities=["payment-processing"],
+        min_security_score=70,
+    )
+    for result in response.results:
+        print(f"{result.score:.2f}  {result.agent.fqdn}  T{result.trust.trust_tier}")
+        print(f"   sec={result.trust.security_score}  trust={result.trust.trust_score}")
+
+    # Paginate
+    while response.has_more:
+        response = await client.search(q="payment", offset=response.next_offset)
+```
+
+#### Composition pattern (zero-trust)
+
+Path B returns directory-attested candidates. Path A re-verifies via DNS substrate
+before invoking — directory is opt-in convenience, never a trust bottleneck.
+
+```python
+from dns_aid.sdk import AgentClient
+from dns_aid.core.discoverer import discover
+
+async with AgentClient() as client:
+    # 1. Cross-domain candidate discovery
+    response = await client.search(q="fraud detection", min_security_score=70)
+
+    for candidate in response.results:
+        # 2. DNS-substrate re-verification with signature requirement
+        verified = await discover(
+            candidate.agent.domain,
+            name=candidate.agent.name,
+            require_signed=True,
+            require_signature_algorithm=["ES256", "Ed25519"],
+        )
+        if verified.agents:
+            # 3. Safe to invoke
+            ...
+```
+
+---
+
+### SearchResponse / SearchResult / TrustAttestation / Provenance (v0.19.0+)
+
+Typed result models in `dns_aid.sdk.search`. All immutable (`frozen=True`) and
+forward-compatible (`extra="ignore"`) so directory schema additions don't break
+SDK consumers.
+
+```python
+class SearchResponse(BaseModel):
+    query: str | None              # Echo of the q parameter from the directory.
+    results: list[SearchResult]    # Ranked results, length <= limit.
+    total: int                     # Matches across all pages (after skip-and-log).
+    limit: int
+    offset: int
+
+    @property
+    def has_more(self) -> bool: ...
+    @property
+    def next_offset(self) -> int | None: ...
+
+class SearchResult(BaseModel):
+    agent: AgentRecord
+    score: float                       # Raw relevance score, not normalized.
+    trust: TrustAttestation            # Defaults to all-zero if directory omits.
+    provenance: Provenance | None      # Built when first_seen / last_seen present.
+
+class TrustAttestation(BaseModel):
+    security_score: int = 0            # 0–100
+    trust_score: int = 0               # 0–100
+    popularity_score: int = 0          # 0–100
+    trust_tier: int = 0                # 0–3 (untiered / basic / enhanced / continuous)
+    safety_status: Literal["active", "blocked"] = "active"
+    dnssec_valid: bool | None = None
+    dane_valid: bool | None = None
+    svcb_valid: bool | None = None
+    endpoint_reachable: bool | None = None
+    protocol_verified: bool | None = None
+    threat_flags: dict[str, Any] = {}
+    breakdown: dict[str, Any] | None = None   # Directory's trust_breakdown.
+    badges: list[str] | None = None           # Directory's trust_badges.
+
+class Provenance(BaseModel):
+    discovery_level: int = 0           # 0 observed / 1 beacon / 2 manifest / 3 federated
+    first_seen: datetime
+    last_seen: datetime
+    last_verified: datetime | None = None
+    company: dict[str, Any] | None = None
+```
+
+---
+
+### Directory exceptions (v0.19.0+)
+
+```python
+from dns_aid.sdk import (
+    DirectoryError,                # Base exception class.
+    DirectoryConfigError,          # directory_api_url not configured (78 EX_CONFIG).
+    DirectoryUnavailableError,     # Transient (75 EX_TEMPFAIL).
+    DirectoryRateLimitedError,     # 429; carries retry_after_seconds detail.
+    DirectoryAuthError,            # 401/403 (77 EX_NOPERM); does NOT inherit from Unavailable.
+)
+```
+
+Every exception carries a `details: dict[str, Any]` attribute with structured fields
+(`directory_url`, `status_code`, `underlying`, etc.) so callers can dispatch on type
+*and* inspect details for richer error handling.
 
 ### InvocationResult
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,61 @@ Route 53 compatibility. This is tracked as a known interoperability issue.
 
 ---
 
+## Path A vs Path B (search surfaces)
+
+DNS-AID exposes two complementary surfaces for finding agents:
+
+| | **Path A** (`discover()`) | **Path B** (`AgentClient.search()`) |
+|---|---|---|
+| **Source of truth** | The target domain's DNS substrate | An opt-in directory backend (e.g. `api.velosecurity-ai.io`) |
+| **Scope** | Single domain — one zone at a time | Cross-domain — every indexed domain in one query |
+| **Filtering** | Pure-Python predicates over an in-memory list (`<50` agents typical) | Backend SQL/index over millions of agents |
+| **Trust signals** | Per-agent JWS verification + DNSSEC | Pre-computed aggregate scores from crawler telemetry |
+| **Network calls** | DNS queries to the target's nameservers + optional HTTPS to the target's `/.well-known/` | Single HTTPS GET to the configured directory |
+| **Auth** | None needed (DNS is unauthenticated) | Currently anonymous; SDK auth handlers planned (Phase 5.6.1) |
+| **Required config** | Nothing | `directory_api_url` (or env var) |
+| **Failure isolation** | DNS errors are scoped to the target domain | Directory outage is logged-and-swallowed; never blocks Path A |
+
+### When to use which
+
+**Use Path A when** you already know the target domain and want authoritative DNS-bound
+data with no third-party trust assumptions. This is the **zero-trust default**.
+
+**Use Path B when** you don't know which domain hosts the agent you want, or you
+need ranking signals across many domains (security score, trust score, popularity)
+that DNS alone can't provide.
+
+### Composition pattern (zero-trust)
+
+The recommended pattern is **search → re-verify → invoke**:
+
+```
+1. Path B: AgentClient.search(q="payment processing")
+   → returns ranked candidates with directory-attested trust signals
+2. Path A: discover(candidate.domain, name=candidate.name, require_signed=True)
+   → re-verifies the candidate via DNS substrate before any invocation
+3. AgentClient.invoke(verified_agent, ...)
+   → Path A is the authoritative trust gate; directory is opt-in convenience
+```
+
+Path B's trust attestations are useful *signals*, not *guarantees*. The directory
+can have stale data, the crawler can be wrong about an endpoint, or a domain can
+revoke an agent between crawls. Path A re-verification catches all of these.
+
+### What lives where in code
+
+| Layer | Path A | Path B |
+|---|---|---|
+| SDK | `dns_aid.core.discoverer.discover()` + `dns_aid.core.filters.apply_filters()` | `dns_aid.sdk.client.AgentClient.search()` + `dns_aid.sdk.search` (typed models) + `dns_aid.sdk.exceptions` |
+| CLI | `dns-aid discover` (with new filter flags as of v0.19.0) | `dns-aid search` (new in v0.19.0) |
+| MCP tool | `discover_agents_via_dns` | `search_agents` |
+
+The CLI and MCP-tool surfaces are thin wrappers — both path A and path B converge
+on the SDK layer, so cross-interface parity (FR-024/FR-025) is enforced by tests
+that round-trip the same inputs through every surface.
+
+---
+
 ## Discovery Modes
 
 ### Pure DNS Discovery

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1272,6 +1272,107 @@ for r in ranked:
     print(f"{r.agent_fqdn}: score={r.composite_score:.1f}")
 ```
 
+### Path A: Filtered single-domain discovery (v0.19.0+)
+
+`discover()` now accepts in-memory filter kwargs that operate on the post-enrichment
+agent list. Useful when you already know the target domain but only want a subset:
+
+```python
+from dns_aid import discover
+
+# All-of capability match + auth type + realm
+result = await discover(
+    "example.com",
+    capabilities=["payment-processing", "fraud-detection"],
+    auth_type="oauth2",
+    realm="prod",
+)
+
+# Trust-gated: only signed agents with allow-listed algorithms
+result = await discover(
+    "example.com",
+    require_signed=True,
+    require_signature_algorithm=["ES256", "Ed25519"],
+)
+
+# Substring search across description / use_cases / capabilities
+result = await discover("example.com", text_match="payment")
+```
+
+The same filters are exposed on the CLI:
+
+```bash
+dns-aid discover example.com \
+    --capabilities payment-processing --capabilities fraud-detection \
+    --auth-type oauth2 --realm prod --json
+
+dns-aid discover example.com \
+    --require-signed \
+    --require-signature-algorithm ES256 \
+    --require-signature-algorithm Ed25519
+```
+
+### Path B: Cross-domain search via the directory (v0.19.0+)
+
+`AgentClient.search()` is opt-in: configure a directory backend, then query across
+every domain it has indexed.
+
+```bash
+# Configure the directory once via env var
+export DNS_AID_SDK_DIRECTORY_API_URL=https://api.velosecurity-ai.io
+```
+
+```python
+from dns_aid.sdk import AgentClient, SDKConfig
+
+async with AgentClient(config=SDKConfig.from_env()) as client:
+    response = await client.search(
+        q="payment processing",
+        protocol="mcp",
+        capabilities=["payment-processing"],
+        min_security_score=70,
+        verified_only=True,
+        limit=10,
+    )
+
+    for r in response.results:
+        print(f"{r.score:.2f}  {r.agent.fqdn}  T{r.trust.trust_tier}/{r.trust.trust_score}")
+
+    # Walk subsequent pages
+    while response.has_more:
+        response = await client.search(q="payment", offset=response.next_offset)
+```
+
+CLI:
+
+```bash
+dns-aid search "payment processing" --protocol mcp \
+    --capabilities payment-processing --min-security-score 70 --verified-only --json
+```
+
+#### Zero-trust composition
+
+Path B candidates → Path A re-verification before invoking:
+
+```python
+from dns_aid.sdk import AgentClient
+from dns_aid.core.discoverer import discover
+
+async with AgentClient() as client:
+    response = await client.search(q="fraud detection", min_security_score=70)
+
+    for candidate in response.results:
+        verified = await discover(
+            candidate.agent.domain,
+            name=candidate.agent.name,
+            require_signed=True,
+        )
+        if verified.agents:
+            agent = verified.agents[0]
+            # Safe to invoke — DNS substrate confirms the directory's claim.
+            ...
+```
+
 ### Advanced: Connection Reuse & DB Persistence
 
 ```python
@@ -1518,8 +1619,9 @@ python examples/demo_full.py
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DNS_AID_HTTP_PUSH_URL` | No | — | Optional endpoint to push telemetry signals |
-| `DNS_AID_TELEMETRY_API_URL` | No | — | Optional endpoint to fetch community rankings |
-| `DNS_AID_DIRECTORY_API_URL` | No | — | Optional endpoint to query agent directory |
+| `DNS_AID_SDK_DIRECTORY_API_URL` | No | — | Base URL for `AgentClient.search()` and `fetch_rankings()` (Path B) (v0.19.0+) |
+| `DNS_AID_SDK_TELEMETRY_API_URL` | No | — | **Deprecated alias** for `DNS_AID_SDK_DIRECTORY_API_URL`. Emits one `DeprecationWarning` per process. |
+| `DNS_AID_FETCH_ALLOWLIST` | No | — | Comma-separated hostnames to bypass SSRF DNS-resolution check (testing only) |
 
 ### Backend-Specific Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.18.6"
+version = "0.19.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -305,6 +305,67 @@ def discover(
             help="Verify JWS signatures on agents (alternative to DNSSEC)",
         ),
     ] = False,
+    capabilities: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--capabilities",
+            help="Required capability (repeatable; all-of match).",
+        ),
+    ] = None,
+    capabilities_any: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--capabilities-any",
+            help="Any-of capability match (repeatable).",
+        ),
+    ] = None,
+    auth_type: Annotated[
+        str | None,
+        typer.Option("--auth-type", help="Filter by auth type (oauth2, api_key, ...)."),
+    ] = None,
+    intent: Annotated[
+        str | None,
+        typer.Option(
+            "--intent",
+            help="Filter by intent (query / command / transaction / subscription).",
+        ),
+    ] = None,
+    transport: Annotated[
+        str | None,
+        typer.Option("--transport", help="Filter by transport (Path A: matches protocol)."),
+    ] = None,
+    realm: Annotated[
+        str | None,
+        typer.Option("--realm", help="Filter by realm."),
+    ] = None,
+    min_dnssec: Annotated[
+        bool,
+        typer.Option(
+            "--min-dnssec",
+            help="Only return records whose DNS response was DNSSEC-validated.",
+        ),
+    ] = False,
+    text_match: Annotated[
+        str | None,
+        typer.Option(
+            "--text-match",
+            help="Case-insensitive substring match across description, use_cases, capabilities.",
+        ),
+    ] = None,
+    require_signed: Annotated[
+        bool,
+        typer.Option(
+            "--require-signed",
+            help="Only return records whose JWS signature verified (auto-enables --verify-signatures).",
+        ),
+    ] = False,
+    require_signature_algorithm: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--require-signature-algorithm",
+            help="Restrict --require-signed matches to records whose verified algorithm is in this allow-list (repeatable).",
+        ),
+    ] = None,
 ):
     """
     Discover agents at a domain using DNS-AID protocol.
@@ -317,23 +378,37 @@ def discover(
     Example:
         dns-aid discover example.com
         dns-aid discover example.com --protocol mcp
-        dns-aid discover example.com --name chat
-        dns-aid discover example.com --use-http-index
+        dns-aid discover example.com --name chat --require-signed
+        dns-aid discover example.com --capabilities payment-processing --auth-type oauth2
     """
     from dns_aid.core.discoverer import discover as do_discover
 
     method = "HTTP index" if use_http_index else "DNS"
     console.print(f"\n[bold]Discovering agents at {domain} via {method}...[/bold]\n")
 
-    result = run_async(
-        do_discover(
-            domain=domain,
-            protocol=protocol,
-            name=name,
-            use_http_index=use_http_index,
-            verify_signatures=verify_signatures,
+    try:
+        result = run_async(
+            do_discover(
+                domain=domain,
+                protocol=protocol,
+                name=name,
+                use_http_index=use_http_index,
+                verify_signatures=verify_signatures,
+                capabilities=capabilities,
+                capabilities_any=capabilities_any,
+                auth_type=auth_type,
+                intent=intent,
+                transport=transport,
+                realm=realm,
+                min_dnssec=min_dnssec,
+                text_match=text_match,
+                require_signed=require_signed,
+                require_signature_algorithm=require_signature_algorithm,
+            )
         )
-    )
+    except ValueError as exc:
+        error_console.print(f"[red]Invalid filter combination:[/red] {exc}")
+        raise typer.Exit(code=64) from exc
 
     if json_output:
         import json
@@ -391,6 +466,225 @@ def discover(
     console.print(table)
     console.print(f"\n[dim]Query: {result.query}[/dim]")
     console.print(f"[dim]Time: {result.query_time_ms:.2f}ms[/dim]")
+
+
+# ============================================================================
+# SEARCH COMMAND (Path B — directory-backed cross-domain search)
+# ============================================================================
+
+
+# Exit codes mirror BSD ``sysexits.h`` so shell automation can dispatch on them.
+_EXIT_TRANSIENT = 75  # EX_TEMPFAIL — directory unreachable / 5xx / timeout / 429
+_EXIT_AUTH = 77  # EX_NOPERM — directory rejected credentials (401/403)
+_EXIT_CONFIG = 78  # EX_CONFIG — directory_api_url not set
+
+
+@app.command()
+def search(
+    query: Annotated[
+        str | None,
+        typer.Argument(help="Free-text query (omit to browse all matches)."),
+    ] = None,
+    protocol: Annotated[
+        str | None,
+        typer.Option("--protocol", "-p", help="Filter by protocol (mcp / a2a / https)."),
+    ] = None,
+    domain: Annotated[
+        str | None,
+        typer.Option("--domain", help="Filter by domain."),
+    ] = None,
+    capabilities: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--capabilities",
+            help="Required capability (repeatable; matches all-of).",
+        ),
+    ] = None,
+    intent: Annotated[
+        str | None,
+        typer.Option(
+            "--intent",
+            help="Action intent (query / command / transaction / subscription).",
+        ),
+    ] = None,
+    auth_type: Annotated[
+        str | None,
+        typer.Option("--auth-type", help="Filter by auth type (oauth2, api_key, bearer, ...)."),
+    ] = None,
+    transport: Annotated[
+        str | None,
+        typer.Option("--transport", help="Filter by transport (streamable-http, https, sse, ...)."),
+    ] = None,
+    realm: Annotated[
+        str | None,
+        typer.Option("--realm", help="Filter by realm (multi-tenant scope)."),
+    ] = None,
+    min_security_score: Annotated[
+        int | None,
+        typer.Option("--min-security-score", help="Minimum security score (0-100)."),
+    ] = None,
+    verified_only: Annotated[
+        bool,
+        typer.Option("--verified-only", help="Restrict to DCV-verified domains only."),
+    ] = False,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", help="Page size (1-10000).", min=1, max=10000),
+    ] = 20,
+    offset: Annotated[
+        int,
+        typer.Option("--offset", help="Pagination offset.", min=0),
+    ] = 0,
+    directory_url: Annotated[
+        str | None,
+        typer.Option(
+            "--directory-url",
+            help="Override the configured directory backend URL for this invocation.",
+        ),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", "-j", help="Emit JSON output.")] = False,
+) -> None:
+    """
+    Cross-domain agent search via the configured DNS-AID directory backend.
+
+    Issues a single search call against the directory and prints ranked results with
+    trust attestations. Requires ``directory_api_url`` configured (or pass
+    ``--directory-url`` to override per invocation).
+
+    Exit codes (sysexits.h):
+
+    * 0  — success (including zero results)
+    * 64 — usage error (Typer default)
+    * 75 — transient failure (directory unreachable / 5xx / 429)
+    * 77 — auth failure (401/403)
+    * 78 — configuration error (no directory_api_url)
+
+    Examples:
+        dns-aid search "payment processing" --protocol mcp --capabilities payment-processing
+        dns-aid search --intent transaction --auth-type oauth2 --min-security-score 70
+        dns-aid search "fraud detection" --json
+    """
+    import json as _json
+
+    from dns_aid.sdk import (
+        AgentClient,
+        DirectoryAuthError,
+        DirectoryConfigError,
+        DirectoryUnavailableError,
+        SDKConfig,
+    )
+    from dns_aid.sdk.search import SearchResponse
+
+    config = SDKConfig.from_env()
+    if directory_url is not None:
+        config = config.model_copy(update={"directory_api_url": directory_url})
+
+    async def _run() -> SearchResponse:
+        async with AgentClient(config=config) as client:
+            return await client.search(
+                q=query,
+                protocol=protocol,  # type: ignore[arg-type]
+                domain=domain,
+                capabilities=capabilities,
+                min_security_score=min_security_score,
+                verified_only=verified_only,
+                intent=intent,
+                auth_type=auth_type,
+                transport=transport,
+                realm=realm,
+                limit=limit,
+                offset=offset,
+            )
+
+    try:
+        response = run_async(_run())
+    except DirectoryConfigError as exc:
+        if json_output:
+            error_console.print_json(
+                _json.dumps(
+                    {
+                        "error": {
+                            "class": "DirectoryConfigError",
+                            "message": str(exc),
+                            "details": exc.details,
+                        }
+                    }
+                )
+            )
+        else:
+            error_console.print(f"[red]Configuration error:[/red] {exc}")
+            error_console.print(
+                f"[dim]Set environment variable {exc.details.get('env_var')} or use --directory-url.[/dim]"
+            )
+        raise typer.Exit(code=_EXIT_CONFIG) from exc
+    except DirectoryAuthError as exc:
+        if json_output:
+            error_console.print_json(
+                _json.dumps(
+                    {
+                        "error": {
+                            "class": "DirectoryAuthError",
+                            "message": str(exc),
+                            "details": exc.details,
+                        }
+                    }
+                )
+            )
+        else:
+            error_console.print(f"[red]Auth failed:[/red] {exc}")
+        raise typer.Exit(code=_EXIT_AUTH) from exc
+    except DirectoryUnavailableError as exc:
+        if json_output:
+            error_console.print_json(
+                _json.dumps(
+                    {
+                        "error": {
+                            "class": type(exc).__name__,
+                            "message": str(exc),
+                            "details": exc.details,
+                        }
+                    }
+                )
+            )
+        else:
+            error_console.print(f"[yellow]Directory unavailable:[/yellow] {exc}")
+        raise typer.Exit(code=_EXIT_TRANSIENT) from exc
+
+    if json_output:
+        console.print_json(response.model_dump_json())
+        return
+
+    if not response.results:
+        console.print(f"[yellow]No agents matched the query (total {response.total}).[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Score", justify="right")
+    table.add_column("FQDN")
+    table.add_column("Tier", justify="right")
+    table.add_column("Sec", justify="right")
+    table.add_column("Trust", justify="right")
+    table.add_column("Capabilities")
+
+    for result in response.results:
+        agent = result.agent
+        fqdn = f"_{agent.name}._{agent.protocol.value}._agents.{agent.domain}"
+        table.add_row(
+            f"{result.score:.2f}",
+            fqdn,
+            f"T{result.trust.trust_tier}",
+            str(result.trust.security_score),
+            str(result.trust.trust_score),
+            ", ".join(agent.capabilities) if agent.capabilities else "-",
+        )
+
+    console.print(table)
+    shown = len(response.results) + response.offset
+    console.print(
+        f"\n[dim]Showing {response.offset + 1}-{shown} of {response.total} results.[/dim]"
+    )
+    if response.has_more:
+        console.print(f"[dim]Use --offset {response.next_offset} to see the next page.[/dim]")
 
 
 # ============================================================================

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -11,6 +11,8 @@ records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import shlex
 import time
 from typing import Any, Literal
@@ -23,6 +25,7 @@ import structlog
 
 from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
+from dns_aid.core.filters import apply_filters
 from dns_aid.core.http_index import HttpIndexAgent, fetch_http_index_or_empty
 from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol
 
@@ -106,39 +109,75 @@ async def discover(
     use_http_index: bool = False,
     enrich_endpoints: bool = True,
     verify_signatures: bool = False,
+    *,
+    # Path A in-memory filter kwargs (FR-002, FR-021..FR-023). All optional; default
+    # behavior is unchanged when none are passed.
+    capabilities: list[str] | None = None,
+    capabilities_any: list[str] | None = None,
+    auth_type: str | None = None,
+    intent: str | None = None,
+    transport: str | None = None,
+    realm: str | None = None,
+    min_dnssec: bool = False,
+    text_match: str | None = None,
+    require_signed: bool = False,
+    require_signature_algorithm: list[str] | None = None,
 ) -> DiscoveryResult:
     """
     Discover AI agents at a domain using DNS-AID protocol.
 
-    Queries DNS for SVCB records under _agents.{domain} and returns
-    discovered agent endpoints.
+    Queries DNS for SVCB records under _agents.{domain} and returns discovered agent
+    endpoints, optionally filtered by structured kwargs.
 
     Args:
-        domain: Domain to search for agents (e.g., "example.com")
-        protocol: Filter by protocol ("a2a", "mcp", or None for all)
-        name: Filter by specific agent name (or None for all)
-        require_dnssec: Require DNSSEC validation (raises if invalid)
+        domain: Domain to search for agents (e.g., "example.com").
+        protocol: Filter by protocol ("a2a", "mcp", or None for all).
+        name: Filter by specific agent name (or None for all).
+        require_dnssec: Require DNSSEC validation (raises if invalid).
         use_http_index: If True, fetch agent list from HTTP endpoint
-                        (/.well-known/agents-index.json) instead of using
-                        DNS-only discovery. Default False (pure DNS).
-        enrich_endpoints: If True (default), fetch .well-known/agent-card.json
-                         from each discovered agent's host to resolve
-                         protocol-specific endpoint paths (e.g., /mcp).
-        verify_signatures: If True, verify JWS signatures on agents that have
-                          a `sig` parameter but no DNSSEC validation. Invalid
-                          signatures are logged but don't block discovery.
+            (``/.well-known/agents-index.json``) instead of DNS-only discovery.
+        enrich_endpoints: If True (default), fetch ``.well-known/agent-card.json``
+            from each discovered agent's host to resolve protocol-specific endpoint paths.
+        verify_signatures: If True, verify JWS signatures. Implicit when ``require_signed``
+            is set so the trust filter has data to act on.
+        capabilities: All-of capability match. Empty list explicitly matches no records.
+        capabilities_any: Any-of capability match. Empty list explicitly matches no records.
+        auth_type: Case-insensitive exact match against ``agent.auth_type``.
+        intent: Match against ``agent.category``; substring fallback against capabilities.
+        transport: For Path A this matches ``agent.protocol.value`` (DNS substrate does not
+            surface the wire transport binding; use Path B for streamable-http / sse / etc.).
+        realm: Exact match against ``agent.realm``.
+        min_dnssec: When True, only records with DNSSEC-validated DNS responses pass.
+        text_match: Case-insensitive substring across description, use_cases, capabilities.
+        require_signed: Only records whose JWS signature verified pass. Auto-enables
+            ``verify_signatures``.
+        require_signature_algorithm: Restrict ``require_signed`` to records whose verified
+            algorithm appears in this allow-list. Requires ``require_signed=True``.
 
     Returns:
-        DiscoveryResult with list of discovered agents
+        DiscoveryResult with the post-filter list of agents.
+
+    Raises:
+        ValueError: ``text_match`` is the empty string, or
+            ``require_signature_algorithm`` is set without ``require_signed=True``.
+        DNSSECError: ``require_dnssec=True`` and the response was not authenticated.
 
     Example:
-        >>> result = await discover("example.com", protocol="mcp")
+        >>> result = await discover(
+        ...     "example.com",
+        ...     protocol="mcp",
+        ...     capabilities=["payment-processing"],
+        ...     auth_type="oauth2",
+        ...     require_signed=True,
+        ... )
         >>> for agent in result.agents:
         ...     print(f"{agent.name}: {agent.endpoint_url}")
-
-        # Using HTTP index for richer metadata
-        >>> result = await discover("example.com", use_http_index=True)
     """
+    if require_signed and not verify_signatures:
+        # Implicit upgrade: trust filter needs verification to have run (FR-023).
+        verify_signatures = True
+        logger.debug("sdk.discover_implicit_verify_signatures", reason="require_signed=True")
+
     start_time = time.perf_counter()
 
     protocol = _normalize_protocol(protocol)
@@ -164,9 +203,68 @@ async def discover(
     )
 
     agents = await _execute_discovery(domain, protocol, name, use_http_index, query)
+
+    # Path A name filter — applied here, *before* enrichment, so we don't fetch
+    # cap docs / agent cards / JWKS for agents we're about to discard.
+    # ``_execute_discovery`` already short-circuits to a single SVCB query when
+    # both ``name`` and ``protocol`` are set; this branch covers the remaining
+    # case (name without protocol) where the substrate did a full-zone walk.
+    # Comparison is case-insensitive: DNS labels are case-insensitive per
+    # RFC 1035, so ``--name Test`` should match a record published as ``test``.
+    if name and not (use_http_index or protocol):
+        needle = name.lower()
+        agents = [a for a in agents if a.name.lower() == needle]
+
     dnssec_validated = await _apply_post_discovery(
         agents, require_dnssec, enrich_endpoints, verify_signatures, domain
     )
+
+    # Propagate domain-level DNSSEC outcome onto each agent so per-agent trust filters
+    # (``min_dnssec``) have a record-level signal to evaluate.
+    if dnssec_validated:
+        for agent in agents:
+            agent.dnssec_validated = True
+
+    # Apply Path A in-memory filters (FR-002, FR-021..FR-023). When no filter kwargs are
+    # set, ``apply_filters`` short-circuits and returns the input list unchanged.
+    pre_filter_count = len(agents)
+    agents = apply_filters(
+        agents,
+        capabilities=capabilities,
+        capabilities_any=capabilities_any,
+        auth_type=auth_type,
+        intent=intent,
+        transport=transport,
+        realm=realm,
+        min_dnssec=min_dnssec,
+        text_match=text_match,
+        require_signed=require_signed,
+        require_signature_algorithm=require_signature_algorithm,
+    )
+    if len(agents) != pre_filter_count:
+        active_filters = [
+            n
+            for n, v in (
+                ("capabilities", capabilities),
+                ("capabilities_any", capabilities_any),
+                ("auth_type", auth_type),
+                ("intent", intent),
+                ("transport", transport),
+                ("realm", realm),
+                ("min_dnssec", min_dnssec),
+                ("text_match", text_match),
+                ("require_signed", require_signed),
+                ("require_signature_algorithm", require_signature_algorithm),
+            )
+            if v
+        ]
+        logger.debug(
+            "sdk.discover_filtered",
+            domain=domain,
+            pre_filter_count=pre_filter_count,
+            post_filter_count=len(agents),
+            filters_applied=active_filters,
+        )
 
     elapsed_ms = (time.perf_counter() - start_time) * 1000
 
@@ -1029,16 +1127,20 @@ async def _verify_agent_signatures(
     from dns_aid.core.jwks import verify_record_signature
 
     for agent in agents_with_sig:
+        if agent.sig is None:
+            continue
         try:
-            is_valid, payload = await verify_record_signature(domain, agent.sig)
+            is_valid, _payload = await verify_record_signature(domain, agent.sig)
+            agent.signature_verified = is_valid
+            agent.signature_algorithm = _extract_jws_algorithm(agent.sig) if is_valid else None
 
             if is_valid:
                 logger.info(
                     "JWS signature verified",
                     agent=agent.name,
                     fqdn=agent.fqdn,
+                    algorithm=agent.signature_algorithm,
                 )
-                # Could add a verified flag to AgentRecord in future
             else:
                 logger.warning(
                     "JWS signature verification failed",
@@ -1046,8 +1148,31 @@ async def _verify_agent_signatures(
                     fqdn=agent.fqdn,
                 )
         except Exception as e:
+            agent.signature_verified = False
+            agent.signature_algorithm = None
             logger.warning(
                 "JWS verification error",
                 agent=agent.name,
                 error=str(e),
             )
+
+
+def _extract_jws_algorithm(jws: str) -> str | None:
+    """
+    Decode the JWS protected header and return the ``alg`` claim.
+
+    Returns ``None`` when the JWS is malformed or the header lacks an ``alg``. Used by
+    the verification path to surface the algorithm onto the AgentRecord so trust filters
+    can apply algorithm allow-lists without re-parsing the signature.
+    """
+    try:
+        header_b64 = jws.split(".", 1)[0]
+        padding = "=" * (-len(header_b64) % 4)
+        header_bytes = base64.urlsafe_b64decode(header_b64 + padding)
+        header = json.loads(header_bytes)
+    except (ValueError, IndexError, json.JSONDecodeError):
+        return None
+    alg = header.get("alg")
+    if alg is None:
+        return None
+    return str(alg)

--- a/src/dns_aid/core/filters.py
+++ b/src/dns_aid/core/filters.py
@@ -1,0 +1,207 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pure-function filter primitives for Path A discovery.
+
+Functions in this module operate on already-enriched :class:`AgentRecord` lists returned
+from DNS-substrate discovery. All filters are *post-discovery* — they run after the
+discoverer has fetched cap documents, agent cards, JWKS, and verified signatures, so
+predicates have access to the fully populated record.
+
+The module is intentionally a flat collection of small functions rather than a class
+hierarchy or DSL: filtering a small in-memory list is a query, not a domain object, and
+list comprehensions remain the most readable expression of "select records matching X".
+"""
+
+from __future__ import annotations
+
+from dns_aid.core.models import AgentRecord
+
+
+def apply_filters(
+    records: list[AgentRecord],
+    *,
+    capabilities: list[str] | None = None,
+    capabilities_any: list[str] | None = None,
+    auth_type: str | None = None,
+    intent: str | None = None,
+    transport: str | None = None,
+    realm: str | None = None,
+    min_dnssec: bool = False,
+    text_match: str | None = None,
+    require_signed: bool = False,
+    require_signature_algorithm: list[str] | None = None,
+) -> list[AgentRecord]:
+    """
+    Return the subset of ``records`` matching every filter that is set.
+
+    All keyword arguments are independently optional. ``None`` (or ``False`` for boolean
+    filters) means "no constraint". When every filter is unset, the input list is returned
+    unchanged with no allocation — the no-op fast path keeps existing callers free of
+    overhead.
+
+    Filter semantics:
+
+    * ``capabilities`` — all-of match. Empty list matches **no** records (caller asked for
+      "every capability in an empty set"; the empty constraint is treated as "explicit
+      no-match" rather than vacuously true, matching the spec's edge-case guidance).
+    * ``capabilities_any`` — any-of match. Empty list matches **no** records.
+    * ``auth_type`` — case-insensitive exact match against ``agent.auth_type``.
+    * ``intent`` — exact match against ``agent.category``; falls back to substring match
+      against capabilities when ``category`` is unset.
+    * ``transport`` — exact match against the agent's protocol identifier (Path A surfaces
+      the agent protocol, not the underlying wire transport; see :func:`_matches_transport`).
+    * ``realm`` — exact match against ``agent.realm``.
+    * ``min_dnssec`` — when ``True``, only records whose ``agent.dnssec_validated`` is True pass.
+    * ``text_match`` — case-insensitive substring match across ``description``, ``use_cases``,
+      and ``capabilities``. Empty string is a programming error and raises ``ValueError``.
+    * ``require_signed`` — when ``True``, only records whose JWS signature verified pass.
+    * ``require_signature_algorithm`` — restrict ``require_signed`` matches to records whose
+      verified signature algorithm appears in this list.
+
+    Args:
+        records: Already-enriched records returned by the discoverer.
+
+    Returns:
+        A new list containing the subset of ``records`` matching every active filter, or
+        the original list if no filters are set.
+
+    Raises:
+        ValueError: ``text_match`` is the empty string, or ``require_signature_algorithm``
+            is set but ``require_signed`` is False.
+    """
+    if text_match is not None and text_match == "":
+        raise ValueError("text_match cannot be empty; use None to skip the filter")
+    if require_signature_algorithm and not require_signed:
+        raise ValueError("require_signature_algorithm requires require_signed=True to take effect")
+
+    no_constraints = (
+        capabilities is None
+        and capabilities_any is None
+        and auth_type is None
+        and intent is None
+        and transport is None
+        and realm is None
+        and not min_dnssec
+        and text_match is None
+        and not require_signed
+        and not require_signature_algorithm
+    )
+    if no_constraints:
+        return records
+
+    return [
+        record
+        for record in records
+        if _matches_capabilities_all(record, capabilities)
+        and _matches_capabilities_any(record, capabilities_any)
+        and _matches_auth_type(record, auth_type)
+        and _matches_intent(record, intent)
+        and _matches_transport(record, transport)
+        and _matches_realm(record, realm)
+        and _matches_min_dnssec(record, min_dnssec)
+        and _matches_text(record, text_match)
+        and _matches_signed(record, require_signed, require_signature_algorithm)
+    ]
+
+
+def _matches_capabilities_all(record: AgentRecord, required: list[str] | None) -> bool:
+    if required is None:
+        return True
+    if not required:
+        # Empty list means "explicit no-match" per spec (distinct from None = no constraint).
+        return False
+    record_caps = {c.lower() for c in record.capabilities}
+    return all(item.lower() in record_caps for item in required)
+
+
+def _matches_capabilities_any(record: AgentRecord, required_any: list[str] | None) -> bool:
+    if required_any is None:
+        return True
+    if not required_any:
+        return False
+    record_caps = {c.lower() for c in record.capabilities}
+    return any(item.lower() in record_caps for item in required_any)
+
+
+def _matches_auth_type(record: AgentRecord, expected: str | None) -> bool:
+    if expected is None:
+        return True
+    if record.auth_type is None:
+        return False
+    return record.auth_type.lower() == expected.lower()
+
+
+def _matches_intent(record: AgentRecord, expected: str | None) -> bool:
+    if expected is None:
+        return True
+    needle = expected.lower()
+    if record.category and record.category.lower() == needle:
+        return True
+    return any(needle in cap.lower() for cap in record.capabilities)
+
+
+def _matches_transport(record: AgentRecord, expected: str | None) -> bool:
+    """
+    Transport filter for Path A.
+
+    Path A's ``AgentRecord`` does not surface a discrete transport field — DNS substrate
+    discovery exposes the agent protocol (mcp / a2a / https), not the underlying transport
+    binding (streamable-http / stdio / sse / etc.). For Path A, transport falls back to
+    the protocol identifier so the same query string used in Path B (where the directory
+    has full transport metadata) still semantically matches at the protocol level.
+    """
+    if expected is None:
+        return True
+    return record.protocol.value.lower() == expected.lower()
+
+
+def _matches_realm(record: AgentRecord, expected: str | None) -> bool:
+    if expected is None:
+        return True
+    return record.realm == expected
+
+
+def _matches_min_dnssec(record: AgentRecord, required: bool) -> bool:
+    if not required:
+        return True
+    return record.dnssec_validated
+
+
+def _matches_text(record: AgentRecord, query: str | None) -> bool:
+    if query is None:
+        return True
+    needle = query.lower()
+    haystack_parts: list[str] = []
+    if record.description:
+        haystack_parts.append(record.description)
+    haystack_parts.extend(record.use_cases)
+    haystack_parts.extend(record.capabilities)
+    return any(needle in part.lower() for part in haystack_parts)
+
+
+def _matches_signed(
+    record: AgentRecord,
+    require: bool,
+    allowed_algorithms: list[str] | None,
+) -> bool:
+    """
+    Trust gate: pass only records whose JWS signature actually verified.
+
+    Records without a ``sig`` parameter, with a ``sig`` that did not verify, or with a
+    verified algorithm not in the optional ``allowed_algorithms`` list are excluded.
+    Records where verification was never attempted (``signature_verified is None``) are
+    also excluded — the filter requires positive verification, not the absence of
+    rejection.
+    """
+    if not require:
+        return True
+    if record.signature_verified is not True:
+        return False
+    if record.signature_algorithm is None:
+        return False
+    if allowed_algorithms:
+        allowed = {algo.lower() for algo in allowed_algorithms}
+        return record.signature_algorithm.lower() in allowed
+    return True

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -388,6 +388,33 @@ class AgentRecord(BaseModel):
         exclude=True,  # Exclude from serialization by default
     )
 
+    # DNSSEC validation status for THIS agent's DNS lookup.
+    # Populated by the discoverer when DNSSEC validation runs (either via
+    # ``require_dnssec=True`` or the ``min_dnssec`` Path A filter). Default ``False`` matches
+    # the prior behavior for any caller that doesn't enable DNSSEC validation.
+    dnssec_validated: bool = Field(
+        default=False,
+        description="True when the domain hosting this agent presented a DNSSEC-validated "
+        "response (AD flag set). False when validation did not occur or did not succeed.",
+    )
+
+    # JWS verification result (populated by the discoverer's signature-verification step
+    # when ``verify_signatures=True``). Both fields remain ``None`` when verification was
+    # not attempted; ``signature_verified=False`` indicates verification ran and rejected
+    # the signature.
+    signature_verified: bool | None = Field(
+        default=None,
+        description="True when JWS signature verification succeeded against the domain's "
+        "JWKS, False when verification ran and rejected the signature, None when "
+        "verification was not attempted.",
+    )
+    signature_algorithm: str | None = Field(
+        default=None,
+        description="JWS algorithm identifier (e.g., 'Ed25519', 'ES256') reported by a "
+        "successful signature verification. None when verification did not succeed or was "
+        "not attempted.",
+    )
+
     model_config = {"arbitrary_types_allowed": True}
 
     @field_validator("name", mode="before")

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -410,6 +410,16 @@ def discover_agents_via_dns(
     protocol: Literal["mcp", "a2a"] | None = None,
     name: str | None = None,
     use_http_index: bool = False,
+    capabilities: list[str] | None = None,
+    capabilities_any: list[str] | None = None,
+    auth_type: str | None = None,
+    intent: Literal["query", "command", "transaction", "subscription"] | None = None,
+    transport: str | None = None,
+    realm: str | None = None,
+    min_dnssec: bool = False,
+    text_match: str | None = None,
+    require_signed: bool = False,
+    require_signature_algorithm: list[str] | None = None,
 ) -> dict:
     """
     Discover AI agents at any public domain using the DNS-AID protocol (no credentials needed).
@@ -491,6 +501,16 @@ def discover_agents_via_dns(
             protocol=protocol,
             name=name,
             use_http_index=use_http_index,
+            capabilities=capabilities,
+            capabilities_any=capabilities_any,
+            auth_type=auth_type,
+            intent=intent,
+            transport=transport,
+            realm=realm,
+            min_dnssec=min_dnssec,
+            text_match=text_match,
+            require_signed=require_signed,
+            require_signature_algorithm=require_signature_algorithm,
         )
 
     try:
@@ -526,6 +546,166 @@ def discover_agents_via_dns(
             "success": False,
             "error": "discover_error",
             "message": str(e),
+        }
+
+
+@mcp.tool(
+    title="Search Agents via Directory",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def search_agents(
+    q: str | None = None,
+    protocol: Literal["mcp", "a2a", "https"] | None = None,
+    domain: str | None = None,
+    capabilities: list[str] | None = None,
+    min_security_score: int | None = None,
+    verified_only: bool = False,
+    intent: Literal["query", "command", "transaction", "subscription"] | None = None,
+    auth_type: str | None = None,
+    transport: str | None = None,
+    realm: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict:
+    """
+    Cross-domain agent search via the configured DNS-AID directory backend (Path B).
+
+    Use this tool when:
+      - You don't yet know which domain hosts the agent you want.
+      - You need to find agents by capability, intent, or auth type across many domains.
+      - You want ranked results with pre-computed trust scores so you can decide
+        whether to invoke directly or re-verify cryptographically via DNS first.
+
+    Requires the directory backend to be configured server-side
+    (``DNS_AID_SDK_DIRECTORY_API_URL``). If not configured, returns a structured
+    ``directory_not_configured`` error so the caller can fall back to per-domain
+    ``discover_agents_via_dns`` calls.
+
+    Args:
+        q: Free-text query (e.g., "payment processing"). Omit to browse with filters only.
+        protocol: Restrict to a protocol (``mcp`` / ``a2a`` / ``https``).
+        domain: Restrict to a single domain.
+        capabilities: All-of capability match — every entry must be present on the agent.
+        min_security_score: Minimum security score (0–100). Higher = stricter.
+        verified_only: Restrict to DCV-verified domains only.
+        intent: Filter by action intent (query / command / transaction / subscription).
+        auth_type: Filter by auth type (``oauth2``, ``api_key``, ``bearer``, ``mtls``,
+            ``http_msg_sig``, etc.).
+        transport: Filter by transport (``streamable-http``, ``https``, ``sse``, ``stdio``).
+        realm: Filter by realm (multi-tenant scoping identifier).
+        limit: Page size (1–10000). Default 20.
+        offset: Pagination offset.
+
+    Returns:
+        Success: ``{"success": True, "results": [...], "total": int, "limit": int,
+        "offset": int, "has_more": bool}`` where each result carries the agent payload,
+        relevance ``score``, ``trust`` attestation (security/trust scores, tier badge,
+        sub-scores), and optional ``provenance`` (crawler attribution).
+
+        Failure: ``{"success": False, "error": "<class>", "message": "...", "details": {...}}``
+        with structured error class — never raises. Error classes:
+          - ``directory_not_configured`` (configuration; not transient)
+          - ``directory_unavailable`` (transient; retry with backoff recommended)
+          - ``directory_rate_limited`` (transient; honor ``retry_after_seconds``)
+          - ``directory_auth_failed`` (auth; review credentials)
+          - ``invalid_arguments`` (caller-supplied args failed schema validation)
+
+    Composition pattern (zero-trust):
+
+        1. Call ``search_agents`` for cross-domain candidates.
+        2. For each result, call ``discover_agents_via_dns`` with that agent's domain
+           and name to re-verify endpoint authority via DNS substrate before invoking.
+        3. Use ``call_agent_tool`` only against the verified subset.
+    """
+    from dns_aid.sdk import (
+        AgentClient,
+        DirectoryAuthError,
+        DirectoryConfigError,
+        DirectoryRateLimitedError,
+        DirectoryUnavailableError,
+    )
+
+    async def _do_search() -> dict:
+        async with AgentClient() as client:
+            response = await client.search(
+                q=q,
+                protocol=protocol,
+                domain=domain,
+                capabilities=capabilities,
+                min_security_score=min_security_score,
+                verified_only=verified_only,
+                intent=intent,
+                auth_type=auth_type,
+                transport=transport,
+                realm=realm,
+                limit=limit,
+                offset=offset,
+            )
+            return {
+                "success": True,
+                "results": [
+                    {
+                        "agent": r.agent.model_dump(mode="json"),
+                        "score": r.score,
+                        "trust": r.trust.model_dump(mode="json"),
+                        "provenance": r.provenance.model_dump(mode="json")
+                        if r.provenance is not None
+                        else None,
+                    }
+                    for r in response.results
+                ],
+                "total": response.total,
+                "limit": response.limit,
+                "offset": response.offset,
+                "has_more": response.has_more,
+            }
+
+    try:
+        return _run_async(_do_search())
+    except DirectoryConfigError as exc:
+        return {
+            "success": False,
+            "error": "directory_not_configured",
+            "message": str(exc),
+            "details": exc.details,
+            "remediation": "Set DNS_AID_SDK_DIRECTORY_API_URL or configure SDKConfig.directory_api_url.",
+        }
+    except DirectoryRateLimitedError as exc:
+        return {
+            "success": False,
+            "error": "directory_rate_limited",
+            "message": str(exc),
+            "details": exc.details,
+            "transient": True,
+            "retry_recommended": True,
+        }
+    except DirectoryAuthError as exc:
+        return {
+            "success": False,
+            "error": "directory_auth_failed",
+            "message": str(exc),
+            "details": exc.details,
+            "remediation": "Verify the SDK auth handler configuration for the directory backend.",
+        }
+    except DirectoryUnavailableError as exc:
+        return {
+            "success": False,
+            "error": "directory_unavailable",
+            "message": str(exc),
+            "details": exc.details,
+            "transient": True,
+            "retry_recommended": True,
+        }
+    except ValidationError as exc:
+        return {
+            "success": False,
+            "error": "invalid_arguments",
+            "validation_errors": _format_validation_error(exc),
         }
 
 

--- a/src/dns_aid/sdk/__init__.py
+++ b/src/dns_aid/sdk/__init__.py
@@ -16,18 +16,40 @@ Example:
 
 from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.exceptions import (
+    DirectoryAuthError,
+    DirectoryConfigError,
+    DirectoryError,
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
 from dns_aid.sdk.models import (
     AgentScorecard,
     InvocationResult,
     InvocationSignal,
     InvocationStatus,
 )
+from dns_aid.sdk.search import (
+    Provenance,
+    SearchResponse,
+    SearchResult,
+    TrustAttestation,
+)
 
 __all__ = [
     "AgentClient",
-    "SDKConfig",
-    "InvocationSignal",
-    "InvocationResult",
-    "InvocationStatus",
     "AgentScorecard",
+    "DirectoryAuthError",
+    "DirectoryConfigError",
+    "DirectoryError",
+    "DirectoryRateLimitedError",
+    "DirectoryUnavailableError",
+    "InvocationResult",
+    "InvocationSignal",
+    "InvocationStatus",
+    "Provenance",
+    "SDKConfig",
+    "SearchResponse",
+    "SearchResult",
+    "TrustAttestation",
 ]

--- a/src/dns_aid/sdk/_config.py
+++ b/src/dns_aid/sdk/_config.py
@@ -9,7 +9,9 @@ Configures the AgentClient behavior including timeouts, exporters, and caller id
 
 from __future__ import annotations
 
+import functools
 import os
+import warnings
 
 from pydantic import BaseModel, Field
 
@@ -50,8 +52,11 @@ class SDKConfig(BaseModel):
     # HTTP push (fire-and-forget POST to telemetry API)
     http_push_url: str | None = Field(
         default=None,
-        description="URL to POST signals to (e.g., https://api.example.com/api/v1/telemetry/signals). "
-        "If set, enables HTTP push automatically.",
+        description="Full URL to POST signals to "
+        "(e.g., https://directory.example.com/api/v1/telemetry/signals). "
+        "When unset, signals are pushed to "
+        "``{resolved_directory_url}/api/v1/telemetry/signals`` if a directory URL is configured. "
+        "Set this only to override the derived path.",
     )
 
     # Console logging
@@ -60,11 +65,22 @@ class SDKConfig(BaseModel):
         description="Print signals to console/log for debugging.",
     )
 
-    # Telemetry API for fetching community rankings
+    # Directory backend (canonical name; drives fetch_rankings, search, and signal push).
+    directory_api_url: str | None = Field(
+        default=None,
+        description="Base URL of the DNS-AID directory backend "
+        "(e.g., https://directory.example.com). "
+        "Drives ``AgentClient.search()``, ``AgentClient.fetch_rankings()``, and the signal-push "
+        "default destination. ``None`` keeps the SDK in DNS-substrate-only mode with no directory "
+        "dependency.",
+    )
+
+    # Deprecated alias for directory_api_url. Honored for one minor release.
     telemetry_api_url: str | None = Field(
         default=None,
-        description="Base URL for telemetry API to fetch community-wide rankings. "
-        "If not set, fetch_rankings() returns an empty list.",
+        description="**DEPRECATED**: alias for ``directory_api_url``. Honored for one minor release; "
+        "set ``directory_api_url`` instead. When both are set, ``directory_api_url`` wins and a "
+        "one-time DeprecationWarning is emitted on first resolution.",
     )
 
     # Policy enforcement (Phase 6)
@@ -97,6 +113,25 @@ class SDKConfig(BaseModel):
         description="Seconds before an open circuit transitions to half-open.",
     )
 
+    @property
+    def resolved_directory_url(self) -> str | None:
+        """
+        Single source of truth for the directory backend base URL.
+
+        Resolution order: ``directory_api_url`` (canonical) → ``telemetry_api_url`` (deprecated).
+        When the deprecated alias is the active source, a single ``DeprecationWarning`` is emitted
+        per process the first time this property is accessed.
+
+        Returns:
+            The resolved directory base URL, or ``None`` if neither field is set.
+        """
+        if self.directory_api_url is not None:
+            return self.directory_api_url
+        if self.telemetry_api_url is not None:
+            _warn_telemetry_alias_once()
+            return self.telemetry_api_url
+        return None
+
     @classmethod
     def from_env(cls) -> SDKConfig:
         """Build config from environment variables."""
@@ -109,6 +144,7 @@ class SDKConfig(BaseModel):
             otel_endpoint=os.getenv("DNS_AID_SDK_OTEL_ENDPOINT"),
             otel_export_format=os.getenv("DNS_AID_SDK_OTEL_EXPORT_FORMAT", "otlp"),
             console_signals=os.getenv("DNS_AID_SDK_CONSOLE_SIGNALS", "").lower() == "true",
+            directory_api_url=os.getenv("DNS_AID_SDK_DIRECTORY_API_URL"),
             telemetry_api_url=os.getenv("DNS_AID_SDK_TELEMETRY_API_URL"),
             policy_mode=os.getenv("DNS_AID_POLICY_MODE", "permissive"),
             policy_cache_ttl=int(os.getenv("DNS_AID_POLICY_CACHE_TTL", "300")),
@@ -117,3 +153,19 @@ class SDKConfig(BaseModel):
             circuit_breaker_threshold=int(os.getenv("DNS_AID_CIRCUIT_BREAKER_THRESHOLD", "5")),
             circuit_breaker_cooldown=float(os.getenv("DNS_AID_CIRCUIT_BREAKER_COOLDOWN", "60")),
         )
+
+
+@functools.cache
+def _warn_telemetry_alias_once() -> None:
+    """
+    Emit a single ``DeprecationWarning`` per process when the legacy alias is active.
+
+    Idempotency is delegated to :func:`functools.cache`: subsequent calls are no-ops
+    until ``_warn_telemetry_alias_once.cache_clear()`` is invoked (used by tests).
+    """
+    warnings.warn(
+        "SDKConfig.telemetry_api_url is deprecated; use directory_api_url instead. "
+        "The alias will be removed in a future minor release.",
+        DeprecationWarning,
+        stacklevel=3,
+    )

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import threading
 import time as _time
 from types import TracebackType
+from typing import Any, Literal
 
 import httpx
 import structlog
@@ -22,6 +23,12 @@ from dns_aid.sdk._circuit_breaker import CircuitBreaker
 from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.auth import resolve_auth_handler
 from dns_aid.sdk.auth.base import AuthHandler
+from dns_aid.sdk.exceptions import (
+    DirectoryAuthError,
+    DirectoryConfigError,
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
 from dns_aid.sdk.models import InvocationResult, InvocationSignal, InvocationStatus
 from dns_aid.sdk.policy.evaluator import PolicyEvaluator
 from dns_aid.sdk.policy.models import PolicyContext, PolicyViolationError
@@ -30,7 +37,9 @@ from dns_aid.sdk.protocols.a2a import A2AProtocolHandler
 from dns_aid.sdk.protocols.base import ProtocolHandler
 from dns_aid.sdk.protocols.https import HTTPSProtocolHandler
 from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
+from dns_aid.sdk.search import SearchResponse
 from dns_aid.sdk.signals.collector import SignalCollector
+from dns_aid.utils.url_safety import UnsafeURLError, redact_url_for_log, validate_fetch_url
 
 logger = structlog.get_logger(__name__)
 
@@ -305,11 +314,20 @@ class AgentClient:
                 signal.policy_fetch_time_ms = policy_fetch_ms
             signal.target_policy_result = target_policy_result
 
-        # HTTP push to telemetry API if configured (true fire-and-forget via thread)
-        if self._config.http_push_url:
+        # HTTP push to telemetry API if configured (true fire-and-forget via thread).
+        # Resolution order:
+        #   1. Explicit ``http_push_url`` override (back-compat: full URL).
+        #   2. Derived from ``resolved_directory_url`` + signals path (preferred new path).
+        #   3. None: push is disabled.
+        push_url = self._config.http_push_url
+        if push_url is None:
+            base = self._config.resolved_directory_url
+            if base is not None:
+                push_url = f"{base.rstrip('/')}/api/v1/telemetry/signals"
+        if push_url:
             thread = threading.Thread(
                 target=self._push_signal_http_sync,
-                args=(signal, self._config.http_push_url),
+                args=(signal, push_url),
                 daemon=True,
             )
             thread.start()
@@ -412,11 +430,15 @@ class AgentClient:
                 "async with AgentClient() as client: ..."
             )
 
-        if not self._config.telemetry_api_url:
-            logger.debug("sdk.fetch_rankings_skipped", reason="telemetry_api_url not configured")
+        directory_base = self._config.resolved_directory_url
+        if not directory_base:
+            logger.debug(
+                "sdk.fetch_rankings_skipped",
+                reason="directory_api_url not configured",
+            )
             return []
 
-        url = f"{self._config.telemetry_api_url}/api/v1/telemetry/rankings"
+        url = f"{directory_base.rstrip('/')}/api/v1/telemetry/rankings"
         params = {"limit": limit}
 
         logger.debug("sdk.fetch_rankings", url=url, limit=limit, fqdns=fqdns)
@@ -446,7 +468,516 @@ class AgentClient:
             logger.warning("sdk.fetch_rankings_error", exc_info=True)
             return []
 
+    async def search(
+        self,
+        q: str | None = None,
+        *,
+        protocol: Literal["mcp", "a2a", "https"] | None = None,
+        domain: str | None = None,
+        capabilities: list[str] | None = None,
+        min_security_score: int | None = None,
+        verified_only: bool = False,
+        intent: str | None = None,
+        auth_type: str | None = None,
+        transport: str | None = None,
+        realm: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> SearchResponse:
+        """
+        Cross-domain agent search via the configured DNS-AID directory backend (Path B).
+
+        Issues ``GET {resolved_directory_url}/api/v1/search`` and returns a typed
+        :class:`SearchResponse`. Path B is **opt-in**: invoking ``search()`` without
+        ``directory_api_url`` configured raises :class:`DirectoryConfigError` immediately,
+        before any network work. Failures are mapped to the structured exception hierarchy
+        in :mod:`dns_aid.sdk.exceptions` so callers can dispatch on type.
+
+        Args:
+            q: Free-text query, or ``None`` for browse-all-with-filters mode.
+            protocol: Restrict to ``mcp`` / ``a2a`` / ``https``.
+            domain: Restrict to a single domain.
+            capabilities: All-of capability match — every entry must be present.
+            min_security_score: Minimum security score (0–100).
+            verified_only: Restrict to DCV-verified domains.
+            intent: Action intent filter (query / command / transaction / subscription).
+            auth_type: Auth type filter.
+            transport: Transport filter.
+            realm: Multi-tenant realm filter.
+            limit: Page size (1–10000). Default 20.
+            offset: Pagination offset.
+
+        Returns:
+            :class:`SearchResponse` with ranked results, trust attestations, optional
+            crawler provenance, and pagination state.
+
+        Raises:
+            DirectoryConfigError: ``directory_api_url`` is not configured.
+            DirectoryAuthError: Directory rejected credentials (HTTP 401/403).
+            DirectoryRateLimitedError: Directory rate-limited the call (HTTP 429); the
+                ``retry_after_seconds`` detail mirrors the ``Retry-After`` header.
+            DirectoryUnavailableError: Transient failure — connect refused, timeout, 5xx,
+                404 (wrong URL), or response shape the SDK can't validate.
+            RuntimeError: ``AgentClient`` is not in an async context manager.
+
+        Example::
+
+            async with AgentClient() as client:
+                response = await client.search(
+                    "payment processing",
+                    protocol="mcp",
+                    capabilities=["payment-processing"],
+                    min_security_score=70,
+                )
+                for result in response.results:
+                    print(result.score, result.agent.fqdn, result.trust.trust_tier)
+        """
+        if self._http_client is None:
+            raise RuntimeError(
+                "AgentClient must be used as an async context manager: "
+                "async with AgentClient() as client: ..."
+            )
+
+        directory_base = self._config.resolved_directory_url
+        if directory_base is None:
+            logger.debug("sdk.search_skipped", reason="directory_api_url_not_configured")
+            raise DirectoryConfigError(
+                "AgentClient.search() requires a configured directory backend; "
+                "set SDKConfig.directory_api_url or DNS_AID_SDK_DIRECTORY_API_URL.",
+                details={
+                    "missing_field": "directory_api_url",
+                    "env_var": "DNS_AID_SDK_DIRECTORY_API_URL",
+                },
+            )
+
+        try:
+            validated_base = validate_fetch_url(directory_base)
+        except UnsafeURLError as exc:
+            # The URL failed validation — it might be ``https://user:pass@host``,
+            # malformed scheme, or pointing at a private IP. Whatever the reason,
+            # strip userinfo before logging or surfacing in the error so we never
+            # leak credentials a misconfigured caller might have stuffed into the URL.
+            redacted = redact_url_for_log(directory_base)
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=redacted,
+                error_class="UnsafeURLError",
+                underlying="UnsafeURLError",
+            )
+            raise DirectoryUnavailableError(
+                f"Configured directory URL failed safety validation: {exc}",
+                details={
+                    "directory_url": redacted,
+                    "status_code": None,
+                    "underlying": "UnsafeURLError",
+                },
+            ) from exc
+
+        url = f"{validated_base.rstrip('/')}/api/v1/search"
+        params = _build_search_params(
+            q=q,
+            protocol=protocol,
+            domain=domain,
+            capabilities=capabilities,
+            min_security_score=min_security_score,
+            verified_only=verified_only,
+            intent=intent,
+            auth_type=auth_type,
+            transport=transport,
+            realm=realm,
+            limit=limit,
+            offset=offset,
+        )
+
+        logger.debug(
+            "sdk.search_started",
+            directory_url=validated_base,
+            q=q,
+            protocol=protocol,
+            limit=limit,
+            offset=offset,
+        )
+        started = _time.monotonic()
+
+        try:
+            # ``follow_redirects=False`` is intentional: validate_fetch_url ran the
+            # SSRF check on the *initial* URL only. If the directory (or any host
+            # in a redirect chain) returns ``Location: https://internal.local``,
+            # following it would bypass the SSRF guard. The directory contract
+            # is a single-shot HTTPS request to ``/api/v1/search``; redirects
+            # are never legitimate here.
+            resp = await self._http_client.get(url, params=params, follow_redirects=False)
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                error_class=type(exc).__name__,
+                underlying=type(exc).__name__,
+            )
+            raise DirectoryUnavailableError(
+                f"Directory request failed: {exc}",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": None,
+                    "underlying": type(exc).__name__,
+                },
+            ) from exc
+
+        latency_ms = (_time.monotonic() - started) * 1000.0
+
+        # ── Reject 3xx (no auto-redirect — see follow_redirects=False above). ──
+        # A directory that responds with a redirect is misconfigured; surfacing
+        # that as DirectoryUnavailableError is more useful than letting the body
+        # parse fail with a cryptic "expected JSON, got HTML" message.
+        if 300 <= resp.status_code < 400:
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                status_code=resp.status_code,
+                redirect_target=resp.headers.get("Location"),
+            )
+            raise DirectoryUnavailableError(
+                f"Directory responded with HTTP {resp.status_code} redirect; "
+                "redirects are not followed (SSRF guard). Reconfigure the "
+                "``directory_api_url`` to point at the canonical endpoint.",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": resp.status_code,
+                    "underlying": "UnexpectedRedirect",
+                },
+            )
+
+        if resp.status_code == 429:
+            retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                status_code=429,
+                retry_after_seconds=retry_after,
+            )
+            raise DirectoryRateLimitedError(
+                "Directory rate-limited the search request.",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": 429,
+                    "underlying": "HTTPStatusError",
+                    "retry_after_seconds": retry_after,
+                },
+            )
+
+        if resp.status_code in (401, 403):
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                status_code=resp.status_code,
+            )
+            raise DirectoryAuthError(
+                f"Directory rejected credentials (HTTP {resp.status_code}).",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": resp.status_code,
+                    "auth_handler_class": None,
+                },
+            )
+
+        if resp.status_code >= 400:
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                status_code=resp.status_code,
+                body=resp.text[:200],
+            )
+            raise DirectoryUnavailableError(
+                f"Directory returned HTTP {resp.status_code}.",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": resp.status_code,
+                    "underlying": "HTTPStatusError",
+                },
+            )
+
+        # ── Response size guard. ──
+        # The directory contract is small JSON (~1KB per result × <=10000 results
+        # max). Bound the body at 10 MB to defend against a misbehaving directory
+        # that forgot pagination or returned an oversized page. The body is
+        # already buffered by httpx at this point — the guard rejects parsing
+        # rather than ingestion. Streaming-with-byte-cap is future work tracked
+        # in :doc:`phase-5.6.1-sdk-directory-auth`'s sibling work.
+        body_size = len(resp.content)
+        if body_size > _SEARCH_MAX_RESPONSE_BYTES:
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                status_code=resp.status_code,
+                body_bytes=body_size,
+                max_bytes=_SEARCH_MAX_RESPONSE_BYTES,
+            )
+            raise DirectoryUnavailableError(
+                f"Directory response exceeded {_SEARCH_MAX_RESPONSE_BYTES} bytes "
+                f"({body_size} received); refusing to parse.",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": resp.status_code,
+                    "underlying": "ResponseTooLarge",
+                    "body_bytes": body_size,
+                },
+            )
+
+        try:
+            adapted = _adapt_search_payload(resp.json())
+            response = SearchResponse.model_validate(adapted)
+        except ValueError as exc:
+            logger.warning(
+                "sdk.search_failed",
+                directory_url=validated_base,
+                error_class="ValidationError",
+                underlying=type(exc).__name__,
+            )
+            raise DirectoryUnavailableError(
+                f"Directory response failed schema validation: {exc}",
+                details={
+                    "directory_url": validated_base,
+                    "status_code": resp.status_code,
+                    "underlying": type(exc).__name__,
+                },
+            ) from exc
+
+        logger.debug(
+            "sdk.search_completed",
+            directory_url=validated_base,
+            result_count=len(response.results),
+            total=response.total,
+            latency_ms=round(latency_ms, 2),
+        )
+        return response
+
     @classmethod
     def register_handler(cls, protocol: str, handler_cls: type[ProtocolHandler]) -> None:
         """Register a custom protocol handler."""
         _HANDLERS[protocol] = handler_cls
+
+
+def _build_search_params(
+    *,
+    q: str | None,
+    protocol: str | None,
+    domain: str | None,
+    capabilities: list[str] | None,
+    min_security_score: int | None,
+    verified_only: bool,
+    intent: str | None,
+    auth_type: str | None,
+    transport: str | None,
+    realm: str | None,
+    limit: int,
+    offset: int,
+) -> list[tuple[str, str | int | float | bool | None]]:
+    """Serialize search kwargs to HTTP query parameters; ``None`` values are omitted."""
+    params: list[tuple[str, str | int | float | bool | None]] = []
+    if q is not None:
+        params.append(("q", q))
+    if protocol is not None:
+        params.append(("protocol", protocol))
+    if domain is not None:
+        params.append(("domain", domain.lower()))
+    if capabilities is not None:
+        for cap in capabilities:
+            params.append(("capabilities", cap))
+    if min_security_score is not None:
+        params.append(("min_security_score", str(min_security_score)))
+    if verified_only:
+        params.append(("verified_only", "true"))
+    if intent is not None:
+        params.append(("intent", intent))
+    if auth_type is not None:
+        params.append(("auth_type", auth_type))
+    if transport is not None:
+        params.append(("transport", transport))
+    if realm is not None:
+        params.append(("realm", realm))
+    params.append(("limit", str(limit)))
+    params.append(("offset", str(offset)))
+    return params
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    """Parse an HTTP ``Retry-After`` header to integer seconds; ``None`` if unparseable."""
+    if not value:
+        return None
+    try:
+        return int(value.strip())
+    except ValueError:
+        # Retry-After can also be an HTTP-date — surface as None and let caller back off
+        # using their own policy. Date parsing is intentionally not implemented here.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Wire-shape adapter (Path B)
+# ---------------------------------------------------------------------------
+#
+# The directory backend (`dns_aid_directory.api.schemas.AgentResponse`) exposes
+# trust + provenance signals as flat fields *on the agent object*, plus a
+# couple of small shape quirks vs the SDK's typed models:
+#
+#   * ``agent.target_host`` is absent — the directory only emits ``endpoint_url``;
+#     the SDK's :class:`AgentRecord` requires ``target_host``.
+#   * ``agent.bap`` is a comma-separated string (e.g. ``"mcp/1,a2a/1"``); the SDK
+#     types it as ``list[str]``.
+#   * Trust signals (``security_score``, ``trust_score``, ``popularity_score``,
+#     ``trust_tier``, ``safety_status``, ``dnssec_valid``, ``dane_valid``,
+#     ``svcb_valid``, ``endpoint_reachable``, ``protocol_verified``,
+#     ``threat_flags``, ``trust_breakdown``, ``trust_badges``) live flat on the
+#     agent; the SDK exposes them via :class:`TrustAttestation` nested under
+#     ``SearchResult.trust``.
+#   * Provenance signals (``discovery_level``, ``first_seen``, ``last_seen``,
+#     ``last_verified``, ``company``) live flat on the agent; the SDK exposes
+#     them via :class:`Provenance` nested under ``SearchResult.provenance``.
+#
+# This adapter is the *only* place in the SDK that knows about the directory's
+# wire shape. If the directory schema changes, only this function needs an
+# update — the typed SDK contract stays stable for callers.
+
+
+# AgentRecord fields where the directory may write explicit ``None`` but the SDK
+# types them as non-Optional with a default. The adapter removes these keys when
+# the directory wrote ``null`` so Pydantic applies the field's declared default
+# instead of failing validation.
+_AGENT_FIELDS_STRIP_IF_NONE = ("capabilities", "version", "bap", "use_cases")
+
+# Hard cap on /api/v1/search response size. The directory contract is small JSON
+# (a single ``limit=10000`` page is bounded above by ~10 MB at directory's
+# documented field set). Set the SDK guard at the same level so an honest
+# maximum-page response still parses, but any further excess is rejected
+# without invoking the JSON parser.
+_SEARCH_MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+
+def _adapt_search_payload(raw: dict[str, Any]) -> dict[str, Any]:
+    """Translate the directory's raw ``/api/v1/search`` JSON into the SDK's typed shape.
+
+    This is purely structural. No values are invented — fields the directory does
+    not provide are left absent so the typed models can use their declared defaults.
+    The function mutates ``raw`` in place for efficiency (no need to deep-copy a
+    response we are about to discard) and returns it for chaining.
+
+    Three independent concerns:
+
+    1. **Lift flat trust + provenance signals** off the agent into nested objects.
+    2. **Coerce wire-shape quirks**: ``bap`` string → list, ``target_host`` from
+       ``endpoint_url``.
+    3. **Strip explicit nulls** for AgentRecord fields where the directory writes
+       ``None`` but the SDK type is non-Optional. Pydantic will then use the
+       declared default (e.g. ``capabilities: list = []``, ``version: str = "1.0.0"``).
+
+    **Skip-and-log on insufficient data**: when the directory returns an agent
+    with no derivable ``target_host`` (no ``endpoint_url`` and no pre-set
+    ``target_host``), the record is dropped and logged at WARN with the
+    directory URL + agent fqdn. The search response then carries only records
+    the directory could fully describe; the caller never sees a fabricated
+    endpoint. ``total`` is reduced accordingly so the page count stays honest.
+    """
+    from urllib.parse import urlparse
+
+    results = raw.get("results")
+    if not isinstance(results, list):
+        return raw
+
+    kept: list[Any] = []
+    for result in results:
+        if not isinstance(result, dict):
+            kept.append(result)  # leave malformed entries for the validator to reject
+            continue
+        agent = result.get("agent")
+        if not isinstance(agent, dict):
+            kept.append(result)
+            continue
+
+        # ── Lift trust signals: pop from agent, place under result["trust"]. ──
+        # ``setdefault`` preserves any caller-supplied trust block (used by tests).
+        result.setdefault(
+            "trust",
+            {
+                "security_score": agent.pop("security_score", 0),
+                "trust_score": agent.pop("trust_score", 0),
+                "popularity_score": agent.pop("popularity_score", 0),
+                "trust_tier": agent.pop("trust_tier", 0),
+                "safety_status": agent.pop("safety_status", "active"),
+                "dnssec_valid": agent.pop("dnssec_valid", None),
+                "dane_valid": agent.pop("dane_valid", None),
+                "svcb_valid": agent.pop("svcb_valid", None),
+                "endpoint_reachable": agent.pop("endpoint_reachable", None),
+                "protocol_verified": agent.pop("protocol_verified", None),
+                "threat_flags": agent.pop("threat_flags", {}),
+                "breakdown": agent.pop("trust_breakdown", None),
+                "badges": agent.pop("trust_badges", None),
+            },
+        )
+
+        # ── Lift provenance signals only if the directory supplied first_seen/last_seen. ──
+        # Provenance is optional in the SDK contract; we only build it when there are
+        # actual signals to populate it with.
+        if "first_seen" in agent or "last_seen" in agent:
+            result.setdefault(
+                "provenance",
+                {
+                    "discovery_level": agent.pop("discovery_level", 0),
+                    "first_seen": agent.pop("first_seen", None),
+                    "last_seen": agent.pop("last_seen", None),
+                    "last_verified": agent.pop("last_verified", None),
+                    "company": agent.pop("company", None),
+                },
+            )
+
+        # ── Adapt agent shape: split comma-separated ``bap`` string into list. ──
+        # Done before the ``_AGENT_FIELDS_STRIP_IF_NONE`` pass so ``bap=None`` still
+        # gets stripped.
+        bap = agent.get("bap")
+        if isinstance(bap, str):
+            agent["bap"] = [item.strip() for item in bap.split(",") if item.strip()]
+
+        # ── Adapt agent shape: derive ``target_host`` from ``endpoint_url`` only. ──
+        # If neither field is set, drop the record and log — never fabricate. The
+        # directory's data quality issue surfaces via the WARN log; the caller
+        # gets a smaller-but-honest result set.
+        if not agent.get("target_host"):
+            endpoint_url = agent.get("endpoint_url")
+            if isinstance(endpoint_url, str) and endpoint_url:
+                hostname = urlparse(endpoint_url).hostname
+                if hostname:
+                    agent["target_host"] = hostname
+
+        if not agent.get("target_host"):
+            logger.warning(
+                "sdk.search_record_skipped",
+                reason="no_derivable_target_host",
+                fqdn=agent.get("fqdn"),
+                name=agent.get("name"),
+                domain=agent.get("domain"),
+            )
+            continue  # drop the record from the result set
+
+        # ── Strip explicit nulls for AgentRecord fields with non-None types + defaults. ──
+        for key in _AGENT_FIELDS_STRIP_IF_NONE:
+            if key in agent and agent[key] is None:
+                del agent[key]
+
+        kept.append(result)
+
+    # Adjust ``total`` to reflect the records actually returned. The directory's
+    # original total is meaningless to the caller once we've filtered locally:
+    # paginating with the directory's total would loop forever.
+    dropped = len(results) - len(kept)
+    if dropped:
+        original_total = raw.get("total")
+        if isinstance(original_total, int):
+            raw["total"] = max(0, original_total - dropped)
+        logger.info(
+            "sdk.search_filter_summary",
+            kept=len(kept),
+            dropped=dropped,
+            adjusted_total=raw.get("total"),
+        )
+    raw["results"] = kept
+
+    return raw

--- a/src/dns_aid/sdk/exceptions.py
+++ b/src/dns_aid/sdk/exceptions.py
@@ -1,0 +1,103 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SDK exception hierarchy for directory-backed operations.
+
+The class hierarchy distinguishes configuration errors (the directory was never set up) from
+transient errors (the directory is temporarily unavailable) so callers can dispatch on type
+and shells can map distinct exit codes:
+
+* :class:`DirectoryError` — base; never raised directly.
+* :class:`DirectoryConfigError` — caller invoked a directory-tied method without configuring
+  ``directory_api_url``. Caller MUST treat as configuration; should not retry.
+* :class:`DirectoryUnavailableError` — directory is reachable in principle but unavailable now
+  (5xx response, connect refused, timeout, body validation failure). Caller SHOULD retry.
+* :class:`DirectoryRateLimitedError` — directory rate-limited the call (HTTP 429). Caller
+  SHOULD honor ``Retry-After`` before retrying.
+* :class:`DirectoryAuthError` — directory rejected the call's credentials (HTTP 401/403).
+  Caller MUST review auth handler config; should not retry blindly.
+
+Each subclass carries a typed ``details`` mapping with structured context for log analyzers
+(``directory_url``, ``status_code``, ``underlying``, ``retry_after_seconds`` as applicable),
+keeping diagnostic data out of free-form message strings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class DirectoryError(Exception):
+    """
+    Base class for failures of directory-backed SDK operations.
+
+    Subclasses carry a ``details`` mapping with structured context. Never raised directly;
+    callers should ``except`` the specific subclass or this base for catch-all dispatch.
+    """
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details: dict[str, Any] = dict(details) if details else {}
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.message!r}, details={self.details!r})"
+
+
+class DirectoryConfigError(DirectoryError):
+    """
+    Directory-tied SDK method invoked without a configured ``directory_api_url``.
+
+    ``details`` keys:
+
+    * ``missing_field`` — the configuration field name (always ``"directory_api_url"``).
+    * ``env_var`` — the environment variable that would have populated it
+      (always ``"DNS_AID_SDK_DIRECTORY_API_URL"``).
+    """
+
+
+class DirectoryUnavailableError(DirectoryError):
+    """
+    Directory backend is currently unavailable (transient failure).
+
+    Raised on connect refused, DNS failure, TLS error, network timeout, HTTP 5xx, HTTP 4xx
+    other than 401/403/429, and unexpected response shapes. Callers SHOULD retry with backoff.
+
+    ``details`` keys:
+
+    * ``directory_url`` — the resolved base URL that was contacted.
+    * ``status_code`` — HTTP status code if applicable, else ``None``.
+    * ``underlying`` — class name of the underlying exception (e.g., ``"ConnectError"``,
+      ``"ValidationError"``) when one wrapped this failure.
+    """
+
+
+class DirectoryRateLimitedError(DirectoryUnavailableError):
+    """
+    Directory rate-limited the call (HTTP 429).
+
+    Inherits from :class:`DirectoryUnavailableError` so a generic ``except DirectoryUnavailableError``
+    catches both rate-limit and other transient failures. Callers SHOULD honor ``Retry-After``.
+
+    ``details`` keys (in addition to those of :class:`DirectoryUnavailableError`):
+
+    * ``retry_after_seconds`` — value of the ``Retry-After`` header in seconds, or ``None``
+      if the directory did not provide one.
+    """
+
+
+class DirectoryAuthError(DirectoryError):
+    """
+    Directory rejected the call's authentication credentials (HTTP 401 or 403).
+
+    Distinct from :class:`DirectoryUnavailableError` because retrying without changing auth
+    configuration will not succeed. Callers MUST review the auth handler.
+
+    ``details`` keys:
+
+    * ``directory_url`` — the resolved base URL that was contacted.
+    * ``status_code`` — ``401`` or ``403``.
+    * ``auth_handler_class`` — class name of the resolved AuthHandler subclass, or ``None``
+      if no auth handler was configured.
+    """

--- a/src/dns_aid/sdk/mesh.py
+++ b/src/dns_aid/sdk/mesh.py
@@ -1,0 +1,227 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Mesh transport abstraction for DNS-AID agent-to-agent connectivity.
+
+Provides a pluggable transport layer that decouples *how bytes travel*
+(direct HTTPS, Ziti overlay, future meshes) from *what the bytes mean*
+(MCP, A2A, HTTPS protocol handlers).
+
+Architecture::
+
+    ProtocolHandler (MCP / A2A / HTTPS)
+            │
+    MeshConnection (async read/write/close)
+            │
+    MeshTransport (direct / ziti / future)
+
+Transport is orthogonal to protocol.  MCP over Ziti, A2A over direct,
+custom protocol over a future mesh — all combinations work.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from types import TracebackType
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+class MeshConnection(ABC):
+    """Bidirectional async byte stream over a mesh (or direct) connection.
+
+    This is the fundamental primitive for agent-to-agent communication.
+    Protocol handlers frame messages on top of this connection.
+    The connection may travel through a direct HTTPS path, a Ziti
+    service mesh, or any future agent mesh transport.
+    """
+
+    @abstractmethod
+    async def open(
+        self,
+        *,
+        target: str,
+        port: int = 443,
+        mesh_meta: str | None = None,
+    ) -> None:
+        """Open the connection to the target.
+
+        Args:
+            target: Target hostname or service name.
+            port: Target port.
+            mesh_meta: Mesh-specific metadata (e.g., Ziti service name as JSON).
+        """
+        ...
+
+    @abstractmethod
+    async def read(self, n: int = -1) -> bytes:
+        """Read up to *n* bytes.  -1 means read until EOF."""
+        ...
+
+    @abstractmethod
+    async def write(self, data: bytes) -> None:
+        """Write *data* to the connection."""
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the connection and release resources."""
+        ...
+
+    async def __aenter__(self) -> MeshConnection:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+
+class MeshTransport(ABC):
+    """Factory for mesh connections.  Registered per-client or globally."""
+
+    @property
+    @abstractmethod
+    def mesh_name(self) -> str:
+        """Transport identifier, e.g. ``"direct"``, ``"ziti"``."""
+        ...
+
+    @abstractmethod
+    async def connect(
+        self,
+        *,
+        target: str,
+        port: int = 443,
+        mesh_meta: str | None = None,
+    ) -> MeshConnection:
+        """Create and open a connection through this mesh.
+
+        Args:
+            target: Target hostname or service name.
+            port: Target port.
+            mesh_meta: Mesh-specific metadata (JSON string or plain value).
+
+        Returns:
+            An opened :class:`MeshConnection`.
+        """
+        ...
+
+    async def close(self) -> None:  # noqa: B027
+        """Cleanup hook (identity teardown, context shutdown)."""
+
+
+class MeshNotAvailableError(Exception):
+    """Raised when an agent requires a mesh transport that is not registered."""
+
+    def __init__(self, mesh: str) -> None:
+        self.mesh = mesh
+        super().__init__(
+            f"Mesh transport '{mesh}' required by agent but not registered. "
+            f"Install the mesh provider package and call "
+            f"client.register_mesh('{mesh}', provider)."
+        )
+
+
+# ── Direct (default) transport ──────────────────────────────────
+
+
+class DirectMeshConnection(MeshConnection):
+    """Default: wraps httpx.AsyncClient for backward compat with HTTP-based handlers.
+
+    This is what existing MCP/A2A/HTTPS handlers use during the transition period.
+    The connection exposes the underlying ``httpx.AsyncClient`` so that legacy
+    ``ProtocolHandler.invoke()`` callers can continue to use it directly.
+    """
+
+    def __init__(self, http_client: httpx.AsyncClient | None = None) -> None:
+        self._http_client = http_client
+        self._owns_client = http_client is None
+        self._target: str | None = None
+        self._port: int = 443
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        """Access the underlying httpx client for legacy handlers."""
+        if self._http_client is None:
+            raise RuntimeError("DirectMeshConnection not opened")
+        return self._http_client
+
+    async def open(
+        self,
+        *,
+        target: str,
+        port: int = 443,
+        mesh_meta: str | None = None,
+    ) -> None:
+        self._target = target
+        self._port = port
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+            )
+            self._owns_client = True
+
+    async def read(self, n: int = -1) -> bytes:
+        raise NotImplementedError(
+            "DirectMeshConnection does not support raw read(); "
+            "use http_client for HTTP-based protocols."
+        )
+
+    async def write(self, data: bytes) -> None:
+        raise NotImplementedError(
+            "DirectMeshConnection does not support raw write(); "
+            "use http_client for HTTP-based protocols."
+        )
+
+    async def close(self) -> None:
+        if self._owns_client and self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+
+class DirectMeshTransport(MeshTransport):
+    """Default mesh — plain HTTPS via httpx.  No overlay."""
+
+    def __init__(self, http_client: httpx.AsyncClient | None = None) -> None:
+        self._http_client = http_client
+
+    @property
+    def mesh_name(self) -> str:
+        return "direct"
+
+    async def connect(
+        self,
+        *,
+        target: str,
+        port: int = 443,
+        mesh_meta: str | None = None,
+    ) -> DirectMeshConnection:
+        conn = DirectMeshConnection(http_client=self._http_client)
+        await conn.open(target=target, port=port, mesh_meta=mesh_meta)
+        return conn
+
+
+# ── Module-level default registry ───────────────────────────────
+
+_MESH_TRANSPORTS: dict[str, MeshTransport] = {}
+
+
+def register_default_mesh(mesh: str, transport: MeshTransport) -> None:
+    """Register a mesh transport in the module-level default registry.
+
+    Typically called by entry_point plugins at import time.
+    """
+    _MESH_TRANSPORTS[mesh] = transport
+
+
+def get_default_mesh(mesh: str) -> MeshTransport | None:
+    """Look up a mesh transport from the module-level registry."""
+    return _MESH_TRANSPORTS.get(mesh)

--- a/src/dns_aid/sdk/search.py
+++ b/src/dns_aid/sdk/search.py
@@ -1,0 +1,210 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Typed result models for cross-domain agent search (Path B).
+
+Every Path B response from the dns-aid-directory backend is deserialized into the typed
+models below, never returned to callers as raw dicts. Models are immutable
+(``frozen=True``) and forward-compatible (``extra="ignore"``) so directory schema additions
+do not break SDK consumers; removed/renamed fields surface as Pydantic
+``ValidationError`` and are mapped to :class:`~dns_aid.sdk.exceptions.DirectoryUnavailableError`
+by the SDK, prompting the caller to retry or upgrade.
+
+The shape of these models faithfully mirrors the directory's
+``dns_aid_directory.api.schemas.AgentResponse`` / ``SearchResultItem`` /
+``SearchResponse`` contract. The directory exposes trust + provenance signals as flat
+fields on each agent; the SDK's wire-shape adapter
+(:func:`~dns_aid.sdk.client._adapt_search_payload`) lifts those flat fields into the
+typed nested objects below before validation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from dns_aid.core.models import AgentRecord
+
+
+class TrustAttestation(BaseModel):
+    """
+    Pre-computed trust signals from the directory.
+
+    Carries the signals a caller needs to decide whether to invoke an agent directly or
+    to re-verify via Path A first. Field shape mirrors the directory's flat
+    ``AgentResponse`` exactly: aggregate scores live on the 0..100 scale,
+    per-signal verification flags are tri-state (``True`` / ``False`` / ``None``),
+    and ``threat_flags`` is an open extensible map keyed by signal name.
+
+    Every field has a sensible default so the model is constructable from sparse
+    directory data — a freshly indexed agent that hasn't been crawl-verified yet will
+    still produce a valid ``TrustAttestation`` (with all verification flags ``None``
+    and scores defaulting to 0).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    # Aggregate scores (always present in directory output, default 0)
+    security_score: Annotated[int, Field(ge=0, le=100)] = Field(
+        default=0,
+        description="Aggregate security score, 0..100. 0 if not yet computed.",
+    )
+    trust_score: Annotated[int, Field(ge=0, le=100)] = Field(
+        default=0,
+        description="Overall trust score combining security, reliability, and community signals, 0..100.",
+    )
+    popularity_score: Annotated[int, Field(ge=0, le=100)] = Field(
+        default=0,
+        description="Caller-popularity score, 0..100. Driven by directory telemetry.",
+    )
+
+    # Trust tier ladder
+    trust_tier: Annotated[int, Field(ge=0, le=3)] = Field(
+        default=0,
+        description="Discrete trust tier: 0 untiered, 1 basic, 2 enhanced, 3 continuous.",
+    )
+
+    # Safety status (gate for invocation)
+    safety_status: Literal["active", "blocked"] = Field(
+        default="active",
+        description="Directory's safety verdict. ``blocked`` agents should not be invoked.",
+    )
+
+    # Per-signal verification flags. ``None`` = not yet evaluated; ``True``/``False`` = evaluated.
+    dnssec_valid: bool | None = Field(
+        default=None,
+        description="DNSSEC validation passed for the agent's DNS records.",
+    )
+    dane_valid: bool | None = Field(
+        default=None,
+        description="DANE/TLSA binding verified.",
+    )
+    svcb_valid: bool | None = Field(
+        default=None,
+        description="SVCB record schema is valid.",
+    )
+    endpoint_reachable: bool | None = Field(
+        default=None,
+        description="Crawler successfully reached the agent's endpoint.",
+    )
+    protocol_verified: bool | None = Field(
+        default=None,
+        description="Endpoint implements the claimed protocol (A2A agent card, MCP initialize).",
+    )
+
+    # Threat indicators — extensible map keyed by signal name.
+    threat_flags: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Threat-detection flags from the directory's safety pipeline.",
+    )
+
+    # Optional rich evidence — directory may expose these for advanced callers.
+    breakdown: dict[str, Any] | None = Field(
+        default=None,
+        description="Per-signal trust score breakdown (directory's ``trust_breakdown``).",
+    )
+    badges: list[str] | None = Field(
+        default=None,
+        description="Trust badges (directory's ``trust_badges``), e.g., 'Verified', 'DNSSEC'.",
+    )
+
+
+class Provenance(BaseModel):
+    """
+    Crawler provenance attribution for a directory-indexed agent.
+
+    Surfaces *when* the directory first observed an agent, when it last refreshed the
+    record, and how it was discovered. Field shape mirrors the directory's flat
+    ``AgentResponse`` exactly. ``first_seen`` and ``last_seen`` are required because the
+    directory always populates them on insert.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    discovery_level: Annotated[int, Field(ge=0, le=3)] = Field(
+        default=0,
+        description="0 observed, 1 DNS beacon detected, 2 manifest published, 3 federated.",
+    )
+    first_seen: datetime = Field(
+        description="When the directory first added this agent to the index."
+    )
+    last_seen: datetime = Field(
+        description="Wall-clock time of the directory's most recent crawl of this agent."
+    )
+    last_verified: datetime | None = Field(
+        default=None,
+        description="Wall-clock time of the directory's last successful verification crawl.",
+    )
+    company: dict[str, Any] | None = Field(
+        default=None,
+        description="Opaque company / organization metadata (directory's ``CompanyMetadata``).",
+    )
+
+
+class SearchResult(BaseModel):
+    """
+    A single ranked result from a directory query.
+
+    ``agent`` reuses the existing :class:`~dns_aid.core.models.AgentRecord` model so the
+    composition pattern (Path B → Path A re-verify) can pass the agent directly into
+    ``discover()`` without translation. ``score`` is the directory's relevance score
+    (raw float; the directory does not normalize), and ``trust`` carries pre-computed
+    trust signals so the caller can reason about re-verification without a second round
+    trip.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    agent: AgentRecord = Field(description="The agent payload, validated against AgentRecord.")
+    score: Annotated[float, Field(ge=0.0)] = Field(
+        description="Directory's relevance score (raw — higher is more relevant). Not normalized.",
+    )
+    trust: TrustAttestation = Field(
+        default_factory=TrustAttestation,
+        description="Pre-computed trust evidence lifted from the directory's flat agent fields.",
+    )
+    provenance: Provenance | None = Field(
+        default=None,
+        description="Crawler provenance metadata lifted from the directory's flat agent fields.",
+    )
+
+
+class SearchResponse(BaseModel):
+    """
+    Full response envelope for a single :meth:`AgentClient.search` invocation.
+
+    Carries the echo of the request (``query`` — just the ``q`` string the directory
+    sends back), the ranked results page (``results``), and pagination state
+    (``total``, ``limit``, ``offset``). Helper properties ``has_more`` and
+    ``next_offset`` make iterating subsequent pages a one-liner.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    query: str | None = Field(
+        default=None,
+        description="Echo of the ``q`` parameter the directory accepted (or None if not echoed).",
+    )
+    results: list[SearchResult] = Field(
+        description="Ranked results page; length is at most ``limit``."
+    )
+    total: Annotated[int, Field(ge=0)] = Field(
+        description="Total number of matching agents across all pages."
+    )
+    limit: Annotated[int, Field(ge=1, le=10000)] = Field(description="Effective page size.")
+    offset: Annotated[int, Field(ge=0)] = Field(description="Effective pagination offset.")
+
+    @property
+    def has_more(self) -> bool:
+        """True when at least one matching agent exists beyond this page's window."""
+        return self.offset + len(self.results) < self.total
+
+    @property
+    def next_offset(self) -> int | None:
+        """Offset to pass on the next page, or ``None`` if this page exhausts the result set."""
+        if not self.has_more:
+            return None
+        return self.offset + len(self.results)

--- a/src/dns_aid/utils/url_safety.py
+++ b/src/dns_aid/utils/url_safety.py
@@ -23,12 +23,34 @@ class UnsafeURLError(ValueError):
     """Raised when a URL fails safety validation."""
 
 
+def redact_url_for_log(url: str) -> str:
+    """Strip ``user:pass@`` userinfo from a URL before it goes to a log line.
+
+    A defensive complement to :func:`validate_fetch_url` — even though that
+    function rejects URLs with userinfo at the input boundary, code paths that
+    log the *raw user-supplied* URL (e.g. on the validation-failure branch
+    itself) must redact first to avoid leaking credentials to the log stream.
+    """
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(url)
+    if not (parsed.username or parsed.password):
+        return url
+    # netloc is what carries userinfo; rebuild it from hostname (and port if present).
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
 def validate_fetch_url(url: str) -> str:
     """
     Validate that a URL is safe to fetch.
 
     Enforces:
     - HTTPS scheme only (no http://, file://, etc.)
+    - No userinfo (credentials in URL): rejects ``https://user:pass@host`` to prevent
+      accidental credential leaks via logs and error messages
     - Resolved IP must not be private, loopback, or link-local
     - Allows override via DNS_AID_FETCH_ALLOWLIST env var
 
@@ -48,6 +70,15 @@ def validate_fetch_url(url: str) -> str:
     # Enforce HTTPS
     if parsed.scheme != "https":
         raise UnsafeURLError(f"Only HTTPS URLs are allowed, got scheme '{parsed.scheme}': {url}")
+
+    # Reject ``https://user:pass@host`` — credentials must come via auth handlers,
+    # not the URL string. Allowing them here would result in the credentials being
+    # logged at every level (DEBUG/WARN) the URL is referenced.
+    if parsed.username or parsed.password:
+        raise UnsafeURLError(
+            "URLs with embedded credentials (userinfo) are not allowed; "
+            "use SDKConfig auth fields instead."
+        )
 
     hostname = parsed.hostname
     if not hostname:

--- a/tests/integration/test_directory_outage.py
+++ b/tests/integration/test_directory_outage.py
@@ -1,0 +1,194 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Directory-outage isolation integration test (FR-005, SC-005, US4).
+
+The contract under test is the zero-trust isolation guarantee: a directory
+backend that flips between healthy and unreachable mid-session must NOT prevent
+Path A discovery on the same client. Path B failures get bubbled up with a
+typed exception, the directory URL stays configured, and a *subsequent* Path A
+discovery on the same ``AgentClient`` instance proceeds normally.
+
+The earlier suite (``tests/unit/sdk/test_path_isolation.py``) covers the
+single-shot case — one Path B failure, one Path A success. This integration
+test interleaves multiple Path B and Path A calls on the same client to flush
+out subtler corruption modes (lingering cancelled tasks, half-closed connection
+pools, stale auth state) that only surface with sustained traffic.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from dns_aid.core.discoverer import discover
+from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.exceptions import (
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
+
+
+def _mock_response(status_code: int, *, body: Any = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = {}
+    resp.json = MagicMock(return_value=body)
+    resp.text = "" if body is None else str(body)
+    return resp
+
+
+def _empty_discovery() -> DiscoveryResult:
+    return DiscoveryResult(
+        query="_index._agents.example.com",
+        domain="example.com",
+        agents=[],
+        dnssec_validated=False,
+        cached=False,
+        query_time_ms=1.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_directory_outage_does_not_corrupt_path_a(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sustained Path B churn (5xx → 200 → 503 → 429) leaves Path A untouched."""
+    monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+    config = SDKConfig(directory_api_url="https://directory.test.example/")
+
+    # Cycle through a realistic outage pattern: transient 503, recovery, 429
+    # backpressure, hard 502. ``itertools.cycle`` gives us a deterministic stream
+    # that exhausts every error path the SDK maps to a typed exception.
+    response_cycle = itertools.cycle(
+        [
+            _mock_response(503),
+            _mock_response(
+                200,
+                body={
+                    "query": "x",
+                    "results": [],
+                    "total": 0,
+                    "limit": 20,
+                    "offset": 0,
+                },
+            ),
+            _mock_response(429, body=None),
+            _mock_response(502),
+        ]
+    )
+
+    async with AgentClient(config=config) as client:
+        assert client._http_client is not None
+        original_http_client = client._http_client
+
+        async def cycling_get(url: str, params: Any = None, **kwargs: Any) -> MagicMock:
+            return next(response_cycle)
+
+        client._http_client.get = cycling_get  # type: ignore[method-assign]
+
+        # Note: ``next(response_cycle)`` advances every call — including 429, which
+        # the SDK raises as DirectoryRateLimitedError (a subclass of
+        # DirectoryUnavailableError). Catching the parent covers all four cases.
+        path_b_outcomes: list[type[Exception] | str] = []
+        for _ in range(8):
+            try:
+                response = await client.search(q="x")
+                path_b_outcomes.append("ok")
+                # The successful body has total=0; pagination still parses cleanly.
+                assert response.total == 0
+            except DirectoryRateLimitedError:
+                path_b_outcomes.append("rate_limited")
+            except DirectoryUnavailableError:
+                path_b_outcomes.append("unavailable")
+
+        # Each cycle has a 1/4 chance of being "ok"; over 8 calls we should have
+        # at least one of every outcome. Assert the *shape* of the outcome stream
+        # rather than exact counts so cycle internals aren't load-bearing.
+        assert "ok" in path_b_outcomes
+        assert "unavailable" in path_b_outcomes
+        assert "rate_limited" in path_b_outcomes
+
+        # ── Critical invariant ── despite the churn, the http client must still
+        # be the same instance, still open, still bound to the configured base URL.
+        assert client._http_client is original_http_client
+        assert client._http_client.is_closed is False
+        assert client._config.directory_api_url == "https://directory.test.example/"
+
+        # ── Path A must still work on the SAME process. The free ``discover()``
+        # function is independent of AgentClient state, but a real caller will
+        # call both on the same event loop, so we exercise that pattern here.
+        with (
+            patch(
+                "dns_aid.core.discoverer._execute_discovery",
+                new=AsyncMock(
+                    return_value=[
+                        AgentRecord(
+                            name="payments",
+                            domain="example.com",
+                            protocol=Protocol.MCP,
+                            target_host="payments.example.com",
+                            port=443,
+                            capabilities=["payment-processing"],
+                        )
+                    ]
+                ),
+            ),
+            patch(
+                "dns_aid.core.discoverer._apply_post_discovery",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            path_a_result = await discover("example.com")
+
+        assert path_a_result.domain == "example.com"
+        assert {a.name for a in path_a_result.agents} == {"payments"}
+
+
+@pytest.mark.asyncio
+async def test_directory_recovery_after_extended_outage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    After a sustained Path B outage, the very next successful Path B call must
+    return cleanly — no warm-up retries, no stale auth headers, no leaked state.
+    """
+    monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+    config = SDKConfig(directory_api_url="https://directory.test.example/")
+
+    healthy_body = {
+        "query": "x",
+        "results": [],
+        "total": 0,
+        "limit": 20,
+        "offset": 0,
+    }
+
+    # 5 consecutive failures then a recovery — what a real directory outage with
+    # eventual repair looks like.
+    responses = [_mock_response(503)] * 5 + [_mock_response(200, body=healthy_body)]
+    iterator = iter(responses)
+
+    async with AgentClient(config=config) as client:
+        assert client._http_client is not None
+
+        async def get(url: str, params: Any = None, **kwargs: Any) -> MagicMock:
+            return next(iterator)
+
+        client._http_client.get = get  # type: ignore[method-assign]
+
+        for _ in range(5):
+            with pytest.raises(DirectoryUnavailableError):
+                await client.search(q="x")
+
+        # Recovery: same client, no reset needed.
+        recovered = await client.search(q="x")
+        assert recovered.total == 0
+        assert recovered.results == []

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -1,0 +1,144 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared fixtures for cross-interface parity tests (FR-024, FR-025, US4).
+
+The whole point of US4 is the *equivalent surfaces* invariant: identical inputs
+must produce identical outputs whether they enter the system through the SDK,
+the CLI, or the MCP tool. The fixtures here build the canonical Path A agent
+set and Path B search response *once*, so the parity matrix asserts equality
+against a single source of truth instead of re-deriving expectations per surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dns_aid.core.models import AgentRecord, Protocol
+
+
+@pytest.fixture
+def parity_agents() -> list[AgentRecord]:
+    """Three agents with mixed metadata to exercise every Path A filter at once."""
+    return [
+        AgentRecord(
+            name="payments",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="payments.example.com",
+            port=443,
+            capabilities=["payment-processing", "fraud-detection"],
+            description="Process card payments and run fraud heuristics.",
+            auth_type="oauth2",
+            realm="prod",
+            sig="hdr.payload.sig",
+            signature_verified=True,
+            signature_algorithm="ES256",
+            dnssec_validated=True,
+        ),
+        AgentRecord(
+            name="search",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="search.example.com",
+            port=443,
+            capabilities=["search"],
+            description="Catalog full-text search.",
+            auth_type="api_key",
+            realm="prod",
+            dnssec_validated=True,
+        ),
+        AgentRecord(
+            name="legacy",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="legacy.example.com",
+            port=443,
+            capabilities=["fraud-detection"],
+            description="Older fraud rules engine, kept for staging.",
+            auth_type="oauth2",
+            realm="staging",
+            sig="hdr.payload.sig",
+            signature_verified=True,
+            signature_algorithm="HS256",
+            dnssec_validated=False,
+        ),
+    ]
+
+
+@pytest.fixture
+def parity_search_payload() -> dict[str, Any]:
+    """
+    Canonical /api/v1/search response in the directory's flat wire shape.
+
+    Mirrors ``dns_aid_directory.api.schemas.SearchResponse`` exactly: ``query``
+    is a string echo, results carry only ``agent`` + ``score``, and trust +
+    provenance signals live flat on the agent. The SDK's
+    ``_adapt_search_payload`` lifts these into the typed nested objects
+    ``TrustAttestation`` / ``Provenance`` before validation — so this fixture
+    exercises the production round-trip, not a pre-adapted SDK shape.
+    """
+    return {
+        "query": "payments",
+        "results": [
+            {
+                "agent": {
+                    "fqdn": "_payments._mcp._agents.example.com",
+                    "name": "payments",
+                    "domain": "example.com",
+                    "protocol": "mcp",
+                    "endpoint_url": "https://payments.example.com",
+                    "port": 443,
+                    "capabilities": ["payment-processing", "fraud-detection"],
+                    "description": "Process card payments.",
+                    "auth_type": "oauth2",
+                    "bap": "mcp/1,a2a/1",
+                    # Trust signals flat on the agent.
+                    "security_score": 88,
+                    "trust_score": 91,
+                    "popularity_score": 80,
+                    "trust_tier": 1,
+                    "safety_status": "active",
+                    "dnssec_valid": True,
+                    "dane_valid": False,
+                    "svcb_valid": True,
+                    "endpoint_reachable": True,
+                    "protocol_verified": True,
+                    "trust_badges": ["Verified", "DNSSEC"],
+                    # Provenance signals flat on the agent.
+                    "discovery_level": 2,
+                    "first_seen": "2026-04-01T00:00:00Z",
+                    "last_seen": "2026-05-01T00:00:00Z",
+                    "last_verified": "2026-04-30T00:00:00Z",
+                },
+                "score": 39.2,
+            },
+            {
+                "agent": {
+                    "fqdn": "_search._mcp._agents.example.com",
+                    "name": "search",
+                    "domain": "example.com",
+                    "protocol": "mcp",
+                    "endpoint_url": "https://search.example.com",
+                    "port": 443,
+                    "capabilities": ["search"],
+                    "description": "Catalog search.",
+                    "auth_type": "api_key",
+                    "security_score": 72,
+                    "trust_score": 70,
+                    "popularity_score": 60,
+                    "trust_tier": 2,
+                    "safety_status": "active",
+                    "first_seen": "2026-04-15T00:00:00Z",
+                    "last_seen": "2026-05-01T00:00:00Z",
+                },
+                "score": 28.4,
+            },
+        ],
+        "total": 2,
+        "limit": 20,
+        "offset": 0,
+    }

--- a/tests/parity/test_discover_parity.py
+++ b/tests/parity/test_discover_parity.py
@@ -1,0 +1,221 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Path A (discover) cross-interface parity matrix — FR-024, FR-025, US4.
+
+For every Path A filter combination, the SDK free function, the CLI command,
+and the MCP tool MUST return the same agent set. Any divergence is a contract
+break: an agent that drives all three surfaces (e.g., a tool wrapping the CLI
+under the hood, or a planner alternating between SDK and MCP) will get a
+*different* answer depending on which surface it picked, which breaks zero-trust
+composition guarantees.
+
+The test pins one canonical agent fixture (see ``conftest.parity_agents``) and
+asserts that when each surface is given the same filter args, the **agent name
+set, ordering, and the trust-related boolean fields** are identical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+from dns_aid.core.discoverer import discover
+from dns_aid.core.models import AgentRecord
+from dns_aid.mcp.server import discover_agents_via_dns
+
+# Each entry is (filter_kwargs, expected_agent_names).  Cover one pure-pipeline
+# control row plus every Path A filter axis at least once.
+DISCOVER_FILTER_CASES: list[tuple[dict[str, Any], set[str]]] = [
+    ({}, {"payments", "search", "legacy"}),
+    ({"capabilities": ["payment-processing", "fraud-detection"]}, {"payments"}),
+    ({"capabilities_any": ["search", "fraud-detection"]}, {"payments", "search", "legacy"}),
+    ({"auth_type": "oauth2"}, {"payments", "legacy"}),
+    ({"realm": "prod"}, {"payments", "search"}),
+    ({"text_match": "fraud"}, {"payments", "legacy"}),
+    ({"min_dnssec": True}, {"payments", "search"}),
+    ({"require_signed": True}, {"payments", "legacy"}),
+    (
+        {"require_signed": True, "require_signature_algorithm": ["ES256", "Ed25519"]},
+        {"payments"},
+    ),
+    (
+        {
+            "capabilities": ["fraud-detection"],
+            "auth_type": "oauth2",
+            "realm": "prod",
+        },
+        {"payments"},
+    ),
+]
+
+
+def _patches(agents: list[AgentRecord]) -> list[Any]:
+    """Stub the substrate so no DNS or HTTP fires for any of the three surfaces."""
+    return [
+        patch(
+            "dns_aid.core.discoverer._execute_discovery",
+            new=AsyncMock(return_value=agents),
+        ),
+        patch(
+            "dns_aid.core.discoverer._apply_post_discovery",
+            new=AsyncMock(return_value=False),
+        ),
+    ]
+
+
+def _kwargs_to_cli_args(kwargs: dict[str, Any]) -> list[str]:
+    """Translate a kwargs dict into the corresponding ``dns-aid discover`` flags."""
+    args: list[str] = []
+    for key, value in kwargs.items():
+        flag = "--" + key.replace("_", "-")
+        if isinstance(value, bool):
+            if value:
+                args.append(flag)
+            continue
+        if isinstance(value, list):
+            for item in value:
+                args.extend([flag, str(item)])
+            continue
+        args.extend([flag, str(value)])
+    return args
+
+
+def _extract_json_payload(output: str) -> dict[str, Any]:
+    """
+    The CLI emits a human-readable status banner ahead of the JSON payload.
+
+    We slice from the first ``{`` to the matching closing brace. ``json.loads``
+    is tolerant of trailing whitespace/newlines so we just go to the end of
+    the captured output.
+    """
+    start = output.find("{")
+    if start == -1:
+        raise AssertionError(f"CLI output contained no JSON object:\n{output}")
+    return json.loads(output[start:])
+
+
+@pytest.mark.parametrize(
+    ("filter_kwargs", "expected_names"),
+    DISCOVER_FILTER_CASES,
+    ids=[
+        "no-filters",
+        "capabilities-all-of",
+        "capabilities-any-of",
+        "auth-type",
+        "realm",
+        "text-match",
+        "min-dnssec",
+        "require-signed",
+        "require-algorithm-allowlist",
+        "combined-filters",
+    ],
+)
+def test_discover_parity_across_surfaces(
+    parity_agents: list[AgentRecord],
+    filter_kwargs: dict[str, Any],
+    expected_names: set[str],
+) -> None:
+    """
+    Test stays synchronous on purpose.
+
+    The CLI uses ``asyncio.run()`` internally, and ``asyncio.run`` can't be
+    invoked from a thread that already has a running event loop. If we marked
+    this test ``@pytest.mark.asyncio`` the CLI would explode with
+    ``RuntimeError: asyncio.run() cannot be called from a running event loop``
+    the moment ``CliRunner.invoke`` ran. Keeping the test sync and bridging to
+    the async SDK with our own ``asyncio.run`` is the cleaner answer: each
+    surface runs under the same execution model it would use in production.
+    """
+    # SDK surface — bridge to async with a fresh loop, matching production.
+    patches = _patches(parity_agents)
+    for p in patches:
+        p.start()
+    try:
+        sdk_result = asyncio.run(discover("example.com", **filter_kwargs))
+        sdk_names = {a.name for a in sdk_result.agents}
+    finally:
+        for p in patches:
+            p.stop()
+
+    # MCP surface — call the registered tool function directly.
+    patches = _patches(parity_agents)
+    for p in patches:
+        p.start()
+    try:
+        mcp_result = discover_agents_via_dns(domain="example.com", **filter_kwargs)
+        assert "agents" in mcp_result, mcp_result  # bail loudly if MCP errored
+        mcp_names = {a["name"] for a in mcp_result["agents"]}
+    finally:
+        for p in patches:
+            p.stop()
+
+    # CLI surface — invoke through Typer's runner.
+    cli_runner = CliRunner()
+    patches = _patches(parity_agents)
+    for p in patches:
+        p.start()
+    try:
+        cli_args = ["discover", "example.com", "--json"] + _kwargs_to_cli_args(filter_kwargs)
+        cli_result = cli_runner.invoke(app, cli_args)
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert cli_result.exit_code == 0, cli_result.output
+    cli_payload = _extract_json_payload(cli_result.output)
+    cli_names = {a["name"] for a in cli_payload["agents"]}
+
+    # The headline parity claim.
+    assert sdk_names == mcp_names == cli_names == expected_names, (
+        f"Surface drift detected: sdk={sdk_names}, mcp={mcp_names}, cli={cli_names}, "
+        f"expected={expected_names}"
+    )
+
+
+def test_discover_parity_signature_fields_propagate(
+    parity_agents: list[AgentRecord],
+) -> None:
+    """``signature_verified`` and ``signature_algorithm`` survive every transport."""
+    patches = _patches(parity_agents)
+    for p in patches:
+        p.start()
+    try:
+        sdk_result = asyncio.run(
+            discover(
+                "example.com",
+                require_signed=True,
+                require_signature_algorithm=["ES256", "Ed25519"],
+            )
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    sdk_payments = next(a for a in sdk_result.agents if a.name == "payments")
+    assert sdk_payments.signature_verified is True
+    assert sdk_payments.signature_algorithm == "ES256"
+
+    patches = _patches(parity_agents)
+    for p in patches:
+        p.start()
+    try:
+        mcp_result = discover_agents_via_dns(
+            domain="example.com",
+            require_signed=True,
+            require_signature_algorithm=["ES256", "Ed25519"],
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    # MCP currently exposes a curated subset of AgentRecord — assert the agent
+    # shows up. Trust attestations live on Path B, not Path A.
+    assert {a["name"] for a in mcp_result["agents"]} == {"payments"}

--- a/tests/parity/test_search_parity.py
+++ b/tests/parity/test_search_parity.py
@@ -1,0 +1,222 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Path B (search) cross-interface parity matrix — FR-024, FR-025, US4.
+
+For every Path B query, the SDK ``AgentClient.search()`` call, the CLI
+``dns-aid search`` invocation, and the MCP ``search_agents`` tool MUST agree
+on the same set of results, totals, and trust attestations. We patch the
+single point where all three converge — :meth:`AgentClient.search` — and
+record every call. Two assertions then matter:
+
+1. Every surface delivered the same kwargs to the SDK (no surface dropped or
+   renamed a filter on the way down).
+2. Every surface returned the same user-visible result set up the stack
+   (no surface dropped or reformatted a result on the way up).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+from dns_aid.mcp.server import search_agents
+from dns_aid.sdk import AgentClient, SDKConfig
+from dns_aid.sdk.search import SearchResponse
+
+SEARCH_FILTER_CASES: list[dict[str, Any]] = [
+    {"q": "payments"},
+    {"q": "fraud", "protocol": "mcp"},
+    {"capabilities": ["payment-processing"]},
+    {"intent": "transaction", "auth_type": "oauth2"},
+    {"min_security_score": 70, "verified_only": True},
+    {"realm": "prod", "transport": "streamable-http", "limit": 50, "offset": 10},
+]
+
+
+_DIRECTORY_URL = "https://directory.test.example/"
+
+
+@pytest.fixture(autouse=True)
+def _allow_directory_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow our offline test hostname through the SDK SSRF allowlist."""
+    monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+    monkeypatch.setenv("DNS_AID_SDK_DIRECTORY_API_URL", _DIRECTORY_URL)
+
+
+def _patched_search(
+    response: SearchResponse,
+) -> tuple[Any, list[dict[str, Any]]]:
+    """Patch :meth:`AgentClient.search` to return ``response`` and record kwargs."""
+    captured: list[dict[str, Any]] = []
+
+    async def fake_search(self: AgentClient, **kwargs: Any) -> SearchResponse:
+        captured.append(kwargs)
+        return response
+
+    return patch.object(AgentClient, "search", new=fake_search), captured
+
+
+def _kwargs_to_cli_args(kwargs: dict[str, Any]) -> list[str]:
+    args: list[str] = []
+    pos_query = kwargs.pop("q", None)
+    if pos_query is not None:
+        args.append(pos_query)
+    for key, value in kwargs.items():
+        flag = "--" + key.replace("_", "-")
+        if isinstance(value, bool):
+            if value:
+                args.append(flag)
+            continue
+        if isinstance(value, list):
+            for item in value:
+                args.extend([flag, str(item)])
+            continue
+        args.extend([flag, str(value)])
+    return args
+
+
+@pytest.mark.parametrize("filter_kwargs", SEARCH_FILTER_CASES)
+def test_search_parity_across_surfaces(
+    parity_search_payload: dict[str, Any],
+    filter_kwargs: dict[str, Any],
+) -> None:
+    # The fixture is in the directory's flat wire shape; the SDK runs
+    # ``_adapt_search_payload`` before validation in production, so we apply the
+    # same transformation here to produce the typed response surfaces compare
+    # against. This keeps the fixture single-source-of-truth (live API shape).
+    # Deepcopy because the adapter mutates the dict in place.
+    import copy
+
+    from dns_aid.sdk.client import _adapt_search_payload
+
+    response = SearchResponse.model_validate(
+        _adapt_search_payload(copy.deepcopy(parity_search_payload))
+    )
+    expected_names = [r.agent.name for r in response.results]
+    expected_total = response.total
+
+    # ── SDK surface ──
+    sdk_patcher, sdk_captured = _patched_search(response)
+    with sdk_patcher:
+
+        async def _call_sdk() -> SearchResponse:
+            async with AgentClient(config=SDKConfig.from_env()) as client:
+                return await client.search(**filter_kwargs)
+
+        sdk_response = asyncio.run(_call_sdk())
+
+    sdk_names = [r.agent.name for r in sdk_response.results]
+    assert sdk_names == expected_names
+    assert sdk_response.total == expected_total
+    assert len(sdk_captured) == 1
+
+    # ── MCP surface ──
+    mcp_patcher, mcp_captured = _patched_search(response)
+    with mcp_patcher:
+        # The MCP tool builds its own AgentClient via SDKConfig.from_env(),
+        # so the env vars set by the autouse fixture above are picked up.
+        mcp_result = search_agents(**filter_kwargs)
+
+    assert mcp_result["success"] is True, mcp_result
+    mcp_names = [r["agent"]["name"] for r in mcp_result["results"]]
+    assert mcp_names == expected_names
+    assert mcp_result["total"] == expected_total
+    assert len(mcp_captured) == 1
+
+    # ── CLI surface ──
+    cli_patcher, cli_captured = _patched_search(response)
+    with cli_patcher:
+        cli_runner = CliRunner()
+        cli_args = ["search", "--json"] + _kwargs_to_cli_args(dict(filter_kwargs))
+        cli_result = cli_runner.invoke(app, cli_args)
+
+    assert cli_result.exit_code == 0, cli_result.output
+    cli_payload = json.loads(cli_result.output)
+    cli_names = [r["agent"]["name"] for r in cli_payload["results"]]
+    assert cli_names == expected_names
+    assert cli_payload["total"] == expected_total
+    assert len(cli_captured) == 1
+
+    # ── Headline parity claim: every surface forwarded the SAME kwargs ──
+    sdk_call_kwargs = sdk_captured[0]
+    mcp_call_kwargs = mcp_captured[0]
+    cli_call_kwargs = cli_captured[0]
+
+    # CLI's ``--limit`` defaults to 20 when not set; normalise so we compare
+    # what the user actually asked for, not Typer-injected defaults.
+    expected_kwargs = _normalize(filter_kwargs)
+    assert _normalize(sdk_call_kwargs) == expected_kwargs, (
+        f"SDK forwarded different kwargs: {sdk_call_kwargs} vs {filter_kwargs}"
+    )
+    assert _normalize(mcp_call_kwargs) == expected_kwargs, (
+        f"MCP forwarded different kwargs: {mcp_call_kwargs} vs {filter_kwargs}"
+    )
+    assert _normalize(cli_call_kwargs) == expected_kwargs, (
+        f"CLI forwarded different kwargs: {cli_call_kwargs} vs {filter_kwargs}"
+    )
+
+
+def _normalize(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Drop SDK-default values so each surface compares on user-supplied filters only."""
+    defaults = {
+        "q": None,
+        "protocol": None,
+        "domain": None,
+        "capabilities": None,
+        "min_security_score": None,
+        "verified_only": False,
+        "intent": None,
+        "auth_type": None,
+        "transport": None,
+        "realm": None,
+        "limit": 20,
+        "offset": 0,
+    }
+    return {k: v for k, v in kwargs.items() if defaults.get(k, object()) != v}
+
+
+def test_search_parity_error_class_consistency(
+    parity_search_payload: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A misconfigured directory must produce structurally equivalent failure
+    signals on each surface — even though the carriers differ
+    (exception / non-zero exit code / structured ``success: False`` envelope).
+    """
+    from dns_aid.sdk.exceptions import DirectoryConfigError
+
+    monkeypatch.delenv("DNS_AID_SDK_DIRECTORY_API_URL", raising=False)
+    monkeypatch.delenv("DNS_AID_SDK_TELEMETRY_API_URL", raising=False)
+
+    # Sanity-check our env scrubbing: any leftover process-level config would
+    # mask the failure path the parity assertion depends on.
+    assert os.environ.get("DNS_AID_SDK_DIRECTORY_API_URL") is None
+    assert os.environ.get("DNS_AID_SDK_TELEMETRY_API_URL") is None
+
+    # SDK raises DirectoryConfigError.
+    async def _call_sdk() -> None:
+        async with AgentClient(config=SDKConfig()) as client:
+            await client.search(q="x")
+
+    with pytest.raises(DirectoryConfigError):
+        asyncio.run(_call_sdk())
+
+    # MCP returns a structured envelope.
+    mcp_result = search_agents(q="x")
+    assert mcp_result["success"] is False
+    assert mcp_result["error"] == "directory_not_configured"
+
+    # CLI exits 78 (EX_CONFIG).
+    cli_runner = CliRunner()
+    cli_result = cli_runner.invoke(app, ["search", "x"])
+    assert cli_result.exit_code == 78

--- a/tests/unit/cli/test_discover_filters.py
+++ b/tests/unit/cli/test_discover_filters.py
@@ -1,0 +1,135 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the new Path A filter flags on ``dns-aid discover``.
+
+Validates that every flag introduced by US2/US3 reaches the underlying ``discover()``
+call with the right shape, AND that pre-existing flag combinations still produce the
+same results (backwards-compat regression).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+from dns_aid.core.models import DiscoveryResult
+
+
+def _empty_discovery_result() -> DiscoveryResult:
+    return DiscoveryResult(
+        query="_index._agents.example.com",
+        domain="example.com",
+        agents=[],
+        dnssec_validated=False,
+        cached=False,
+        query_time_ms=1.5,
+    )
+
+
+runner = CliRunner()
+
+
+class TestFilterFlagsReachDiscoverer:
+    def test_every_filter_flag_arrives_at_discoverer(self) -> None:
+        captured: dict[str, Any] = {}
+
+        async def fake_discover(*args: Any, **kwargs: Any) -> DiscoveryResult:
+            captured.update(kwargs)
+            return _empty_discovery_result()
+
+        with patch("dns_aid.core.discoverer.discover", new=fake_discover):
+            result = runner.invoke(
+                app,
+                [
+                    "discover",
+                    "example.com",
+                    "--protocol",
+                    "mcp",
+                    "--capabilities",
+                    "payment-processing",
+                    "--capabilities",
+                    "fraud-detection",
+                    "--capabilities-any",
+                    "alt-payment",
+                    "--auth-type",
+                    "oauth2",
+                    "--intent",
+                    "transaction",
+                    "--transport",
+                    "mcp",
+                    "--realm",
+                    "prod",
+                    "--min-dnssec",
+                    "--text-match",
+                    "payments",
+                    "--require-signed",
+                    "--require-signature-algorithm",
+                    "ES256",
+                    "--require-signature-algorithm",
+                    "Ed25519",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["domain"] == "example.com"
+        assert captured["protocol"] == "mcp"
+        assert captured["capabilities"] == ["payment-processing", "fraud-detection"]
+        assert captured["capabilities_any"] == ["alt-payment"]
+        assert captured["auth_type"] == "oauth2"
+        assert captured["intent"] == "transaction"
+        assert captured["transport"] == "mcp"
+        assert captured["realm"] == "prod"
+        assert captured["min_dnssec"] is True
+        assert captured["text_match"] == "payments"
+        assert captured["require_signed"] is True
+        assert captured["require_signature_algorithm"] == ["ES256", "Ed25519"]
+
+
+class TestBackwardsCompat:
+    """Pre-existing flags must continue to produce identical behavior."""
+
+    def test_legacy_invocation_still_calls_discover(self) -> None:
+        captured: dict[str, Any] = {}
+
+        async def fake_discover(*args: Any, **kwargs: Any) -> DiscoveryResult:
+            captured.update(kwargs)
+            return _empty_discovery_result()
+
+        with patch("dns_aid.core.discoverer.discover", new=fake_discover):
+            result = runner.invoke(
+                app,
+                ["discover", "example.com", "--protocol", "mcp", "--name", "payments"],
+            )
+
+        assert result.exit_code == 0
+        assert captured["domain"] == "example.com"
+        assert captured["protocol"] == "mcp"
+        assert captured["name"] == "payments"
+        # New filter kwargs default to None / False — nothing surprising threaded through.
+        assert captured["capabilities"] is None
+        assert captured["min_dnssec"] is False
+        assert captured["require_signed"] is False
+
+
+class TestInvalidCombination:
+    def test_algorithm_without_require_signed_exits_64(self) -> None:
+        # The discoverer raises ValueError; CLI maps to exit 64 (usage error).
+        with patch(
+            "dns_aid.core.discoverer.discover",
+            new=AsyncMock(side_effect=ValueError("require_signed=True needed")),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "discover",
+                    "example.com",
+                    "--require-signature-algorithm",
+                    "ES256",
+                ],
+            )
+        assert result.exit_code == 64

--- a/tests/unit/cli/test_search_command.py
+++ b/tests/unit/cli/test_search_command.py
@@ -1,0 +1,310 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the ``dns-aid search`` CLI subcommand.
+
+Covers:
+- flag parsing for every Path B filter
+- output formatting (human + JSON)
+- exit codes mapped from DirectoryError subclasses (sysexits.h)
+- ``--directory-url`` per-invocation override
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk.exceptions import (
+    DirectoryAuthError,
+    DirectoryConfigError,
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
+from dns_aid.sdk.search import (
+    SearchResponse,
+    SearchResult,
+    TrustAttestation,
+)
+
+
+def _make_response(results: int = 1, total: int = 1, offset: int = 0) -> SearchResponse:
+    return SearchResponse(
+        query="payments",
+        results=[
+            SearchResult(
+                agent=AgentRecord(
+                    name=f"agent{i}",
+                    domain="example.com",
+                    protocol=Protocol.MCP,
+                    target_host=f"agent{i}.example.com",
+                    port=443,
+                    capabilities=["payment-processing"],
+                ),
+                # Directory uses raw scores; CLI formatting handles >= 1.0.
+                score=39.2 - (i * 0.1),
+                trust=TrustAttestation(
+                    security_score=80,
+                    trust_score=75,
+                    popularity_score=60,
+                    trust_tier=2,
+                    safety_status="active",
+                    dnssec_valid=True,
+                    dane_valid=False,
+                    svcb_valid=True,
+                    endpoint_reachable=True,
+                    protocol_verified=True,
+                    badges=["Verified"],
+                ),
+            )
+            for i in range(results)
+        ],
+        total=total,
+        limit=20,
+        offset=offset,
+    )
+
+
+runner = CliRunner()
+
+
+class TestHappyPath:
+    def test_renders_human_table(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            return_value=_make_response(results=2, total=5),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "payments",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "agent0" in result.output
+        assert "T2" in result.output
+        # Pagination summary appears when more results exist.
+        assert "Showing" in result.output
+        assert "of 5 results" in result.output
+
+    def test_json_output_serializes_response(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            return_value=_make_response(results=1, total=1),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "payments",
+                    "--json",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+
+        assert result.exit_code == 0
+        # JSON envelope must include the whole SearchResponse shape.
+        assert '"results"' in result.output
+        assert '"total"' in result.output
+        assert '"trust_tier"' in result.output
+
+    def test_zero_results_exits_zero(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            return_value=_make_response(results=0, total=0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "no-such-thing",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+
+        assert result.exit_code == 0
+        assert "No agents matched" in result.output
+
+
+class TestFilterPropagation:
+    def test_every_filter_flag_reaches_search(self) -> None:
+        """Each CLI filter flag must arrive at AgentClient.search() with the right shape."""
+        captured: dict[str, Any] = {}
+
+        async def fake_search(self: Any, *args: Any, **kwargs: Any) -> SearchResponse:
+            captured.update(kwargs)
+            return _make_response(results=0, total=0)
+
+        with patch("dns_aid.sdk.client.AgentClient.search", new=fake_search):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "payments",
+                    "--protocol",
+                    "mcp",
+                    "--domain",
+                    "example.com",
+                    "--capabilities",
+                    "payment-processing",
+                    "--capabilities",
+                    "fraud-detection",
+                    "--intent",
+                    "transaction",
+                    "--auth-type",
+                    "oauth2",
+                    "--transport",
+                    "streamable-http",
+                    "--realm",
+                    "prod",
+                    "--min-security-score",
+                    "70",
+                    "--verified-only",
+                    "--limit",
+                    "10",
+                    "--offset",
+                    "20",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["q"] == "payments"
+        assert captured["protocol"] == "mcp"
+        assert captured["domain"] == "example.com"
+        assert captured["capabilities"] == ["payment-processing", "fraud-detection"]
+        assert captured["intent"] == "transaction"
+        assert captured["auth_type"] == "oauth2"
+        assert captured["transport"] == "streamable-http"
+        assert captured["realm"] == "prod"
+        assert captured["min_security_score"] == 70
+        assert captured["verified_only"] is True
+        assert captured["limit"] == 10
+        assert captured["offset"] == 20
+
+
+class TestExitCodes:
+    def test_config_error_exits_78(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryConfigError(
+                "no url",
+                details={
+                    "missing_field": "directory_api_url",
+                    "env_var": "DNS_AID_SDK_DIRECTORY_API_URL",
+                },
+            ),
+        ):
+            result = runner.invoke(app, ["search", "x"])
+        assert result.exit_code == 78
+
+    def test_auth_error_exits_77(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryAuthError("bad token", details={"status_code": 401}),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "x",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 77
+
+    def test_unavailable_exits_75(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryUnavailableError("down", details={"status_code": 503}),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "x",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 75
+
+    def test_rate_limited_exits_75(self) -> None:
+        # DirectoryRateLimitedError inherits from DirectoryUnavailableError.
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryRateLimitedError(
+                "slow", details={"status_code": 429, "retry_after_seconds": 30}
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "x",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 75
+
+    def test_json_error_envelope_on_failure(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryUnavailableError(
+                "down", details={"status_code": 503, "underlying": "HTTPStatusError"}
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "x",
+                    "--json",
+                    "--directory-url",
+                    "https://directory.test.example",
+                ],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 75
+        assert '"error"' in result.output
+        assert "DirectoryUnavailableError" in result.output
+
+
+class TestLimitBounds:
+    def test_limit_zero_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["search", "x", "--limit", "0"],
+            env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+        )
+        # Typer enforces min=1 → exit 2 (usage error).
+        assert result.exit_code != 0

--- a/tests/unit/core/test_discoverer_filters.py
+++ b/tests/unit/core/test_discoverer_filters.py
@@ -1,0 +1,391 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end tests for ``discover()`` Path A filter kwargs.
+
+The filter primitives are unit-tested in :mod:`tests.unit.core.test_filters`. This
+module verifies the *wiring*: ``discover()`` correctly threads its new kwargs through
+to :func:`apply_filters` after enrichment, and the resulting ``DiscoveryResult.agents``
+reflects the filtered subset.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.core.discoverer import discover
+from dns_aid.core.models import AgentRecord, Protocol
+
+
+def _agent(
+    name: str,
+    *,
+    capabilities: list[str] | None = None,
+    auth_type: str | None = None,
+    realm: str | None = None,
+    description: str | None = None,
+    sig: str | None = None,
+    signature_verified: bool | None = None,
+    signature_algorithm: str | None = None,
+    dnssec_validated: bool = False,
+) -> AgentRecord:
+    return AgentRecord(
+        name=name,
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host=f"{name}.example.com",
+        port=443,
+        capabilities=capabilities or [],
+        description=description,
+        auth_type=auth_type,
+        realm=realm,
+        sig=sig,
+        signature_verified=signature_verified,
+        signature_algorithm=signature_algorithm,
+        dnssec_validated=dnssec_validated,
+    )
+
+
+@pytest.fixture
+def mocked_pipeline() -> list[AgentRecord]:
+    """Three agents with mixed metadata so filters can discriminate."""
+    return [
+        _agent(
+            "payments",
+            capabilities=["payment-processing", "fraud-detection"],
+            auth_type="oauth2",
+            realm="prod",
+            description="Process card payments.",
+            sig="hdr.payload.sig",
+            signature_verified=True,
+            signature_algorithm="ES256",
+        ),
+        _agent(
+            "search",
+            capabilities=["search"],
+            auth_type="api_key",
+            realm="prod",
+        ),
+        _agent(
+            "weak",
+            capabilities=["fraud-detection"],
+            auth_type="oauth2",
+            sig="hdr.payload.sig",
+            signature_verified=True,
+            signature_algorithm="HS256",
+        ),
+    ]
+
+
+def _patch_discovery(agents: list[AgentRecord]):
+    """Stub ``_execute_discovery`` and ``_apply_post_discovery`` so no DNS or HTTP fires."""
+    return [
+        patch(
+            "dns_aid.core.discoverer._execute_discovery",
+            new=AsyncMock(return_value=agents),
+        ),
+        patch(
+            "dns_aid.core.discoverer._apply_post_discovery",
+            new=AsyncMock(return_value=False),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_filters_returns_full_set(mocked_pipeline: list[AgentRecord]) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com")
+        assert {a.name for a in result.agents} == {"payments", "search", "weak"}
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_capabilities_all_of(mocked_pipeline: list[AgentRecord]) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover(
+            "example.com",
+            capabilities=["payment-processing", "fraud-detection"],
+        )
+        assert [a.name for a in result.agents] == ["payments"]
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_capabilities_any_of(mocked_pipeline: list[AgentRecord]) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover(
+            "example.com",
+            capabilities_any=["search", "fraud-detection"],
+        )
+        assert {a.name for a in result.agents} == {"payments", "search", "weak"}
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_auth_type_filter(mocked_pipeline: list[AgentRecord]) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", auth_type="oauth2")
+        assert {a.name for a in result.agents} == {"payments", "weak"}
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_match_substring(mocked_pipeline: list[AgentRecord]) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", text_match="payment")
+        assert {a.name for a in result.agents} == {"payments"}
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_realm_filter(mocked_pipeline: list[AgentRecord]) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", realm="prod")
+        assert {a.name for a in result.agents} == {"payments", "search"}
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_min_dnssec_propagates_from_dnssec_validated(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    """When DNSSEC validation succeeds, every agent gets ``dnssec_validated=True``."""
+    with (
+        patch(
+            "dns_aid.core.discoverer._execute_discovery",
+            new=AsyncMock(return_value=mocked_pipeline),
+        ),
+        patch(
+            "dns_aid.core.discoverer._apply_post_discovery",
+            new=AsyncMock(return_value=True),  # DNSSEC validated for the domain.
+        ),
+    ):
+        result = await discover("example.com", min_dnssec=True)
+        assert len(result.agents) == 3
+        assert all(a.dnssec_validated for a in result.agents)
+
+
+@pytest.mark.asyncio
+async def test_min_dnssec_excludes_when_unvalidated(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)  # Returns dnssec_validated=False
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", min_dnssec=True)
+        assert result.agents == []
+    finally:
+        for p in patches:
+            p.stop()
+
+
+# US3 — trust filtering
+
+
+@pytest.mark.asyncio
+async def test_require_signed_only_returns_verified(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", require_signed=True)
+        # ``payments`` and ``weak`` both have signature_verified=True; ``search`` has no sig.
+        assert {a.name for a in result.agents} == {"payments", "weak"}
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_require_signature_algorithm_allow_list(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover(
+            "example.com",
+            require_signed=True,
+            require_signature_algorithm=["ES256", "Ed25519"],
+        )
+        # Only ``payments`` has algorithm ES256; ``weak`` uses HS256.
+        assert [a.name for a in result.agents] == ["payments"]
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_algorithm_without_require_signed_raises_value_error(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(ValueError, match="require_signed=True"):
+            await discover(
+                "example.com",
+                require_signature_algorithm=["ES256"],
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_text_match_empty_string_raises_value_error(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(ValueError, match="text_match cannot be empty"):
+            await discover("example.com", text_match="")
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_require_signed_implies_verify_signatures(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    """``require_signed=True`` must auto-enable verify_signatures (FR-023)."""
+    captured: dict[str, object] = {}
+
+    async def stub_post_discovery(
+        agents: list[AgentRecord],
+        require_dnssec: bool,
+        enrich_endpoints: bool,
+        verify_signatures: bool,
+        domain: str,
+    ) -> bool:
+        captured["verify_signatures"] = verify_signatures
+        return False
+
+    with (
+        patch(
+            "dns_aid.core.discoverer._execute_discovery",
+            new=AsyncMock(return_value=mocked_pipeline),
+        ),
+        patch("dns_aid.core.discoverer._apply_post_discovery", new=stub_post_discovery),
+    ):
+        await discover("example.com", require_signed=True)
+
+    assert captured["verify_signatures"] is True
+
+
+@pytest.mark.asyncio
+async def test_combined_filters(mocked_pipeline: list[AgentRecord]) -> None:
+    """Multiple filters compose with logical AND."""
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover(
+            "example.com",
+            capabilities=["payment-processing"],
+            auth_type="oauth2",
+            require_signed=True,
+            require_signature_algorithm=["ES256"],
+        )
+        assert [a.name for a in result.agents] == ["payments"]
+    finally:
+        for p in patches:
+            p.stop()
+
+
+# ----- name filter -----
+#
+# When ``name`` is passed without ``protocol``, ``_execute_discovery`` cannot
+# short-circuit to a single SVCB query (no protocol means no FQDN to query). It
+# falls back to a full-zone walk and returns every agent. ``discover()`` must
+# then post-filter by exact name. Without the post-filter, ``--name`` would be a
+# silent no-op when used alone — the kind of bug a CLI user would only catch by
+# noticing a result count that's clearly wrong.
+
+
+@pytest.mark.asyncio
+async def test_name_alone_filters_post_substrate_walk(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", name="search")
+        assert [a.name for a in result.agents] == ["search"]
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_name_with_no_match_returns_empty(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        result = await discover("example.com", name="nonexistent")
+        assert result.agents == []
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_name_filter_is_case_insensitive(
+    mocked_pipeline: list[AgentRecord],
+) -> None:
+    """DNS labels are case-insensitive (RFC 1035); the post-filter must match."""
+    patches = _patch_discovery(mocked_pipeline)
+    for p in patches:
+        p.start()
+    try:
+        # Fixture has agent named ``payments``; query with mixed case.
+        result = await discover("example.com", name="PaYmEnTs")
+        assert [a.name for a in result.agents] == ["payments"]
+    finally:
+        for p in patches:
+            p.stop()

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -1,0 +1,287 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for ``dns_aid.core.filters.apply_filters``.
+
+Exercises every filter primitive in isolation against fixture ``AgentRecord`` lists. No
+DNS, no HTTP — pure list-comp predicates over already-enriched records.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.core.filters import apply_filters
+from dns_aid.core.models import AgentRecord, Protocol
+
+
+def _agent(
+    name: str,
+    *,
+    domain: str = "example.com",
+    protocol: Protocol = Protocol.MCP,
+    capabilities: list[str] | None = None,
+    description: str | None = None,
+    use_cases: list[str] | None = None,
+    category: str | None = None,
+    auth_type: str | None = None,
+    realm: str | None = None,
+    sig: str | None = None,
+    signature_verified: bool | None = None,
+    signature_algorithm: str | None = None,
+    dnssec_validated: bool = False,
+) -> AgentRecord:
+    return AgentRecord(
+        name=name,
+        domain=domain,
+        protocol=protocol,
+        target_host=f"{name}.{domain}",
+        port=443,
+        capabilities=capabilities or [],
+        description=description,
+        use_cases=use_cases or [],
+        category=category,
+        auth_type=auth_type,
+        realm=realm,
+        sig=sig,
+        signature_verified=signature_verified,
+        signature_algorithm=signature_algorithm,
+        dnssec_validated=dnssec_validated,
+    )
+
+
+@pytest.fixture
+def records() -> list[AgentRecord]:
+    return [
+        _agent(
+            "payments",
+            capabilities=["payment-processing", "fraud-detection"],
+            description="Process card payments and refunds.",
+            category="transaction",
+            auth_type="oauth2",
+            realm="prod",
+            dnssec_validated=True,
+            sig="header.payload.signature",
+            signature_verified=True,
+            signature_algorithm="ES256",
+        ),
+        _agent(
+            "search",
+            capabilities=["search", "ranking"],
+            description="Indexed full-text search.",
+            category="query",
+            auth_type="api_key",
+            realm="prod",
+            dnssec_validated=False,
+        ),
+        _agent(
+            "legacy",
+            capabilities=["payment-processing"],
+            description="Legacy payment shim.",
+            category="transaction",
+            auth_type="bearer",
+            realm="staging",
+            dnssec_validated=False,
+            sig="header.payload.signature",
+            signature_verified=False,
+            signature_algorithm=None,
+        ),
+        _agent(
+            "weak-sig",
+            capabilities=["fraud-detection"],
+            auth_type="oauth2",
+            sig="header.payload.signature",
+            signature_verified=True,
+            signature_algorithm="HS256",
+        ),
+    ]
+
+
+class TestNoConstraintsFastPath:
+    def test_returns_input_unchanged(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records)
+        assert out is records  # identity, not a copy
+
+    def test_all_none_kwargs_short_circuits(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(
+            records,
+            capabilities=None,
+            capabilities_any=None,
+            auth_type=None,
+            intent=None,
+            transport=None,
+            realm=None,
+            min_dnssec=False,
+            text_match=None,
+            require_signed=False,
+            require_signature_algorithm=None,
+        )
+        assert out is records
+
+
+class TestCapabilities:
+    def test_all_of_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, capabilities=["payment-processing", "fraud-detection"])
+        assert [r.name for r in out] == ["payments"]
+
+    def test_all_of_case_insensitive(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, capabilities=["PAYMENT-PROCESSING"])
+        assert {r.name for r in out} == {"payments", "legacy"}
+
+    def test_empty_list_explicit_no_match(self, records: list[AgentRecord]) -> None:
+        # Per spec: empty list is "explicit no-match" — distinct from None ("no constraint").
+        out = apply_filters(records, capabilities=[])
+        assert out == []
+
+    def test_empty_any_list_explicit_no_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, capabilities_any=[])
+        assert out == []
+
+    def test_any_of_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, capabilities_any=["search", "fraud-detection"])
+        assert {r.name for r in out} == {"payments", "search", "weak-sig"}
+
+    def test_no_match_returns_empty(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, capabilities=["nonexistent-cap"])
+        assert out == []
+
+
+class TestAuthType:
+    def test_exact_match_case_insensitive(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, auth_type="OAUTH2")
+        assert {r.name for r in out} == {"payments", "weak-sig"}
+
+    def test_no_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, auth_type="mtls")
+        assert out == []
+
+
+class TestIntent:
+    def test_match_against_category(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, intent="transaction")
+        assert {r.name for r in out} == {"payments", "legacy"}
+
+    def test_substring_fallback_against_capabilities(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, intent="search")
+        # Matches by category (search) AND substring in capabilities (search/ranking).
+        assert {r.name for r in out} == {"search"}
+
+
+class TestTransport:
+    def test_match_against_protocol(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, transport="mcp")
+        assert len(out) == len(records)
+
+    def test_no_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, transport="streamable-http")
+        # Path A doesn't surface streamable-http transport; falls back to protocol value.
+        assert out == []
+
+
+class TestRealm:
+    def test_exact_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, realm="prod")
+        assert {r.name for r in out} == {"payments", "search"}
+
+    def test_no_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, realm="missing")
+        assert out == []
+
+
+class TestMinDNSSEC:
+    def test_excludes_unvalidated(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, min_dnssec=True)
+        assert {r.name for r in out} == {"payments"}
+
+    def test_default_keeps_unvalidated(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, min_dnssec=False)
+        assert len(out) == len(records)
+
+
+class TestTextMatch:
+    def test_substring_in_description(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, text_match="payment")
+        # Matches "Process card payments" (description), "Legacy payment shim" (description),
+        # "payment-processing" (capability).
+        assert {r.name for r in out} == {"payments", "legacy"}
+
+    def test_substring_in_capabilities(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, text_match="ranking")
+        assert {r.name for r in out} == {"search"}
+
+    def test_case_insensitive(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, text_match="PAYMENT")
+        assert {r.name for r in out} == {"payments", "legacy"}
+
+    def test_empty_string_raises(self, records: list[AgentRecord]) -> None:
+        with pytest.raises(ValueError, match="text_match cannot be empty"):
+            apply_filters(records, text_match="")
+
+    def test_missing_description_safe(self) -> None:
+        agent = _agent("noop", description=None, use_cases=[], capabilities=["x"])
+        out = apply_filters([agent], text_match="missing")
+        assert out == []
+
+
+class TestRequireSigned:
+    def test_only_verified_records_pass(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, require_signed=True)
+        assert {r.name for r in out} == {"payments", "weak-sig"}
+
+    def test_unsigned_records_excluded(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, require_signed=True)
+        assert "search" not in {r.name for r in out}
+
+    def test_failed_verification_excluded(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, require_signed=True)
+        assert "legacy" not in {r.name for r in out}
+
+
+class TestRequireSignatureAlgorithm:
+    def test_allow_list_match(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(
+            records,
+            require_signed=True,
+            require_signature_algorithm=["ES256", "Ed25519"],
+        )
+        assert {r.name for r in out} == {"payments"}
+
+    def test_allow_list_excludes_weak_algorithm(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(
+            records,
+            require_signed=True,
+            require_signature_algorithm=["ES256"],
+        )
+        assert "weak-sig" not in {r.name for r in out}
+
+    def test_algorithm_match_case_insensitive(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(
+            records,
+            require_signed=True,
+            require_signature_algorithm=["es256"],
+        )
+        assert {r.name for r in out} == {"payments"}
+
+    def test_algorithm_without_require_signed_raises(self, records: list[AgentRecord]) -> None:
+        with pytest.raises(ValueError, match="require_signed=True"):
+            apply_filters(
+                records,
+                require_signature_algorithm=["ES256"],
+            )
+
+
+class TestComposite:
+    def test_multiple_filters_combined(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(
+            records,
+            capabilities=["payment-processing"],
+            auth_type="oauth2",
+            min_dnssec=True,
+            require_signed=True,
+        )
+        assert {r.name for r in out} == {"payments"}
+
+    def test_returns_new_list_when_filtering(self, records: list[AgentRecord]) -> None:
+        out = apply_filters(records, capabilities=["payment-processing"])
+        assert out is not records

--- a/tests/unit/core/test_filters_robustness.py
+++ b/tests/unit/core/test_filters_robustness.py
@@ -1,0 +1,180 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Path A filter robustness tests — every filter must survive a minimally-populated
+``AgentRecord`` without crashing.
+
+Path A search runs in pure Python over already-fetched DNS substrate data. Some
+agents in real DNS zones will have only the bare minimum fields the discoverer
+could resolve (no description, no use_cases, no realm, no auth_type, no JWS).
+The filter pipeline has to:
+
+1. Never raise on a sparse record — at worst, it filters the record out.
+2. Treat absent fields the same as ``None`` (no constraint match) for filter
+   purposes — never as truthy / matching.
+3. Compose filters with logical AND — a sparse record matches a filter only
+   when *that filter's* condition is met, never by accident through other
+   missing fields.
+
+These tests are independent of any network/DNS — they exercise the pure
+:func:`dns_aid.core.filters.apply_filters` over hand-built records.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.core.filters import apply_filters
+from dns_aid.core.models import AgentRecord, Protocol
+
+
+def _minimal_agent(name: str = "minimal") -> AgentRecord:
+    """An agent with only the four required AgentRecord fields. Everything else
+    falls to its declared default (None / [] / False / 443)."""
+    return AgentRecord(
+        name=name,
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host=f"{name}.example.com",
+    )
+
+
+def _full_agent() -> AgentRecord:
+    """Agent with every filterable field populated."""
+    return AgentRecord(
+        name="full",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="full.example.com",
+        capabilities=["payment-processing", "fraud-detection"],
+        description="Process card payments and fraud heuristics.",
+        use_cases=["B2B payments", "Subscription billing"],
+        category="finance",
+        auth_type="oauth2",
+        realm="prod",
+        sig="hdr.payload.sig",
+        signature_verified=True,
+        signature_algorithm="ES256",
+        dnssec_validated=True,
+    )
+
+
+class TestEveryFilterSurvivesMinimalAgent:
+    """Exercise every public filter against a sparse record — none must raise."""
+
+    def test_capabilities_all_against_empty_capabilities(self) -> None:
+        result = apply_filters([_minimal_agent()], capabilities=["payment-processing"])
+        assert result == []  # required cap absent → filtered out, not crashed
+
+    def test_capabilities_any_against_empty_capabilities(self) -> None:
+        result = apply_filters([_minimal_agent()], capabilities_any=["search"])
+        assert result == []
+
+    def test_auth_type_against_none(self) -> None:
+        result = apply_filters([_minimal_agent()], auth_type="oauth2")
+        assert result == []
+
+    def test_intent_against_none_category(self) -> None:
+        # Sparse agent has no category and no capabilities — substring scan
+        # over an empty list correctly returns False.
+        result = apply_filters([_minimal_agent()], intent="transaction")
+        assert result == []
+
+    def test_realm_against_none(self) -> None:
+        result = apply_filters([_minimal_agent()], realm="prod")
+        assert result == []
+
+    def test_min_dnssec_against_default_false(self) -> None:
+        # ``dnssec_validated`` defaults to False; min_dnssec=True excludes.
+        result = apply_filters([_minimal_agent()], min_dnssec=True)
+        assert result == []
+
+    def test_text_match_against_none_description(self) -> None:
+        # Description is None, use_cases empty, capabilities empty → no
+        # haystack to scan; returns False without raising.
+        result = apply_filters([_minimal_agent()], text_match="payment")
+        assert result == []
+
+    def test_require_signed_against_unsigned(self) -> None:
+        # No sig field at all → signature_verified is None → filter excludes.
+        result = apply_filters([_minimal_agent()], require_signed=True)
+        assert result == []
+
+    def test_require_signature_algorithm_requires_require_signed(self) -> None:
+        with pytest.raises(ValueError, match="require_signed=True"):
+            apply_filters(
+                [_minimal_agent()], require_signature_algorithm=["ES256"]
+            )
+
+    def test_no_filters_returns_input_unchanged(self) -> None:
+        # Sparse agent + no constraints = passthrough.
+        agents = [_minimal_agent()]
+        assert apply_filters(agents) is agents
+
+
+class TestSparseAndFullCompose:
+    """Mixed lists: sparse agents shouldn't 'leak' through filters meant to
+    select on populated metadata, and full agents shouldn't be filtered out
+    by accident due to None handling on adjacent records.
+    """
+
+    def test_filter_targeting_full_excludes_sparse(self) -> None:
+        result = apply_filters(
+            [_minimal_agent(), _full_agent()],
+            capabilities=["payment-processing"],
+        )
+        assert [a.name for a in result] == ["full"]
+
+    def test_filter_targeting_sparse_traits_excludes_full(self) -> None:
+        # ``realm=None`` doesn't have a way to filter for "no realm" — there's
+        # no inverse filter — so this just confirms ``realm="prod"`` selects
+        # only the full agent and doesn't accidentally match the sparse one.
+        result = apply_filters(
+            [_minimal_agent(), _full_agent()], realm="prod"
+        )
+        assert [a.name for a in result] == ["full"]
+
+    def test_compound_filter_requires_all_conditions(self) -> None:
+        # AND semantics: full agent passes; sparse fails on every condition.
+        result = apply_filters(
+            [_minimal_agent(), _full_agent()],
+            auth_type="oauth2",
+            realm="prod",
+            require_signed=True,
+            require_signature_algorithm=["ES256"],
+        )
+        assert [a.name for a in result] == ["full"]
+
+
+class TestEdgeCaseInputs:
+    def test_empty_record_list_returns_empty(self) -> None:
+        assert apply_filters([], capabilities=["x"]) == []
+        assert apply_filters([]) == []
+
+    def test_text_match_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="text_match cannot be empty"):
+            apply_filters([_minimal_agent()], text_match="")
+
+    def test_capabilities_empty_list_means_explicit_no_match(self) -> None:
+        # Per spec: empty list ≠ None. None means "no constraint" (passthrough);
+        # empty list means "every cap in an empty set" which is vacuously true
+        # in math but explicitly defined as no-match in our contract. Confirms
+        # the filter doesn't fall back to vacuous-true semantics.
+        result = apply_filters([_full_agent()], capabilities=[])
+        assert result == []
+
+    def test_capabilities_any_empty_list_means_explicit_no_match(self) -> None:
+        result = apply_filters([_full_agent()], capabilities_any=[])
+        assert result == []
+
+    def test_case_insensitive_matching_across_filters(self) -> None:
+        # capabilities, auth_type, intent, text_match all do case-insensitive
+        # comparisons — verify with mixed-case query inputs.
+        result = apply_filters(
+            [_full_agent()],
+            capabilities=["Payment-Processing"],
+            auth_type="OAuth2",
+            text_match="FRAUD",
+        )
+        assert [a.name for a in result] == ["full"]

--- a/tests/unit/mcp/test_discover_via_dns_filters.py
+++ b/tests/unit/mcp/test_discover_via_dns_filters.py
@@ -1,0 +1,78 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the extended ``discover_agents_via_dns`` MCP tool — Path A filter args.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from dns_aid.core.models import DiscoveryResult
+from dns_aid.mcp.server import discover_agents_via_dns
+
+
+def _empty_result() -> DiscoveryResult:
+    return DiscoveryResult(
+        query="_index._agents.example.com",
+        domain="example.com",
+        agents=[],
+        dnssec_validated=False,
+        cached=False,
+        query_time_ms=1.0,
+    )
+
+
+def test_filter_args_propagate_to_discoverer() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_discover(*args: Any, **kwargs: Any) -> DiscoveryResult:
+        captured.update(kwargs)
+        return _empty_result()
+
+    with patch("dns_aid.core.discoverer.discover", new=fake_discover):
+        result = discover_agents_via_dns(
+            domain="example.com",
+            protocol="mcp",
+            capabilities=["payment-processing"],
+            capabilities_any=["alt-payment"],
+            auth_type="oauth2",
+            intent="transaction",
+            transport="mcp",
+            realm="prod",
+            min_dnssec=True,
+            text_match="payment",
+            require_signed=True,
+            require_signature_algorithm=["ES256"],
+        )
+
+    assert result["domain"] == "example.com"
+    assert captured["capabilities"] == ["payment-processing"]
+    assert captured["capabilities_any"] == ["alt-payment"]
+    assert captured["auth_type"] == "oauth2"
+    assert captured["intent"] == "transaction"
+    assert captured["transport"] == "mcp"
+    assert captured["realm"] == "prod"
+    assert captured["min_dnssec"] is True
+    assert captured["text_match"] == "payment"
+    assert captured["require_signed"] is True
+    assert captured["require_signature_algorithm"] == ["ES256"]
+
+
+def test_legacy_call_still_works() -> None:
+    """Pre-existing tool invocations (no filter args) MUST produce identical behavior."""
+    captured: dict[str, Any] = {}
+
+    async def fake_discover(*args: Any, **kwargs: Any) -> DiscoveryResult:
+        captured.update(kwargs)
+        return _empty_result()
+
+    with patch("dns_aid.core.discoverer.discover", new=fake_discover):
+        result = discover_agents_via_dns(domain="example.com", protocol="mcp")
+
+    assert result["domain"] == "example.com"
+    # New kwargs default to None / False so legacy paths see no behavior change.
+    assert captured["capabilities"] is None
+    assert captured["require_signed"] is False

--- a/tests/unit/mcp/test_search_agents_tool.py
+++ b/tests/unit/mcp/test_search_agents_tool.py
@@ -1,0 +1,205 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the ``search_agents`` MCP tool.
+
+Validates:
+- happy-path dispatch returns the SearchResponse serialized as a JSON-friendly dict
+- every ``DirectoryError`` subclass converts to a structured ``{"success": False, ...}``
+  envelope with the documented ``error`` discriminator (FR-017: never raises to MCP transport)
+- argument propagation across SDK boundary
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.mcp.server import search_agents
+from dns_aid.sdk.exceptions import (
+    DirectoryAuthError,
+    DirectoryConfigError,
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
+from dns_aid.sdk.search import (
+    Provenance,
+    SearchResponse,
+    SearchResult,
+    TrustAttestation,
+)
+
+
+def _make_response() -> SearchResponse:
+    now = datetime.now(UTC)
+    return SearchResponse(
+        query="payments",
+        results=[
+            SearchResult(
+                agent=AgentRecord(
+                    name="payments",
+                    domain="example.com",
+                    protocol=Protocol.MCP,
+                    target_host="payments.example.com",
+                    port=443,
+                    capabilities=["payment-processing"],
+                ),
+                score=39.4,
+                trust=TrustAttestation(
+                    security_score=87,
+                    trust_score=83,
+                    popularity_score=70,
+                    trust_tier=2,
+                    safety_status="active",
+                    dnssec_valid=True,
+                    dane_valid=False,
+                    svcb_valid=True,
+                    endpoint_reachable=True,
+                    protocol_verified=True,
+                    badges=["Verified", "DNSSEC"],
+                ),
+                provenance=Provenance(
+                    discovery_level=2,
+                    first_seen=now,
+                    last_seen=now,
+                    last_verified=now,
+                ),
+            )
+        ],
+        total=5,
+        limit=20,
+        offset=0,
+    )
+
+
+class TestHappyPath:
+    def test_returns_serialized_search_response(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            return_value=_make_response(),
+        ):
+            result = search_agents(q="payments", protocol="mcp")
+
+        assert result["success"] is True
+        assert result["total"] == 5
+        assert len(result["results"]) == 1
+        assert result["results"][0]["agent"]["name"] == "payments"
+        assert result["results"][0]["score"] == 39.4
+        assert result["results"][0]["trust"]["trust_tier"] == 2
+        assert result["results"][0]["trust"]["badges"] == ["Verified", "DNSSEC"]
+        assert result["results"][0]["provenance"]["discovery_level"] == 2
+        assert result["has_more"] is True
+
+    def test_arguments_propagate_to_sdk(self) -> None:
+        captured: dict[str, Any] = {}
+
+        async def fake_search(self: Any, *args: Any, **kwargs: Any) -> SearchResponse:
+            captured.update(kwargs)
+            return _make_response()
+
+        with patch("dns_aid.sdk.client.AgentClient.search", new=fake_search):
+            search_agents(
+                q="payments",
+                protocol="mcp",
+                domain="example.com",
+                capabilities=["payment-processing"],
+                min_security_score=70,
+                verified_only=True,
+                intent="transaction",
+                auth_type="oauth2",
+                transport="streamable-http",
+                realm="prod",
+                limit=10,
+                offset=20,
+            )
+
+        assert captured["q"] == "payments"
+        assert captured["protocol"] == "mcp"
+        assert captured["domain"] == "example.com"
+        assert captured["capabilities"] == ["payment-processing"]
+        assert captured["min_security_score"] == 70
+        assert captured["verified_only"] is True
+        assert captured["intent"] == "transaction"
+        assert captured["auth_type"] == "oauth2"
+        assert captured["transport"] == "streamable-http"
+        assert captured["realm"] == "prod"
+        assert captured["limit"] == 10
+        assert captured["offset"] == 20
+
+
+class TestErrorEnvelopes:
+    """Errors MUST return structured envelopes — never raise to the MCP transport."""
+
+    def test_config_error_returns_structured_envelope(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryConfigError(
+                "no url",
+                details={
+                    "missing_field": "directory_api_url",
+                    "env_var": "DNS_AID_SDK_DIRECTORY_API_URL",
+                },
+            ),
+        ):
+            result = search_agents(q="x")
+
+        assert result["success"] is False
+        assert result["error"] == "directory_not_configured"
+        assert result["details"]["env_var"] == "DNS_AID_SDK_DIRECTORY_API_URL"
+        assert "remediation" in result
+
+    def test_unavailable_error_returns_structured_envelope(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryUnavailableError(
+                "down", details={"directory_url": "https://x.example", "status_code": 503}
+            ),
+        ):
+            result = search_agents(q="x")
+
+        assert result["success"] is False
+        assert result["error"] == "directory_unavailable"
+        assert result["transient"] is True
+        assert result["retry_recommended"] is True
+        assert result["details"]["status_code"] == 503
+
+    def test_rate_limited_returns_distinct_envelope(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryRateLimitedError(
+                "slow",
+                details={
+                    "directory_url": "https://x.example",
+                    "status_code": 429,
+                    "retry_after_seconds": 30,
+                },
+            ),
+        ):
+            result = search_agents(q="x")
+
+        # MUST surface as ``directory_rate_limited``, NOT ``directory_unavailable``,
+        # so the AI agent can dispatch on the specific case.
+        assert result["error"] == "directory_rate_limited"
+        assert result["details"]["retry_after_seconds"] == 30
+
+    def test_auth_error_returns_structured_envelope(self) -> None:
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryAuthError(
+                "bad token", details={"directory_url": "https://x.example", "status_code": 401}
+            ),
+        ):
+            result = search_agents(q="x")
+
+        assert result["success"] is False
+        assert result["error"] == "directory_auth_failed"
+        assert "remediation" in result
+        assert result["details"]["status_code"] == 401

--- a/tests/unit/sdk/test_client_search.py
+++ b/tests/unit/sdk/test_client_search.py
@@ -1,0 +1,466 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for ``AgentClient.search()`` — Path B cross-domain agent search.
+
+Validates the full HTTP contract:
+- happy path: request URL, query params, response deserialization
+- configuration: ``DirectoryConfigError`` when ``directory_api_url`` is unset
+- transient failures: connect errors, 5xx, 4xx → ``DirectoryUnavailableError``
+- rate limit: 429 → ``DirectoryRateLimitedError`` carrying ``retry_after_seconds``
+- auth failures: 401/403 → ``DirectoryAuthError``
+- schema drift: response Pydantic validation failure → ``DirectoryUnavailableError``
+- isolation: ``search()`` failure paths do not corrupt the client for subsequent calls
+
+All tests are offline (no live HTTP) using ``unittest.mock`` to stub ``AsyncClient.get``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.exceptions import (
+    DirectoryAuthError,
+    DirectoryConfigError,
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
+from dns_aid.sdk.search import SearchResponse
+
+
+def _agent_payload(name: str = "payments", domain: str = "example.com") -> dict[str, Any]:
+    """Build a directory-shaped agent payload with flat trust + provenance signals.
+
+    Mirrors ``dns_aid_directory.api.schemas.AgentResponse`` exactly: uses
+    ``endpoint_url`` (no ``target_host``), encodes ``bap`` as a comma-separated
+    string, and carries trust scores + verification flags + provenance flat on
+    the agent. The SDK's ``_adapt_search_payload`` lifts these into typed nested
+    objects before Pydantic validation.
+    """
+    return {
+        "fqdn": f"_{name}._mcp._agents.{domain}",
+        "name": name,
+        "domain": domain,
+        "protocol": "mcp",
+        "endpoint_url": f"https://{name}.{domain}",
+        "port": 443,
+        "capabilities": ["payment-processing"],
+        "bap": "mcp/1,a2a/1",
+        # Trust signals flat on the agent (directory contract).
+        "security_score": 80,
+        "trust_score": 75,
+        "popularity_score": 60,
+        "trust_tier": 2,
+        "safety_status": "active",
+        "dnssec_valid": True,
+        "dane_valid": False,
+        "svcb_valid": True,
+        "endpoint_reachable": True,
+        "protocol_verified": True,
+        "threat_flags": {},
+        "trust_breakdown": {"dnssec": 1.0, "tls_strength": 0.9},
+        "trust_badges": ["Verified"],
+        # Provenance signals flat on the agent (directory contract).
+        "discovery_level": 2,
+        "first_seen": "2026-01-01T00:00:00Z",
+        "last_seen": "2026-05-01T00:00:00Z",
+        "last_verified": "2026-04-30T00:00:00Z",
+    }
+
+
+def _success_body(
+    *,
+    results: int = 1,
+    total: int = 1,
+    limit: int = 20,
+    offset: int = 0,
+    query: str = "payments",
+) -> dict[str, Any]:
+    """Build a directory-shaped /api/v1/search response body."""
+    return {
+        "query": query,
+        "results": [
+            {
+                "agent": _agent_payload(name=f"agent{i}"),
+                # Directory uses raw scores (not normalized to 0..1).
+                "score": 39.2 - (i * 0.1),
+            }
+            for i in range(results)
+        ],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def _mock_response(
+    status_code: int,
+    *,
+    body: Any = None,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.json = MagicMock(return_value=body)
+    resp.text = "" if body is None else str(body)
+    return resp
+
+
+@pytest.fixture
+def public_directory_url(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Use the URL allowlist so SSRF validation accepts our test hostname offline."""
+    url = "https://directory.test.example/"
+    monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+    return url
+
+
+class TestNotConfigured:
+    @pytest.mark.asyncio
+    async def test_raises_config_error_when_directory_url_missing(self) -> None:
+        config = SDKConfig()
+        async with AgentClient(config=config) as client:
+            with pytest.raises(DirectoryConfigError) as exc_info:
+                await client.search(q="anything")
+        assert exc_info.value.details["missing_field"] == "directory_api_url"
+        assert exc_info.value.details["env_var"] == "DNS_AID_SDK_DIRECTORY_API_URL"
+
+    @pytest.mark.asyncio
+    async def test_raises_runtime_error_outside_context_manager(self) -> None:
+        config = SDKConfig(directory_api_url="https://directory.example.com")
+        client = AgentClient(config=config)
+        with pytest.raises(RuntimeError, match="async context manager"):
+            await client.search(q="x")
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_typed_search_response(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(200, body=_success_body(results=2, total=5))
+            )
+            response = await client.search(q="payments", limit=20)
+
+        assert isinstance(response, SearchResponse)
+        assert response.total == 5
+        assert len(response.results) == 2
+        assert response.results[0].agent.name == "agent0"
+        assert response.has_more is True
+        assert response.next_offset == 2
+
+    @pytest.mark.asyncio
+    async def test_serializes_all_filter_kwargs_to_query_params(
+        self, public_directory_url: str
+    ) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            captured: dict[str, Any] = {}
+
+            async def fake_get(url: str, params: Any = None, **kwargs: Any) -> MagicMock:
+                captured["url"] = url
+                captured["params"] = params
+                return _mock_response(200, body=_success_body())
+
+            client._http_client.get = fake_get  # type: ignore[method-assign]
+            await client.search(
+                q="payments",
+                protocol="mcp",
+                domain="ACME.example",
+                capabilities=["payment-processing", "fraud-detection"],
+                min_security_score=70,
+                verified_only=True,
+                intent="transaction",
+                auth_type="oauth2",
+                transport="streamable-http",
+                realm="prod",
+                limit=10,
+                offset=20,
+            )
+
+        assert captured["url"].endswith("/api/v1/search")
+        params: list[tuple[str, Any]] = captured["params"]
+        param_keys = [k for k, _ in params]
+        assert ("q", "payments") in params
+        assert ("protocol", "mcp") in params
+        # Domain MUST be lowercased on the wire.
+        assert ("domain", "acme.example") in params
+        # Capabilities is repeatable.
+        assert param_keys.count("capabilities") == 2
+        assert ("min_security_score", "70") in params
+        assert ("verified_only", "true") in params
+        assert ("limit", "10") in params
+        assert ("offset", "20") in params
+
+    @pytest.mark.asyncio
+    async def test_omits_unset_optional_params(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            captured: dict[str, Any] = {}
+
+            async def fake_get(url: str, params: Any = None, **kwargs: Any) -> MagicMock:
+                captured["params"] = params
+                return _mock_response(200, body=_success_body())
+
+            client._http_client.get = fake_get  # type: ignore[method-assign]
+            await client.search()
+
+        param_keys = [k for k, _ in captured["params"]]
+        assert "q" not in param_keys
+        assert "protocol" not in param_keys
+        assert "verified_only" not in param_keys
+        # limit and offset always sent so the directory has a deterministic page.
+        assert "limit" in param_keys
+        assert "offset" in param_keys
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_connect_error_maps_to_unavailable(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=httpx.ConnectError("connection refused")
+            )
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        assert exc_info.value.details["status_code"] is None
+        assert exc_info.value.details["underlying"] == "ConnectError"
+
+    @pytest.mark.asyncio
+    async def test_500_maps_to_unavailable(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(500, body={"error": "internal"})
+            )
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        assert exc_info.value.details["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_404_maps_to_unavailable(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(404)
+            )
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        assert exc_info.value.details["status_code"] == 404
+
+    @pytest.mark.asyncio
+    async def test_429_maps_to_rate_limited_with_retry_after(
+        self, public_directory_url: str
+    ) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(429, headers={"Retry-After": "30"})
+            )
+            with pytest.raises(DirectoryRateLimitedError) as exc_info:
+                await client.search(q="x")
+
+        # Specific subclass; also covered by base catch.
+        assert isinstance(exc_info.value, DirectoryUnavailableError)
+        assert exc_info.value.details["retry_after_seconds"] == 30
+
+    @pytest.mark.asyncio
+    async def test_429_with_unparseable_retry_after(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(
+                    429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+                )
+            )
+            with pytest.raises(DirectoryRateLimitedError) as exc_info:
+                await client.search(q="x")
+
+        # HTTP-date format is intentionally not parsed; retry policy is caller's choice.
+        assert exc_info.value.details["retry_after_seconds"] is None
+
+    @pytest.mark.asyncio
+    async def test_401_maps_to_auth_error(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(401)
+            )
+            with pytest.raises(DirectoryAuthError) as exc_info:
+                await client.search(q="x")
+
+        assert exc_info.value.details["status_code"] == 401
+        # Auth errors are NOT transient: must NOT inherit from Unavailable.
+        assert not isinstance(exc_info.value, DirectoryUnavailableError)
+
+    @pytest.mark.asyncio
+    async def test_403_maps_to_auth_error(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(403)
+            )
+            with pytest.raises(DirectoryAuthError):
+                await client.search(q="x")
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_body_maps_to_unavailable(
+        self, public_directory_url: str
+    ) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            # Body missing required ``query`` key — Pydantic ValidationError.
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(200, body={"results": [], "total": 0})
+            )
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        # Explicit signal that the directory's response shape was not recognized.
+        assert "ValidationError" in str(exc_info.value.details["underlying"])
+
+
+class TestSecurityGuards:
+    """Security regressions: redirect rejection, response size guard, userinfo
+    rejection. Each is a defense the SDK adds beyond what httpx provides natively.
+    """
+
+    @pytest.mark.asyncio
+    async def test_3xx_redirect_rejected_with_clear_error(
+        self, public_directory_url: str
+    ) -> None:
+        # follow_redirects=False is set on the search call; a directory that
+        # responds with a redirect is misconfigured. Surface that explicitly
+        # instead of letting the body parse fail with a confusing JSON error.
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(
+                    302, headers={"Location": "https://internal.local/"}
+                )
+            )
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        assert exc_info.value.details["status_code"] == 302
+        assert exc_info.value.details["underlying"] == "UnexpectedRedirect"
+
+    @pytest.mark.asyncio
+    async def test_oversized_response_rejected_before_json_parse(
+        self, public_directory_url: str
+    ) -> None:
+        # The SDK refuses to parse responses bigger than _SEARCH_MAX_RESPONSE_BYTES,
+        # protecting against directory bugs (e.g. forgot pagination) returning
+        # a multi-GB body.
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+
+            # Build a Mock response whose ``content`` exceeds the cap. We don't
+            # actually need 10 MB of bytes — bypass via ``len()`` patching.
+            from unittest.mock import PropertyMock
+
+            from dns_aid.sdk.client import _SEARCH_MAX_RESPONSE_BYTES
+
+            oversized = MagicMock(spec=httpx.Response)
+            oversized.status_code = 200
+            oversized.headers = {}
+            type(oversized).content = PropertyMock(
+                return_value=b"x" * (_SEARCH_MAX_RESPONSE_BYTES + 1)
+            )
+
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=oversized
+            )
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        assert exc_info.value.details["underlying"] == "ResponseTooLarge"
+        assert exc_info.value.details["body_bytes"] == _SEARCH_MAX_RESPONSE_BYTES + 1
+
+    @pytest.mark.asyncio
+    async def test_userinfo_in_directory_url_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SDKConfig allows constructing a config with creds-in-URL (the rejection
+        # happens at validate_fetch_url inside search()) — but the search call
+        # MUST surface DirectoryUnavailableError without ever logging or echoing
+        # the password.
+        monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+        config = SDKConfig(
+            directory_api_url="https://igor:s3cret@directory.test.example/"
+        )
+        async with AgentClient(config=config) as client:
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+
+        # Critical: the password must NOT appear in any user-visible field.
+        details = exc_info.value.details
+        assert "s3cret" not in str(exc_info.value)
+        assert "s3cret" not in str(details.get("directory_url", ""))
+        # And the redacted URL retains scheme + host so callers can still
+        # identify which directory failed.
+        assert "directory.test.example" in str(details.get("directory_url", ""))
+
+
+class TestPathIsolation:
+    """Search failures must not corrupt the client for subsequent calls."""
+
+    @pytest.mark.asyncio
+    async def test_failure_then_success_on_same_client(self, public_directory_url: str) -> None:
+        config = SDKConfig(directory_api_url=public_directory_url)
+        async with AgentClient(config=config) as client:
+            assert client._http_client is not None
+
+            # Round 1: 500 error.
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(500)
+            )
+            with pytest.raises(DirectoryUnavailableError):
+                await client.search(q="x")
+
+            # Round 2: success on the same client instance.
+            client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+                return_value=_mock_response(200, body=_success_body())
+            )
+            response = await client.search(q="x")
+            assert isinstance(response, SearchResponse)
+            assert response.total == 1
+
+
+class TestSSRFGuard:
+    @pytest.mark.asyncio
+    async def test_unsafe_directory_url_raises_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DNS_AID_FETCH_ALLOWLIST", raising=False)
+        # Localhost / loopback resolves to 127.0.0.1 → should be rejected by url_safety.
+        config = SDKConfig(directory_api_url="https://localhost/")
+        async with AgentClient(config=config) as client:
+            with pytest.raises(DirectoryUnavailableError) as exc_info:
+                await client.search(q="x")
+        assert exc_info.value.details["underlying"] == "UnsafeURLError"

--- a/tests/unit/sdk/test_config_migration.py
+++ b/tests/unit/sdk/test_config_migration.py
@@ -1,0 +1,162 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for SDKConfig directory-URL migration semantics (FR-018, FR-019, FR-020).
+
+The deprecated ``telemetry_api_url`` MUST continue to work as an alias for
+``directory_api_url`` for one minor release. When both are set, the canonical field wins
+and a DeprecationWarning is emitted exactly once per process.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+
+from dns_aid.sdk._config import SDKConfig, _warn_telemetry_alias_once
+
+
+@pytest.fixture(autouse=True)
+def _reset_deprecation_latch() -> None:
+    """Reset the ``functools.cache`` latch between tests so each test sees a fresh state."""
+    _warn_telemetry_alias_once.cache_clear()
+
+
+class TestResolvedDirectoryURL:
+    """``SDKConfig.resolved_directory_url`` is the single source of truth."""
+
+    def test_returns_none_when_neither_field_set(self) -> None:
+        config = SDKConfig()
+        assert config.resolved_directory_url is None
+
+    def test_returns_directory_api_url_when_only_canonical_field_set(self) -> None:
+        config = SDKConfig(directory_api_url="https://directory.example.com")
+        assert config.resolved_directory_url == "https://directory.example.com"
+
+    def test_returns_telemetry_api_url_when_only_alias_set(self) -> None:
+        config = SDKConfig(telemetry_api_url="https://legacy.example.com")
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert config.resolved_directory_url == "https://legacy.example.com"
+
+    def test_directory_api_url_wins_when_both_set(self) -> None:
+        config = SDKConfig(
+            directory_api_url="https://canonical.example.com",
+            telemetry_api_url="https://legacy.example.com",
+        )
+        assert config.resolved_directory_url == "https://canonical.example.com"
+
+
+class TestDeprecationWarning:
+    """Deprecation warning fires once per process when the legacy alias is the active source."""
+
+    def test_warning_emitted_when_legacy_alias_resolves(self) -> None:
+        config = SDKConfig(telemetry_api_url="https://legacy.example.com")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = config.resolved_directory_url
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 1
+        assert "telemetry_api_url is deprecated" in str(deprecation_warnings[0].message)
+
+    def test_warning_only_emitted_once_per_process(self) -> None:
+        config = SDKConfig(telemetry_api_url="https://legacy.example.com")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = config.resolved_directory_url
+            _ = config.resolved_directory_url
+            _ = config.resolved_directory_url
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 1
+
+    def test_no_warning_when_canonical_field_used(self) -> None:
+        config = SDKConfig(directory_api_url="https://canonical.example.com")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = config.resolved_directory_url
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecation_warnings == []
+
+    def test_no_warning_when_both_fields_set(self) -> None:
+        config = SDKConfig(
+            directory_api_url="https://canonical.example.com",
+            telemetry_api_url="https://legacy.example.com",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = config.resolved_directory_url
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecation_warnings == []
+
+
+class TestEnvVarPopulation:
+    """``SDKConfig.from_env`` honors both new and legacy environment variables."""
+
+    def test_directory_api_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DNS_AID_SDK_DIRECTORY_API_URL", "https://directory.example.com")
+        monkeypatch.delenv("DNS_AID_SDK_TELEMETRY_API_URL", raising=False)
+        config = SDKConfig.from_env()
+        assert config.directory_api_url == "https://directory.example.com"
+        assert config.telemetry_api_url is None
+
+    def test_legacy_telemetry_api_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DNS_AID_SDK_DIRECTORY_API_URL", raising=False)
+        monkeypatch.setenv("DNS_AID_SDK_TELEMETRY_API_URL", "https://legacy.example.com")
+        config = SDKConfig.from_env()
+        assert config.directory_api_url is None
+        assert config.telemetry_api_url == "https://legacy.example.com"
+
+    def test_both_env_vars_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DNS_AID_SDK_DIRECTORY_API_URL", "https://canonical.example.com")
+        monkeypatch.setenv("DNS_AID_SDK_TELEMETRY_API_URL", "https://legacy.example.com")
+        config = SDKConfig.from_env()
+        assert config.directory_api_url == "https://canonical.example.com"
+        assert config.telemetry_api_url == "https://legacy.example.com"
+        assert config.resolved_directory_url == "https://canonical.example.com"
+
+
+class TestWarnHelper:
+    """The internal warn-once helper is process-scoped and idempotent."""
+
+    def test_helper_warns_once(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _warn_telemetry_alias_once()
+            _warn_telemetry_alias_once()
+            _warn_telemetry_alias_once()
+        assert sum(1 for w in caught if issubclass(w.category, DeprecationWarning)) == 1
+
+
+class TestBackwardsCompatibility:
+    """Existing callers of SDKConfig must continue to work unchanged."""
+
+    def test_config_with_only_existing_fields_still_works(self) -> None:
+        config = SDKConfig(timeout_seconds=15.0, telemetry_api_url="https://api.test.io")
+        assert config.timeout_seconds == 15.0
+        assert config.telemetry_api_url == "https://api.test.io"
+
+    def test_config_default_construction_unchanged(self) -> None:
+        config = SDKConfig()
+        # Previously ``telemetry_api_url`` defaulted to None; check that's still the case
+        # AND the new ``directory_api_url`` also defaults to None.
+        assert config.telemetry_api_url is None
+        assert config.directory_api_url is None
+        # And every other previously-default field stays at its prior default.
+        assert config.timeout_seconds == 30.0
+        assert config.max_retries == 0
+        assert config.policy_mode == "permissive"
+
+
+def test_config_serialization_roundtrip() -> None:
+    """Pydantic model_dump → SDKConfig should preserve directory URL fields."""
+    original = SDKConfig(
+        directory_api_url="https://directory.example.com",
+        telemetry_api_url="https://legacy.example.com",
+    )
+    dumped: dict[str, Any] = original.model_dump()
+    restored = SDKConfig.model_validate(dumped)
+    assert restored.directory_api_url == original.directory_api_url
+    assert restored.telemetry_api_url == original.telemetry_api_url

--- a/tests/unit/sdk/test_exceptions.py
+++ b/tests/unit/sdk/test_exceptions.py
@@ -1,0 +1,123 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the directory exception hierarchy.
+
+The hierarchy supports two dispatch patterns:
+
+1. Specific subclass (``except DirectoryConfigError`` or ``except DirectoryAuthError``) for
+   distinct remediation paths.
+2. Catch-all (``except DirectoryError``) for callers who treat any directory failure the same.
+
+``DirectoryRateLimitedError`` inherits from ``DirectoryUnavailableError`` so a catch-all
+``except DirectoryUnavailableError`` covers transient + rate-limited failures together.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.sdk.exceptions import (
+    DirectoryAuthError,
+    DirectoryConfigError,
+    DirectoryError,
+    DirectoryRateLimitedError,
+    DirectoryUnavailableError,
+)
+
+
+class TestHierarchy:
+    """Class hierarchy and ``isinstance`` dispatch."""
+
+    def test_config_error_inherits_from_base(self) -> None:
+        err = DirectoryConfigError("not configured")
+        assert isinstance(err, DirectoryError)
+        assert isinstance(err, Exception)
+
+    def test_unavailable_error_inherits_from_base(self) -> None:
+        err = DirectoryUnavailableError("backend down")
+        assert isinstance(err, DirectoryError)
+
+    def test_rate_limited_error_inherits_from_unavailable(self) -> None:
+        err = DirectoryRateLimitedError("slow down")
+        assert isinstance(err, DirectoryUnavailableError)
+        assert isinstance(err, DirectoryError)
+
+    def test_auth_error_inherits_from_base(self) -> None:
+        err = DirectoryAuthError("bad token")
+        assert isinstance(err, DirectoryError)
+
+    def test_auth_error_does_not_inherit_from_unavailable(self) -> None:
+        # Auth errors are NOT transient — caller must change config, not retry.
+        err = DirectoryAuthError("bad token")
+        assert not isinstance(err, DirectoryUnavailableError)
+
+
+class TestDetailsField:
+    """``details`` carries structured context for log analyzers, separate from ``message``."""
+
+    def test_details_defaults_to_empty_dict(self) -> None:
+        err = DirectoryConfigError("not configured")
+        assert err.details == {}
+
+    def test_details_populated_via_kwarg(self) -> None:
+        err = DirectoryConfigError(
+            "not configured",
+            details={
+                "missing_field": "directory_api_url",
+                "env_var": "DNS_AID_SDK_DIRECTORY_API_URL",
+            },
+        )
+        assert err.details == {
+            "missing_field": "directory_api_url",
+            "env_var": "DNS_AID_SDK_DIRECTORY_API_URL",
+        }
+
+    def test_details_is_isolated_from_kwarg_dict(self) -> None:
+        # Mutating the original dict after construction MUST NOT affect the exception.
+        original = {"directory_url": "https://x.example.com"}
+        err = DirectoryUnavailableError("down", details=original)
+        original["directory_url"] = "MUTATED"
+        assert err.details["directory_url"] == "https://x.example.com"
+
+    def test_message_accessible_via_attribute(self) -> None:
+        err = DirectoryConfigError("not configured")
+        assert err.message == "not configured"
+        assert str(err) == "not configured"
+
+    def test_repr_includes_class_name_and_details(self) -> None:
+        err = DirectoryConfigError("not configured", details={"missing_field": "x"})
+        rendered = repr(err)
+        assert "DirectoryConfigError" in rendered
+        assert "not configured" in rendered
+        assert "missing_field" in rendered
+
+
+class TestDispatchPatterns:
+    """Realistic ``except`` patterns across the hierarchy."""
+
+    def test_specific_subclass_catch(self) -> None:
+        with pytest.raises(DirectoryConfigError):
+            raise DirectoryConfigError("not configured")
+
+    def test_catch_all_via_base(self) -> None:
+        for err_class in (
+            DirectoryConfigError,
+            DirectoryUnavailableError,
+            DirectoryRateLimitedError,
+            DirectoryAuthError,
+        ):
+            with pytest.raises(DirectoryError):
+                raise err_class("test")
+
+    def test_rate_limited_caught_as_unavailable(self) -> None:
+        with pytest.raises(DirectoryUnavailableError):
+            raise DirectoryRateLimitedError("slow down", details={"retry_after_seconds": 30})
+
+    def test_auth_error_not_caught_as_unavailable(self) -> None:
+        with pytest.raises(DirectoryAuthError):
+            try:
+                raise DirectoryAuthError("bad token")
+            except DirectoryUnavailableError:
+                pytest.fail("DirectoryAuthError should not be caught as DirectoryUnavailableError")

--- a/tests/unit/sdk/test_mesh.py
+++ b/tests/unit/sdk/test_mesh.py
@@ -1,0 +1,220 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sdk.mesh — MeshConnection, MeshTransport, DirectMesh* ABCs."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.sdk.mesh import (
+    DirectMeshConnection,
+    DirectMeshTransport,
+    MeshConnection,
+    MeshNotAvailableError,
+    MeshTransport,
+    _MESH_TRANSPORTS,
+    get_default_mesh,
+    register_default_mesh,
+)
+
+
+# ── Concrete test doubles ───────────────────────────────────────
+
+
+class StubMeshConnection(MeshConnection):
+    """Minimal concrete MeshConnection for testing."""
+
+    def __init__(self) -> None:
+        self.opened = False
+        self.closed = False
+        self._buffer = b""
+
+    async def open(
+        self, *, target: str, port: int = 443, mesh_meta: str | None = None
+    ) -> None:
+        self.opened = True
+        self.target = target
+        self.port = port
+        self.mesh_meta = mesh_meta
+
+    async def read(self, n: int = -1) -> bytes:
+        data = self._buffer[:n] if n > 0 else self._buffer
+        self._buffer = self._buffer[len(data) :]
+        return data
+
+    async def write(self, data: bytes) -> None:
+        self._buffer += data
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class StubMeshTransport(MeshTransport):
+    """Minimal concrete MeshTransport for testing."""
+
+    @property
+    def mesh_name(self) -> str:
+        return "stub"
+
+    async def connect(
+        self, *, target: str, port: int = 443, mesh_meta: str | None = None
+    ) -> StubMeshConnection:
+        conn = StubMeshConnection()
+        await conn.open(target=target, port=port, mesh_meta=mesh_meta)
+        return conn
+
+
+# ── MeshConnection ABC tests ────────────────────────────────────
+
+
+class TestMeshConnectionABC:
+    """Test that MeshConnection ABC enforces the contract."""
+
+    def test_cannot_instantiate_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            MeshConnection()  # type: ignore[abstract]
+
+    async def test_concrete_open_read_write_close(self) -> None:
+        conn = StubMeshConnection()
+        await conn.open(target="agent.example.com", port=8443, mesh_meta='{"svc":"x"}')
+        assert conn.opened
+        assert conn.target == "agent.example.com"
+        assert conn.port == 8443
+        assert conn.mesh_meta == '{"svc":"x"}'
+
+        await conn.write(b"hello")
+        data = await conn.read(5)
+        assert data == b"hello"
+
+        await conn.close()
+        assert conn.closed
+
+    async def test_async_context_manager(self) -> None:
+        conn = StubMeshConnection()
+        await conn.open(target="x.com")
+
+        async with conn:
+            await conn.write(b"test")
+            assert await conn.read() == b"test"
+
+        assert conn.closed
+
+
+# ── MeshTransport ABC tests ─────────────────────────────────────
+
+
+class TestMeshTransportABC:
+    """Test that MeshTransport ABC enforces the contract."""
+
+    def test_cannot_instantiate_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            MeshTransport()  # type: ignore[abstract]
+
+    async def test_concrete_connect(self) -> None:
+        transport = StubMeshTransport()
+        assert transport.mesh_name == "stub"
+
+        conn = await transport.connect(target="agent.example.com", mesh_meta='{"svc":"billing"}')
+        assert isinstance(conn, StubMeshConnection)
+        assert conn.opened
+        assert conn.target == "agent.example.com"
+
+    async def test_close_is_optional_noop(self) -> None:
+        transport = StubMeshTransport()
+        await transport.close()  # Should not raise
+
+
+# ── DirectMeshConnection tests ──────────────────────────────────
+
+
+class TestDirectMeshConnection:
+    """Test DirectMeshConnection (httpx wrapper)."""
+
+    async def test_open_creates_client_when_none(self) -> None:
+        conn = DirectMeshConnection()
+        await conn.open(target="agent.example.com", port=443)
+        assert conn.http_client is not None
+        await conn.close()
+
+    async def test_open_reuses_provided_client(self) -> None:
+        import httpx
+
+        client = httpx.AsyncClient()
+        conn = DirectMeshConnection(http_client=client)
+        await conn.open(target="x.com")
+        assert conn.http_client is client
+        await conn.close()
+        # Does NOT close provided client (owns_client=False)
+        assert not client.is_closed
+        await client.aclose()
+
+    async def test_read_raises_not_implemented(self) -> None:
+        conn = DirectMeshConnection()
+        await conn.open(target="x.com")
+        with pytest.raises(NotImplementedError, match="raw read"):
+            await conn.read()
+        await conn.close()
+
+    async def test_write_raises_not_implemented(self) -> None:
+        conn = DirectMeshConnection()
+        await conn.open(target="x.com")
+        with pytest.raises(NotImplementedError, match="raw write"):
+            await conn.write(b"data")
+        await conn.close()
+
+    def test_http_client_raises_before_open(self) -> None:
+        conn = DirectMeshConnection()
+        with pytest.raises(RuntimeError, match="not opened"):
+            _ = conn.http_client
+
+
+# ── DirectMeshTransport tests ───────────────────────────────────
+
+
+class TestDirectMeshTransport:
+    """Test DirectMeshTransport (default, no overlay)."""
+
+    def test_mesh_name(self) -> None:
+        transport = DirectMeshTransport()
+        assert transport.mesh_name == "direct"
+
+    async def test_connect_returns_direct_connection(self) -> None:
+        transport = DirectMeshTransport()
+        conn = await transport.connect(target="agent.example.com")
+        assert isinstance(conn, DirectMeshConnection)
+        assert conn.http_client is not None
+        await conn.close()
+
+
+# ── MeshNotAvailableError tests ─────────────────────────────────
+
+
+class TestMeshNotAvailableError:
+    """Test error message and attributes."""
+
+    def test_message_includes_mesh_name(self) -> None:
+        err = MeshNotAvailableError("ziti")
+        assert err.mesh == "ziti"
+        assert "ziti" in str(err)
+        assert "register_mesh" in str(err)
+
+
+# ── Module-level registry tests ─────────────────────────────────
+
+
+class TestModuleRegistry:
+    """Test register_default_mesh / get_default_mesh."""
+
+    def test_register_and_get(self) -> None:
+        transport = StubMeshTransport()
+        old = _MESH_TRANSPORTS.copy()
+        try:
+            register_default_mesh("stub", transport)
+            assert get_default_mesh("stub") is transport
+        finally:
+            _MESH_TRANSPORTS.clear()
+            _MESH_TRANSPORTS.update(old)
+
+    def test_get_unknown_returns_none(self) -> None:
+        assert get_default_mesh("nonexistent") is None

--- a/tests/unit/sdk/test_path_isolation.py
+++ b/tests/unit/sdk/test_path_isolation.py
@@ -1,0 +1,130 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Path A / Path B isolation tests (FR-005, SC-005, QS-009).
+
+Path B failures (directory unreachable, config missing, auth rejected) MUST NOT prevent
+a subsequent Path A discovery on the same client. This is the foundational guarantee
+that lets callers safely write zero-trust composition flows: search → re-verify → invoke.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from dns_aid.core.models import DiscoveryResult
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.exceptions import (
+    DirectoryConfigError,
+    DirectoryUnavailableError,
+)
+
+
+def _mock_response(status_code: int, body: Any = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = {}
+    resp.json = MagicMock(return_value=body)
+    resp.text = "" if body is None else str(body)
+    return resp
+
+
+def _empty_discovery_result() -> DiscoveryResult:
+    return DiscoveryResult(
+        query="_index._agents.example.com",
+        domain="example.com",
+        agents=[],
+        dnssec_validated=False,
+        cached=False,
+        query_time_ms=1.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_failure_does_not_corrupt_subsequent_discover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+    config = SDKConfig(directory_api_url="https://directory.test.example/")
+
+    async with AgentClient(config=config) as client:
+        assert client._http_client is not None
+        # Path B fails with a transient 503.
+        client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+            return_value=_mock_response(503)
+        )
+        with pytest.raises(DirectoryUnavailableError):
+            await client.search(q="x")
+
+        # Path A succeeds on the SAME client instance — the search failure left no
+        # poisoned state behind.
+        # Path A is the free ``discover()`` function — independent of AgentClient state.
+        from dns_aid.core.discoverer import discover
+
+        with (
+            patch(
+                "dns_aid.core.discoverer._execute_discovery",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "dns_aid.core.discoverer._apply_post_discovery",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            result = await discover("example.com")
+        assert result.domain == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_directory_config_error_does_not_corrupt_path_a() -> None:
+    """Calling search() without directory configured must NOT break Path A."""
+    config = SDKConfig()  # No directory_api_url.
+
+    async with AgentClient(config=config) as client:
+        with pytest.raises(DirectoryConfigError):
+            await client.search(q="x")
+
+        # Path A is the free ``discover()`` function — independent of AgentClient state.
+        from dns_aid.core.discoverer import discover
+
+        with (
+            patch(
+                "dns_aid.core.discoverer._execute_discovery",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "dns_aid.core.discoverer._apply_post_discovery",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            result = await discover("example.com")
+        assert result.domain == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_search_connect_error_does_not_close_http_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed search MUST leave self._http_client open for subsequent calls."""
+    monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
+    config = SDKConfig(directory_api_url="https://directory.test.example/")
+
+    async with AgentClient(config=config) as client:
+        assert client._http_client is not None
+        original_client = client._http_client
+
+        client._http_client.get = AsyncMock(  # type: ignore[method-assign]
+            side_effect=httpx.ConnectError("refused")
+        )
+        with pytest.raises(DirectoryUnavailableError):
+            await client.search(q="x")
+
+        # Critical invariant: the http client is still the same, still open.
+        assert client._http_client is original_client
+        assert client._http_client.is_closed is False

--- a/tests/unit/sdk/test_search_adapter.py
+++ b/tests/unit/sdk/test_search_adapter.py
@@ -1,0 +1,378 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for ``_adapt_search_payload`` — the wire-shape adapter that bridges the
+directory's flat ``AgentResponse`` to the SDK's typed ``SearchResult.trust`` /
+``SearchResult.provenance`` nested objects, plus the small AgentRecord shape
+quirks (``target_host`` from ``endpoint_url``, ``bap`` string→list).
+
+The adapter is the *only* place in the SDK that knows about the directory's
+wire shape. If the directory schema drifts, every other piece of SDK code
+should keep working as long as this adapter and the typed models stay in sync.
+That makes the adapter a load-bearing piece worth testing in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dns_aid.sdk.client import _adapt_search_payload
+from dns_aid.sdk.search import SearchResponse
+
+
+def _directory_agent(**overrides: Any) -> dict[str, Any]:
+    """Minimal directory-shaped agent payload with all required-ish identity fields."""
+    base: dict[str, Any] = {
+        "fqdn": "_payments._mcp._agents.example.com",
+        "name": "payments",
+        "domain": "example.com",
+        "protocol": "mcp",
+        "endpoint_url": "https://payments.example.com",
+        "port": 443,
+        "first_seen": "2026-04-01T00:00:00Z",
+        "last_seen": "2026-05-01T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _directory_response(agent: dict[str, Any], score: float = 39.2) -> dict[str, Any]:
+    return {
+        "query": "payments",
+        "results": [{"agent": agent, "score": score}],
+        "total": 1,
+        "limit": 20,
+        "offset": 0,
+    }
+
+
+class TestTrustSignalLifting:
+    def test_full_trust_block_is_lifted(self) -> None:
+        agent = _directory_agent(
+            security_score=88,
+            trust_score=91,
+            popularity_score=72,
+            trust_tier=2,
+            safety_status="active",
+            dnssec_valid=True,
+            dane_valid=False,
+            svcb_valid=True,
+            endpoint_reachable=True,
+            protocol_verified=True,
+            threat_flags={"phishing": False},
+            trust_breakdown={"dnssec": 1.0},
+            trust_badges=["Verified"],
+        )
+        payload = _adapt_search_payload(_directory_response(agent))
+
+        result = payload["results"][0]
+        assert "security_score" not in result["agent"]
+        assert "trust_breakdown" not in result["agent"]
+        trust = result["trust"]
+        assert trust["security_score"] == 88
+        assert trust["trust_score"] == 91
+        assert trust["popularity_score"] == 72
+        assert trust["trust_tier"] == 2
+        assert trust["safety_status"] == "active"
+        assert trust["dnssec_valid"] is True
+        assert trust["dane_valid"] is False
+        assert trust["threat_flags"] == {"phishing": False}
+        # Renamed: ``trust_breakdown`` (directory) → ``breakdown`` (SDK).
+        assert trust["breakdown"] == {"dnssec": 1.0}
+        # Renamed: ``trust_badges`` (directory) → ``badges`` (SDK).
+        assert trust["badges"] == ["Verified"]
+
+    def test_sparse_agent_uses_defaults(self) -> None:
+        # Directory may return an agent with no trust signals computed yet.
+        agent = _directory_agent()
+        payload = _adapt_search_payload(_directory_response(agent))
+        trust = payload["results"][0]["trust"]
+        assert trust["security_score"] == 0
+        assert trust["trust_score"] == 0
+        assert trust["popularity_score"] == 0
+        assert trust["trust_tier"] == 0
+        assert trust["safety_status"] == "active"
+        assert trust["dnssec_valid"] is None
+
+    def test_pre_existing_trust_block_is_preserved(self) -> None:
+        # If a caller (e.g. a test) supplies a pre-built trust block, the
+        # adapter must NOT clobber it. ``setdefault`` semantics.
+        body = _directory_response(_directory_agent(security_score=99))
+        body["results"][0]["trust"] = {
+            "security_score": 50,
+            "trust_score": 50,
+            "popularity_score": 50,
+        }
+        payload = _adapt_search_payload(body)
+        # Caller-supplied block wins; agent-side ``security_score=99`` ignored.
+        assert payload["results"][0]["trust"]["security_score"] == 50
+
+
+class TestProvenanceLifting:
+    def test_provenance_lifted_when_first_seen_present(self) -> None:
+        agent = _directory_agent(
+            discovery_level=2,
+            last_verified="2026-04-30T00:00:00Z",
+            company={"name": "Acme"},
+        )
+        payload = _adapt_search_payload(_directory_response(agent))
+        prov = payload["results"][0]["provenance"]
+        assert prov["discovery_level"] == 2
+        assert prov["first_seen"] == "2026-04-01T00:00:00Z"
+        assert prov["last_seen"] == "2026-05-01T00:00:00Z"
+        assert prov["last_verified"] == "2026-04-30T00:00:00Z"
+        assert prov["company"] == {"name": "Acme"}
+
+    def test_provenance_skipped_when_neither_timestamp_present(self) -> None:
+        # An agent with no ``first_seen``/``last_seen`` is malformed by directory
+        # contract — but the adapter should refuse to fabricate provenance for
+        # it rather than producing a zero-value Provenance object.
+        agent = {
+            "fqdn": "_x._mcp._agents.example.com",
+            "name": "x",
+            "domain": "example.com",
+            "protocol": "mcp",
+            "endpoint_url": "https://x.example.com",
+            "port": 443,
+        }
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert "provenance" not in payload["results"][0]
+
+
+class TestAgentShapeQuirks:
+    def test_target_host_derived_from_endpoint_url(self) -> None:
+        agent = _directory_agent(endpoint_url="https://flex.twilio.com:8443/path")
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert payload["results"][0]["agent"]["target_host"] == "flex.twilio.com"
+
+    def test_target_host_unchanged_if_already_set(self) -> None:
+        # If an upstream caller (or a future directory version) supplies
+        # ``target_host`` directly, the adapter must not overwrite it.
+        agent = _directory_agent(target_host="explicit.example.com")
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert payload["results"][0]["agent"]["target_host"] == "explicit.example.com"
+
+    def test_record_dropped_when_endpoint_url_missing(self) -> None:
+        # When the directory has neither ``target_host`` nor a parseable
+        # ``endpoint_url``, the record is DROPPED rather than fabricated. The
+        # SDK never invents an endpoint a caller might invoke. ``total`` is
+        # adjusted so pagination stays consistent.
+        agent = _directory_agent(endpoint_url=None)
+        body = _directory_response(agent)
+        original_total = body["total"]
+        payload = _adapt_search_payload(body)
+        assert payload["results"] == []
+        assert payload["total"] == max(0, original_total - 1)
+
+    def test_record_dropped_when_endpoint_url_unparseable(self) -> None:
+        # Garbage ``endpoint_url`` (no scheme, no hostname) → no derivable host
+        # → record dropped.
+        agent = _directory_agent(endpoint_url="not-a-url")
+        body = _directory_response(agent)
+        payload = _adapt_search_payload(body)
+        assert payload["results"] == []
+
+    def test_drop_logs_warning_with_agent_identity(self) -> None:
+        from structlog.testing import capture_logs
+
+        agent = _directory_agent(endpoint_url=None)
+        with capture_logs() as cap:
+            _adapt_search_payload(_directory_response(agent))
+
+        # The WARN must carry enough identity so an operator can correlate the
+        # drop back to a specific directory record. ``fqdn`` + ``name`` + ``domain``
+        # are all present on every directory agent, so we assert all three made it
+        # into the log event.
+        skip_events = [e for e in cap if e.get("event") == "sdk.search_record_skipped"]
+        assert len(skip_events) == 1
+        event = skip_events[0]
+        assert event["log_level"] == "warning"
+        assert event["fqdn"] == "_payments._mcp._agents.example.com"
+        assert event["name"] == "payments"
+        assert event["domain"] == "example.com"
+        assert event["reason"] == "no_derivable_target_host"
+
+    def test_bap_string_split_into_list(self) -> None:
+        agent = _directory_agent(bap="mcp/1, a2a/1 ,https/1")
+        payload = _adapt_search_payload(_directory_response(agent))
+        # Trim whitespace, drop empty entries.
+        assert payload["results"][0]["agent"]["bap"] == ["mcp/1", "a2a/1", "https/1"]
+
+    def test_bap_list_passes_through_unchanged(self) -> None:
+        agent = _directory_agent(bap=["mcp/1", "a2a/1"])
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert payload["results"][0]["agent"]["bap"] == ["mcp/1", "a2a/1"]
+
+
+class TestExplicitNullStripping:
+    """The directory writes ``null`` for some fields the SDK types as non-Optional.
+
+    Stripping the key lets Pydantic apply the field's declared default (e.g.
+    ``capabilities: list = []``, ``version: str = "1.0.0"``). Without this
+    coercion, a real-world agent record with ``"capabilities": null`` would fail
+    validation and abort the entire search response.
+    """
+
+    def test_null_capabilities_stripped(self) -> None:
+        agent = _directory_agent(capabilities=None)
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert "capabilities" not in payload["results"][0]["agent"]
+
+    def test_null_version_stripped(self) -> None:
+        agent = _directory_agent(version=None)
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert "version" not in payload["results"][0]["agent"]
+
+    def test_null_bap_stripped(self) -> None:
+        agent = _directory_agent(bap=None)
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert "bap" not in payload["results"][0]["agent"]
+
+    def test_null_use_cases_stripped(self) -> None:
+        agent = _directory_agent(use_cases=None)
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert "use_cases" not in payload["results"][0]["agent"]
+
+    def test_non_null_values_preserved(self) -> None:
+        agent = _directory_agent(
+            capabilities=["a", "b"],
+            version="2.0",
+            bap="mcp/1",
+            use_cases=["x"],
+        )
+        payload = _adapt_search_payload(_directory_response(agent))
+        result_agent = payload["results"][0]["agent"]
+        assert result_agent["capabilities"] == ["a", "b"]
+        assert result_agent["version"] == "2.0"
+        assert result_agent["bap"] == ["mcp/1"]
+        assert result_agent["use_cases"] == ["x"]
+
+
+class TestEndToEndValidation:
+    """The adapter output must be parseable by SearchResponse end-to-end."""
+
+    def test_full_directory_response_parses_to_typed_search_response(self) -> None:
+        agent = _directory_agent(
+            security_score=97,
+            trust_score=75,
+            popularity_score=99,
+            trust_tier=2,
+            bap="mcp/1,a2a/1",
+            trust_badges=["Verified"],
+            discovery_level=2,
+        )
+        payload = _adapt_search_payload(_directory_response(agent, score=39.2))
+        response = SearchResponse.model_validate(payload)
+
+        assert response.query == "payments"
+        assert response.total == 1
+        assert len(response.results) == 1
+        result = response.results[0]
+        assert result.agent.target_host == "payments.example.com"
+        assert result.agent.bap == ["mcp/1", "a2a/1"]
+        assert result.score == 39.2
+        assert result.trust.security_score == 97
+        assert result.trust.popularity_score == 99
+        assert result.trust.badges == ["Verified"]
+        assert result.provenance is not None
+        assert result.provenance.discovery_level == 2
+
+    def test_empty_results_array_returns_unchanged(self) -> None:
+        body = {"query": "x", "results": [], "total": 0, "limit": 20, "offset": 0}
+        payload = _adapt_search_payload(body)
+        response = SearchResponse.model_validate(payload)
+        assert response.results == []
+
+    def test_malformed_results_field_is_left_alone(self) -> None:
+        # If ``results`` is not a list (e.g. directory broken / proxy ate the
+        # body), the adapter must not crash — it returns the payload as-is so
+        # the typed validator can raise the proper structured error.
+        body = {"query": "x", "results": "not-a-list"}
+        payload = _adapt_search_payload(body)
+        assert payload["results"] == "not-a-list"
+
+
+class TestSearchResilience:
+    """The adapter must NOT break when the directory returns sparse records.
+
+    A freshly indexed agent (just observed, no crawl yet) might have only
+    name / domain / protocol / endpoint_url / first_seen / last_seen — and
+    nothing else. The SDK's job is to surface what's there, not insist on
+    a fully populated record.
+    """
+
+    def test_minimal_record_parses_to_valid_search_result(self) -> None:
+        # Directory contract: only fqdn, name, domain, protocol, first_seen,
+        # last_seen are required. ``endpoint_url`` is optional but we need it
+        # (or target_host) to construct an AgentRecord.
+        minimal_agent = {
+            "fqdn": "_minimal._mcp._agents.example.com",
+            "name": "minimal",
+            "domain": "example.com",
+            "protocol": "mcp",
+            "endpoint_url": "https://minimal.example.com",
+            "first_seen": "2026-04-01T00:00:00Z",
+            "last_seen": "2026-05-01T00:00:00Z",
+        }
+        body = {
+            "query": "minimal",
+            "results": [{"agent": minimal_agent, "score": 1.0}],
+            "total": 1,
+            "limit": 20,
+            "offset": 0,
+        }
+        payload = _adapt_search_payload(body)
+        response = SearchResponse.model_validate(payload)
+
+        assert len(response.results) == 1
+        result = response.results[0]
+        # Identity preserved.
+        assert result.agent.name == "minimal"
+        assert result.agent.target_host == "minimal.example.com"
+        # Everything else fell back to defaults — no crash.
+        assert result.agent.capabilities == []
+        assert result.agent.bap == []
+        assert result.agent.description is None
+        # Trust attestation built from defaults.
+        assert result.trust.security_score == 0
+        assert result.trust.trust_score == 0
+        assert result.trust.dnssec_valid is None
+        # Provenance built from required first_seen / last_seen.
+        assert result.provenance is not None
+        assert result.provenance.discovery_level == 0
+
+    def test_mixed_complete_and_incomplete_records(self) -> None:
+        # The directory returns 3 agents: two complete, one missing endpoint_url.
+        # The adapter must keep the two and drop the third — total adjusted.
+        complete_a = _directory_agent(name="a", endpoint_url="https://a.example.com")
+        complete_b = _directory_agent(name="b", endpoint_url="https://b.example.com")
+        incomplete = _directory_agent(name="c", endpoint_url=None)
+        body = {
+            "query": "x",
+            "results": [
+                {"agent": complete_a, "score": 1.0},
+                {"agent": incomplete, "score": 0.9},
+                {"agent": complete_b, "score": 0.8},
+            ],
+            "total": 3,
+            "limit": 20,
+            "offset": 0,
+        }
+        payload = _adapt_search_payload(body)
+        response = SearchResponse.model_validate(payload)
+
+        assert [r.agent.name for r in response.results] == ["a", "b"]
+        # ``total`` reduced by the number dropped — pagination stays honest.
+        assert response.total == 2
+
+    def test_field_with_value_zero_is_not_stripped(self) -> None:
+        # ``0`` is falsy but it's a meaningful default for score fields. Make
+        # sure the null-stripping pass distinguishes ``None`` from ``0`` /
+        # ``""`` / ``[]``.
+        agent = _directory_agent(security_score=0, trust_score=0, popularity_score=0)
+        payload = _adapt_search_payload(_directory_response(agent))
+        trust = payload["results"][0]["trust"]
+        assert trust["security_score"] == 0
+        assert trust["trust_score"] == 0
+        assert trust["popularity_score"] == 0

--- a/tests/unit/sdk/test_search_models.py
+++ b/tests/unit/sdk/test_search_models.py
@@ -1,0 +1,243 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the typed Path B result models.
+
+The model shapes mirror the directory's ``AgentResponse`` /
+``SearchResultItem`` / ``SearchResponse`` contract. These tests pin three things:
+
+1. **Bounds enforcement** on every score (0..100 ints) and tier (0..3).
+2. **Defaults are sensible** so sparse directory output (a freshly indexed agent)
+   still produces a valid model.
+3. **Forward compatibility** (``extra="ignore"``) — directory schema additions
+   don't break the SDK.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk.search import (
+    Provenance,
+    SearchResponse,
+    SearchResult,
+    TrustAttestation,
+)
+
+
+def _make_agent(name: str = "payments", domain: str = "example.com") -> AgentRecord:
+    return AgentRecord(
+        name=name,
+        domain=domain,
+        protocol=Protocol.MCP,
+        target_host=f"{name}.{domain}",
+        port=443,
+    )
+
+
+class TestTrustAttestationDefaults:
+    """A freshly indexed agent (no crawl yet) must produce a valid TrustAttestation."""
+
+    def test_constructable_with_no_args(self) -> None:
+        attestation = TrustAttestation()
+        assert attestation.security_score == 0
+        assert attestation.trust_score == 0
+        assert attestation.popularity_score == 0
+        assert attestation.trust_tier == 0
+        assert attestation.safety_status == "active"
+        assert attestation.dnssec_valid is None
+        assert attestation.dane_valid is None
+        assert attestation.svcb_valid is None
+        assert attestation.endpoint_reachable is None
+        assert attestation.protocol_verified is None
+        assert attestation.threat_flags == {}
+        assert attestation.breakdown is None
+        assert attestation.badges is None
+
+    def test_full_construction(self) -> None:
+        attestation = TrustAttestation(
+            security_score=88,
+            trust_score=91,
+            popularity_score=72,
+            trust_tier=2,
+            safety_status="active",
+            dnssec_valid=True,
+            dane_valid=False,
+            svcb_valid=True,
+            endpoint_reachable=True,
+            protocol_verified=True,
+            threat_flags={"phishing": False},
+            breakdown={"dnssec": 1.0, "tls_strength": 0.9},
+            badges=["Verified", "DNSSEC"],
+        )
+        assert attestation.popularity_score == 72
+        assert attestation.dane_valid is False
+        assert attestation.threat_flags == {"phishing": False}
+        assert attestation.badges == ["Verified", "DNSSEC"]
+
+
+class TestTrustAttestationBounds:
+    @pytest.mark.parametrize("score", [-1, 101, 200])
+    def test_security_score_bounds(self, score: int) -> None:
+        with pytest.raises(ValidationError):
+            TrustAttestation(security_score=score)
+
+    @pytest.mark.parametrize("score", [-1, 101])
+    def test_trust_score_bounds(self, score: int) -> None:
+        with pytest.raises(ValidationError):
+            TrustAttestation(trust_score=score)
+
+    @pytest.mark.parametrize("score", [-1, 101])
+    def test_popularity_score_bounds(self, score: int) -> None:
+        with pytest.raises(ValidationError):
+            TrustAttestation(popularity_score=score)
+
+    @pytest.mark.parametrize("tier", [-1, 4, 5])
+    def test_trust_tier_bounds(self, tier: int) -> None:
+        with pytest.raises(ValidationError):
+            TrustAttestation(trust_tier=tier)
+
+    def test_safety_status_literal_enforced(self) -> None:
+        # Allowed values
+        TrustAttestation(safety_status="active")
+        TrustAttestation(safety_status="blocked")
+        # Disallowed value
+        with pytest.raises(ValidationError):
+            TrustAttestation(safety_status="quarantined")  # type: ignore[arg-type]
+
+
+class TestTrustAttestationImmutabilityAndForwardCompat:
+    def test_immutability(self) -> None:
+        attestation = TrustAttestation(security_score=80)
+        with pytest.raises(ValidationError):
+            attestation.security_score = 99  # type: ignore[misc]
+
+    def test_extra_fields_ignored(self) -> None:
+        # Forward compatibility: directory may add fields the SDK doesn't know about.
+        attestation = TrustAttestation.model_validate(
+            {
+                "security_score": 80,
+                "trust_score": 75,
+                "popularity_score": 60,
+                "trust_tier": 2,
+                "safety_status": "active",
+                "future_signal": "directory-side feature we don't surface yet",
+            }
+        )
+        assert attestation.security_score == 80
+
+
+class TestProvenance:
+    def test_valid_construction(self) -> None:
+        now = datetime.now(UTC)
+        prov = Provenance(
+            discovery_level=2,
+            first_seen=now,
+            last_seen=now,
+        )
+        assert prov.discovery_level == 2
+        assert prov.last_verified is None
+        assert prov.company is None
+
+    def test_first_seen_and_last_seen_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Provenance(discovery_level=1)  # type: ignore[call-arg]
+
+    def test_discovery_level_bounds(self) -> None:
+        now = datetime.now(UTC)
+        with pytest.raises(ValidationError):
+            Provenance(discovery_level=4, first_seen=now, last_seen=now)
+
+    def test_company_pass_through(self) -> None:
+        now = datetime.now(UTC)
+        prov = Provenance(
+            discovery_level=0,
+            first_seen=now,
+            last_seen=now,
+            company={"name": "Acme", "domain": "acme.com"},
+        )
+        assert prov.company == {"name": "Acme", "domain": "acme.com"}
+
+
+class TestSearchResult:
+    def test_default_trust_attached(self) -> None:
+        # No trust block supplied — model fills in a default-constructed
+        # TrustAttestation rather than failing validation.
+        result = SearchResult(agent=_make_agent(), score=39.2)
+        assert isinstance(result.trust, TrustAttestation)
+        assert result.trust.security_score == 0
+        assert result.provenance is None
+
+    def test_score_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SearchResult(agent=_make_agent(), score=-0.01)
+
+    def test_raw_score_above_one_accepted(self) -> None:
+        # Directory uses raw scores; we removed the <=1.0 ceiling so 39.2 is fine.
+        result = SearchResult(agent=_make_agent(), score=39.2)
+        assert result.score == 39.2
+
+
+class TestSearchResponse:
+    def _response(
+        self,
+        results: list[SearchResult],
+        total: int,
+        offset: int = 0,
+        query: str | None = "payments",
+    ) -> SearchResponse:
+        return SearchResponse(
+            query=query,
+            results=results,
+            total=total,
+            limit=20,
+            offset=offset,
+        )
+
+    def test_has_more_true_when_more_results_exist(self) -> None:
+        results = [
+            SearchResult(agent=_make_agent(name=f"a{i}"), score=0.5)
+            for i in range(20)
+        ]
+        response = self._response(results, total=50, offset=0)
+        assert response.has_more is True
+        assert response.next_offset == 20
+
+    def test_has_more_false_at_last_page(self) -> None:
+        results = [
+            SearchResult(agent=_make_agent(name=f"a{i}"), score=0.5)
+            for i in range(7)
+        ]
+        response = self._response(results, total=27, offset=20)
+        assert response.has_more is False
+        assert response.next_offset is None
+
+    def test_empty_results_with_zero_total(self) -> None:
+        response = self._response([], total=0)
+        assert response.has_more is False
+        assert response.next_offset is None
+
+    def test_query_echo_is_optional(self) -> None:
+        # Some directories may not echo the query — None is allowed.
+        response = self._response([], total=0, query=None)
+        assert response.query is None
+
+    def test_extra_response_fields_ignored(self) -> None:
+        # Forward compatibility for the response envelope.
+        response = SearchResponse.model_validate(
+            {
+                "query": "x",
+                "results": [],
+                "total": 0,
+                "limit": 20,
+                "offset": 0,
+                "future_envelope_field": ["a", "b"],
+            }
+        )
+        assert response.total == 0
+        assert response.query == "x"

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -93,6 +93,69 @@ class TestValidateFetchUrl:
             assert result == "https://localhost/test"
 
 
+class TestUserinfoRejection:
+    """``https://user:pass@host`` URLs must be rejected at the input boundary."""
+
+    def test_user_only_userinfo_rejected(self):
+        with pytest.raises(UnsafeURLError, match="userinfo"):
+            validate_fetch_url("https://user@example.com/api/v1/search")
+
+    def test_user_password_userinfo_rejected(self):
+        with pytest.raises(UnsafeURLError, match="userinfo"):
+            validate_fetch_url("https://user:secret@example.com/api/v1/search")
+
+    def test_userinfo_rejection_does_not_leak_credentials_in_message(self):
+        # The raised error message must not echo the password back — the
+        # whole point of rejecting userinfo is to avoid credential leakage.
+        with pytest.raises(UnsafeURLError) as exc_info:
+            validate_fetch_url("https://user:hunter2@example.com/")
+        assert "hunter2" not in str(exc_info.value)
+        assert "user" not in str(exc_info.value).lower() or "userinfo" in str(exc_info.value)
+
+    def test_userinfo_rejected_even_when_host_is_allowlisted(self):
+        # Allowlist controls SSRF behavior, not credential hygiene.
+        with patch.dict(os.environ, {"DNS_AID_FETCH_ALLOWLIST": "example.com"}):
+            with pytest.raises(UnsafeURLError, match="userinfo"):
+                validate_fetch_url("https://user:pass@example.com/")
+
+
+class TestRedactUrlForLog:
+    """:func:`redact_url_for_log` strips userinfo so a URL is safe to log."""
+
+    def test_url_without_userinfo_returns_unchanged(self):
+        from dns_aid.utils.url_safety import redact_url_for_log
+
+        url = "https://example.com/api/v1/search?q=x"
+        assert redact_url_for_log(url) == url
+
+    def test_user_password_stripped(self):
+        from dns_aid.utils.url_safety import redact_url_for_log
+
+        redacted = redact_url_for_log("https://user:secret@example.com/path")
+        assert "secret" not in redacted
+        assert "user" not in redacted
+        assert redacted.startswith("https://example.com/")
+
+    def test_user_only_stripped(self):
+        from dns_aid.utils.url_safety import redact_url_for_log
+
+        redacted = redact_url_for_log("https://user@example.com/path")
+        assert "user" not in redacted
+
+    def test_port_preserved_when_userinfo_stripped(self):
+        from dns_aid.utils.url_safety import redact_url_for_log
+
+        redacted = redact_url_for_log("https://user:pass@example.com:8443/path")
+        assert redacted == "https://example.com:8443/path"
+
+    def test_query_string_preserved(self):
+        from dns_aid.utils.url_safety import redact_url_for_log
+
+        redacted = redact_url_for_log("https://user:pass@example.com/search?q=foo&limit=10")
+        assert redacted.endswith("?q=foo&limit=10")
+        assert "pass" not in redacted
+
+
 class TestCapSha256Verification:
     """Tests for cap_sha256 integrity verification in cap_fetcher."""
 


### PR DESCRIPTION
## Summary

Extends `dns-aid-core` with two coherent search surfaces, a cross-interface parity test matrix, and orthogonal security hardening on outbound HTTP.

### Path A — `discover()` filter kwargs (in-memory, no new dependencies)

Adds structured filter kwargs to the existing `discover()` function. Filtering operates in-memory on already-enriched `AgentRecord` objects — no DB, no schema change, no new network calls. Per-domain agent sets are small (<50 typically) so list-comp filtering in pure Python is appropriate.

Filters: `capabilities` (all-of), `capabilities_any` (any-of), `auth_type`, `intent`, `transport`, `realm`, `min_dnssec`, `text_match` (substring across description + use_cases + capabilities), `require_signed`, `require_signature_algorithm`.

Default behaviour **unchanged** — all kwargs default to `None`, existing callers produce identical results (verified by backwards-compat regression tests).

### Path B — `AgentClient.search()` opt-in HTTP wrapper

New opt-in method wrapping the existing directory `/api/v1/search` endpoint. Mirrors the existing `fetch_rankings()` opt-in pattern — activated via `directory_api_url` config (env var `DNS_AID_DIRECTORY_API_URL`). Directory outage does **not** break Path A discovery.

Filter vocabulary symmetric with Path A: `q`, `protocol`, `domain`, `capabilities`, `min_security_score`, `verified_only`, `intent`, `auth_type`, `transport`, `realm`, `limit`, `offset`.

Wire-shape adapter (`_adapt_search_payload`) lifts flat directory fields to typed nested objects; skips and logs records missing `target_host` rather than fabricating URLs.

### CLI + MCP

- New `dns-aid search` subcommand
- New `search_agents` MCP tool
- Existing `dns-aid discover` extended with Path A filter flags

### Security hardening (orthogonal to the search feature)

- SSRF guard: `validate_fetch_url` userinfo rejection + `redact_url_for_log` helper
- `SearchResponse` size guard (10 MiB limit)
- `follow_redirects=False` on all outbound directory calls; 3xx → `DirectoryUnavailableError(UnexpectedRedirect)`
- Skip-and-log on records missing `target_host` (no silent URL fabrication)

### Composition pattern

```python
# Cross-domain candidate discovery via directory (opt-in)
candidates = await client.search("fraud detection", capabilities=["fraud-detection"])

# Re-verify each candidate before invoke (zero-trust — directory is convenience, not trust bottleneck)
for c in candidates.results:
    record = await discover(c.domain, name=c.name, require_signed=True)
```

## Test plan

- [x] Cross-interface parity matrix: SDK / CLI / MCP all forward identical kwargs for Path A and Path B
- [x] 1480 unit tests passing (`test_mesh_invoke` pre-existing failure excluded — predates this branch, tracked separately)
- [x] Integration test: directory outage does not affect Path A discovery
- [x] Backwards-compat regression: `discover()` and `dns-aid discover` without new flags produce identical results to today
- [x] `ruff check src/` — clean
- [x] `ruff format --check src/` — clean
- [x] `mypy src/dns_aid/` — clean
- [x] DCO sign-off on commit

## Deferred (tracked in `docs/impl/`)

- Path B SDK directory auth — `docs/impl/phase-5.6.1-sdk-directory-auth.md`
- Path B `capabilities_any` + `min_dnssec` server-side filters — `docs/impl/phase-5.7.1-pathb-filter-parity.md`
- Path B JWKS-aware search (requires crawler enrichment)