### PR TITLE
security: bump urllib3 >=2.7.0 (CVE-2026-44431, CVE-2026-44432)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,9 @@ dev = [
     "common-expression-language>=0.5.0",
     "cel-python>=0.5.0",
     # Direct floors on transitive deps to close Dependabot alerts:
-    "lxml>=6.1.0",      # CVE-2026-41066 (high) — XXE in iterparse, via cyclonedx-bom
-    "pygments>=2.20.0", # CVE-2026-4539 (low) — ReDoS in GUID regex, via rich/pytest/cel
+    "lxml>=6.1.0",       # CVE-2026-41066 (high) — XXE in iterparse, via cyclonedx-bom
+    "pygments>=2.20.0",  # CVE-2026-4539 (low) — ReDoS in GUID regex, via rich/pytest/cel
+    "urllib3>=2.7.0",    # CVE-2026-44431 + CVE-2026-44432 (high) — header leak + decompression bomb
 ]
 all = [
     # CLI
@@ -145,6 +146,7 @@ all = [
     # Transitive floors (Dependabot)
     "lxml>=6.1.0",
     "pygments>=2.20.0",
+    "urllib3>=2.7.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.18.6"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -649,6 +649,7 @@ all = [
     { name = "rich" },
     { name = "ruff" },
     { name = "typer" },
+    { name = "urllib3" },
     { name = "uvicorn" },
 ]
 cel = [
@@ -678,6 +679,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "urllib3" },
 ]
 jws = [
     { name = "cryptography" },
@@ -752,6 +754,8 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "typer", marker = "extra == 'all'", specifier = ">=0.12.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
+    { name = "urllib3", marker = "extra == 'all'", specifier = ">=2.7.0" },
+    { name = "urllib3", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
 ]
@@ -2241,11 +2245,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes Dependabot alerts #12 and #13.

| CVE | Severity | Summary | Fixed in |
|---|---|---|---|
| CVE-2026-44431 | High | Sensitive headers forwarded across origins in proxied low-level redirects | urllib3 2.7.0 |
| CVE-2026-44432 | High | Decompression-bomb safeguards bypassed in parts of the streaming API | urllib3 2.7.0 |

`urllib3` is a transitive dependency (pulled in by `httpx` and `boto3`). Pins `urllib3>=2.7.0` as a direct floor in `dev` and `all` extras, following the existing pattern for `lxml`, `pygments`, `pyjwt`, and `python-multipart`. Lock file regenerated — `urllib3 2.6.3 → 2.7.0`.