### PR TITLE
chore(ci): scope dependabot-auto-merge permissions to job level

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Workflow defaults to read-only (principle of least privilege).
+# The auto-merge job below escalates to the writes it actually needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write       # required by `gh pr merge --auto` to enqueue merge
+      pull-requests: write  # required to comment / update PR state
 
     steps:
       - name: Detect self-modifying changes


### PR DESCRIPTION
## Summary

Move the `permissions:` block in `.github/workflows/dependabot-auto-merge.yml` from workflow level (top-level) to job level, mirroring the pattern already used in `release.yml`.

Before: every job inherits `contents: write` + `pull-requests: write`.
After: workflow defaults to `contents: read`; only the `auto-merge` job opts into the writes it actually needs to enqueue a merge.

If another job is added to this workflow later, it inherits the read-only default and must explicitly opt in to any escalation.

Closes the Scorecard `TokenPermissionsID` high-severity alert on this workflow (#187).

## Test plan

- [x] YAML parses.
- [ ] CI green on the PR.
- [ ] Next Dependabot patch PR still gets auto-merge enqueued (validates the job-level permissions are enough).