### PR TITLE
chore(ci): tighten Dependabot auto-merge rules

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,18 +14,44 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
+      - name: Detect self-modifying changes
+        # Block auto-merge for any PR that touches this workflow file itself.
+        # Without this guard a Dependabot bump of an action used here could silently
+        # change merge behavior on every future PR.
+        id: workflow-touch
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
+            | grep -Fxq '.github/workflows/dependabot-auto-merge.yml'; then
+            echo "self_modifying=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "self_modifying=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-merge patch updates
-        # Merge patch bumps and GitHub Actions updates when CI passes.
-        # Minor and major updates are left for human review.
+      - name: Auto-merge eligible updates
+        # Eligibility rules:
+        #   - Any ecosystem: semver-patch only (SemVer contract: bug fixes, no behavior change).
+        #   - github_actions: also accept semver-minor (sandboxed, additive features rarely break inputs).
+        #   - Block any PR that touches this workflow file itself (self-modifying automation risk).
+        #   - All other updates (majors, non-actions minors) require human review.
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.package-ecosystem == 'github_actions'
+          steps.workflow-touch.outputs.self_modifying == 'false' &&
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            (
+              steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+              steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            )
+          )
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Tightens the Dependabot auto-merge policy after observing that the previous rules over-trusted the `github_actions` ecosystem.

**Before** — any update in the `github_actions` ecosystem auto-merged regardless of semver level, including majors. That over-trust surfaced concretely in #116 (KineticCafe/actions-dco 1.3.4 → 3.0.0) and #118 (dependabot/fetch-metadata 2 → 3): both got queued for auto-merge despite being major bumps, and #118 in particular updates the very action this workflow consumes — a classic self-modifying automation risk where a v3 output rename would silently flip the merge condition false on every future PR.

**After**:

- Any ecosystem: `semver-patch` only (SemVer contract: bug fixes, no behavior change).
- `github_actions`: also accept `semver-minor` (sandboxed; additive action features rarely break inputs).
- Block any PR that modifies `.github/workflows/dependabot-auto-merge.yml` itself.
- All other updates (majors, non-actions minors) fall through to manual review.

The self-modifying guard uses the GitHub Files API rather than a local diff, so no `actions/checkout` step is required.

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`).
- [x] Auto-merge already disabled on #116 and #118 (manual review pending).
- [ ] On merge, the next Dependabot patch PR will exercise the new rules end-to-end.

## Follow-ups (out of scope here)

- Pin GitHub Actions to commit SHA (OpenSSF Scorecard "pinned-dependencies" pillar).