### PR TITLE
chore(ci): SHA-pin dependabot/fetch-metadata and testbed image

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Workflow defaults to read-only (principle of least privilege).
+# The auto-merge job below escalates to the writes it actually needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write       # required by `gh pr merge --auto` to enqueue merge
+      pull-requests: write  # required to comment / update PR state
 
     steps:
       - name: Detect self-modifying changes

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/tests/testbed/agents/Dockerfile
+++ b/tests/testbed/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsutils \


### PR DESCRIPTION
## Summary

Apply OpenSSF Scorecard "pinned-dependencies" practice to the two unpinned references in the repo that can be resolved trivially:

- `.github/workflows/dependabot-auto-merge.yml`: `dependabot/fetch-metadata@v2` → `@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2.5.0`
- `tests/testbed/agents/Dockerfile`: `python:3.12-slim` → `python:3.12-slim@sha256:ec948fa5f9...`

Tags are mutable upstream; digests/SHAs are not. Dependabot still proposes version bumps and updates both the SHA and the trailing version comment, so update visibility is preserved.

Closes the two PinnedDependenciesID alerts that needed code changes:
- #189 `thirdPartyGitHubAction not pinned by hash`
- #184 `containerImage not pinned by hash`

## What this PR intentionally does *not* do

The remaining 20 `PinnedDependenciesID` alerts target `pip install` commands across `ci.yml`, `security.yml`, `release.yml`, and the Dockerfiles. Properly fixing those requires either:

1. Maintaining a hash-pinned `requirements-ci.txt` per extras set (`dev`, `dev,cli,mcp,route53`, etc.) with `pip install --require-hashes`, or
2. Migrating workflow installs to `uv sync --frozen` (the workspace `uv.lock` already carries hashes).

Option 2 is the cleaner long-term path. Tracking as a separate follow-up — the deps in question are CI/build tooling (pytest, ruff, mypy, build, cyclonedx-bom) that run in sandboxed runners, so the threat model is materially different from application runtime deps.

## Stacked on #120

This branch was cut off `chore/auto-merge-permissions-scope` (PR #120). Once #120 merges, GitHub will rebase this diff cleanly against `main`.

## Test plan

- [x] YAML parses.
- [x] Dockerfile digest verified via `docker pull python:3.12-slim` matches resolved digest.
- [ ] CI green on the PR.