### PR TITLE
chore: replace internal directory URLs with example.com placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`search()` (Path B) → `discover(domain, name=, require_signed=True)` (Path A)**:
   documented in API reference and demonstrated end-to-end against the live
-  `api.velosecurity-ai.io` + `highvelocitynetworking.com` fixtures. Path B is opt-in
+  `api.example.com` + `highvelocitynetworking.com` fixtures. Path B is opt-in
   convenience; Path A re-verification is the authoritative trust gate.
 
 ### Changed
@@ -145,7 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   telemetry signal push currently make anonymous requests. Phase 5.6's `AuthHandler`
   infrastructure is not yet wired into directory-side calls. Tracked in
   `docs/impl/phase-5.6.1-sdk-directory-auth.md` in the main DNS-AID repo. The live
-  directory at `api.velosecurity-ai.io` does not currently require auth, so this is
+  directory at `api.example.com` does not currently require auth, so this is
   non-blocking; landing it before private/internal-tenant search filters (per
   Phase 10) becomes a hard requirement.
 - **Path B JWS / signature filtering** — directory does not yet expose per-agent
@@ -157,7 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 1484 unit + parity + integration tests pass on this branch.
 - `mypy` clean across 79 source files; ruff + ruff-format clean on all touched
   files; `bandit` reports 0 new findings.
-- Live integration verified end-to-end against `https://api.velosecurity-ai.io/api/v1/search`
+- Live integration verified end-to-end against `https://api.example.com/api/v1/search`
   and the `highvelocitynetworking.com` Route 53 zone — SDK / CLI / MCP / Path B → Path A
   composition all green.
 - Backwards compatibility preserved: every existing `discover()`, `dns-aid discover`,
@@ -737,7 +737,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 - **Changelog URL** — Added to `[project.urls]` in pyproject.toml
 
 ### Changed
-- **Neutral Branding** — Removed all personal domain references (`velosecurity-ai.io`, `highvelocitynetworking.com`) from source, docs, and examples; replaced with `example.com` (RFC 2606)
+- **Neutral Branding** — Removed all personal domain references (`example.com`, `highvelocitynetworking.com`) from source, docs, and examples; replaced with `example.com` (RFC 2606)
 - **Repository URLs** — All URLs now point to `infobloxopen/dns-aid-core` (pyproject.toml, Dockerfile, CHANGELOG, docs)
 - **Telemetry Push URL** — MCP server default is now `None`; configured via `DNS_AID_SDK_HTTP_PUSH_URL` env var
 - **AWS Zone ID** — Docstring examples use `ZEXAMPLEZONEID` placeholder instead of real zone ID

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ DNS-AID enables AI agents to discover each other via DNS, using the internet's e
 
 The DNS-AID protocol is implementation-agnostic — it works against any DNS provider and any directory implementation. The library in this repository is sufficient on its own; the items below are independent, community-operated services that demonstrate what can be built on top of DNS-AID.
 
-🌐 **Hosted Agent Directory** (operated by Infoblox): [directory.velosecurity-ai.io](https://directory.velosecurity-ai.io) — indexes DNS-AID agents discovered across public DNS, with full-text search, capability filtering, trust scoring, lifecycle/sunset tracking, and copy-paste configs for Claude Desktop / Cursor / the SDK. API docs at [api.velosecurity-ai.io/api/v1/docs](https://api.velosecurity-ai.io/api/v1/docs).
+🌐 **Hosted Agent Directory** (operated by Infoblox): [directory.example.com](https://directory.example.com) — indexes DNS-AID agents discovered across public DNS, with full-text search, capability filtering, trust scoring, lifecycle/sunset tracking, and copy-paste configs for Claude Desktop / Cursor / the SDK. API docs at [api.example.com/api/v1/docs](https://api.example.com/api/v1/docs).
 
 You are encouraged to run your own directory or telemetry backend — the indexer is a thin layer over the same DNS records this library publishes and discovers, and the SDK telemetry sink is configurable via `DNS_AID_SDK_HTTP_PUSH_URL` (off by default).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ DNS-AID exposes two complementary surfaces for finding agents:
 
 | | **Path A** (`discover()`) | **Path B** (`AgentClient.search()`) |
 |---|---|---|
-| **Source of truth** | The target domain's DNS substrate | An opt-in directory backend (e.g. `api.velosecurity-ai.io`) |
+| **Source of truth** | The target domain's DNS substrate | An opt-in directory backend (e.g. `api.example.com`) |
 | **Scope** | Single domain — one zone at a time | Cross-domain — every indexed domain in one query |
 | **Filtering** | Pure-Python predicates over an in-memory list (`<50` agents typical) | Backend SQL/index over millions of agents |
 | **Trust signals** | Per-agent JWS verification + DNSSEC | Pre-computed aggregate scores from crawler telemetry |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1319,7 +1319,7 @@ every domain it has indexed.
 
 ```bash
 # Configure the directory once via env var
-export DNS_AID_SDK_DIRECTORY_API_URL=https://api.velosecurity-ai.io
+export DNS_AID_SDK_DIRECTORY_API_URL=https://api.example.com
 ```
 
 ```python


### PR DESCRIPTION
Remove `velosecurity-ai.io` from all public-facing docs and examples — internal product URLs should not appear in LF-bound open-source code. Replaced with `example.com` (RFC 2606) placeholder throughout README, CHANGELOG, architecture, and getting-started docs.