### PR TITLE
feat(experimental): EDNS(0) agent-hint signaling [experimental]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ DNS-AID enables AI agents to discover each other via DNS, using the internet's e
 - [Architecture](docs/architecture.md) — protocol layers, metadata resolution, integration points
 - [Integrations](docs/integrations.md) — backend-specific setup notes
 - [Demo Guide](docs/demo-guide.md) — end-to-end walkthrough for talks and presentations
+- [Experimental Features](docs/experimental/README.md) — unstable APIs and forward-looking proposals (e.g., EDNS(0) `agent-hint` signaling)
 - [Privacy Policy](PRIVACY.md) | [Security Policy](SECURITY.md) | [Trademarks](TRADEMARKS.md)
 
 ## Companion services

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1771,6 +1771,109 @@ Disabled by default (`http_push_url=None`). Configure via `SDKConfig` or the `DN
 
 ---
 
+## Experimental: EDNS(0) signaling
+
+> ⚠ **Unstable.** APIs in this section live in `dns_aid.experimental` and may change or be removed in any release. They are not covered by semver guarantees. Full design rationale: [docs/experimental/edns-signaling.md](experimental/edns-signaling.md).
+
+Lets a client attach selector filters to outgoing DNS queries via an EDNS(0) option (code 65430, private use). Hint-aware DNS hops — including hint-aware authoritative servers — can narrow the response or short-circuit with a cached match. Stock authoritative servers treat the option as inert per RFC 6891.
+
+Activate by setting `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` in the environment. Without the flag the code paths are dormant even when the symbols are imported.
+
+### AgentHint
+
+```python
+from dns_aid.experimental import AgentHint
+
+hint = AgentHint(
+    capabilities=["chat", "code-review"],
+    intent="summarize",
+    transport="mcp",
+    auth_type="bearer",
+)
+```
+
+Fields (all optional, all default `None`):
+
+| Field | Type | Selector code | Notes |
+|-------|------|---------------|-------|
+| `capabilities` | `list[str] \| None` | 0x01 | Comma-joined on the wire. Empty / whitespace-only strings are stripped. |
+| `intent` | `str \| None` | 0x02 | Single tag. |
+| `transport` | `str \| None` | 0x03 | One of `"mcp"`, `"a2a"`, `"https"`. |
+| `auth_type` | `str \| None` | 0x04 | One of `"none"`, `"bearer"`, `"oauth2"`, `"mtls"`. |
+
+Methods:
+- `encode() -> bytes` — produce the EDNS(0) option payload (raises `ValueError` if any selector value exceeds 255 UTF-8 bytes or the total payload exceeds 512).
+- `signature() -> str` — stable cache-key string. Order-independent (`capabilities` sorted).
+
+### AgentHintEcho
+
+Response-side echo from a hint-aware hop, listing the selector codes the responder actually applied. Absence means no upstream filtering happened — fall back to local filtering.
+
+```python
+from dns_aid.experimental import AgentHintEcho
+
+echo = AgentHintEcho(applied_selectors=[0x01, 0x02])
+```
+
+### EdnsSignalingAdvertisement
+
+Publisher advertisement carried in `cap-doc`, `agent-card`, or `agents-index.json`:
+
+```json
+{
+  "edns_signaling": {
+    "version": 0,
+    "honored_selectors": ["capabilities", "intent", "transport"],
+    "note": "Recommends client-side pre-filtering."
+  }
+}
+```
+
+Lifted automatically onto `CapabilityDocument.edns_signaling`, `A2AAgentCard.edns_signaling`, and `HttpIndexAgent.edns_signaling`. Stored as `dict | None` (forward-compat on unknown shapes).
+
+### EdnsAwareResolver
+
+In-process programmable hop (Locus 1 in the design doc). Wraps `dns.asyncresolver.Resolver`, attaches the hint as an EDNS option on outgoing queries (when the env flag is set), and caches answers keyed by `(qname, qtype, hint_signature)`.
+
+```python
+from dns_aid.experimental import AgentHint, EdnsAwareResolver
+
+resolver = EdnsAwareResolver(ttl_seconds=60)
+result = await resolver.resolve(
+    "_chat._mcp._agents.example.com", "SVCB",
+    agent_hint=AgentHint(capabilities=["chat"]),
+)
+# result.answer — dnspython Answer
+# result.echo   — AgentHintEcho | None (presence == upstream is hint-aware)
+```
+
+### Integration with discover()
+
+```python
+from dns_aid import discover
+from dns_aid.experimental import AgentHint
+
+result = await discover(
+    "example.com",
+    agent_hint=AgentHint(capabilities=["chat"], transport="mcp"),
+)
+```
+
+The `agent_hint=` kwarg is accepted unconditionally for forward-compat. The option is only emitted on the wire when `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` is set.
+
+### CLI: `dns-aid edns-probe`
+
+```bash
+DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 \
+  dns-aid edns-probe example.com \
+  --capabilities=chat,code --intent=summarize --transport=mcp \
+  --show-wire
+```
+
+Prints an `[experimental]` banner on stderr, performs a cache-miss → cache-hit demonstration with `EdnsAwareResolver`, and reports any `AgentHintEcho` received.
+
+---
+
 ## Version
 
 ```python

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -687,3 +687,33 @@ async def get_record(
 
 This enables reliable reconciliation state-checking without depending on
 public DNS resolver support for SVCB records.
+
+## Experimental namespace (`src/dns_aid/experimental/`)
+
+A fourth subpackage sits alongside `core/`, `sdk/`, and `backends/`: `experimental/`.
+It is a stability-marked staging area for forward-looking features that need
+real code and a public design doc but are not yet stable enough to commit to
+across semver releases.
+
+Rules:
+
+- APIs in `experimental` are **not** subject to semver. They may change shape or
+  disappear in any release, including patch versions.
+- Symbols are **never** re-exported from `dns_aid/__init__.py`. Callers must
+  import explicitly: `from dns_aid.experimental import AgentHint`. This makes
+  accidental adoption visible at the import line.
+- Each feature has a **per-feature environment flag** (e.g.
+  `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1`). When the flag is unset, related runtime
+  code paths stay dormant even if the symbols are imported.
+- Each feature has a **design doc** under `docs/experimental/`, written with
+  section headers that map to future IETF-draft sections (Overview, Motivation,
+  Wire Format, Privacy, Security, Open Questions, Future Work).
+- When a feature graduates to stable, it moves out of `experimental/` into the
+  appropriate tier, gets re-exported from the top-level package, and its design
+  doc relocates from `docs/experimental/` to `docs/rfc/`.
+
+Currently shipped:
+
+| Feature | Module | Env flag | Doc |
+|---|---|---|---|
+| EDNS(0) `agent-hint` signaling | `experimental/edns_hint.py`, `experimental/edns_cache.py` | `DNS_AID_EXPERIMENTAL_EDNS_HINTS` | [edns-signaling.md](experimental/edns-signaling.md) |

--- a/docs/experimental/README.md
+++ b/docs/experimental/README.md
@@ -1,0 +1,38 @@
+# Experimental DNS-AID features
+
+This directory holds design proposals and rationale documents for **experimental** features that ship in the `dns_aid.experimental` Python subpackage.
+
+## ⚠ Stability
+
+APIs and wire formats described in this directory are **unstable**. They are NOT covered by the semver guarantees that apply to `dns_aid.core` and `dns_aid.sdk`. They may change shape, change behaviour, or be removed entirely in any release — including patch versions.
+
+If you build on an experimental feature, pin the patch version of `dns-aid` and watch the CHANGELOG.
+
+## Conventions
+
+Every experimental feature follows the same shape:
+
+| Aspect | Where it lives |
+|---|---|
+| Code | `src/dns_aid/experimental/<feature>.py` |
+| Public symbols | Imported explicitly: `from dns_aid.experimental import X`. Never re-exported from `dns_aid/__init__.py`. |
+| Runtime gate | A per-feature environment variable, e.g. `DNS_AID_EXPERIMENTAL_<FEATURE>=1`. Without the flag set, related code paths stay dormant. |
+| CLI surface | Commands print `[experimental]` to stderr on every invocation. |
+| Tests | `tests/unit/test_<feature>.py` is required. |
+| Design doc | `docs/experimental/<feature>.md` (this directory). Section headers should map cleanly to future RFC structure so content lifts into a draft when an LF spec home arrives. |
+| ABNF / wire format | `docs/experimental/<feature>.abnf` (kept separate from `docs/rfc/wire-format.abnf` so the experimental status is unambiguous). |
+
+## Current proposals
+
+- **[EDNS(0) agent-hint signaling](edns-signaling.md)** — client signals selector filters to a hint-aware DNS hop (resolver, forwarder, or authoritative) to enable per-query response narrowing and warm-cache short-circuits. Wire format: option code 65430 (private use). Reference programmable hop: in-process `EdnsAwareResolver`. Status: design + client-side spike.
+
+## Migrating an experimental feature to stable
+
+When a feature graduates to stable:
+
+1. Move the design doc from `docs/experimental/` to `docs/rfc/` (rename to a `-stable` suffix or whatever fits the section).
+2. Move the code from `src/dns_aid/experimental/` to its proper tier (`core/`, `sdk/`, or backends).
+3. Re-export public symbols from `dns_aid/__init__.py` if appropriate.
+4. Drop the env-flag gate; the feature is on by default.
+5. Update `CHANGELOG.md` with a `BREAKING:` line if the public surface changed during the experimental phase.
+6. Update `docs/api-reference.md` to remove the "Experimental" marking.

--- a/docs/experimental/edns-signaling.abnf
+++ b/docs/experimental/edns-signaling.abnf
@@ -1,0 +1,108 @@
+; DNS-AID experimental EDNS(0) agent-hint option — wire format
+; Reference: docs/experimental/edns-signaling.md
+;
+; ⚠ EXPERIMENTAL. This wire format is unstable. Option-code 65430 sits in the
+; RFC 6891 private-use range (65001–65534) and is subject to change before any
+; IANA coordination.
+;
+; This file extends the core DNS-AID ABNF (docs/rfc/wire-format.abnf) with the
+; experimental agent-hint option. ABNF rules from RFC 5234.
+
+; ==================================================================
+; Core ABNF rules referenced (from RFC 5234)
+; ==================================================================
+
+DIGIT          = %x30-39                        ; 0-9
+ALPHA          = %x41-5A / %x61-7A              ; A-Z / a-z
+OCTET          = %x00-FF
+BIT            = "0" / "1"
+
+; ==================================================================
+; EDNS(0) framing context (from RFC 6891 §6.1.2)
+; ==================================================================
+;
+; agent-hint is carried as a single OPTION entry inside the RDATA of the
+; OPT pseudo-RR:
+;
+;     OPT.RDATA = *agent-hint-option / *(other-option) / *agent-hint-option
+;
+; Where each EDNS option entry is:
+;
+;     option         = option-code option-length option-data
+;     option-code    = 2OCTET   ; big-endian; 65430 = 0xFF96 for agent-hint
+;     option-length  = 2OCTET   ; big-endian length of option-data, in octets
+;     option-data    = *OCTET   ; opaque to the EDNS framing; defined per option-code
+
+; ==================================================================
+; agent-hint option (option-code = 65430)
+; ==================================================================
+
+; option-data when option-code = 65430.  Either a request payload or an echo.
+agent-hint-data    = agent-hint-request / agent-hint-echo
+
+; -- Request -------------------------------------------------------
+
+agent-hint-request = version-request selector-count *selector
+                     ; total length: 2 + sum(selector lengths)
+                     ; SHOULD NOT exceed 512 octets in any single option
+
+version-request    = %x00
+                     ; v0; high bit clear distinguishes a request from an echo
+
+selector-count     = OCTET
+                     ; number of selectors that follow (0–255)
+
+selector           = selector-code selector-length selector-value
+
+selector-code      = OCTET
+                     ; 0x01 = capabilities (UTF-8 comma list)
+                     ; 0x02 = intent       (UTF-8 single tag)
+                     ; 0x03 = transport    (UTF-8: "mcp" | "a2a" | "https")
+                     ; 0x04 = auth_type    (UTF-8: "none" | "bearer" | "oauth2" | "mtls")
+                     ; 0x05–0xFF reserved.  Consumers MUST silently ignore
+                     ; unknown selector codes (forward-compat).
+
+selector-length    = OCTET                       ; length of selector-value in bytes
+selector-value     = *OCTET                      ; UTF-8 encoded, length-prefixed
+
+; -- Response echo (RFC 8914-style additive context) ---------------
+
+agent-hint-echo    = version-echo applied-count *applied-selector
+                     ; emitted by a hint-aware hop in the response.  Absence is
+                     ; meaningful — it means no upstream filtering happened.
+
+version-echo       = %x80
+                     ; v0; high bit set distinguishes an echo from a request.
+                     ; Lower 7 bits carry the version number; 0x80 == version 0 echo.
+
+applied-count      = OCTET                       ; number of selector codes that follow
+
+applied-selector   = OCTET                       ; selector-code that the hop honoured.
+                     ; Selector codes appearing here MUST also have appeared in
+                     ; the corresponding request.
+
+; ==================================================================
+; Publisher advertisement (JSON, not on the wire) — Channel 1
+; ==================================================================
+;
+; Embedded inside cap-doc, agent-card, or http-index JSON. Not part of any DNS
+; wire format; included here for completeness so implementers see the whole
+; signaling surface in one place.
+;
+;     "edns_signaling": {
+;       "version":           <integer>,
+;       "honored_selectors": [<selector-name>, ...],
+;       "note":              <string?>          // optional
+;     }
+;
+; Where <selector-name> ∈ {"capabilities", "intent", "transport", "auth_type"} for v0.
+
+; ==================================================================
+; SVCB advertisement parameter (optional) — Channel 2 static
+; ==================================================================
+;
+; Optional SVCB SvcParam at the zone apex (_agents.{domain}). v0 reserves the
+; following key for forward use; not emitted by the v0 reference implementation.
+;
+;     key65409 = "agent-hint"
+;     value    = "v=0;selectors=<selector-name>(,<selector-name>)*"

--- a/docs/experimental/edns-signaling.md
+++ b/docs/experimental/edns-signaling.md
@@ -1,0 +1,249 @@
+# Experimental: EDNS(0) `agent-hint` signaling for DNS-AID
+
+**Status:** Experimental. APIs and wire format are unstable.
+**Module:** `dns_aid.experimental` (`AgentHint`, `AgentHintEcho`, `EdnsSignalingAdvertisement`, `EdnsAwareResolver`)
+**Runtime gate:** `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1`
+
+---
+
+## 1. Overview
+
+DNS-AID today is a one-shot lookup protocol: a client knows what to ask, sends an SVCB query, and gets back an endpoint. The protocol works well when the client already knows the agent name and the publisher's domain, but it offers no mechanism for the client to communicate **what kind of agent it's looking for** while resolution is in progress. Any pre-filtering must happen client-side, after the full record set has been fetched.
+
+This document proposes an experimental EDNS(0) option — `agent-hint` — that lets the client attach a compact set of selector filters to its outgoing DNS query. Any hop on the resolution path that understands the option can use the hint to narrow the response, return a cached pre-filtered answer, or short-circuit the query entirely. Hops that don't understand the option treat it as inert, per RFC 6891 §6.1.1, and the query proceeds normally — the option degrades gracefully.
+
+The goal is not to change DNS. The goal is to give the agent-discovery flow a substrate-level signal mechanism that mirrors the way DNS recursion itself amortizes cost: expensive at the cold edge, cheap when a downstream cache has the answer. For agent discovery the equivalent of "the answer is cached at my local resolver" is "a hint-aware hop on this resolution path has a recent matching SVCB record and can hand it back without an upstream walk."
+
+## 2. Motivation
+
+Consider the three discovery scenarios from `draft-mozleywilliams-dnsop-dnsaid-01` §3:
+
+1. **Known endpoint and domain** — direct SVCB lookup. Already cheap.
+2. **Known domain, unknown service** — query `_index._agents.{domain}`, then walk the named entries. Multiple round trips; the index tells you names but not metadata.
+3. **Unknown / wildcard** — search provider or federated registry. Most expensive.
+
+Scenarios 2 and 3 commonly produce *N* candidates of which the client only wants a handful that match its needs — capabilities, intent, transport, auth posture. Today the client filters all *N* locally after fetching, often after also fetching enrichment metadata (cap docs, agent cards) for records it will discard.
+
+The `agent-hint` option moves the filter description to the query itself. If any hop along the path understands the option, that hop can:
+
+- Return only the subset that matches (a hint-aware authoritative)
+- Serve a cached pre-filtered answer (a hint-aware recursive resolver or forwarder)
+- Short-circuit the query entirely (the client's own resolver wrapper, when the hint matches a recent cache entry)
+
+Cost decays across three states:
+
+- **Cold** — no caches anywhere. Client falls back to search/registry. Expensive.
+- **Warm** — at least one hop is hint-aware and has a fresh matching record. No expensive search, possibly no DNS round-trip at all.
+- **Hot** — the client itself has already parsed and stored an SVCB record as a long-lived "skill" reference. No query at all until the record is invalidated (failed invoke, scheduled re-verification, manual flush).
+
+The hint is most useful at the **warm** state. At hot, it is bypassed. At cold, Path B search/registry is the right answer.
+
+## 3. Conceptual model
+
+The hint flows from the client toward the authoritative server. Any hop that understands the option may act on it. Hops that don't simply forward the option per RFC 6891 (commodity authoritative servers serve the same records they would have served without the option):
+
+```
+                          query + agent-hint EDNS opt
+   ┌─────────────┐ ─────────────────────────────────────▶ ┌──────────────┐
+   │  Agent      │                                         │ Forwarder /  │
+   │  runtime    │                                         │ recursive    │  (Locus 2 — optional)
+   │  (Locus 1)  │ ◀──── narrowed/cached response  ────── │ (hint-aware  │
+   └─────────────┘                                         │  if running  │
+          │                                                │  extension)  │
+          │                                                └──────┬───────┘
+          │                                                       │
+          │                                                       ▼
+          │                                              ┌──────────────────┐
+          │                                              │  Authoritative   │
+          │  reads edns_signaling advertisement          │  DNS server      │  (Locus 3 — optional)
+          │  from cap-doc / agent-card JSON              │  (hint-aware     │
+          │  AND/OR honored_selectors echoed in OPT      │   if running     │
+          │  response from hint-aware authoritative      │   extension)     │
+          └─────────────────────────────────────────────▶│   OR             │
+                                                         │   stock BIND /   │
+                                                         │   Route53 / CF   │
+                                                         │   (inert, ignores│
+                                                         │    the option)   │
+                                                         └──────────────────┘
+```
+
+**Locus 1 — in-process client cache.** The agent's own resolver wrapper reads the hint, checks a local cache keyed by `(qname, qtype, hint_signature)`. Cache hit short-circuits the query. The reference implementation, `EdnsAwareResolver`, ships with this PR. Always usable; no infrastructure required.
+
+**Locus 2 — hint-aware forwarder / recursive resolver.** A corporate gateway or shared resolver that understands the hint, serves cached pre-filtered responses, or rewrites the query before forwarding. Out of scope for this PR; valid future deployment.
+
+**Locus 3 — hint-aware authoritative server.** A DNS server implementation that inspects the hint on incoming queries and narrows the response set to records matching the selectors. For example: a domain publishes 50 agents, the client queries with `capabilities=chat & intent=summarize`, the authoritative returns just the 2 records that match. Out of scope for this PR's reference implementation; the wire format and advertisement schema are designed to support this hop without modification.
+
+Commodity authoritative servers (stock BIND, Route53, Cloudflare) are inert to unknown options per RFC 6891. They will respond identically with or without the option. That is a valid, lowest-common-denominator deployment — the client-side cache at Locus 1 still provides value.
+
+## 4. Wire format
+
+### 4.1 Request
+
+EDNS(0) option-code **65430** (private use, RFC 6891 §6.1.1, range 65001–65534).
+
+```
++------+------+------+------+------+------+
+| OPTION-CODE = 65430  | OPTION-LENGTH    |
++----------------------+------------------+
+| VERSION (1B)  | SELECTOR-COUNT (1B)     |
++---------------+-------------------------+
+| selector-code (1B) | selector-length (1B) | selector-value (N B UTF-8) |
++--------------------+----------------------+----------------------------+
+                    ...
+```
+
+- **VERSION** — `0x00` for the current version. The high bit (`0x80`) is reserved for the response-side echo (see §4.2).
+- **SELECTOR-COUNT** — number of selectors that follow. May be zero.
+- Each selector is a 1-byte type code, a 1-byte length, and a length-prefixed UTF-8 value (≤ 255 bytes).
+- Total option payload SHOULD NOT exceed 512 bytes (soft cap to keep EDNS budget reasonable).
+
+Consumers MUST ignore selector codes they don't recognise rather than reject the whole option.
+
+### 4.2 Response echo
+
+A hint-aware hop MAY include an `agent-hint` option in its response with the VERSION byte's high bit set (`0x80`) to indicate "this is an echo, not a request." The payload lists the selector codes the responder actually honoured:
+
+```
++------+------+------+------+------+------+
+| OPTION-CODE = 65430  | OPTION-LENGTH    |
++----------------------+------------------+
+| VERSION (0x80) | APPLIED-COUNT (1B)     |
++----------------+------------------------+
+| selector-code (1B) | selector-code (1B) | ...                          |
++--------------------+----------------------+------------------------+
+```
+
+Absence of an echo on a response is meaningful — it tells the client no upstream filtering happened, and the client should fall back to local filtering against the returned record set. This mirrors RFC 8914 (Extended DNS Errors) in pattern: response-only, non-mandatory, additive context.
+
+### 4.3 Selectors v0
+
+| Code | Name | Value format | Example |
+|------|------|--------------|---------|
+| 0x01 | `capabilities` | Comma-separated UTF-8 list | `"chat,code-review"` |
+| 0x02 | `intent` | Single UTF-8 tag | `"summarize"` |
+| 0x03 | `transport` | `"mcp"` \| `"a2a"` \| `"https"` | `"mcp"` |
+| 0x04 | `auth_type` | `"none"` \| `"bearer"` \| `"oauth2"` \| `"mtls"` | `"bearer"` |
+
+Codes `0x05` through `0xFF` are reserved for future selectors. The taxonomy intentionally matches the existing Path A filter kwargs on `dns_aid.discover()`.
+
+### 4.4 Worked example
+
+A client looking for an MCP-transport, bearer-auth chat agent emits an option payload of:
+
+```
+version=0x00  count=0x04
+0x01 0x04 "chat"
+0x02 0x09 "summarize"
+0x03 0x03 "mcp"
+0x04 0x06 "bearer"
+```
+
+Bytes on the wire: `00 04 01 04 63 68 61 74 02 09 73 75 6d 6d 61 72 69 7a 65 03 03 6d 63 70 04 06 62 65 61 72 65 72` (32 bytes payload, well under the 512-byte cap).
+
+A hint-aware authoritative that applied both `capabilities` and `transport` (but not `intent` or `auth_type`) would echo:
+
+```
+version=0x80  count=0x02
+0x01 0x03
+```
+
+Bytes: `80 02 01 03` (4 bytes payload).
+
+## 5. Publisher advertisement
+
+A hint-aware deployment advertises across two complementary channels.
+
+### 5.1 Channel 1 — well-known JSON
+
+Every publisher (hint-aware or not) MAY include an `edns_signaling` block in their `cap-doc`, `agent-card`, or `agents-index.json`:
+
+```json
+{
+  "name": "chat-agent",
+  ...
+  "edns_signaling": {
+    "version": 0,
+    "honored_selectors": ["capabilities", "intent", "transport"],
+    "note": "Recommends client-side pre-filtering with these selectors."
+  }
+}
+```
+
+This tells the client which selectors are *meaningful* for this publisher's agents — i.e. the publisher has populated the matching metadata fields so filtering on them will actually narrow results. Independent of whether any hop on the DNS resolution path is hint-aware; useful even with stock authoritative software.
+
+### 5.2 Channel 2 — DNS-layer signal
+
+A hint-aware authoritative or recursive server signals its capability in one of two ways:
+
+1. **OPT response echo** (preferred) — described in §4.2. The presence of an echo on a query response is itself the advertisement: "this responder processed your hint."
+2. **SVCB advertisement parameter** (optional, static advertisement at zone-discovery time) — a new param key `key65409 = "agent-hint"` on the apex SVCB record at `_agents.{domain}`, with a value like `v=0;selectors=capabilities,intent,transport`. Tells clients before they emit their first hint that this zone's authoritative will honour it. v0 keeps this optional; the echo carries the same information reactively.
+
+Channels are complementary. A client uses Channel 1 to decide *which selectors to populate*, and Channel 2 to know *whether to expect upstream narrowing or rely on local filtering*.
+
+## 6. Reference implementation
+
+The PR that introduces this document ships three modules under `dns_aid.experimental`:
+
+- `AgentHint` — Pydantic model for the request payload, with `encode()`, `signature()`, and `decode_agent_hint()`.
+- `AgentHintEcho` — model for the response echo payload.
+- `EdnsAwareResolver` — Locus 1 implementation. Wraps `dns.asyncresolver.Resolver`, attaches the option on outgoing queries (when a hint and the env flag are present), caches answers keyed by `(qname, qtype, hint_signature)`, and surfaces any upstream `AgentHintEcho` on the result.
+
+Integration with `dns_aid.discover()`:
+
+```python
+from dns_aid import discover
+from dns_aid.experimental import AgentHint
+
+result = await discover(
+    "example.com",
+    agent_hint=AgentHint(capabilities=["chat"], transport="mcp"),
+)
+```
+
+The `agent_hint` kwarg is accepted unconditionally for forward-compat. The option is only emitted on the wire when `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` is set in the environment.
+
+A CLI demonstration command is available: `dns-aid edns-probe <domain>` (also env-gated).
+
+## 7. Privacy considerations
+
+Hints leak query intent — capabilities, intent, transport, auth posture — to **every hop that sees them**. This is more than a bare SVCB query reveals.
+
+Clients SHOULD:
+
+- Omit selectors when querying on public networks or for sensitive intents.
+- Consider that the recursive resolver, all forwarders, and the authoritative server see the full hint set.
+- Treat the hint as opt-in metadata sharing: by sending it, the client opts into being identifiable along axes the bare DNS query would not have exposed.
+
+Operators of recursive resolvers SHOULD consider scrubbing or summarizing `agent-hint` payloads at the recursive boundary, similar to ECS (RFC 7871) source-prefix scrubbing.
+
+EDNS padding (RFC 7830) can be used in conjunction with `agent-hint` to make payload-size analysis less informative.
+
+## 8. Security considerations
+
+- **Programmable-hop trust.** A hint-aware hop that narrows the response set is a trusted relay for filtering semantics. A malicious or compromised hop could omit matching records, return records that don't match the selectors, or fabricate records. DNSSEC continues to protect the answer-set integrity (when present) but cannot vouch for filtering semantics — only that the records returned were authentically published.
+- **Echo unauthenticated.** The response echo (§4.2) is unsigned. DNSSEC signs the answer set but not OPT records. A hop could lie about what it filtered. Clients SHOULD validate by re-applying selectors locally to the returned records; treat the echo as a hint, not a guarantee.
+- **Cache poisoning at Locus 1.** The reference `EdnsAwareResolver` caches by hint signature. An attacker who can inject a forged DNS response on a cache miss could pollute the cache for any future query with that signature. Standard DNS poisoning mitigations apply; running DNSSEC validation on the path closes the most common vector.
+- **Hint tampering on the path.** Forwarders that don't understand the option are required to propagate it per RFC 6891, but a hostile forwarder could rewrite or strip the option. The reference implementation tolerates strip gracefully (the option simply doesn't reach the upstream hop, and local filtering takes over). Rewrite is more concerning: a forwarder injecting a different `intent` or `auth_type` could cause the client to be served a different agent than it asked for. Mitigation is the same as for echo trust — the client SHOULD re-apply selectors locally.
+
+## 9. Open questions
+
+1. **Middlebox transparency.** Novel 65xxx options may be stripped by forwarders that don't pass unknown options through, despite the RFC 6891 requirement. The reference implementation is designed to remain useful even when the option never leaves the client (Locus 1). Operators relying on Locus 2 or 3 should test their path with `tcpdump`.
+2. **Selector taxonomy lock-in.** Once selector codes `0x01`–`0x04` ship, changing them is painful — hint-aware implementations will index and cache on those codes. Worth a separate taxonomy review pass before any IANA action.
+3. **Echo authentication.** Is unauthenticated echo enough? A signed echo would require a different transport (the OPT record can't be DNSSEC-signed). Alternative: include a hash of the applied-selector set in the answer-section TXT, signed alongside the SVCB. Deferred to future work.
+4. **Draft alignment.** Likely a separate `draft-XXX-dnsaid-edns-signaling` rather than an appendix to `draft-mozleywilliams-dnsop-dnsaid-01`, because the wire-format addition and authoritative-side semantics are substantial.
+
+## 10. Future work
+
+- **Hint-aware authoritative reference implementation.** This PR ships the wire format, the client-side spike, and the advertisement schema. A reference hint-aware authoritative is the next major step in the maturity ladder.
+- **IANA option-code reservation.** Currently in the private-use range. Promote when the design stabilizes.
+- **Recursive-resolver / forwarder reference.** Locus 2 deployment — likely shipped as a sidecar service or an extension to an existing recursive.
+- **Integration with the SDK search wrapper (Path B).** A hint-aware Path B directory could carry the hint forward across multi-domain searches.
+- **Padding strategy.** Recommended sizing and chaff to mitigate intent-inference attacks on the hint payload.
+
+## 11. References
+
+- [RFC 6891](https://www.rfc-editor.org/rfc/rfc6891) — Extension Mechanisms for DNS (EDNS(0))
+- [RFC 7871](https://www.rfc-editor.org/rfc/rfc7871) — Client Subnet in DNS Queries
+- [RFC 8914](https://www.rfc-editor.org/rfc/rfc8914) — Extended DNS Errors (echo pattern reference)
+- [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) — DNS-AID main spec
+- [draft-ietf-dnsop-svcb-https](https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/) — SVCB record type (RFC 9460)

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Annotated
 
 import typer
@@ -2480,6 +2481,119 @@ def dcv_revoke(
         else:
             error_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
+
+
+# ============================================================================
+# EXPERIMENTAL: edns-probe — demonstrate EDNS(0) agent-hint signaling
+# ============================================================================
+
+
+@app.command("edns-probe")
+def edns_probe(
+    domain: Annotated[str, typer.Argument(help="Domain to discover agents at")],
+    capabilities: Annotated[
+        str | None,
+        typer.Option("--capabilities", help="Comma-separated capabilities filter"),
+    ] = None,
+    intent: Annotated[str | None, typer.Option("--intent", help="Single intent tag filter")] = None,
+    transport: Annotated[
+        str | None,
+        typer.Option("--transport", help="Transport: mcp | a2a | https"),
+    ] = None,
+    auth_type: Annotated[
+        str | None,
+        typer.Option("--auth-type", help="Auth type: none | bearer | oauth2 | mtls"),
+    ] = None,
+    show_wire: Annotated[
+        bool,
+        typer.Option(
+            "--show-wire",
+            help="Print the EDNS option payload bytes (hex) for manual wire correlation.",
+        ),
+    ] = False,
+) -> None:
+    """[experimental] Demonstrate EDNS(0) agent-hint signaling end-to-end.
+
+    Constructs an AgentHint from the CLI flags, wraps the discovery resolver
+    with EdnsAwareResolver, performs two discover() calls back-to-back, and
+    reports the cache miss/hit behavior plus any AgentHintEcho the upstream
+    returned.
+
+    Requires DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 in the environment. Without the
+    flag, the command prints how to enable and exits non-zero.
+    """
+    import os
+    import sys
+
+    if os.environ.get("DNS_AID_EXPERIMENTAL_EDNS_HINTS", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        error_console.print(
+            "[yellow]Set DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 to enable this command.[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    print(
+        "[experimental] EDNS(0) agent-hint signaling is unstable; APIs may change.", file=sys.stderr
+    )
+
+    from dns_aid import discover
+    from dns_aid.experimental import AgentHint
+
+    caps_list = [c.strip() for c in capabilities.split(",") if c.strip()] if capabilities else None
+    hint = AgentHint(
+        capabilities=caps_list,
+        intent=intent,
+        transport=transport,
+        auth_type=auth_type,
+    )
+
+    console.print(
+        f"[bold]Probing {domain}[/bold] with hint signature: [cyan]{hint.signature() or '(empty)'}[/cyan]"
+    )
+    if show_wire:
+        payload = hint.encode()
+        console.print(f"  Wire payload ({len(payload)} bytes): [dim]{payload.hex()}[/dim]")
+
+    # First call — cold
+    console.print("\n[bold]Call 1[/bold] (expect upstream DNS query)")
+    t0 = time.perf_counter()
+    result1 = run_async(discover(domain, agent_hint=hint))
+    elapsed1_ms = (time.perf_counter() - t0) * 1000
+    console.print(
+        f"  agents={len(result1.agents)} dnssec={result1.dnssec_validated} "
+        f"elapsed={elapsed1_ms:.1f}ms"
+    )
+
+    # Second call — same hint, demonstrates that without an EdnsAwareResolver wrapping,
+    # the second call still hits DNS. The cache lives in EdnsAwareResolver itself;
+    # the standard discover() path doesn't share it. We demonstrate the cache
+    # separately below.
+    console.print("\n[bold]Call 2[/bold] via EdnsAwareResolver (in-process cache, Locus 1)")
+    from dns_aid.experimental import EdnsAwareResolver
+
+    resolver = EdnsAwareResolver()
+    fqdn_hint = f"_index._agents.{domain}"
+    t0 = time.perf_counter()
+    cached1 = run_async(resolver.resolve(fqdn_hint, "TXT", agent_hint=hint))
+    miss_ms = (time.perf_counter() - t0) * 1000
+    t0 = time.perf_counter()
+    cached2 = run_async(resolver.resolve(fqdn_hint, "TXT", agent_hint=hint))
+    hit_ms = (time.perf_counter() - t0) * 1000
+    console.print(f"  Cache miss: {miss_ms:.2f}ms — upstream resolve happened")
+    console.print(f"  Cache hit:  {hit_ms:.2f}ms — no upstream call")
+    if cached1.echo is not None:
+        applied = ",".join(str(c) for c in cached1.echo.applied_selectors)
+        console.print(f"  Upstream echoed applied selectors: [green]{applied}[/green]")
+    else:
+        console.print(
+            "  No echo from upstream — stock authoritative or stripped en route. "
+            "Local filtering is the only narrowing that happened."
+        )
+    # Reference cached2 so linters know it's intentional
+    _ = cached2
 
 
 # ============================================================================

--- a/src/dns_aid/core/_edns_hint_ctx.py
+++ b/src/dns_aid/core/_edns_hint_ctx.py
@@ -1,0 +1,76 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Internal helper: per-call EDNS(0) ``agent-hint`` plumbing for the discovery layer.
+
+⚠ Experimental. See ``docs/experimental/edns-signaling.md``.
+
+This module is intentionally tiny and private (leading underscore in the name)
+because both ``discoverer.py`` and ``indexer.py`` need to read the same active
+hint without creating an import cycle (discoverer already imports from indexer).
+
+The contextvar is set by :func:`dns_aid.core.discoverer.discover` for the
+duration of the call, then reset in ``finally``. Helpers that build a
+``dns.asyncresolver.Resolver`` call :func:`apply_agent_hint_to_resolver` to
+attach the EDNS option when both the contextvar and the env flag are set.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+from typing import TYPE_CHECKING
+
+import dns.asyncresolver
+import structlog
+
+if TYPE_CHECKING:
+    from dns_aid.experimental.edns_hint import AgentHint
+
+logger = structlog.get_logger(__name__)
+
+_AGENT_HINT_CTX: contextvars.ContextVar[AgentHint | None] = contextvars.ContextVar(
+    "dns_aid_agent_hint", default=None
+)
+_EDNS_HINTS_ENV_FLAG = "DNS_AID_EXPERIMENTAL_EDNS_HINTS"
+
+
+def set_agent_hint(hint: AgentHint | None) -> contextvars.Token:
+    """Set the active hint and return a token for reset()."""
+    return _AGENT_HINT_CTX.set(hint)
+
+
+def reset_agent_hint(token: contextvars.Token) -> None:
+    """Restore the previous hint value."""
+    _AGENT_HINT_CTX.reset(token)
+
+
+def apply_agent_hint_to_resolver(resolver: dns.asyncresolver.Resolver) -> None:
+    """Attach the active agent-hint EDNS option to ``resolver`` if enabled.
+
+    No-op unless both: (a) a non-None hint is set on the contextvar, AND (b)
+    the ``DNS_AID_EXPERIMENTAL_EDNS_HINTS`` environment variable is truthy.
+    Import of the experimental module is lazy so non-experimental users never
+    load it.
+    """
+    if os.environ.get(_EDNS_HINTS_ENV_FLAG, "").lower() not in ("1", "true", "yes"):
+        return
+    hint = _AGENT_HINT_CTX.get()
+    if hint is None:
+        return
+    try:
+        import dns.edns
+
+        from dns_aid.experimental.edns_hint import AGENT_HINT_OPTION_CODE
+
+        option = dns.edns.GenericOption(dns.edns.OptionType(AGENT_HINT_OPTION_CODE), hint.encode())
+        resolver.use_edns(0, 0, 4096, options=[option])
+        logger.debug(
+            "experimental.agent_hint_attached",
+            option_code=AGENT_HINT_OPTION_CODE,
+            signature=hint.signature(),
+        )
+    except Exception as e:
+        # Experimental path must never break core discovery on failure.
+        logger.warning("experimental.agent_hint_attach_failed", error=str(e))

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -112,6 +112,9 @@ class A2AAgentCard:
     default_input_modes: list[str] = field(default_factory=lambda: ["text"])
     default_output_modes: list[str] = field(default_factory=lambda: ["text"])
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Experimental: publisher's EDNS(0) agent-hint advertisement. Stored as the
+    # raw dict from JSON. See docs/experimental/edns-signaling.md.
+    edns_signaling: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> A2AAgentCard:
@@ -134,6 +137,11 @@ class A2AAgentCard:
         if "authentication" in data and isinstance(data["authentication"], dict):
             auth = A2AAuthentication.from_dict(data["authentication"])
 
+        # Experimental: lift edns_signaling advertisement if present
+        edns_signaling = data.get("edns_signaling")
+        if not isinstance(edns_signaling, dict):
+            edns_signaling = None
+
         # Collect unknown fields as metadata
         known_keys = {
             "name",
@@ -145,6 +153,7 @@ class A2AAgentCard:
             "authentication",
             "defaultInputModes",
             "defaultOutputModes",
+            "edns_signaling",
         }
         metadata = {k: v for k, v in data.items() if k not in known_keys}
 
@@ -159,6 +168,7 @@ class A2AAgentCard:
             default_input_modes=data.get("defaultInputModes", ["text"]),
             default_output_modes=data.get("defaultOutputModes", ["text"]),
             metadata=metadata,
+            edns_signaling=edns_signaling,
         )
 
     @classmethod

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -46,6 +46,10 @@ class CapabilityDocument:
     use_cases: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
     raw_data: dict[str, Any] = field(default_factory=dict)
+    # Experimental: publisher's EDNS(0) agent-hint advertisement. Stored as the
+    # raw dict from the JSON to avoid coupling core to the experimental package.
+    # See docs/experimental/edns-signaling.md.
+    edns_signaling: dict[str, Any] | None = None
 
 
 def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bool:
@@ -178,7 +182,13 @@ async def fetch_cap_document(
         capabilities = _extract_capabilities_multi_format(data)
         use_cases = _extract_string_list(data, "use_cases")
 
-        known_keys = {"capabilities", "version", "description", "use_cases"}
+        # Experimental: lift the publisher's edns_signaling advertisement if present.
+        # Stored as a dict; forward-compat on unknown versions / shapes.
+        edns_signaling = data.get("edns_signaling")
+        if not isinstance(edns_signaling, dict):
+            edns_signaling = None
+
+        known_keys = {"capabilities", "version", "description", "use_cases", "edns_signaling"}
         metadata = {k: v for k, v in data.items() if k not in known_keys}
 
         doc = CapabilityDocument(
@@ -188,6 +198,7 @@ async def fetch_cap_document(
             use_cases=use_cases,
             metadata=metadata,
             raw_data=data,
+            edns_signaling=edns_signaling,
         )
 
         logger.debug(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -15,7 +15,7 @@ import base64
 import json
 import shlex
 import time
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 import dns.asyncresolver
@@ -23,11 +23,23 @@ import dns.rdatatype
 import dns.resolver
 import structlog
 
+from dns_aid.core._edns_hint_ctx import (
+    apply_agent_hint_to_resolver as _apply_agent_hint_to_resolver,
+)
+from dns_aid.core._edns_hint_ctx import (
+    reset_agent_hint as _reset_agent_hint,
+)
+from dns_aid.core._edns_hint_ctx import (
+    set_agent_hint as _set_agent_hint,
+)
 from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
 from dns_aid.core.filters import apply_filters
 from dns_aid.core.http_index import HttpIndexAgent, fetch_http_index_or_empty
 from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol
+
+if TYPE_CHECKING:
+    from dns_aid.experimental.edns_hint import AgentHint
 
 logger = structlog.get_logger(__name__)
 
@@ -122,6 +134,10 @@ async def discover(
     text_match: str | None = None,
     require_signed: bool = False,
     require_signature_algorithm: list[str] | None = None,
+    # Experimental: EDNS(0) agent-hint signaling. See docs/experimental/edns-signaling.md.
+    # Accepted unconditionally for forward-compat; only injected on the wire when
+    # DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 is set in the environment.
+    agent_hint: AgentHint | None = None,
 ) -> DiscoveryResult:
     """
     Discover AI agents at a domain using DNS-AID protocol.
@@ -179,6 +195,59 @@ async def discover(
         logger.debug("sdk.discover_implicit_verify_signatures", reason="require_signed=True")
 
     start_time = time.perf_counter()
+
+    # Experimental: stash agent_hint on the contextvar so DNS helpers below can
+    # attach it as an EDNS option without threading through every signature.
+    # try/finally guarantees the reset even on exception so the contextvar
+    # doesn't carry stale state across calls within the same async task.
+    _hint_token = _set_agent_hint(agent_hint)
+    try:
+        return await _discover_body(
+            domain,
+            protocol,
+            name,
+            require_dnssec,
+            use_http_index,
+            enrich_endpoints,
+            verify_signatures,
+            capabilities,
+            capabilities_any,
+            auth_type,
+            intent,
+            transport,
+            realm,
+            min_dnssec,
+            text_match,
+            require_signed,
+            require_signature_algorithm,
+            start_time,
+        )
+    finally:
+        _reset_agent_hint(_hint_token)
+
+
+async def _discover_body(
+    domain: str,
+    protocol: str | Protocol | None,
+    name: str | None,
+    require_dnssec: bool,
+    use_http_index: bool,
+    enrich_endpoints: bool,
+    verify_signatures: bool,
+    capabilities: list[str] | None,
+    capabilities_any: list[str] | None,
+    auth_type: str | None,
+    intent: str | None,
+    transport: str | None,
+    realm: str | None,
+    min_dnssec: bool,
+    text_match: str | None,
+    require_signed: bool,
+    require_signature_algorithm: list[str] | None,
+    start_time: float,
+) -> DiscoveryResult:
+    """Body of discover(), extracted so the public surface can wrap it in a
+    contextvar try/finally for the experimental agent_hint plumbing."""
 
     protocol = _normalize_protocol(protocol)
 
@@ -298,6 +367,7 @@ async def _query_single_agent(
 
     try:
         resolver = dns.asyncresolver.Resolver()
+        _apply_agent_hint_to_resolver(resolver)
 
         # Query SVCB record
         # Note: dnspython uses type 64 for SVCB
@@ -526,6 +596,7 @@ async def _query_capabilities(fqdn: str) -> list[str]:
 
     try:
         resolver = dns.asyncresolver.Resolver()
+        _apply_agent_hint_to_resolver(resolver)
         answers = await resolver.resolve(fqdn, "TXT")
 
         for rdata in answers:

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -116,6 +116,9 @@ class HttpIndexAgent:
     model_card: ModelCard | None = None
     capability: Capability | None = None
     cost: str | None = None
+    # Experimental: publisher's EDNS(0) agent-hint advertisement. Stored as the
+    # raw dict from JSON. See docs/experimental/edns-signaling.md.
+    edns_signaling: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, name: str, data: dict[str, Any]) -> HttpIndexAgent:
@@ -138,6 +141,11 @@ class HttpIndexAgent:
         model_card = ModelCard.from_dict(model_card_data)
         capability = Capability.from_dict(capability_data)
 
+        # Experimental: lift edns_signaling advertisement if present
+        edns_signaling = data.get("edns_signaling")
+        if not isinstance(edns_signaling, dict):
+            edns_signaling = None
+
         return cls(
             name=name,
             fqdn=location.get("fqdn", ""),
@@ -148,6 +156,7 @@ class HttpIndexAgent:
             model_card=model_card,
             capability=capability,
             cost=capability.cost,
+            edns_signaling=edns_signaling,
         )
 
     @property

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -171,6 +171,9 @@ async def read_index_via_dns(domain: str) -> list[IndexEntry]:
 
     try:
         resolver = dns.asyncresolver.Resolver()
+        from dns_aid.core._edns_hint_ctx import apply_agent_hint_to_resolver
+
+        apply_agent_hint_to_resolver(resolver)
         answers = await resolver.resolve(fqdn, "TXT")
 
         for rdata in answers:

--- a/src/dns_aid/experimental/__init__.py
+++ b/src/dns_aid/experimental/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experimental DNS-AID features.
+
+⚠ APIs in this subpackage are unstable. They may change shape, change behaviour,
+or disappear entirely in any release — including patch versions. They are NOT
+covered by the semver guarantees that apply to ``dns_aid.core`` and ``dns_aid.sdk``.
+
+By convention, experimental features are:
+
+- Never re-exported from the top-level ``dns_aid`` package. Callers import
+  explicitly: ``from dns_aid.experimental import AgentHint``.
+- Gated at runtime by a per-feature environment variable
+  (e.g. ``DNS_AID_EXPERIMENTAL_EDNS_HINTS=1``). Without the flag, the related
+  code paths remain dormant even if the symbols are imported.
+- Documented in ``docs/experimental/`` rather than ``docs/rfc/``.
+
+Currently exported:
+
+- :class:`AgentHint` — request-side EDNS(0) signal carrying selector filters
+- :class:`AgentHintEcho` — response-side echo from a hint-aware DNS hop
+- :class:`EdnsSignalingAdvertisement` — publisher advertisement model (JSON)
+- :class:`EdnsAwareResolver` — in-process programmable hop with hint-keyed cache
+
+See ``docs/experimental/edns-signaling.md`` for the design rationale and wire
+format.
+"""
+
+from __future__ import annotations
+
+from dns_aid.experimental.edns_cache import CachedAnswer, EdnsAwareResolver
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    EdnsSignalingAdvertisement,
+    HintSelector,
+    decode_agent_hint,
+    decode_agent_hint_echo,
+)
+
+__all__ = [
+    "AGENT_HINT_OPTION_CODE",
+    "AgentHint",
+    "AgentHintEcho",
+    "CachedAnswer",
+    "EdnsAwareResolver",
+    "EdnsSignalingAdvertisement",
+    "HintSelector",
+    "decode_agent_hint",
+    "decode_agent_hint_echo",
+]

--- a/src/dns_aid/experimental/edns_cache.py
+++ b/src/dns_aid/experimental/edns_cache.py
@@ -1,0 +1,175 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experimental ``EdnsAwareResolver`` — in-process programmable hop for ``agent-hint``.
+
+⚠ Experimental. See ``docs/experimental/edns-signaling.md``.
+
+This is the Locus 1 reference implementation: a thin wrapper around
+``dns.asyncresolver.Resolver`` that caches answers keyed by
+``(qname, qtype, hint_signature)``. When a query carries an :class:`AgentHint`
+that matches a previous fresh entry, the cached answer is returned without an
+upstream round trip.
+
+The cache is unconditionally per-process and in-memory. It is intentionally
+simple: no eviction policy beyond TTL expiry, no concurrency guards beyond what
+``asyncio`` provides natively (single event loop), no persistence. The point is
+to demonstrate the warm-cache behaviour described in the design doc, not to be
+a production cache.
+
+If the upstream response carries an :class:`AgentHintEcho`, it is surfaced on
+the :class:`CachedAnswer` so callers can see what filtering (if any) happened
+upstream.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import dns.asyncresolver
+import dns.edns
+import structlog
+
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    decode_agent_hint_echo,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_CACHE_TTL_SECONDS: float = 60.0
+
+
+@dataclass
+class CachedAnswer:
+    """A DNS answer captured by :class:`EdnsAwareResolver`.
+
+    Attributes:
+        answer:    The underlying ``dns.resolver.Answer`` (or anything the
+                   wrapped resolver returns).
+        cached_at: Monotonic timestamp of capture.
+        echo:      :class:`AgentHintEcho` if the upstream response carried one,
+                   else ``None``. Absence is meaningful — it tells the caller no
+                   upstream filtering happened.
+    """
+
+    answer: Any
+    cached_at: float
+    echo: AgentHintEcho | None = None
+
+
+CacheKey = tuple[str, str, str | None]
+
+
+class EdnsAwareResolver:
+    """In-process programmable hop that caches DNS answers by hint signature.
+
+    Usage::
+
+        resolver = EdnsAwareResolver()
+        result = await resolver.resolve(
+            "_chat._mcp._agents.example.com", "SVCB",
+            agent_hint=AgentHint(capabilities=["chat"]),
+        )
+        # result.answer is the dns answer; result.echo is the hop's applied selectors
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        upstream: dns.asyncresolver.Resolver | None = None,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._cache: dict[CacheKey, CachedAnswer] = {}
+        # Construct a default upstream resolver here so tests can swap it in.
+        self._upstream = upstream if upstream is not None else dns.asyncresolver.Resolver()
+        # Bypass OS cache so we observe upstream hits, not stale OS positives.
+        self._upstream.cache = None
+
+    async def resolve(
+        self,
+        qname: str,
+        qtype: str,
+        *,
+        agent_hint: AgentHint | None = None,
+    ) -> CachedAnswer:
+        """Resolve ``qname/qtype``, attaching ``agent_hint`` as an EDNS option.
+
+        Returns a :class:`CachedAnswer` containing the answer plus, if present,
+        the upstream :class:`AgentHintEcho`.
+        """
+        signature = agent_hint.signature() if agent_hint is not None else None
+        key: CacheKey = (qname, qtype, signature)
+
+        cached = self._cache.get(key)
+        if cached is not None and (time.monotonic() - cached.cached_at) < self._ttl:
+            logger.debug(
+                "edns-aware cache hit",
+                qname=qname,
+                qtype=qtype,
+                hint_signature=signature,
+            )
+            return cached
+
+        # Cache miss (or expired) — go upstream.
+        if agent_hint is not None:
+            option = dns.edns.GenericOption(
+                dns.edns.OptionType(AGENT_HINT_OPTION_CODE), agent_hint.encode()
+            )
+            # use_edns is sync on the resolver; options is the list of EDNS options to send.
+            self._upstream.use_edns(0, 0, 4096, options=[option])
+        else:
+            # Reset any previously-configured options so the next bare call doesn't leak hints.
+            self._upstream.use_edns(0, 0, 4096, options=[])
+
+        logger.debug(
+            "edns-aware cache miss; resolving upstream",
+            qname=qname,
+            qtype=qtype,
+            hint_signature=signature,
+        )
+        answer = await self._upstream.resolve(qname, qtype)
+        echo = _extract_echo(answer)
+
+        cached = CachedAnswer(answer=answer, cached_at=time.monotonic(), echo=echo)
+        self._cache[key] = cached
+        return cached
+
+    def invalidate(self) -> None:
+        """Drop all cached entries."""
+        self._cache.clear()
+
+
+def _extract_echo(answer: Any) -> AgentHintEcho | None:
+    """Return the :class:`AgentHintEcho` from a response, or ``None`` if absent.
+
+    Looks at ``answer.response.options`` (dnspython attaches EDNS options there
+    on the response message). Silently returns ``None`` for any structural
+    issue — the echo is non-mandatory.
+    """
+    response = getattr(answer, "response", None)
+    if response is None:
+        return None
+    options = getattr(response, "options", None) or []
+    for opt in options:
+        otype = getattr(opt, "otype", None)
+        if otype != AGENT_HINT_OPTION_CODE:
+            continue
+        # dnspython GenericOption stores payload in .data
+        data = getattr(opt, "data", None)
+        if not isinstance(data, (bytes, bytearray)):
+            return None
+        try:
+            return decode_agent_hint_echo(bytes(data))
+        except ValueError:
+            return None
+    return None

--- a/src/dns_aid/experimental/edns_hint.py
+++ b/src/dns_aid/experimental/edns_hint.py
@@ -1,0 +1,301 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experimental EDNS(0) ``agent-hint`` option — request + response wire format.
+
+⚠ Experimental. See ``docs/experimental/edns-signaling.md`` for the full design.
+
+The ``agent-hint`` option carries a compact set of selector filters from the
+client to whichever hop on the resolution path is hint-aware:
+
+- Locus 1: the client's own resolver wrapper (in-process cache, see
+  :mod:`dns_aid.experimental.edns_cache`)
+- Locus 2: a hint-aware recursive resolver / forwarder
+- Locus 3: a hint-aware authoritative DNS server
+
+Stock authoritative servers treat the option as inert per RFC 6891. A hint-aware
+hop MAY include an :class:`AgentHintEcho` option in its response listing the
+selectors it actually applied — this lets the client know what upstream
+filtering happened.
+
+Wire format (request)::
+
+    +------------------+------------------+
+    |  VERSION (0x00)  |  SELECTOR-COUNT  |
+    +------------------+------------------+
+    |  selector-code (1B) | selector-len (1B) | selector-value (N B UTF-8) |
+    +------------------+------------------+
+                       ...
+
+Wire format (response echo)::
+
+    +------------------+------------------+
+    |  VERSION (0x80)  |  APPLIED-COUNT   |
+    +------------------+------------------+
+    |  selector-code (1B) | selector-code (1B) | ...                       |
+    +------------------+------------------+
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+from pydantic import BaseModel, Field, field_validator
+
+# Private-use EDNS(0) option-code range is 65001–65534 (RFC 6891 §6.1.1).
+# 65430 chosen arbitrarily within the range; subject to change before any IANA
+# coordination.
+AGENT_HINT_OPTION_CODE: int = 65430
+
+VERSION_REQUEST: int = 0x00
+VERSION_ECHO: int = 0x80
+ECHO_FLAG_MASK: int = 0x80
+VERSION_NUMBER_MASK: int = 0x7F
+
+MAX_SELECTOR_VALUE_LEN: int = 255  # 1-byte length prefix
+MAX_OPTION_PAYLOAD: int = 512  # soft cap to stay inside reasonable EDNS budget
+
+
+class HintSelector(IntEnum):
+    """Selector codes for ``agent-hint`` v0.
+
+    Codes 0x05–0xFF are reserved for future versions. Consumers MUST ignore
+    selector codes they do not recognise rather than rejecting the whole option.
+    """
+
+    CAPABILITIES = 0x01  # comma-separated list, e.g. "chat,code-review"
+    INTENT = 0x02  # single tag, e.g. "summarize"
+    TRANSPORT = 0x03  # "mcp" | "a2a" | "https"
+    AUTH_TYPE = 0x04  # "none" | "bearer" | "oauth2" | "mtls"
+
+
+# -----------------------------------------------------------------------------
+# Models
+# -----------------------------------------------------------------------------
+
+
+class AgentHint(BaseModel):
+    """Request-side EDNS(0) ``agent-hint`` payload.
+
+    Encodes a small set of selector filters that the client wants applied (by
+    whichever hop on the resolution path is hint-aware). Unrecognised selectors
+    on decode are silently dropped — forward compatibility.
+    """
+
+    capabilities: list[str] | None = Field(
+        default=None,
+        description="List of capability tags the client is looking for.",
+    )
+    intent: str | None = Field(
+        default=None,
+        description="Single intent tag, e.g. 'summarize'.",
+    )
+    transport: str | None = Field(
+        default=None,
+        description="Transport: 'mcp' | 'a2a' | 'https'.",
+    )
+    auth_type: str | None = Field(
+        default=None,
+        description="Auth type: 'none' | 'bearer' | 'oauth2' | 'mtls'.",
+    )
+
+    @field_validator("capabilities")
+    @classmethod
+    def _strip_empty_caps(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        cleaned = [c.strip() for c in v if c and c.strip()]
+        return cleaned or None
+
+    def encode(self) -> bytes:
+        """Encode this hint into the EDNS(0) option payload bytes.
+
+        Raises:
+            ValueError: if any selector value exceeds 255 bytes UTF-8, or the
+                total payload would exceed ``MAX_OPTION_PAYLOAD``.
+        """
+        selectors: list[tuple[int, bytes]] = []
+
+        if self.capabilities:
+            value = ",".join(self.capabilities).encode("utf-8")
+            selectors.append((HintSelector.CAPABILITIES.value, value))
+        if self.intent:
+            selectors.append((HintSelector.INTENT.value, self.intent.encode("utf-8")))
+        if self.transport:
+            selectors.append((HintSelector.TRANSPORT.value, self.transport.encode("utf-8")))
+        if self.auth_type:
+            selectors.append((HintSelector.AUTH_TYPE.value, self.auth_type.encode("utf-8")))
+
+        if len(selectors) > 255:
+            raise ValueError("agent-hint cannot carry more than 255 selectors")
+
+        parts: list[bytes] = [bytes([VERSION_REQUEST, len(selectors)])]
+        for code, value in selectors:
+            if len(value) > MAX_SELECTOR_VALUE_LEN:
+                raise ValueError(
+                    f"selector value for code 0x{code:02x} is {len(value)} bytes; "
+                    f"max is {MAX_SELECTOR_VALUE_LEN}"
+                )
+            parts.append(bytes([code, len(value)]))
+            parts.append(value)
+
+        payload = b"".join(parts)
+        if len(payload) > MAX_OPTION_PAYLOAD:
+            raise ValueError(
+                f"agent-hint payload is {len(payload)} bytes; max is {MAX_OPTION_PAYLOAD}"
+            )
+        return payload
+
+    def signature(self) -> str:
+        """Stable cache-key string for this hint.
+
+        Order-independent: two hints with the same selectors produce the same
+        signature regardless of construction order. ``capabilities`` values are
+        sorted to normalise.
+        """
+        parts: list[str] = []
+        if self.capabilities:
+            parts.append("cap:" + ",".join(sorted(self.capabilities)))
+        if self.intent:
+            parts.append(f"int:{self.intent}")
+        if self.transport:
+            parts.append(f"trn:{self.transport}")
+        if self.auth_type:
+            parts.append(f"aut:{self.auth_type}")
+        return "|".join(parts)
+
+
+class AgentHintEcho(BaseModel):
+    """Response-side echo from a hint-aware DNS hop.
+
+    Lists the selector codes the responder actually applied. Absence of an echo
+    on a response means no upstream filtering happened — the client should fall
+    back to local filtering against the returned record set.
+    """
+
+    applied_selectors: list[int] = Field(
+        default_factory=list,
+        description="Selector codes (HintSelector enum values) that the responder honoured.",
+    )
+
+    def encode(self) -> bytes:
+        """Encode this echo into the EDNS(0) option payload bytes."""
+        if len(self.applied_selectors) > 255:
+            raise ValueError("agent-hint echo cannot carry more than 255 selector codes")
+        for code in self.applied_selectors:
+            if not 0 <= code <= 255:
+                raise ValueError(f"selector code {code} out of range 0–255")
+        return bytes([VERSION_ECHO, len(self.applied_selectors)]) + bytes(self.applied_selectors)
+
+
+class EdnsSignalingAdvertisement(BaseModel):
+    """Publisher advertisement carried in well-known JSON blobs (cap-doc, agent-card).
+
+    Tells the client which selectors are *meaningful* for this publisher's
+    agents — i.e. the publisher has populated the matching metadata fields so
+    filtering on them will actually narrow results.
+
+    Channel-1 advertisement (out-of-band, JSON). Independent of whether any hop
+    on the DNS resolution path is hint-aware (which is the Channel-2 signal —
+    the OPT response echo).
+    """
+
+    version: int = Field(description="Hint protocol version this publisher supports.")
+    honored_selectors: list[str] = Field(
+        default_factory=list,
+        description="Selector names this publisher recommends populating, e.g. "
+        "['capabilities', 'intent', 'transport'].",
+    )
+    note: str | None = Field(
+        default=None,
+        description="Free-form human-readable note from the publisher.",
+    )
+
+
+# -----------------------------------------------------------------------------
+# Decoders
+# -----------------------------------------------------------------------------
+
+
+def decode_agent_hint(payload: bytes) -> AgentHint:
+    """Decode an EDNS(0) ``agent-hint`` request payload into :class:`AgentHint`.
+
+    Unrecognised selector codes are silently skipped (forward compat). Raises
+    :class:`ValueError` for structural malformations (truncated payload, echo
+    bit set, length overflow).
+    """
+    if len(payload) < 2:
+        raise ValueError("agent-hint payload too short (need at least version + count)")
+
+    version_byte = payload[0]
+    if version_byte & ECHO_FLAG_MASK:
+        raise ValueError("agent-hint payload has echo bit set (0x80); use decode_agent_hint_echo()")
+    version_number = version_byte & VERSION_NUMBER_MASK
+    if version_number != 0:
+        raise ValueError(f"unsupported agent-hint version {version_number}; only v0 is defined")
+
+    selector_count = payload[1]
+    cursor = 2
+
+    capabilities: list[str] | None = None
+    intent: str | None = None
+    transport: str | None = None
+    auth_type: str | None = None
+
+    for _ in range(selector_count):
+        if cursor + 2 > len(payload):
+            raise ValueError("agent-hint payload truncated mid-selector header")
+        code = payload[cursor]
+        length = payload[cursor + 1]
+        value_start = cursor + 2
+        value_end = value_start + length
+        if value_end > len(payload):
+            raise ValueError("agent-hint payload truncated mid-selector value")
+        try:
+            value = payload[value_start:value_end].decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError(f"selector code 0x{code:02x} value is not valid UTF-8") from e
+        cursor = value_end
+
+        if code == HintSelector.CAPABILITIES.value:
+            capabilities = [c.strip() for c in value.split(",") if c.strip()] or None
+        elif code == HintSelector.INTENT.value:
+            intent = value
+        elif code == HintSelector.TRANSPORT.value:
+            transport = value
+        elif code == HintSelector.AUTH_TYPE.value:
+            auth_type = value
+        # else: silently drop unknown selectors (forward compat)
+
+    return AgentHint(
+        capabilities=capabilities,
+        intent=intent,
+        transport=transport,
+        auth_type=auth_type,
+    )
+
+
+def decode_agent_hint_echo(payload: bytes) -> AgentHintEcho:
+    """Decode an EDNS(0) ``agent-hint`` response echo payload.
+
+    Raises :class:`ValueError` if the echo bit is not set, or if the payload is
+    truncated.
+    """
+    if len(payload) < 2:
+        raise ValueError("agent-hint echo payload too short (need at least version + count)")
+
+    version_byte = payload[0]
+    if not (version_byte & ECHO_FLAG_MASK):
+        raise ValueError("agent-hint echo payload missing echo bit (0x80)")
+    version_number = version_byte & VERSION_NUMBER_MASK
+    if version_number != 0:
+        raise ValueError(
+            f"unsupported agent-hint echo version {version_number}; only v0 is defined"
+        )
+
+    applied_count = payload[1]
+    if 2 + applied_count > len(payload):
+        raise ValueError("agent-hint echo payload truncated")
+    applied_selectors = list(payload[2 : 2 + applied_count])
+    return AgentHintEcho(applied_selectors=applied_selectors)

--- a/tests/testbed/smoke_edns.sh
+++ b/tests/testbed/smoke_edns.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Manual wire-level verification for the experimental EDNS(0) agent-hint feature.
+#
+# What this does:
+#   1. Brings the testbed up (orga.test BIND9 authoritative + agent-a container)
+#   2. Starts a tcpdump on the agent-a container, listening for DNS traffic to bind-orga
+#   3. Runs `dns-aid edns-probe orga.test` with the experimental flag on
+#   4. Captures the wire and greps for the agent-hint option code (0xff96 = 65430)
+#
+# What you should see:
+#   - tcpdump shows the EDNS(0) OPT pseudo-RR carrying option-code 0xff96 in the
+#     outgoing query packet
+#   - The probe command prints cache miss + hit timings
+#   - No echo is expected: BIND9 stock treats unknown options as inert per RFC 6891
+#
+# Run from: tests/testbed/
+# Not in CI. tcpdump needs CAP_NET_RAW inside the container — works in compose
+# because docker-compose runs containers as root by default.
+set -euo pipefail
+
+echo "=== EDNS(0) agent-hint smoke test ==="
+echo
+
+echo "--- [1] Ensure testbed is up ---"
+docker compose ps --status running | grep -q bind-orga || docker compose up -d bind-orga agent-a
+
+echo
+echo "--- [2] Start tcpdump on agent-a (background) ---"
+# 0xff96 in hex == 65430 decimal == AGENT_HINT_OPTION_CODE
+# Capturing for 5 seconds is plenty to see two probe calls.
+docker exec -d agent-a bash -c \
+  'apt-get install -y -q tcpdump 2>/dev/null || true; tcpdump -i any -nn -X -c 20 host 172.28.0.10 and port 53 > /tmp/edns_capture.txt 2>&1 &'
+sleep 1
+
+echo
+echo "--- [3] Run edns-probe with experimental flag on ---"
+docker exec -e DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 agent-a \
+  dns-aid edns-probe orga.test \
+  --capabilities=chat,code \
+  --intent=summarize \
+  --transport=mcp \
+  --auth-type=bearer \
+  --show-wire
+
+echo
+echo "--- [4] Capture results ---"
+sleep 2
+docker exec agent-a cat /tmp/edns_capture.txt 2>/dev/null | head -80 || \
+  echo "  (tcpdump may not have been installed; install it inside the agent-a container manually)"
+
+echo
+echo "--- [5] Look for the agent-hint option code (0xff96) in the capture ---"
+docker exec agent-a grep -i "ff96\|ff 96" /tmp/edns_capture.txt 2>/dev/null && \
+  echo "  ✓ agent-hint option code 0xff96 (=65430) appeared on the wire" || \
+  echo "  ✗ option code not found in capture — feature flag set? tcpdump captured the right packets?"
+
+echo
+echo "=== smoke_edns.sh complete ==="
+echo
+echo "Reminder: BIND9 stock will not emit an AgentHintEcho — its absence is correct"
+echo "and meaningful. A hint-aware authoritative would echo applied selectors back."

--- a/tests/unit/test_edns_cache.py
+++ b/tests/unit/test_edns_cache.py
@@ -1,0 +1,207 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.experimental.edns_cache — EdnsAwareResolver."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from dns_aid.experimental.edns_cache import EdnsAwareResolver
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    HintSelector,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_upstream(answer=None, echo: AgentHintEcho | None = None) -> MagicMock:
+    """Build a mock upstream resolver suitable for EdnsAwareResolver.
+
+    Uses MagicMock for the resolver instance so sync attrs (cache, use_edns,
+    nameservers) don't produce coroutine warnings; only resolve is AsyncMock.
+    """
+    mock = MagicMock()
+
+    response = MagicMock()
+    if echo is not None:
+        echo_opt = MagicMock()
+        echo_opt.otype = AGENT_HINT_OPTION_CODE
+        echo_opt.data = echo.encode()
+        response.options = [echo_opt]
+    else:
+        response.options = []
+
+    mock_answer = MagicMock()
+    mock_answer.response = response
+
+    mock.resolve = AsyncMock(return_value=answer if answer is not None else mock_answer)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Cache hit / miss
+# ---------------------------------------------------------------------------
+
+
+async def test_first_call_misses_then_caches():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"])
+    result = await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
+
+    assert result.answer is upstream.resolve.return_value
+    upstream.resolve.assert_awaited_once()
+
+
+async def test_second_call_hits_cache_when_signature_matches():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"], intent="summarize")
+    await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
+    await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
+
+    # Two calls, one upstream resolve — second was a cache hit.
+    upstream.resolve.assert_awaited_once()
+
+
+async def test_different_hint_signature_misses_cache():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    h1 = AgentHint(capabilities=["chat"])
+    h2 = AgentHint(capabilities=["code"])
+    await resolver.resolve("_x._mcp._agents.example.com", "SVCB", agent_hint=h1)
+    await resolver.resolve("_x._mcp._agents.example.com", "SVCB", agent_hint=h2)
+
+    # Different hint signatures → both miss.
+    assert upstream.resolve.await_count == 2
+
+
+async def test_no_hint_caches_separately_from_hinted():
+    """A bare call (no hint) and a hinted call cache under different keys."""
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    await resolver.resolve("example.com", "SVCB", agent_hint=None)
+    await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"]))
+    await resolver.resolve("example.com", "SVCB", agent_hint=None)
+
+    # Bare-first, hinted, bare-third → first and third should share a key (one upstream call
+    # between them). hinted is a separate key. Total: 2 upstream calls.
+    assert upstream.resolve.await_count == 2
+
+
+async def test_ttl_expiry_triggers_re_resolution():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream, ttl_seconds=0.05)
+
+    hint = AgentHint(capabilities=["chat"])
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+    time.sleep(0.1)  # wait past TTL (sync sleep is fine — test doesn't depend on the loop)
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+
+    assert upstream.resolve.await_count == 2
+
+
+async def test_invalidate_drops_cache():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"])
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+    resolver.invalidate()
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+
+    assert upstream.resolve.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Upstream wire integration
+# ---------------------------------------------------------------------------
+
+
+async def test_hint_passed_to_upstream_via_use_edns():
+    """When a hint is supplied, the EDNS option must be attached on the upstream resolver."""
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"])
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+
+    upstream.use_edns.assert_called()
+    call = upstream.use_edns.call_args
+    options = call.kwargs.get("options") or (call.args[3] if len(call.args) >= 4 else None)
+    assert options is not None and len(options) == 1
+    opt = options[0]
+    assert opt.otype == AGENT_HINT_OPTION_CODE
+    assert opt.data == hint.encode()
+
+
+async def test_no_hint_clears_previous_options():
+    """A bare resolve must reset use_edns options so a prior hint doesn't leak."""
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    await resolver.resolve("a.example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"]))
+    await resolver.resolve("b.example.com", "SVCB", agent_hint=None)
+
+    # Last use_edns call (for the bare resolve) must have empty options.
+    last_call = upstream.use_edns.call_args
+    options = last_call.kwargs.get("options")
+    assert options == []
+
+
+# ---------------------------------------------------------------------------
+# AgentHintEcho surfacing
+# ---------------------------------------------------------------------------
+
+
+async def test_upstream_echo_surfaced_on_cached_answer():
+    echo = AgentHintEcho(applied_selectors=[HintSelector.CAPABILITIES.value])
+    upstream = _make_upstream(echo=echo)
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    result = await resolver.resolve(
+        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
+    )
+
+    assert result.echo is not None
+    assert result.echo.applied_selectors == [HintSelector.CAPABILITIES.value]
+
+
+async def test_absent_echo_means_no_upstream_filtering():
+    upstream = _make_upstream(echo=None)
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    result = await resolver.resolve(
+        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
+    )
+    assert result.echo is None
+
+
+async def test_malformed_echo_in_response_returns_none():
+    """A malformed echo option in the upstream response is silently treated as absent."""
+    upstream = MagicMock()
+    response = MagicMock()
+    bad_opt = MagicMock()
+    bad_opt.otype = AGENT_HINT_OPTION_CODE
+    bad_opt.data = b"\x80"  # truncated — too short to be a valid echo
+    response.options = [bad_opt]
+    mock_answer = MagicMock()
+    mock_answer.response = response
+    upstream.resolve = AsyncMock(return_value=mock_answer)
+
+    resolver = EdnsAwareResolver(upstream=upstream)
+    result = await resolver.resolve(
+        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
+    )
+    assert result.echo is None

--- a/tests/unit/test_edns_hint.py
+++ b/tests/unit/test_edns_hint.py
@@ -1,0 +1,240 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.experimental.edns_hint — wire format encode/decode."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    EdnsSignalingAdvertisement,
+    HintSelector,
+    decode_agent_hint,
+    decode_agent_hint_echo,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_option_code_in_private_use_range():
+    """Sanity check: chosen option code is in RFC 6891 private-use range."""
+    assert 65001 <= AGENT_HINT_OPTION_CODE <= 65534
+
+
+# ---------------------------------------------------------------------------
+# AgentHint encode / decode — request
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_round_trip_all_selectors():
+    hint = AgentHint(
+        capabilities=["chat", "code-review"],
+        intent="summarize",
+        transport="mcp",
+        auth_type="bearer",
+    )
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.capabilities == ["chat", "code-review"]
+    assert decoded.intent == "summarize"
+    assert decoded.transport == "mcp"
+    assert decoded.auth_type == "bearer"
+
+
+def test_agent_hint_round_trip_partial_selectors():
+    hint = AgentHint(capabilities=["chat"])
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.capabilities == ["chat"]
+    assert decoded.intent is None
+    assert decoded.transport is None
+    assert decoded.auth_type is None
+
+
+def test_agent_hint_empty_hint_encodes_to_header_only():
+    """An AgentHint with no selectors encodes to just (version, count=0)."""
+    payload = AgentHint().encode()
+    assert payload == bytes([0x00, 0x00])
+    decoded = decode_agent_hint(payload)
+    assert decoded.capabilities is None and decoded.intent is None
+
+
+def test_agent_hint_capabilities_strip_empties():
+    """Empty/whitespace-only capability strings are stripped."""
+    hint = AgentHint(capabilities=["chat", "", "  ", "code"])
+    assert hint.capabilities == ["chat", "code"]
+
+
+def test_agent_hint_capabilities_all_empty_becomes_none():
+    """If every capability is empty after stripping, the field is None."""
+    hint = AgentHint(capabilities=["", "   "])
+    assert hint.capabilities is None
+
+
+def test_agent_hint_utf8_value_round_trip():
+    """Selector values are UTF-8 — non-ASCII survives the round trip."""
+    hint = AgentHint(intent="résumé-📝")
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.intent == "résumé-📝"
+
+
+# ---------------------------------------------------------------------------
+# AgentHint encode / decode — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_selector_value_too_long_rejected():
+    """Selector value over 255 bytes UTF-8 must be rejected at encode."""
+    hint = AgentHint(intent="x" * 256)
+    with pytest.raises(ValueError, match="max is 255"):
+        hint.encode()
+
+
+def test_agent_hint_decode_rejects_truncated_header():
+    with pytest.raises(ValueError, match="too short"):
+        decode_agent_hint(b"\x00")
+
+
+def test_agent_hint_decode_rejects_echo_bit_set():
+    """A payload with echo bit must be routed to decode_agent_hint_echo, not decode_agent_hint."""
+    echo_payload = bytes([0x80, 0x00])
+    with pytest.raises(ValueError, match="echo bit set"):
+        decode_agent_hint(echo_payload)
+
+
+def test_agent_hint_decode_rejects_unknown_version():
+    """Version bits 0–6 are the version number; non-zero rejected in v0."""
+    payload = bytes([0x01, 0x00])  # version 1, no selectors
+    with pytest.raises(ValueError, match="unsupported"):
+        decode_agent_hint(payload)
+
+
+def test_agent_hint_decode_rejects_truncated_selector_header():
+    """Payload claims a selector but lacks its 2-byte header."""
+    payload = bytes([0x00, 0x01, 0x01])  # version=0, count=1, then only 1B before EOF
+    with pytest.raises(ValueError, match="truncated mid-selector header"):
+        decode_agent_hint(payload)
+
+
+def test_agent_hint_decode_rejects_truncated_selector_value():
+    """Selector header says length=10 but only 3 bytes follow."""
+    payload = bytes([0x00, 0x01, 0x01, 0x0A, 0x61, 0x62, 0x63])
+    with pytest.raises(ValueError, match="truncated mid-selector value"):
+        decode_agent_hint(payload)
+
+
+def test_agent_hint_decode_silently_drops_unknown_selectors():
+    """Forward-compat: future selector codes must be skipped, not rejected."""
+    # version=0, count=2, selector(0xFE, "x"), selector(0x02, "intent-tag")
+    payload = bytes(
+        [0x00, 0x02]
+        + [0xFE, 0x01, ord("x")]
+        + [HintSelector.INTENT.value, 10]
+        + list(b"intent-tag")
+    )
+    decoded = decode_agent_hint(payload)
+    assert decoded.intent == "intent-tag"
+    # The unknown selector is silently dropped — no error.
+
+
+def test_agent_hint_decode_rejects_invalid_utf8():
+    payload = bytes(
+        [0x00, 0x01, HintSelector.INTENT.value, 0x02, 0xFF, 0xFE]
+    )  # 0xFF 0xFE is not valid UTF-8
+    with pytest.raises(ValueError, match="UTF-8"):
+        decode_agent_hint(payload)
+
+
+# ---------------------------------------------------------------------------
+# AgentHint signature() — cache-key stability
+# ---------------------------------------------------------------------------
+
+
+def test_signature_is_deterministic():
+    h1 = AgentHint(capabilities=["chat"], intent="summarize")
+    h2 = AgentHint(capabilities=["chat"], intent="summarize")
+    assert h1.signature() == h2.signature()
+
+
+def test_signature_is_order_independent_for_capabilities():
+    """Capabilities are sorted in the signature — ordering doesn't change the key."""
+    h1 = AgentHint(capabilities=["chat", "code", "search"])
+    h2 = AgentHint(capabilities=["search", "chat", "code"])
+    assert h1.signature() == h2.signature()
+
+
+def test_signature_differs_when_selectors_differ():
+    h1 = AgentHint(capabilities=["chat"])
+    h2 = AgentHint(capabilities=["search"])
+    assert h1.signature() != h2.signature()
+
+
+def test_signature_empty_hint_is_stable():
+    assert AgentHint().signature() == ""
+
+
+# ---------------------------------------------------------------------------
+# AgentHintEcho — response side
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_echo_round_trip():
+    echo = AgentHintEcho(
+        applied_selectors=[HintSelector.CAPABILITIES.value, HintSelector.INTENT.value]
+    )
+    decoded = decode_agent_hint_echo(echo.encode())
+    assert decoded.applied_selectors == [
+        HintSelector.CAPABILITIES.value,
+        HintSelector.INTENT.value,
+    ]
+
+
+def test_agent_hint_echo_empty_round_trip():
+    """An echo with no applied selectors is valid — means 'I saw the hint but applied nothing'."""
+    decoded = decode_agent_hint_echo(AgentHintEcho().encode())
+    assert decoded.applied_selectors == []
+
+
+def test_agent_hint_echo_decode_rejects_request_payload():
+    """A payload with the echo bit clear must NOT be decoded as an echo."""
+    request_payload = AgentHint(capabilities=["chat"]).encode()
+    with pytest.raises(ValueError, match="missing echo bit"):
+        decode_agent_hint_echo(request_payload)
+
+
+def test_agent_hint_echo_decode_rejects_truncated():
+    with pytest.raises(ValueError, match="truncated"):
+        decode_agent_hint_echo(bytes([0x80, 0x05, 0x01]))  # claims 5 selectors, has 1
+
+
+def test_agent_hint_echo_rejects_out_of_range_selector_code():
+    """Encoded selector codes must fit in one byte."""
+    with pytest.raises(ValueError, match="out of range"):
+        AgentHintEcho(applied_selectors=[300]).encode()
+
+
+# ---------------------------------------------------------------------------
+# EdnsSignalingAdvertisement — JSON publisher channel
+# ---------------------------------------------------------------------------
+
+
+def test_advertisement_round_trip_via_json():
+    """Pydantic model round trips through JSON without losing fields."""
+    adv = EdnsSignalingAdvertisement(
+        version=0,
+        honored_selectors=["capabilities", "intent"],
+        note="prefer pre-filtering",
+    )
+    restored = EdnsSignalingAdvertisement.model_validate_json(adv.model_dump_json())
+    assert restored.version == 0
+    assert restored.honored_selectors == ["capabilities", "intent"]
+    assert restored.note == "prefer pre-filtering"
+
+
+def test_advertisement_optional_note():
+    adv = EdnsSignalingAdvertisement(version=0, honored_selectors=["capabilities"])
+    assert adv.note is None


### PR DESCRIPTION
## Summary

Introduces an **experimental** EDNS(0) option (`agent-hint`, code 65430 in the RFC 6891 private-use range) that lets a DNS-AID client signal selector filters with each outgoing DNS query. Any hop on the resolution path that understands the option can use the hint to narrow the response or short-circuit with a cached pre-filtered match. Stock authoritative servers treat the option as inert per RFC 6891 §6.1.1 — graceful degradation.

This is a **forward-looking design + client-side reference implementation**, not a shipping feature. The primary deliverable is the design doc ([docs/experimental/edns-signaling.md](https://github.com/infobloxopen/dns-aid-core/blob/experimental/edns-signaling/docs/experimental/edns-signaling.md)) with section headers that map cleanly to future IETF-draft structure so the content lifts when an LF spec home arrives.

## Why now

Agent discovery cost should decay over time, analogous to DNS recursion:

- **Cold** — Path B search / registry. Expensive.
- **Warm** — a hint-aware hop on the path has a fresh matching record. Cheap.
- **Hot** — client has the SVCB record stored as a long-lived "skill." Free.

The hint is the substrate-level signal that makes warm-state caching meaningful. Today the client filters all *N* discovered records locally; with `agent-hint`, that work can happen at any hint-aware hop along the resolution path.

## Three loci of processing (design)

1. **Locus 1** — in-process client cache. `EdnsAwareResolver` ships in this PR.
2. **Locus 2** — hint-aware forwarder / recursive resolver. Future work.
3. **Locus 3** — hint-aware authoritative DNS server. Future work; the wire format and advertisement schema are designed to support this hop without modification.

## New \`experimental/\` namespace convention

This PR also establishes a stability-marked staging area for forward-looking features:

- Code: \`src/dns_aid/experimental/\`, parallel to \`core/\`, \`sdk/\`, \`backends/\`
- Never re-exported from \`dns_aid/__init__.py\` — explicit imports only
- Per-feature env-flag gate (\`DNS_AID_EXPERIMENTAL_EDNS_HINTS=1\`)
- CLI commands print \`[experimental]\` banner; exit non-zero without flag
- Design docs in \`docs/experimental/\`, written for clean IETF-draft migration

Documented in \`docs/architecture.md\` and (locally) in \`CLAUDE.md\`.

## What's in this PR

- \`src/dns_aid/experimental/\` — new subpackage: \`AgentHint\`, \`AgentHintEcho\`, \`EdnsSignalingAdvertisement\`, \`EdnsAwareResolver\`
- \`src/dns_aid/core/_edns_hint_ctx.py\` — private contextvar helper shared by discoverer + indexer
- \`src/dns_aid/core/discoverer.py\` — \`agent_hint=\` kwarg on \`discover()\`; body extracted so the contextvar try/finally wraps cleanly
- \`src/dns_aid/core/indexer.py\` — applies the hint on the \`_index._agents.{domain}\` TXT query path
- \`src/dns_aid/core/{cap_fetcher,a2a_card,http_index}.py\` — lift the optional \`edns_signaling\` advertisement from JSON (forward-compat on unknown shapes)
- \`src/dns_aid/cli/main.py\` — new \`dns-aid edns-probe <domain>\` command with \`--show-wire\`
- \`tests/unit/test_edns_hint.py\` + \`test_edns_cache.py\` — **37 new unit tests** covering round-trip, malformed input, signature stability, cache hit/miss/TTL, hint-mismatch, echo surfacing
- \`tests/testbed/smoke_edns.sh\` — manual tcpdump-based wire verification against the BIND9 testbed
- \`docs/experimental/edns-signaling.md\` + \`edns-signaling.abnf\` + \`README.md\` — full design doc + ABNF + index
- \`docs/api-reference.md\` — new "Experimental: EDNS(0) signaling" section
- \`docs/architecture.md\` — new "Experimental namespace" section
- \`README.md\` — Experimental Features pointer in the Documentation list

## CI gates verified locally

- \`ruff format --check src/dns_aid\` — clean
- \`ruff check src/dns_aid\` — clean
- \`mypy src/dns_aid\` — Success: no issues found in 84 source files
- \`pytest tests/unit/\` — 1536 passed (37 new); same 35 pre-existing CEL/ML-DSA failures unchanged

## Test plan

- [x] \`pytest tests/unit/test_edns_hint.py tests/unit/test_edns_cache.py -v\` — all 37 new tests pass
- [x] Full unit suite shows no regressions beyond the pre-existing CEL/ML-DSA failures
- [x] \`mypy src/dns_aid\` clean
- [x] \`ruff format --check\` + \`ruff check\` clean
- [x] CLI feature flag respected: without \`DNS_AID_EXPERIMENTAL_EDNS_HINTS=1\`, \`dns-aid edns-probe\` prints the env-var instruction and exits non-zero
- [x] Lazy import: \`from dns_aid import discover\` does not trigger \`dns_aid.experimental\` import (verified via \`python -c\`)
- [ ] Wire verification via \`tests/testbed/smoke_edns.sh\` (manual, requires Docker)

## Out of scope (forward work)

- Reference hint-aware authoritative server
- IANA option-code reservation (currently private-use)
- Recursive/forwarder reference implementation at Locus 2
- Echo authentication (DNSSEC doesn't cover OPT records — open question in design doc §9)