### PR TITLE
feat(experimental): EDNS(0) agent-hint signaling [experimental]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@ DNS-AID enables AI agents to discover each other via DNS, using the internet's e
 - [Experimental Features](docs/experimental/README.md) — unstable APIs and forward-looking proposals (e.g., EDNS(0) `agent-hint` signaling)
 - [Privacy Policy](PRIVACY.md) | [Security Policy](SECURITY.md) | [Trademarks](TRADEMARKS.md)
 
-## Companion services
+## Ecosystem and Integrations
 
-The DNS-AID protocol is implementation-agnostic — it works against any DNS provider and any directory implementation. The library in this repository is sufficient on its own; the items below are independent, community-operated services that demonstrate what can be built on top of DNS-AID.
+DNS-AID is a **substrate**. The library in this repository is sufficient on its own — it publishes and resolves agent records against any DNS provider, with no dependency on a particular directory, indexer, or telemetry backend.
 
-🌐 **Hosted Agent Directory** (operated by Infoblox): [directory.example.com](https://directory.example.com) — indexes DNS-AID agents discovered across public DNS, with full-text search, capability filtering, trust scoring, lifecycle/sunset tracking, and copy-paste configs for Claude Desktop / Cursor / the SDK. API docs at [api.example.com/api/v1/docs](https://api.example.com/api/v1/docs).
-
-You are encouraged to run your own directory or telemetry backend — the indexer is a thin layer over the same DNS records this library publishes and discovers, and the SDK telemetry sink is configurable via `DNS_AID_SDK_HTTP_PUSH_URL` (off by default).
+When a search, indexing, or telemetry layer is useful, the SDK can point at any HTTP endpoint that implements the documented interfaces. Operators are encouraged to run their own — the indexer is a thin layer over the same DNS records this library publishes and discovers, and the SDK telemetry sink is configurable via `DNS_AID_SDK_HTTP_PUSH_URL` (off by default). Independent directory implementations exist across the ecosystem; DNS-AID is designed to remain interoperable with any of them rather than canonicalize a single one.
 
 ## Quick Start
 
@@ -68,7 +66,7 @@ agents = await dns_aid.discover("example.com")
 for agent in agents:
     print(f"{agent.name}: {agent.endpoint_url}")
 
-# Discover via HTTP index (ANS-compatible, richer metadata)
+# Discover via HTTP index (richer metadata; format aligns with the ANS schema)
 agents = await dns_aid.discover("example.com", use_http_index=True)
 
 # Filtered discovery — pure-Python predicates over the in-memory result (v0.19.0+)
@@ -86,35 +84,28 @@ result = await dns_aid.verify("_my-agent._mcp._agents.example.com")
 print(f"Security Score: {result.security_score}/100")
 ```
 
-### Path B: cross-domain search via opt-in directory (v0.19.0+)
+### Path B: cross-domain search via an external directory (v0.19.0+)
 
-When you don't yet know which domain hosts the agent you want, query a configured
-directory backend for ranked candidates with pre-computed trust signals:
+When the caller does not yet know which domain hosts the agent it wants, the SDK can query any directory backend that implements the search endpoint. The directory layer is **opt-in convenience**; the DNS substrate remains the authoritative trust gate.
 
 ```python
 from dns_aid.sdk import AgentClient, SDKConfig
 
-# directory_api_url can also be set via DNS_AID_SDK_DIRECTORY_API_URL env var.
-config = SDKConfig(directory_api_url="https://api.example.com")
+# Point at whichever directory the caller has chosen to trust.
+# Can also be set via DNS_AID_SDK_DIRECTORY_API_URL.
+config = SDKConfig(directory_api_url="https://your-directory.example.com")
 
 async with AgentClient(config=config) as client:
-    response = await client.search(
-        q="payment processing",
-        protocol="mcp",
-        capabilities=["payment-processing"],
-        min_security_score=70,
-        verified_only=True,
-    )
+    response = await client.search(q="payment processing", protocol="mcp")
     for r in response.results:
-        print(f"{r.score:.2f}  {r.agent.fqdn}  T{r.trust.trust_tier}")
+        print(r.agent.fqdn)
 ```
 
-**Zero-trust composition**: Path B → Path A re-verify before invoking. Directory is
-opt-in convenience; DNS substrate is the authoritative trust gate.
+After the directory returns candidates, re-resolve each one through Path A and validate signatures / DNSSEC before invoking. This is the substrate-as-authority pattern: the directory provides ranking and discovery convenience, but never sits in the trust path between the caller and the agent.
 
 ```python
 async with AgentClient(config=config) as client:
-    response = await client.search(q="fraud detection", min_security_score=70)
+    response = await client.search(q="fraud detection")
     for candidate in response.results:
         verified = await dns_aid.discover(
             candidate.agent.domain,
@@ -123,6 +114,8 @@ async with AgentClient(config=config) as client:
         )
         # Invoke only when DNS substrate confirms the directory's claim.
 ```
+
+The SDK exposes additional filter parameters (`capabilities`, `min_security_score`, `verified_only`, etc.) for directories that compute and return those signals; see [API Reference](docs/api-reference.md) for the full surface. The semantics of those values are defined by whichever directory the caller has chosen — DNS-AID does not centralize them.
 
 ### SDK: Invoke Agents & Capture Telemetry (v0.6.0+)
 
@@ -138,37 +131,31 @@ print(f"Latency: {resp.signal.invocation_latency_ms}ms")
 print(f"Status:  {resp.signal.status}")
 print(f"Tools:   {resp.data}")
 
-# Rank multiple agents by performance
+# Rank multiple agents by your own local telemetry signals
 ranked = await dns_aid.rank(result.agents, method="tools/list")
 for r in ranked:
     print(f"{r.agent_fqdn}: score={r.composite_score:.1f}")
-
-# Fetch community-wide rankings from telemetry API (v0.6.0+)
-from dns_aid.sdk import AgentClient, SDKConfig
-
-config = SDKConfig(telemetry_api_url="https://api.example.com")
-async with AgentClient(config) as client:
-    rankings = await client.fetch_rankings(limit=10)
-    for r in rankings:
-        print(f"{r['agent_fqdn']}: {r['composite_score']}")
 ```
 
-For advanced usage (connection reuse, OTEL export):
+For advanced usage (connection reuse, OpenTelemetry export, pluggable telemetry sink):
 
 ```python
 from dns_aid.sdk import AgentClient, SDKConfig
 
 config = SDKConfig(
-    otel_enabled=True,         # Export to OpenTelemetry
+    otel_enabled=True,         # Export to any OpenTelemetry collector
     caller_id="my-app",
-    http_push_url="https://api.example.com/v1/telemetry/signals",
+    # Optional: push telemetry to any HTTP endpoint the caller controls
+    # http_push_url="https://your-telemetry.example.com/v1/signals",
 )
 
 async with AgentClient(config=config) as client:
     resp = await client.invoke(agent, method="tools/call", arguments={...})
     fqdns = [a.fqdn for a in agents]
-    ranked = client.rank(fqdns)  # Rank by local telemetry signals
+    ranked = client.rank(fqdns)  # Rank by the caller's own observed telemetry
 ```
+
+If an external aggregator publishes community-wide rankings over HTTP, the SDK can fetch them via `client.fetch_rankings(...)`; the endpoint is configured by the caller, not by the library.
 
 ## CLI Usage
 
@@ -217,11 +204,11 @@ dns-aid discover example.com \
     --auth-type oauth2 --realm prod \
     --require-signed --require-signature-algorithm ES256
 
-# Cross-domain search via configured directory backend (v0.19.0+)
-export DNS_AID_SDK_DIRECTORY_API_URL=https://api.example.com
-dns-aid search "payment processing" --protocol mcp --min-security-score 70
+# Cross-domain search via a directory the caller has chosen (v0.19.0+)
+export DNS_AID_SDK_DIRECTORY_API_URL=https://your-directory.example.com
+dns-aid search "payment processing" --protocol mcp
 
-# Discover via HTTP index (ANS-compatible, richer metadata)
+# Discover via HTTP index (richer metadata; format aligns with the ANS schema)
 dns-aid discover example.com --use-http-index
 
 # Output as JSON
@@ -249,12 +236,14 @@ dns-aid index sync example.com
 # Publish without updating the index (for internal agents)
 dns-aid publish --name internal-bot --domain example.com --protocol mcp --no-update-index
 
-# Domain Submission to Agent Directory (v0.4.0+)
-# Submit your domain for crawling and indexing
-dns-aid submit example.com
+# Domain Submission to a Directory (v0.4.0+)
+# Submit your domain to a directory of your choice for indexing.
+# The --to flag (or DNS_AID_SDK_DIRECTORY_API_URL) selects which directory.
+dns-aid submit example.com --to https://your-directory.example.com
 
 # Submit with company metadata
 dns-aid submit example.com \
+    --to https://your-directory.example.com \
     --company-name "Example Corp" \
     --company-website "https://example.com" \
     --company-description "We build AI agents"
@@ -314,9 +303,9 @@ if result.verified:
 
 See [Domain Control Validation](docs/api-reference.md#domain-control-validation-dcv) in the API reference for full details.
 
-### HTTP Index Discovery (ANS-Compatible)
+### HTTP Index Discovery
 
-DNS-AID also supports HTTP-based agent discovery for compatibility with ANS-style systems. This provides richer metadata (descriptions, model cards, capabilities, costs) while still validating endpoints via DNS.
+DNS-AID also supports HTTP-based agent discovery, with an index format whose schema aligns with ANS-style directories. This provides richer metadata (descriptions, model cards, capabilities, costs) while still validating endpoints via DNS.
 
 **Endpoint patterns tried (in order):**
 1. `https://index.aiagents.{domain}/index-wellknown` (demo-friendly, no underscores)
@@ -380,7 +369,7 @@ dns-aid-mcp --transport http --port 8000
 | Tool | Description |
 |------|-------------|
 | `publish_agent_to_dns` | Publish an AI agent to DNS (auto-updates index) |
-| `discover_agents_via_dns` | Discover AI agents at a domain (supports `use_http_index` for ANS-compatible discovery) |
+| `discover_agents_via_dns` | Discover AI agents at a domain (supports `use_http_index` for HTTP-index discovery) |
 | `list_agent_tools` | List available tools on a discovered MCP agent |
 | `call_agent_tool` | Call a tool on a discovered MCP agent (proxy requests) |
 | `verify_agent_dns` | Verify DNS-AID records and security |
@@ -617,36 +606,9 @@ GET https://mcp.example.com/.well-known/agent.json
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Server-Side: Agent Directory Pipeline
+### Directory and Indexing Layer (External)
 
-```
-┌──────────────────────────────────────────────────────────────────────────┐
-│                    AGENT DIRECTORY PIPELINE                              │
-│                                                                          │
-│  ┌──────────┐   ┌───────────────┐   ┌──────────────┐   ┌────────────┐  │
-│  │ CRAWLING │──▶│   CURATION    │──▶│   INDEXING   │──▶│  SERVING   │  │
-│  │          │   │               │   │              │   │            │  │
-│  │ DNS SVCB │   │ trust_score   │   │ TSVECTOR     │   │ REST API   │  │
-│  │ HTTP Idx │   │ security_score│   │ full-text    │   │ Search     │  │
-│  │ .well-   │   │ telemetry     │   │ search       │   │ Rankings   │  │
-│  │ known/   │   │ scoring       │   │              │   │            │  │
-│  │ agent.json   │               │   │              │   │            │  │
-│  └──────────┘   └───────────────┘   └──────────────┘   └────────────┘  │
-│       │                                                                  │
-│       ▼                                                                  │
-│  ┌──────────────────────────────────────────────────────────────────┐   │
-│  │             METADATA ENRICHMENT (Phase 5.5)                      │   │
-│  │                                                                  │   │
-│  │  GET /.well-known/agent.json                                     │   │
-│  │    ├─ "aid_version" present? → Parse as DNS-AID AgentMetadata    │   │
-│  │    └─ No? → Try A2A Agent Card → Transform to metadata fields    │   │
-│  │                                                                  │   │
-│  │  Extracts: transport, auth, capabilities (intent/semantics),     │   │
-│  │            lifecycle (deprecated, sunset_date, successor)        │   │
-│  └──────────────────────────────────────────────────────────────────┘   │
-│                                                                          │
-└──────────────────────────────────────────────────────────────────────────┘
-```
+Directory and indexing services that build on top of DNS-AID — crawlers that walk public DNS for agent records, services that index `.well-known/agent.json` metadata, search frontends — are **out of scope for this repository**. They build on the substrate but are operated independently. Implementations are free to define their own scoring, ranking, and curation policy; DNS-AID does not centralize those choices.
 
 ## Choosing the Right Interface
 
@@ -975,81 +937,22 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
-## Why DNS-AID?
+## How DNS-AID Relates to Other Efforts
 
-### vs Competing Proposals
+Agent discovery is an active design space, with multiple proposals working at different layers of the stack. DNS-AID is intentionally narrow: it standardizes a DNS-layer substrate that publishers and resolvers can rely on, leaving directory, ranking, payments, and namespace policy to other efforts. The summary below is meant to help operators understand where DNS-AID fits — not to position it against other work.
 
-| Approach | Problem | DNS-AID Advantage |
-|----------|---------|-------------------|
-| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
-| **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
-| **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
-| **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
-| **NANDA (MIT)** | New P2P overlay network, new ops paradigm | Uses infrastructure your DNS team already operates |
-| **Web3 (ERC-8004)** | Gas fees, crypto wallets, enterprise-hostile | Free DNS queries, no blockchain complexity |
-| **ai.txt / llms.txt** | No integrity verification, free-form JSON | DNSSEC cryptographic verification, structured SVCB |
+**Adjacent efforts**
 
-### Feature Comparison
+- **Agent Name Service (ANS)** — A directory-oriented approach defining a JSON metadata schema and registry interfaces. DNS-AID's HTTP Index format is intentionally aligned with the ANS schema where it overlaps, so an ANS-style directory can be served from the same data a DNS-AID publisher produces.
+- **A2A** — A communication protocol for agent-to-agent messaging. DNS-AID is complementary: A2A defines how two agents talk, DNS-AID defines how one agent finds the other's endpoint to talk to.
+- **AgentDNS** — A separate proposal that builds an agent-naming layer on top of DNS primitives. The two proposals overlap in spirit and differ in mechanism; DNS-AID's choice is to stay inside RFC 9460 SVCB so existing authoritative servers and resolvers work unchanged.
+- **NANDA** — A peer-to-peer overlay approach. Useful in deployments where a DHT-style substrate is preferred; DNS-AID instead targets the DNS infrastructure organizations already operate.
+- **ai.txt / llms.txt** — Free-form text files at well-known URLs. Useful for human-readable discovery; DNS-AID adds structured SVCB records and optional DNSSEC-validated trust.
+- **`.agent` gTLD** — An ICANN new-gTLD effort by the [Agent Community](https://agentcommunity.org/) to create a dedicated namespace (`mycompany.agent`). Complementary to DNS-AID — when `.agent` domains become available, DNS-AID records will work on them too, the same way they work on any other zone.
 
-| Feature | DNS-AID | Central Registry | ai.txt |
-|---------|---------|------------------|--------|
-| **Decentralized** | ✅ | ❌ | ✅ |
-| **Secure (DNSSEC)** | ✅ | Varies | ❌ |
-| **Sovereign** | ✅ | ❌ | ✅ |
-| **Standards-based** | ✅ (IETF) | ❌ | ❌ |
-| **Works with existing infra** | ✅ | ❌ | ✅ |
+**Where DNS-AID is scoped**
 
-### The Sovereignty Question
-
-> **Who controls agent discovery?**
-> - ANS: GoDaddy (US company as gatekeeper)
-> - AgentDNS: China Telecom (state-owned carrier)
-> - Web3: Ethereum Foundation
-> - **DNS-AID: You control your own domain**
->
-> DNS-AID preserves sovereignty. Organizations and nations maintain control over their own agent namespaces with no central authority that can block, censor, or surveil agent discovery.
-
-### Google's Agent Ecosystem
-
-Google is building a full-stack agent platform: **A2A** (communication), **UCP** (payments), and **Gemini/Search** (discovery). While A2A is an open protocol, discovery through Google surfaces means:
-- Google controls visibility (pay-to-rank)
-- Transaction fees via [UCP](https://developers.google.com/merchant/ucp)
-- Platform dependency for reach
-
-**DNS-AID complements A2A** by providing neutral, decentralized discovery — find agents anywhere, not just through Google.
-
-### Understanding the .agent Domain Approach
-
-The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-level domain through ICANN's [new gTLD program](https://newgtlds.icann.org/). Here's how the two approaches compare:
-
-**How .agent Domains Would Work:**
-1. Apply to ICANN for `.agent` gTLD (~$185,000 application fee)
-2. Wait 9-20 months for ICANN approval process
-3. Build registry infrastructure (Open Agent Registry, Inc.)
-4. Sell `.agent` domains through accredited registrars
-5. Users pay annual registration fees (~$15-50/year per domain)
-
-**How DNS-AID Works:**
-1. Use your existing domain (you already own `yourcompany.com`)
-2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
-3. Start discovering and being discovered immediately
-
-| Factor | .agent gTLD | DNS-AID |
-|--------|-------------|---------|
-| **Cost to publish** | ~$15-50/year domain fee | Free (use existing domain) |
-| **Time to start** | Months (gTLD launch + registration) | Minutes |
-| **Who controls discovery** | Registry operator | You (your domain) |
-| **Works today** | ❌ Pending ICANN approval | ✅ Works now |
-| **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
-| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
-
-**The Friendly Take:**
-
-Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
-
-DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
-
-*Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
+DNS-AID standardizes the publish/resolve substrate: SVCB record layout, naming convention, capability and policy parameters, and a DNSSEC-anchored verification path. It does not pick a winning directory, ranking algorithm, payment system, or trust authority. Operators are free to combine DNS-AID with any of the efforts above, or to run it standalone.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ DNS-AID enables AI agents to discover each other via DNS, using the internet's e
 - [Architecture](docs/architecture.md) — protocol layers, metadata resolution, integration points
 - [Integrations](docs/integrations.md) — backend-specific setup notes
 - [Demo Guide](docs/demo-guide.md) — end-to-end walkthrough for talks and presentations
+- [Experimental Features](docs/experimental/README.md) — unstable APIs and forward-looking proposals (e.g., EDNS(0) `agent-hint` signaling)
 - [Privacy Policy](PRIVACY.md) | [Security Policy](SECURITY.md) | [Trademarks](TRADEMARKS.md)
 
 ## Companion services

--- a/README.md
+++ b/README.md
@@ -1004,3 +1004,7 @@ Apache 2.0
 Contributions welcome! This project is intended for contribution to the Linux Foundation Agent AI Foundation.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## Acknowledgments
+
+Thanks to **John Zinky** (Akamai) for design-level input on the experimental EDNS(0) `agent-hint` signaling work — particularly on how hint-aware hops could fit into the broader resolver ecosystem.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1781,29 +1781,47 @@ Activate by setting `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` in the environment. With
 
 ### AgentHint
 
+Two-axis selector taxonomy (see [design doc §4.3](experimental/edns-signaling.md) for the full rationale).
+
 ```python
 from dns_aid.experimental import AgentHint
 
+# Axis 1: shape the answer set; participate in the cache key
+# Axis 2: shape the request lifecycle; do NOT fragment the cache
 hint = AgentHint(
-    capabilities=["chat", "code-review"],
-    intent="summarize",
+    realm="prod",
     transport="mcp",
-    auth_type="bearer",
+    min_trust="signed+dnssec",
+    client_intent_class="invocation",
+    parallelism=4,
+    deadline_ms=30000,
 )
 ```
 
-Fields (all optional, all default `None`):
+**Axis 1 — substrate filters** (codes 0x01–0x0F). Different values mean different answer sets.
 
-| Field | Type | Selector code | Notes |
-|-------|------|---------------|-------|
-| `capabilities` | `list[str] \| None` | 0x01 | Comma-joined on the wire. Empty / whitespace-only strings are stripped. |
-| `intent` | `str \| None` | 0x02 | Single tag. |
-| `transport` | `str \| None` | 0x03 | One of `"mcp"`, `"a2a"`, `"https"`. |
-| `auth_type` | `str \| None` | 0x04 | One of `"none"`, `"bearer"`, `"oauth2"`, `"mtls"`. |
+| Field | Type | Code | Notes |
+|-------|------|------|-------|
+| `realm` | `str \| None` | 0x01 | Multi-tenant scope; matches SVCB `realm=` param. |
+| `transport` | `str \| None` | 0x02 | `"mcp"` \| `"a2a"` \| `"https"`. |
+| `policy_required` | `bool` | 0x03 | When `True`, only records carrying `policy=` URI. Default `False`; not emitted on wire when False (absence = "don't care"). |
+| `min_trust` | `str \| None` | 0x04 | `"signed"` \| `"dnssec"` \| `"signed+dnssec"`. Gated on `sig` param + DNSSEC chain. |
+| `jurisdiction` | `str \| None` | 0x05 | ISO region tag (e.g. `"eu"`, `"us-east"`). |
+
+**Axis 2 — metering / lifecycle** (codes 0x10–0x1F). Drive request policy; do not change the answer set.
+
+| Field | Type | Code | Notes |
+|-------|------|------|-------|
+| `client_intent_class` | `str \| None` | 0x10 | `"discovery"` (browsing) \| `"invocation"` (about to call). |
+| `max_age` | `int \| None` | 0x11 | Seconds; don't return cache entries older than this. |
+| `parallelism` | `int \| None` | 0x12 | Expected sibling-query count. Signals fan-out to caches. |
+| `deadline_ms` | `int \| None` | 0x13 | Wait budget in ms. **Hint-only** — auth cannot refuse for SLA in v0; may prefer faster path / serve stale to meet it. |
 
 Methods:
 - `encode() -> bytes` — produce the EDNS(0) option payload (raises `ValueError` if any selector value exceeds 255 UTF-8 bytes or the total payload exceeds 512).
-- `signature() -> str` — stable cache-key string. Order-independent (`capabilities` sorted).
+- `signature() -> str` — stable cache-key string. **Axis 1 only** — two hints differing only in Axis 2 share a signature, so they hit the same cache entry. This is a load-bearing invariant of the design.
+
+**Not DNS-layer selectors.** `capabilities` and `intent` are intentionally NOT fields on `AgentHint`. They live in the publisher's well-known JSON (see [`EdnsSignalingAdvertisement.honored_selectors`](#ednssignalingadvertisement)) and clients use them for *post-fetch local filtering*, not query-time signaling. The reason is layering: SVCB doesn't carry capability strings, so an auth would have to dereference cap-doc URIs per-query to filter on them, which breaks DNS latency budgets.
 
 ### AgentHintEcho
 
@@ -1841,7 +1859,7 @@ from dns_aid.experimental import AgentHint, EdnsAwareResolver
 resolver = EdnsAwareResolver(ttl_seconds=60)
 result = await resolver.resolve(
     "_chat._mcp._agents.example.com", "SVCB",
-    agent_hint=AgentHint(capabilities=["chat"]),
+    agent_hint=AgentHint(realm="prod", transport="mcp"),
 )
 # result.answer — dnspython Answer
 # result.echo   — AgentHintEcho | None (presence == upstream is hint-aware)
@@ -1855,7 +1873,7 @@ from dns_aid.experimental import AgentHint
 
 result = await discover(
     "example.com",
-    agent_hint=AgentHint(capabilities=["chat"], transport="mcp"),
+    agent_hint=AgentHint(realm="prod", transport="mcp", parallelism=4, deadline_ms=30000),
 )
 ```
 
@@ -1866,9 +1884,12 @@ The `agent_hint=` kwarg is accepted unconditionally for forward-compat. The opti
 ```bash
 DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 \
   dns-aid edns-probe example.com \
-  --capabilities=chat,code --intent=summarize --transport=mcp \
+  --realm prod --transport mcp \
+  --intent-class invocation --parallelism 4 --deadline-ms 30000 \
   --show-wire
 ```
+
+Flags are grouped by axis: `--realm`, `--transport`, `--policy-required`, `--min-trust`, `--jurisdiction` (Axis 1); `--intent-class`, `--max-age`, `--parallelism`, `--deadline-ms` (Axis 2).
 
 Prints an `[experimental]` banner on stderr, performs a cache-miss → cache-hit demonstration with `EdnsAwareResolver`, and reports any `AgentHintEcho` received.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1771,6 +1771,109 @@ Disabled by default (`http_push_url=None`). Configure via `SDKConfig` or the `DN
 
 ---
 
+## Experimental: EDNS(0) signaling
+
+> ⚠ **Unstable.** APIs in this section live in `dns_aid.experimental` and may change or be removed in any release. They are not covered by semver guarantees. Full design rationale: [docs/experimental/edns-signaling.md](experimental/edns-signaling.md).
+
+Lets a client attach selector filters to outgoing DNS queries via an EDNS(0) option (code 65430, private use). Hint-aware DNS hops — including hint-aware authoritative servers — can narrow the response or short-circuit with a cached match. Stock authoritative servers treat the option as inert per RFC 6891.
+
+Activate by setting `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` in the environment. Without the flag the code paths are dormant even when the symbols are imported.
+
+### AgentHint
+
+```python
+from dns_aid.experimental import AgentHint
+
+hint = AgentHint(
+    capabilities=["chat", "code-review"],
+    intent="summarize",
+    transport="mcp",
+    auth_type="bearer",
+)
+```
+
+Fields (all optional, all default `None`):
+
+| Field | Type | Selector code | Notes |
+|-------|------|---------------|-------|
+| `capabilities` | `list[str] \| None` | 0x01 | Comma-joined on the wire. Empty / whitespace-only strings are stripped. |
+| `intent` | `str \| None` | 0x02 | Single tag. |
+| `transport` | `str \| None` | 0x03 | One of `"mcp"`, `"a2a"`, `"https"`. |
+| `auth_type` | `str \| None` | 0x04 | One of `"none"`, `"bearer"`, `"oauth2"`, `"mtls"`. |
+
+Methods:
+- `encode() -> bytes` — produce the EDNS(0) option payload (raises `ValueError` if any selector value exceeds 255 UTF-8 bytes or the total payload exceeds 512).
+- `signature() -> str` — stable cache-key string. Order-independent (`capabilities` sorted).
+
+### AgentHintEcho
+
+Response-side echo from a hint-aware hop, listing the selector codes the responder actually applied. Absence means no upstream filtering happened — fall back to local filtering.
+
+```python
+from dns_aid.experimental import AgentHintEcho
+
+echo = AgentHintEcho(applied_selectors=[0x01, 0x02])
+```
+
+### EdnsSignalingAdvertisement
+
+Publisher advertisement carried in `cap-doc`, `agent-card`, or `agents-index.json`:
+
+```json
+{
+  "edns_signaling": {
+    "version": 0,
+    "honored_selectors": ["capabilities", "intent", "transport"],
+    "note": "Recommends client-side pre-filtering."
+  }
+}
+```
+
+Lifted automatically onto `CapabilityDocument.edns_signaling`, `A2AAgentCard.edns_signaling`, and `HttpIndexAgent.edns_signaling`. Stored as `dict | None` (forward-compat on unknown shapes).
+
+### EdnsAwareResolver
+
+In-process programmable hop (Locus 1 in the design doc). Wraps `dns.asyncresolver.Resolver`, attaches the hint as an EDNS option on outgoing queries (when the env flag is set), and caches answers keyed by `(qname, qtype, hint_signature)`.
+
+```python
+from dns_aid.experimental import AgentHint, EdnsAwareResolver
+
+resolver = EdnsAwareResolver(ttl_seconds=60)
+result = await resolver.resolve(
+    "_chat._mcp._agents.example.com", "SVCB",
+    agent_hint=AgentHint(capabilities=["chat"]),
+)
+# result.answer — dnspython Answer
+# result.echo   — AgentHintEcho | None (presence == upstream is hint-aware)
+```
+
+### Integration with discover()
+
+```python
+from dns_aid import discover
+from dns_aid.experimental import AgentHint
+
+result = await discover(
+    "example.com",
+    agent_hint=AgentHint(capabilities=["chat"], transport="mcp"),
+)
+```
+
+The `agent_hint=` kwarg is accepted unconditionally for forward-compat. The option is only emitted on the wire when `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` is set.
+
+### CLI: `dns-aid edns-probe`
+
+```bash
+DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 \
+  dns-aid edns-probe example.com \
+  --capabilities=chat,code --intent=summarize --transport=mcp \
+  --show-wire
+```
+
+Prints an `[experimental]` banner on stderr, performs a cache-miss → cache-hit demonstration with `EdnsAwareResolver`, and reports any `AgentHintEcho` received.
+
+---
+
 ## Version
 
 ```python

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -687,3 +687,33 @@ async def get_record(
 
 This enables reliable reconciliation state-checking without depending on
 public DNS resolver support for SVCB records.
+
+## Experimental namespace (`src/dns_aid/experimental/`)
+
+A fourth subpackage sits alongside `core/`, `sdk/`, and `backends/`: `experimental/`.
+It is a stability-marked staging area for forward-looking features that need
+real code and a public design doc but are not yet stable enough to commit to
+across semver releases.
+
+Rules:
+
+- APIs in `experimental` are **not** subject to semver. They may change shape or
+  disappear in any release, including patch versions.
+- Symbols are **never** re-exported from `dns_aid/__init__.py`. Callers must
+  import explicitly: `from dns_aid.experimental import AgentHint`. This makes
+  accidental adoption visible at the import line.
+- Each feature has a **per-feature environment flag** (e.g.
+  `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1`). When the flag is unset, related runtime
+  code paths stay dormant even if the symbols are imported.
+- Each feature has a **design doc** under `docs/experimental/`, written with
+  section headers that map to future IETF-draft sections (Overview, Motivation,
+  Wire Format, Privacy, Security, Open Questions, Future Work).
+- When a feature graduates to stable, it moves out of `experimental/` into the
+  appropriate tier, gets re-exported from the top-level package, and its design
+  doc relocates from `docs/experimental/` to `docs/rfc/`.
+
+Currently shipped:
+
+| Feature | Module | Env flag | Doc |
+|---|---|---|---|
+| EDNS(0) `agent-hint` signaling | `experimental/edns_hint.py`, `experimental/edns_cache.py` | `DNS_AID_EXPERIMENTAL_EDNS_HINTS` | [edns-signaling.md](experimental/edns-signaling.md) |

--- a/docs/experimental/README.md
+++ b/docs/experimental/README.md
@@ -1,0 +1,38 @@
+# Experimental DNS-AID features
+
+This directory holds design proposals and rationale documents for **experimental** features that ship in the `dns_aid.experimental` Python subpackage.
+
+## ⚠ Stability
+
+APIs and wire formats described in this directory are **unstable**. They are NOT covered by the semver guarantees that apply to `dns_aid.core` and `dns_aid.sdk`. They may change shape, change behaviour, or be removed entirely in any release — including patch versions.
+
+If you build on an experimental feature, pin the patch version of `dns-aid` and watch the CHANGELOG.
+
+## Conventions
+
+Every experimental feature follows the same shape:
+
+| Aspect | Where it lives |
+|---|---|
+| Code | `src/dns_aid/experimental/<feature>.py` |
+| Public symbols | Imported explicitly: `from dns_aid.experimental import X`. Never re-exported from `dns_aid/__init__.py`. |
+| Runtime gate | A per-feature environment variable, e.g. `DNS_AID_EXPERIMENTAL_<FEATURE>=1`. Without the flag set, related code paths stay dormant. |
+| CLI surface | Commands print `[experimental]` to stderr on every invocation. |
+| Tests | `tests/unit/test_<feature>.py` is required. |
+| Design doc | `docs/experimental/<feature>.md` (this directory). Section headers should map cleanly to future RFC structure so content lifts into a draft when an LF spec home arrives. |
+| ABNF / wire format | `docs/experimental/<feature>.abnf` (kept separate from `docs/rfc/wire-format.abnf` so the experimental status is unambiguous). |
+
+## Current proposals
+
+- **[EDNS(0) agent-hint signaling](edns-signaling.md)** — client signals selector filters to a hint-aware DNS hop (resolver, forwarder, or authoritative) to enable per-query response narrowing and warm-cache short-circuits. Wire format: option code 65430 (private use). Reference programmable hop: in-process `EdnsAwareResolver`. Status: design + client-side spike.
+
+## Migrating an experimental feature to stable
+
+When a feature graduates to stable:
+
+1. Move the design doc from `docs/experimental/` to `docs/rfc/` (rename to a `-stable` suffix or whatever fits the section).
+2. Move the code from `src/dns_aid/experimental/` to its proper tier (`core/`, `sdk/`, or backends).
+3. Re-export public symbols from `dns_aid/__init__.py` if appropriate.
+4. Drop the env-flag gate; the feature is on by default.
+5. Update `CHANGELOG.md` with a `BREAKING:` line if the public surface changed during the experimental phase.
+6. Update `docs/api-reference.md` to remove the "Experimental" marking.

--- a/docs/experimental/edns-signaling.abnf
+++ b/docs/experimental/edns-signaling.abnf
@@ -54,13 +54,41 @@ selector-count     = OCTET
 
 selector           = selector-code selector-length selector-value
 
-selector-code      = OCTET
-                     ; 0x01 = capabilities (UTF-8 comma list)
-                     ; 0x02 = intent       (UTF-8 single tag)
-                     ; 0x03 = transport    (UTF-8: "mcp" | "a2a" | "https")
-                     ; 0x04 = auth_type    (UTF-8: "none" | "bearer" | "oauth2" | "mtls")
-                     ; 0x05–0xFF reserved.  Consumers MUST silently ignore
-                     ; unknown selector codes (forward-compat).
+selector-code      = axis1-code / axis2-code / reserved-code
+                     ; Two-axis taxonomy.  See docs/experimental/edns-signaling.md §4.3.
+                     ; Consumers MUST silently ignore unknown selector codes (forward-compat).
+
+axis1-code         = %x01 / %x02 / %x03 / %x04 / %x05
+                     ; Axis 1 — substrate filters (0x01–0x0F).  Different values
+                     ; change the answer set; participate in cache-key signature.
+                     ;
+                     ;   0x01 = realm            (UTF-8; SVCB realm= match)
+                     ;   0x02 = transport       (UTF-8: "mcp" | "a2a" | "https")
+                     ;   0x03 = policy_required (UTF-8 "1"; absent = "don't care")
+                     ;   0x04 = min_trust       (UTF-8: "signed" | "dnssec" |
+                     ;                                  "signed+dnssec")
+                     ;   0x05 = jurisdiction    (UTF-8: ISO region, e.g. "eu",
+                     ;                                  "us-east")
+                     ;   0x06–0x0F reserved for future Axis-1 selectors.
+
+axis2-code         = %x10 / %x11 / %x12 / %x13
+                     ; Axis 2 — metering / lifecycle (0x10–0x1F).  Drive
+                     ; rate-limit / freshness / prefetch policy.  Do NOT
+                     ; participate in cache-key signature.
+                     ;
+                     ;   0x10 = client_intent_class (UTF-8: "discovery" |
+                     ;                                       "invocation")
+                     ;   0x11 = max_age            (UTF-8 decimal seconds)
+                     ;   0x12 = parallelism        (UTF-8 decimal uint)
+                     ;   0x13 = deadline_ms        (UTF-8 decimal uint;
+                     ;                              hint-only — no SLA refuse
+                     ;                              semantic in v0)
+                     ;   0x14–0x1F reserved for future Axis-2 selectors.
+
+reserved-code      = %x06-0F / %x14-1F / %x20-FF
+                     ; 0x20 reserved for client_cookie  (documented, not coded)
+                     ; 0x21 reserved for correlation_id (documented, not coded)
+                     ; 0x22–0xFF reserved for future axes.
 
 selector-length    = OCTET                       ; length of selector-value in bytes
 selector-value     = *OCTET                      ; UTF-8 encoded, length-prefixed

--- a/docs/experimental/edns-signaling.abnf
+++ b/docs/experimental/edns-signaling.abnf
@@ -1,0 +1,108 @@
+; DNS-AID experimental EDNS(0) agent-hint option — wire format
+; Reference: docs/experimental/edns-signaling.md
+;
+; ⚠ EXPERIMENTAL. This wire format is unstable. Option-code 65430 sits in the
+; RFC 6891 private-use range (65001–65534) and is subject to change before any
+; IANA coordination.
+;
+; This file extends the core DNS-AID ABNF (docs/rfc/wire-format.abnf) with the
+; experimental agent-hint option. ABNF rules from RFC 5234.
+
+; ==================================================================
+; Core ABNF rules referenced (from RFC 5234)
+; ==================================================================
+
+DIGIT          = %x30-39                        ; 0-9
+ALPHA          = %x41-5A / %x61-7A              ; A-Z / a-z
+OCTET          = %x00-FF
+BIT            = "0" / "1"
+
+; ==================================================================
+; EDNS(0) framing context (from RFC 6891 §6.1.2)
+; ==================================================================
+;
+; agent-hint is carried as a single OPTION entry inside the RDATA of the
+; OPT pseudo-RR:
+;
+;     OPT.RDATA = *agent-hint-option / *(other-option) / *agent-hint-option
+;
+; Where each EDNS option entry is:
+;
+;     option         = option-code option-length option-data
+;     option-code    = 2OCTET   ; big-endian; 65430 = 0xFF96 for agent-hint
+;     option-length  = 2OCTET   ; big-endian length of option-data, in octets
+;     option-data    = *OCTET   ; opaque to the EDNS framing; defined per option-code
+
+; ==================================================================
+; agent-hint option (option-code = 65430)
+; ==================================================================
+
+; option-data when option-code = 65430.  Either a request payload or an echo.
+agent-hint-data    = agent-hint-request / agent-hint-echo
+
+; -- Request -------------------------------------------------------
+
+agent-hint-request = version-request selector-count *selector
+                     ; total length: 2 + sum(selector lengths)
+                     ; SHOULD NOT exceed 512 octets in any single option
+
+version-request    = %x00
+                     ; v0; high bit clear distinguishes a request from an echo
+
+selector-count     = OCTET
+                     ; number of selectors that follow (0–255)
+
+selector           = selector-code selector-length selector-value
+
+selector-code      = OCTET
+                     ; 0x01 = capabilities (UTF-8 comma list)
+                     ; 0x02 = intent       (UTF-8 single tag)
+                     ; 0x03 = transport    (UTF-8: "mcp" | "a2a" | "https")
+                     ; 0x04 = auth_type    (UTF-8: "none" | "bearer" | "oauth2" | "mtls")
+                     ; 0x05–0xFF reserved.  Consumers MUST silently ignore
+                     ; unknown selector codes (forward-compat).
+
+selector-length    = OCTET                       ; length of selector-value in bytes
+selector-value     = *OCTET                      ; UTF-8 encoded, length-prefixed
+
+; -- Response echo (RFC 8914-style additive context) ---------------
+
+agent-hint-echo    = version-echo applied-count *applied-selector
+                     ; emitted by a hint-aware hop in the response.  Absence is
+                     ; meaningful — it means no upstream filtering happened.
+
+version-echo       = %x80
+                     ; v0; high bit set distinguishes an echo from a request.
+                     ; Lower 7 bits carry the version number; 0x80 == version 0 echo.
+
+applied-count      = OCTET                       ; number of selector codes that follow
+
+applied-selector   = OCTET                       ; selector-code that the hop honoured.
+                     ; Selector codes appearing here MUST also have appeared in
+                     ; the corresponding request.
+
+; ==================================================================
+; Publisher advertisement (JSON, not on the wire) — Channel 1
+; ==================================================================
+;
+; Embedded inside cap-doc, agent-card, or http-index JSON. Not part of any DNS
+; wire format; included here for completeness so implementers see the whole
+; signaling surface in one place.
+;
+;     "edns_signaling": {
+;       "version":           <integer>,
+;       "honored_selectors": [<selector-name>, ...],
+;       "note":              <string?>          // optional
+;     }
+;
+; Where <selector-name> ∈ {"capabilities", "intent", "transport", "auth_type"} for v0.
+
+; ==================================================================
+; SVCB advertisement parameter (optional) — Channel 2 static
+; ==================================================================
+;
+; Optional SVCB SvcParam at the zone apex (_agents.{domain}). v0 reserves the
+; following key for forward use; not emitted by the v0 reference implementation.
+;
+;     key65409 = "agent-hint"
+;     value    = "v=0;selectors=<selector-name>(,<selector-name>)*"

--- a/docs/experimental/edns-signaling.md
+++ b/docs/experimental/edns-signaling.md
@@ -22,15 +22,18 @@ Consider the three discovery scenarios from `draft-mozleywilliams-dnsop-dnsaid-0
 2. **Known domain, unknown service** — query `_index._agents.{domain}`, then walk the named entries. Multiple round trips; the index tells you names but not metadata.
 3. **Unknown / wildcard** — search provider or federated registry. Most expensive.
 
-Scenarios 2 and 3 commonly produce *N* candidates of which the client only wants a handful that match its needs — capabilities, intent, transport, auth posture. Today the client filters all *N* locally after fetching, often after also fetching enrichment metadata (cap docs, agent cards) for records it will discard.
+Two pressures motivate adding a query-time signaling channel:
 
-The `agent-hint` option moves the filter description to the query itself. If any hop along the path understands the option, that hop can:
+**Filtering at the right layer.** Scenarios 2 and 3 commonly produce *N* candidates of which the client only wants a handful that match its needs. Today the client filters all *N* locally after fetching, often after dereferencing enrichment metadata (cap-docs, agent cards) for records it will discard. Some of that filtering — multi-tenant scope, transport binding, policy posture, jurisdiction — is on data the authoritative server already has at the DNS layer. Pushing those filters into the query lets a hint-aware hop narrow the result set or short-circuit with a cached pre-filtered match.
 
-- Return only the subset that matches (a hint-aware authoritative)
-- Serve a cached pre-filtered answer (a hint-aware recursive resolver or forwarder)
-- Short-circuit the query entirely (the client's own resolver wrapper, when the hint matches a recent cache entry)
+**Async fan-out / parallel agent workflows.** A client running a multi-agent job — research, draft, review, format — dispatches several discoveries in parallel against different domains. Each sibling query shares lifecycle properties: the same wait budget, the same intent class (the client is about to invoke, not browse), the same expected parallelism count. A query-time signal lets a cache anticipate the fan-out and pre-warm related lookups; lets an auth choose a faster code path when the deadline is tight; lets a forwarder rate-limit discovery probes more aggressively than imminent-invocation lookups. None of that requires changing what records get returned — it changes the lifecycle policy applied to the request.
 
-Cost decays across three states:
+These two pressures pull in different directions, which is why the design splits selectors into two axes:
+
+- **Axis 1 — substrate filters.** What records the auth/cache returns. Different values → different answer sets → participate in the cache key.
+- **Axis 2 — metering / lifecycle.** Policy applied to the request: rate limits, freshness, sibling count, deadline. Do not fragment the cache.
+
+Cost decays across three states (orthogonal to which selectors a client uses):
 
 - **Cold** — no caches anywhere. Client falls back to search/registry. Expensive.
 - **Warm** — at least one hop is hint-aware and has a fresh matching record. No expensive search, possibly no DNS round-trip at all.
@@ -67,11 +70,11 @@ The hint flows from the client toward the authoritative server. Any hop that und
                                                          └──────────────────┘
 ```
 
-**Locus 1 — in-process client cache.** The agent's own resolver wrapper reads the hint, checks a local cache keyed by `(qname, qtype, hint_signature)`. Cache hit short-circuits the query. The reference implementation, `EdnsAwareResolver`, ships with this PR. Always usable; no infrastructure required.
+**Locus 1 — in-client programmable hop.** Today this is `EdnsAwareResolver`: a thin resolver wrapper that reads the hint, checks a local cache keyed by `(qname, qtype, hint_signature)`, and short-circuits on a hit. The wire-level emission of the option is also done here. Longer-term, Locus 1 is whatever the SDK grows into — a richer in-process cache that pre-fetches cap-docs on `parallelism` hints, anticipates sibling queries on `client_intent_class=invocation`, and tracks deadlines across a fan-out. The same role might also be filled by a small DNS-like cache process co-located with the agent runtime, fetching agentic metadata out of band and serving warm answers to the agent. Either deployment shape uses the same wire semantics; only the process boundary differs. Locus 1 is always usable — no infrastructure required.
 
 **Locus 2 — hint-aware forwarder / recursive resolver.** A corporate gateway or shared resolver that understands the hint, serves cached pre-filtered responses, or rewrites the query before forwarding. Out of scope for this PR; valid future deployment.
 
-**Locus 3 — hint-aware authoritative server.** A DNS server implementation that inspects the hint on incoming queries and narrows the response set to records matching the selectors. For example: a domain publishes 50 agents, the client queries with `capabilities=chat & intent=summarize`, the authoritative returns just the 2 records that match. Out of scope for this PR's reference implementation; the wire format and advertisement schema are designed to support this hop without modification.
+**Locus 3 — hint-aware authoritative server.** A DNS server implementation that inspects the hint on incoming queries and narrows the response set to records matching the selectors. For example: a domain publishes 50 agents, the client queries with `realm=prod & transport=mcp & policy_required=1`, the authoritative returns just the records that match all three. Out of scope for this PR's reference implementation; the wire format and advertisement schema are designed to support this hop without modification.
 
 Commodity authoritative servers (stock BIND, Route53, Cloudflare) are inert to unknown options per RFC 6891. They will respond identically with or without the option. That is a valid, lowest-common-denominator deployment — the client-side cache at Locus 1 still provides value.
 
@@ -115,39 +118,97 @@ A hint-aware hop MAY include an `agent-hint` option in its response with the VER
 
 Absence of an echo on a response is meaningful — it tells the client no upstream filtering happened, and the client should fall back to local filtering against the returned record set. This mirrors RFC 8914 (Extended DNS Errors) in pattern: response-only, non-mandatory, additive context.
 
-### 4.3 Selectors v0
+### 4.3 Selectors v0 — two axes
 
-| Code | Name | Value format | Example |
-|------|------|--------------|---------|
-| 0x01 | `capabilities` | Comma-separated UTF-8 list | `"chat,code-review"` |
-| 0x02 | `intent` | Single UTF-8 tag | `"summarize"` |
-| 0x03 | `transport` | `"mcp"` \| `"a2a"` \| `"https"` | `"mcp"` |
-| 0x04 | `auth_type` | `"none"` \| `"bearer"` \| `"oauth2"` \| `"mtls"` | `"bearer"` |
+Selector codes are split into two axes by code range. The split is **structural**, not just advisory — it determines cache behaviour (see §4.5).
 
-Codes `0x05` through `0xFF` are reserved for future selectors. The taxonomy intentionally matches the existing Path A filter kwargs on `dns_aid.discover()`.
+#### Axis 1 — substrate filters (codes 0x01–0x0F)
 
-### 4.4 Worked example
+Things the auth/cache can decide on without dereferencing anything out-of-band. Different Axis-1 values mean different *answer sets*.
 
-A client looking for an MCP-transport, bearer-auth chat agent emits an option payload of:
+| Code | Name | Value format | What it asks for |
+|------|------|--------------|------------------|
+| 0x01 | `realm` | UTF-8 | Match SVCB `realm=` param (multi-tenant scope) |
+| 0x02 | `transport` | `"mcp"` \| `"a2a"` \| `"https"` | Encoded in `_{proto}._agents` owner-name and `alpn` |
+| 0x03 | `policy_required` | `"1"` (or absent) | Only records carrying a `policy=` URI |
+| 0x04 | `min_trust` | `"signed"` \| `"dnssec"` \| `"signed+dnssec"` | Gated on `sig` param + DNSSEC chain status |
+| 0x05 | `jurisdiction` | ISO region (e.g. `"eu"`, `"us-east"`) | Compliance lever; needs publisher-side metadata |
+
+`policy_required=0` is the default and is **not** emitted on the wire — absence means "don't care," not "forbid."
+
+Codes `0x06`–`0x0F` are reserved for future Axis-1 selectors.
+
+#### Axis 2 — metering / lifecycle (codes 0x10–0x1F)
+
+Things about the request itself. Drive accept/reject/rate-limit/prefetch policy but do NOT change what records get returned (see §4.5).
+
+| Code | Name | Value format | What it asks for |
+|------|------|--------------|------------------|
+| 0x10 | `client_intent_class` | `"discovery"` \| `"invocation"` | Browsing vs about-to-call; auths can rate-limit discovery harder |
+| 0x11 | `max_age` | UTF-8 decimal seconds | Cache freshness budget (analog to HTTP `Cache-Control: max-age`) |
+| 0x12 | `parallelism` | UTF-8 decimal uint | Expected sibling-query count; signals fan-out to caches |
+| 0x13 | `deadline_ms` | UTF-8 decimal uint | Client's wait budget. **Hint-only** — see honesty note below |
+
+Codes `0x14`–`0x1F` are reserved for future Axis-2 selectors.
+
+**Honesty about `deadline_ms`.** DNS has no semantic for "refuse for SLA reasons." An auth or recursive that sees a tight deadline can: (a) prefer a faster code path; (b) serve a stale cache entry to make the budget; (c) log/audit the deadline class for capacity planning. It cannot return a "won't meet deadline" error in v0 — that would require a new RCODE or a structured error in the OPT response, which is out of scope.
+
+#### Reserved for future axes (0x20+)
+
+| Code | Name | Status | Notes |
+|------|------|--------|-------|
+| 0x20 | `client_cookie` | Documented, not coded | DNS-cookie-style proof-of-work / auth token. Real value for gating high-cost zones. Skipped in v0 code by design — adds an auth dimension that should be specified separately. |
+| 0x21 | `correlation_id` | Documented, not coded | Opaque workflow ID linking sibling queries. Useful for distributed tracing, but linkability across queries has privacy cost. Deferred until taxonomy locks. |
+
+#### Explicitly NOT DNS-layer selectors
+
+`capabilities` and `intent` belong in the **Channel 1 JSON advertisement** (§5.1), not in this wire option. The reason is layering: SVCB doesn't carry capability strings — those live in cap-doc JSON that the auth would have to dereference per-query to filter on. That dereference breaks DNS latency budgets and forces async work into a synchronous handler. The publisher tells the client which selectors are meaningful via `edns_signaling.honored_selectors`; the client uses that list for **post-fetch local filtering**, not query-time signaling.
+
+### 4.4 Worked example: async fan-out
+
+A client running a multi-agent job (research → draft → review → format) dispatches four discoveries in parallel. Each sibling query carries the same metering profile:
+
+- `realm=prod` (Axis 1 — must match published realm)
+- `transport=mcp` (Axis 1)
+- `client_intent_class=invocation` (Axis 2 — about to call, not browsing)
+- `parallelism=4` (Axis 2 — three more siblings coming)
+- `deadline_ms=30000` (Axis 2 — caller will wait at most 30 s)
+
+Wire payload:
 
 ```
-version=0x00  count=0x04
-0x01 0x04 "chat"
-0x02 0x09 "summarize"
-0x03 0x03 "mcp"
-0x04 0x06 "bearer"
+version=0x00  count=0x05
+0x01 0x04 "prod"                     (realm)
+0x02 0x03 "mcp"                      (transport)
+0x10 0x0a "invocation"               (client_intent_class)
+0x12 0x01 "4"                        (parallelism)
+0x13 0x05 "30000"                    (deadline_ms)
 ```
 
-Bytes on the wire: `00 04 01 04 63 68 61 74 02 09 73 75 6d 6d 61 72 69 7a 65 03 03 6d 63 70 04 06 62 65 61 72 65 72` (32 bytes payload, well under the 512-byte cap).
+A hint-aware cache (Locus 1 or 2) that sees this on one of the four sibling queries can:
 
-A hint-aware authoritative that applied both `capabilities` and `transport` (but not `intent` or `auth_type`) would echo:
+- Pre-warm cap-doc fetches for any candidate matching `realm=prod & transport=mcp`
+- Keep the cache entry warm long enough to satisfy the other three siblings (which will share the same `signature()` because their Axis 1 values are identical)
+- Skip cache-tier policy that would otherwise rate-limit a `discovery` burst, because `client_intent_class=invocation` says these are imminent
+
+A hint-aware authoritative that honoured `realm` and `transport` (but not the metering selectors, which don't apply to it) would echo:
 
 ```
 version=0x80  count=0x02
-0x01 0x03
+0x01 0x02
 ```
 
-Bytes: `80 02 01 03` (4 bytes payload).
+Bytes on the wire: `80 02 01 02` (4 bytes payload).
+
+### 4.5 Cache-key semantics (load-bearing invariant)
+
+Axis 1 selectors participate in `AgentHint.signature()`. Axis 2 selectors do not.
+
+This is the key design invariant: two queries that differ only in Axis 2 fields — say, one with `parallelism=4` and another with `parallelism=64` — MUST hit the same cache entry. They are asking for the same *answer set*, just with different policy applied to *how the request is handled*. Fragmenting the cache on metering would defeat the warm-state amortisation the design is built around.
+
+Equivalently: a hint-aware cache keys its entries on Axis 1 selectors only; Axis 2 selectors drive lifecycle decisions (rate limit, prefetch, deadline-aware serving) without affecting what gets cached or what gets returned.
+
+The reference implementation enforces this — `AgentHint.signature()` only includes Axis 1 fields, and `EdnsAwareResolver` uses that signature as its cache key.
 
 ## 5. Publisher advertisement
 
@@ -163,11 +224,13 @@ Every publisher (hint-aware or not) MAY include an `edns_signaling` block in the
   ...
   "edns_signaling": {
     "version": 0,
-    "honored_selectors": ["capabilities", "intent", "transport"],
-    "note": "Recommends client-side pre-filtering with these selectors."
+    "honored_selectors": ["realm", "transport", "capabilities", "intent"],
+    "note": "realm/transport narrow at the DNS layer; capabilities/intent are for client-side post-fetch filtering."
   }
 }
 ```
+
+`honored_selectors` may include both DNS-layer selector names (Axis 1, e.g. `realm`, `transport`) AND JSON-only selectors the client should filter on locally after fetch (e.g. `capabilities`, `intent`). The publisher mixes them because the client uses the same list for both decisions — "what's worth populating in the EDNS option" and "what's worth filtering on locally."
 
 This tells the client which selectors are *meaningful* for this publisher's agents — i.e. the publisher has populated the matching metadata fields so filtering on them will actually narrow results. Independent of whether any hop on the DNS resolution path is hint-aware; useful even with stock authoritative software.
 
@@ -176,9 +239,9 @@ This tells the client which selectors are *meaningful* for this publisher's agen
 A hint-aware authoritative or recursive server signals its capability in one of two ways:
 
 1. **OPT response echo** (preferred) — described in §4.2. The presence of an echo on a query response is itself the advertisement: "this responder processed your hint."
-2. **SVCB advertisement parameter** (optional, static advertisement at zone-discovery time) — a new param key `key65409 = "agent-hint"` on the apex SVCB record at `_agents.{domain}`, with a value like `v=0;selectors=capabilities,intent,transport`. Tells clients before they emit their first hint that this zone's authoritative will honour it. v0 keeps this optional; the echo carries the same information reactively.
+2. **SVCB advertisement parameter** (optional, static advertisement at zone-discovery time) — a new param key `key65409 = "agent-hint"` on the apex SVCB record at `_agents.{domain}`, with a value like `v=0;selectors=realm,transport,min_trust`. Tells clients before they emit their first hint that this zone's authoritative will honour those Axis-1 selectors. v0 keeps this optional; the echo carries the same information reactively.
 
-Channels are complementary. A client uses Channel 1 to decide *which selectors to populate*, and Channel 2 to know *whether to expect upstream narrowing or rely on local filtering*.
+Channels are complementary. A client uses Channel 1 to decide *which selectors to populate* (both DNS-layer and JSON-side), and Channel 2 to know *whether to expect upstream narrowing on the DNS-layer ones or rely on local filtering*.
 
 ## 6. Reference implementation
 
@@ -223,14 +286,18 @@ EDNS padding (RFC 7830) can be used in conjunction with `agent-hint` to make pay
 - **Programmable-hop trust.** A hint-aware hop that narrows the response set is a trusted relay for filtering semantics. A malicious or compromised hop could omit matching records, return records that don't match the selectors, or fabricate records. DNSSEC continues to protect the answer-set integrity (when present) but cannot vouch for filtering semantics — only that the records returned were authentically published.
 - **Echo unauthenticated.** The response echo (§4.2) is unsigned. DNSSEC signs the answer set but not OPT records. A hop could lie about what it filtered. Clients SHOULD validate by re-applying selectors locally to the returned records; treat the echo as a hint, not a guarantee.
 - **Cache poisoning at Locus 1.** The reference `EdnsAwareResolver` caches by hint signature. An attacker who can inject a forged DNS response on a cache miss could pollute the cache for any future query with that signature. Standard DNS poisoning mitigations apply; running DNSSEC validation on the path closes the most common vector.
-- **Hint tampering on the path.** Forwarders that don't understand the option are required to propagate it per RFC 6891, but a hostile forwarder could rewrite or strip the option. The reference implementation tolerates strip gracefully (the option simply doesn't reach the upstream hop, and local filtering takes over). Rewrite is more concerning: a forwarder injecting a different `intent` or `auth_type` could cause the client to be served a different agent than it asked for. Mitigation is the same as for echo trust — the client SHOULD re-apply selectors locally.
+- **Hint tampering on the path.** Forwarders that don't understand the option are required to propagate it per RFC 6891, but a hostile forwarder could rewrite or strip the option. The reference implementation tolerates strip gracefully (the option simply doesn't reach the upstream hop, and local filtering takes over). Rewrite is more concerning: a forwarder injecting a different `realm` or `min_trust` could cause the client to be served a different agent than it asked for. Mitigation is the same as for echo trust — the client SHOULD re-apply Axis-1 selectors locally against the returned record set.
+- **Cookies / proof-of-work (future).** A `client_cookie` selector (reserved code 0x20) would let auths gate high-cost zones against query floods. Not coded in v0; documented as a future extension. When introduced, it raises its own threat model — cookie binding, replay windows, recursive-side honesty about cookie propagation — that needs separate treatment.
+- **Correlation IDs and linkability (future).** A `correlation_id` selector (reserved code 0x21) would let caches and observability tooling group sibling queries from an async fan-out. The cost is that every hop sees the same opaque ID across the fan-out, which makes per-query traffic analysis substantially easier. Defer until the privacy trade-off is explicit.
 
 ## 9. Open questions
 
 1. **Middlebox transparency.** Novel 65xxx options may be stripped by forwarders that don't pass unknown options through, despite the RFC 6891 requirement. The reference implementation is designed to remain useful even when the option never leaves the client (Locus 1). Operators relying on Locus 2 or 3 should test their path with `tcpdump`.
-2. **Selector taxonomy lock-in.** Once selector codes `0x01`–`0x04` ship, changing them is painful — hint-aware implementations will index and cache on those codes. Worth a separate taxonomy review pass before any IANA action.
-3. **Echo authentication.** Is unauthenticated echo enough? A signed echo would require a different transport (the OPT record can't be DNSSEC-signed). Alternative: include a hash of the applied-selector set in the answer-section TXT, signed alongside the SVCB. Deferred to future work.
-4. **Draft alignment.** Likely a separate `draft-XXX-dnsaid-edns-signaling` rather than an appendix to `draft-mozleywilliams-dnsop-dnsaid-01`, because the wire-format addition and authoritative-side semantics are substantial.
+2. **Selector taxonomy lock-in.** Once selector codes ship, changing them is painful — hint-aware implementations will index and cache on those codes. The two-axis split (0x01–0x0F substrate, 0x10–0x1F metering, 0x20+ reserved) buys some headroom, but the specific codes within each axis (REALM=0x01, TRANSPORT=0x02, …) are still a commitment. Worth a separate taxonomy review pass before any IANA action.
+3. **Axis-encoded code ranges vs flat numbering.** v0 encodes the axis into the selector-code range. The benefit is that an on-the-wire inspector can tell at a glance which selectors are answer-shaping (Axis 1) and which are policy-shaping (Axis 2). The cost is a hard ceiling of 15 selectors per axis — enough for the foreseeable future, but a future v1 might want flat numbering with axis declared in a separate registry. Documented so the trade-off is explicit.
+4. **Echo authentication.** Is unauthenticated echo enough? A signed echo would require a different transport (the OPT record can't be DNSSEC-signed). Alternative: include a hash of the applied-selector set in the answer-section TXT, signed alongside the SVCB. Deferred to future work.
+5. **`deadline_ms` enforcement.** v0 makes it a hint-only signal — auth can prefer a faster path or serve stale to make the budget, but cannot return "won't meet deadline." A future revision could add a structured error in the OPT response (RFC 8914-style INFO-CODE) for explicit SLA refusal. Out of scope for v0.
+6. **Draft alignment.** Likely a separate `draft-XXX-dnsaid-edns-signaling` rather than an appendix to `draft-mozleywilliams-dnsop-dnsaid-01`, because the wire-format addition and authoritative-side semantics are substantial.
 
 ## 10. Future work
 

--- a/docs/experimental/edns-signaling.md
+++ b/docs/experimental/edns-signaling.md
@@ -1,0 +1,249 @@
+# Experimental: EDNS(0) `agent-hint` signaling for DNS-AID
+
+**Status:** Experimental. APIs and wire format are unstable.
+**Module:** `dns_aid.experimental` (`AgentHint`, `AgentHintEcho`, `EdnsSignalingAdvertisement`, `EdnsAwareResolver`)
+**Runtime gate:** `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1`
+
+---
+
+## 1. Overview
+
+DNS-AID today is a one-shot lookup protocol: a client knows what to ask, sends an SVCB query, and gets back an endpoint. The protocol works well when the client already knows the agent name and the publisher's domain, but it offers no mechanism for the client to communicate **what kind of agent it's looking for** while resolution is in progress. Any pre-filtering must happen client-side, after the full record set has been fetched.
+
+This document proposes an experimental EDNS(0) option — `agent-hint` — that lets the client attach a compact set of selector filters to its outgoing DNS query. Any hop on the resolution path that understands the option can use the hint to narrow the response, return a cached pre-filtered answer, or short-circuit the query entirely. Hops that don't understand the option treat it as inert, per RFC 6891 §6.1.1, and the query proceeds normally — the option degrades gracefully.
+
+The goal is not to change DNS. The goal is to give the agent-discovery flow a substrate-level signal mechanism that mirrors the way DNS recursion itself amortizes cost: expensive at the cold edge, cheap when a downstream cache has the answer. For agent discovery the equivalent of "the answer is cached at my local resolver" is "a hint-aware hop on this resolution path has a recent matching SVCB record and can hand it back without an upstream walk."
+
+## 2. Motivation
+
+Consider the three discovery scenarios from `draft-mozleywilliams-dnsop-dnsaid-01` §3:
+
+1. **Known endpoint and domain** — direct SVCB lookup. Already cheap.
+2. **Known domain, unknown service** — query `_index._agents.{domain}`, then walk the named entries. Multiple round trips; the index tells you names but not metadata.
+3. **Unknown / wildcard** — search provider or federated registry. Most expensive.
+
+Scenarios 2 and 3 commonly produce *N* candidates of which the client only wants a handful that match its needs — capabilities, intent, transport, auth posture. Today the client filters all *N* locally after fetching, often after also fetching enrichment metadata (cap docs, agent cards) for records it will discard.
+
+The `agent-hint` option moves the filter description to the query itself. If any hop along the path understands the option, that hop can:
+
+- Return only the subset that matches (a hint-aware authoritative)
+- Serve a cached pre-filtered answer (a hint-aware recursive resolver or forwarder)
+- Short-circuit the query entirely (the client's own resolver wrapper, when the hint matches a recent cache entry)
+
+Cost decays across three states:
+
+- **Cold** — no caches anywhere. Client falls back to search/registry. Expensive.
+- **Warm** — at least one hop is hint-aware and has a fresh matching record. No expensive search, possibly no DNS round-trip at all.
+- **Hot** — the client itself has already parsed and stored an SVCB record as a long-lived "skill" reference. No query at all until the record is invalidated (failed invoke, scheduled re-verification, manual flush).
+
+The hint is most useful at the **warm** state. At hot, it is bypassed. At cold, Path B search/registry is the right answer.
+
+## 3. Conceptual model
+
+The hint flows from the client toward the authoritative server. Any hop that understands the option may act on it. Hops that don't simply forward the option per RFC 6891 (commodity authoritative servers serve the same records they would have served without the option):
+
+```
+                          query + agent-hint EDNS opt
+   ┌─────────────┐ ─────────────────────────────────────▶ ┌──────────────┐
+   │  Agent      │                                         │ Forwarder /  │
+   │  runtime    │                                         │ recursive    │  (Locus 2 — optional)
+   │  (Locus 1)  │ ◀──── narrowed/cached response  ────── │ (hint-aware  │
+   └─────────────┘                                         │  if running  │
+          │                                                │  extension)  │
+          │                                                └──────┬───────┘
+          │                                                       │
+          │                                                       ▼
+          │                                              ┌──────────────────┐
+          │                                              │  Authoritative   │
+          │  reads edns_signaling advertisement          │  DNS server      │  (Locus 3 — optional)
+          │  from cap-doc / agent-card JSON              │  (hint-aware     │
+          │  AND/OR honored_selectors echoed in OPT      │   if running     │
+          │  response from hint-aware authoritative      │   extension)     │
+          └─────────────────────────────────────────────▶│   OR             │
+                                                         │   stock BIND /   │
+                                                         │   Route53 / CF   │
+                                                         │   (inert, ignores│
+                                                         │    the option)   │
+                                                         └──────────────────┘
+```
+
+**Locus 1 — in-process client cache.** The agent's own resolver wrapper reads the hint, checks a local cache keyed by `(qname, qtype, hint_signature)`. Cache hit short-circuits the query. The reference implementation, `EdnsAwareResolver`, ships with this PR. Always usable; no infrastructure required.
+
+**Locus 2 — hint-aware forwarder / recursive resolver.** A corporate gateway or shared resolver that understands the hint, serves cached pre-filtered responses, or rewrites the query before forwarding. Out of scope for this PR; valid future deployment.
+
+**Locus 3 — hint-aware authoritative server.** A DNS server implementation that inspects the hint on incoming queries and narrows the response set to records matching the selectors. For example: a domain publishes 50 agents, the client queries with `capabilities=chat & intent=summarize`, the authoritative returns just the 2 records that match. Out of scope for this PR's reference implementation; the wire format and advertisement schema are designed to support this hop without modification.
+
+Commodity authoritative servers (stock BIND, Route53, Cloudflare) are inert to unknown options per RFC 6891. They will respond identically with or without the option. That is a valid, lowest-common-denominator deployment — the client-side cache at Locus 1 still provides value.
+
+## 4. Wire format
+
+### 4.1 Request
+
+EDNS(0) option-code **65430** (private use, RFC 6891 §6.1.1, range 65001–65534).
+
+```
++------+------+------+------+------+------+
+| OPTION-CODE = 65430  | OPTION-LENGTH    |
++----------------------+------------------+
+| VERSION (1B)  | SELECTOR-COUNT (1B)     |
++---------------+-------------------------+
+| selector-code (1B) | selector-length (1B) | selector-value (N B UTF-8) |
++--------------------+----------------------+----------------------------+
+                    ...
+```
+
+- **VERSION** — `0x00` for the current version. The high bit (`0x80`) is reserved for the response-side echo (see §4.2).
+- **SELECTOR-COUNT** — number of selectors that follow. May be zero.
+- Each selector is a 1-byte type code, a 1-byte length, and a length-prefixed UTF-8 value (≤ 255 bytes).
+- Total option payload SHOULD NOT exceed 512 bytes (soft cap to keep EDNS budget reasonable).
+
+Consumers MUST ignore selector codes they don't recognise rather than reject the whole option.
+
+### 4.2 Response echo
+
+A hint-aware hop MAY include an `agent-hint` option in its response with the VERSION byte's high bit set (`0x80`) to indicate "this is an echo, not a request." The payload lists the selector codes the responder actually honoured:
+
+```
++------+------+------+------+------+------+
+| OPTION-CODE = 65430  | OPTION-LENGTH    |
++----------------------+------------------+
+| VERSION (0x80) | APPLIED-COUNT (1B)     |
++----------------+------------------------+
+| selector-code (1B) | selector-code (1B) | ...                          |
++--------------------+----------------------+------------------------+
+```
+
+Absence of an echo on a response is meaningful — it tells the client no upstream filtering happened, and the client should fall back to local filtering against the returned record set. This mirrors RFC 8914 (Extended DNS Errors) in pattern: response-only, non-mandatory, additive context.
+
+### 4.3 Selectors v0
+
+| Code | Name | Value format | Example |
+|------|------|--------------|---------|
+| 0x01 | `capabilities` | Comma-separated UTF-8 list | `"chat,code-review"` |
+| 0x02 | `intent` | Single UTF-8 tag | `"summarize"` |
+| 0x03 | `transport` | `"mcp"` \| `"a2a"` \| `"https"` | `"mcp"` |
+| 0x04 | `auth_type` | `"none"` \| `"bearer"` \| `"oauth2"` \| `"mtls"` | `"bearer"` |
+
+Codes `0x05` through `0xFF` are reserved for future selectors. The taxonomy intentionally matches the existing Path A filter kwargs on `dns_aid.discover()`.
+
+### 4.4 Worked example
+
+A client looking for an MCP-transport, bearer-auth chat agent emits an option payload of:
+
+```
+version=0x00  count=0x04
+0x01 0x04 "chat"
+0x02 0x09 "summarize"
+0x03 0x03 "mcp"
+0x04 0x06 "bearer"
+```
+
+Bytes on the wire: `00 04 01 04 63 68 61 74 02 09 73 75 6d 6d 61 72 69 7a 65 03 03 6d 63 70 04 06 62 65 61 72 65 72` (32 bytes payload, well under the 512-byte cap).
+
+A hint-aware authoritative that applied both `capabilities` and `transport` (but not `intent` or `auth_type`) would echo:
+
+```
+version=0x80  count=0x02
+0x01 0x03
+```
+
+Bytes: `80 02 01 03` (4 bytes payload).
+
+## 5. Publisher advertisement
+
+A hint-aware deployment advertises across two complementary channels.
+
+### 5.1 Channel 1 — well-known JSON
+
+Every publisher (hint-aware or not) MAY include an `edns_signaling` block in their `cap-doc`, `agent-card`, or `agents-index.json`:
+
+```json
+{
+  "name": "chat-agent",
+  ...
+  "edns_signaling": {
+    "version": 0,
+    "honored_selectors": ["capabilities", "intent", "transport"],
+    "note": "Recommends client-side pre-filtering with these selectors."
+  }
+}
+```
+
+This tells the client which selectors are *meaningful* for this publisher's agents — i.e. the publisher has populated the matching metadata fields so filtering on them will actually narrow results. Independent of whether any hop on the DNS resolution path is hint-aware; useful even with stock authoritative software.
+
+### 5.2 Channel 2 — DNS-layer signal
+
+A hint-aware authoritative or recursive server signals its capability in one of two ways:
+
+1. **OPT response echo** (preferred) — described in §4.2. The presence of an echo on a query response is itself the advertisement: "this responder processed your hint."
+2. **SVCB advertisement parameter** (optional, static advertisement at zone-discovery time) — a new param key `key65409 = "agent-hint"` on the apex SVCB record at `_agents.{domain}`, with a value like `v=0;selectors=capabilities,intent,transport`. Tells clients before they emit their first hint that this zone's authoritative will honour it. v0 keeps this optional; the echo carries the same information reactively.
+
+Channels are complementary. A client uses Channel 1 to decide *which selectors to populate*, and Channel 2 to know *whether to expect upstream narrowing or rely on local filtering*.
+
+## 6. Reference implementation
+
+The PR that introduces this document ships three modules under `dns_aid.experimental`:
+
+- `AgentHint` — Pydantic model for the request payload, with `encode()`, `signature()`, and `decode_agent_hint()`.
+- `AgentHintEcho` — model for the response echo payload.
+- `EdnsAwareResolver` — Locus 1 implementation. Wraps `dns.asyncresolver.Resolver`, attaches the option on outgoing queries (when a hint and the env flag are present), caches answers keyed by `(qname, qtype, hint_signature)`, and surfaces any upstream `AgentHintEcho` on the result.
+
+Integration with `dns_aid.discover()`:
+
+```python
+from dns_aid import discover
+from dns_aid.experimental import AgentHint
+
+result = await discover(
+    "example.com",
+    agent_hint=AgentHint(capabilities=["chat"], transport="mcp"),
+)
+```
+
+The `agent_hint` kwarg is accepted unconditionally for forward-compat. The option is only emitted on the wire when `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1` is set in the environment.
+
+A CLI demonstration command is available: `dns-aid edns-probe <domain>` (also env-gated).
+
+## 7. Privacy considerations
+
+Hints leak query intent — capabilities, intent, transport, auth posture — to **every hop that sees them**. This is more than a bare SVCB query reveals.
+
+Clients SHOULD:
+
+- Omit selectors when querying on public networks or for sensitive intents.
+- Consider that the recursive resolver, all forwarders, and the authoritative server see the full hint set.
+- Treat the hint as opt-in metadata sharing: by sending it, the client opts into being identifiable along axes the bare DNS query would not have exposed.
+
+Operators of recursive resolvers SHOULD consider scrubbing or summarizing `agent-hint` payloads at the recursive boundary, similar to ECS (RFC 7871) source-prefix scrubbing.
+
+EDNS padding (RFC 7830) can be used in conjunction with `agent-hint` to make payload-size analysis less informative.
+
+## 8. Security considerations
+
+- **Programmable-hop trust.** A hint-aware hop that narrows the response set is a trusted relay for filtering semantics. A malicious or compromised hop could omit matching records, return records that don't match the selectors, or fabricate records. DNSSEC continues to protect the answer-set integrity (when present) but cannot vouch for filtering semantics — only that the records returned were authentically published.
+- **Echo unauthenticated.** The response echo (§4.2) is unsigned. DNSSEC signs the answer set but not OPT records. A hop could lie about what it filtered. Clients SHOULD validate by re-applying selectors locally to the returned records; treat the echo as a hint, not a guarantee.
+- **Cache poisoning at Locus 1.** The reference `EdnsAwareResolver` caches by hint signature. An attacker who can inject a forged DNS response on a cache miss could pollute the cache for any future query with that signature. Standard DNS poisoning mitigations apply; running DNSSEC validation on the path closes the most common vector.
+- **Hint tampering on the path.** Forwarders that don't understand the option are required to propagate it per RFC 6891, but a hostile forwarder could rewrite or strip the option. The reference implementation tolerates strip gracefully (the option simply doesn't reach the upstream hop, and local filtering takes over). Rewrite is more concerning: a forwarder injecting a different `intent` or `auth_type` could cause the client to be served a different agent than it asked for. Mitigation is the same as for echo trust — the client SHOULD re-apply selectors locally.
+
+## 9. Open questions
+
+1. **Middlebox transparency.** Novel 65xxx options may be stripped by forwarders that don't pass unknown options through, despite the RFC 6891 requirement. The reference implementation is designed to remain useful even when the option never leaves the client (Locus 1). Operators relying on Locus 2 or 3 should test their path with `tcpdump`.
+2. **Selector taxonomy lock-in.** Once selector codes `0x01`–`0x04` ship, changing them is painful — hint-aware implementations will index and cache on those codes. Worth a separate taxonomy review pass before any IANA action.
+3. **Echo authentication.** Is unauthenticated echo enough? A signed echo would require a different transport (the OPT record can't be DNSSEC-signed). Alternative: include a hash of the applied-selector set in the answer-section TXT, signed alongside the SVCB. Deferred to future work.
+4. **Draft alignment.** Likely a separate `draft-XXX-dnsaid-edns-signaling` rather than an appendix to `draft-mozleywilliams-dnsop-dnsaid-01`, because the wire-format addition and authoritative-side semantics are substantial.
+
+## 10. Future work
+
+- **Hint-aware authoritative reference implementation.** This PR ships the wire format, the client-side spike, and the advertisement schema. A reference hint-aware authoritative is the next major step in the maturity ladder.
+- **IANA option-code reservation.** Currently in the private-use range. Promote when the design stabilizes.
+- **Recursive-resolver / forwarder reference.** Locus 2 deployment — likely shipped as a sidecar service or an extension to an existing recursive.
+- **Integration with the SDK search wrapper (Path B).** A hint-aware Path B directory could carry the hint forward across multi-domain searches.
+- **Padding strategy.** Recommended sizing and chaff to mitigate intent-inference attacks on the hint payload.
+
+## 11. References
+
+- [RFC 6891](https://www.rfc-editor.org/rfc/rfc6891) — Extension Mechanisms for DNS (EDNS(0))
+- [RFC 7871](https://www.rfc-editor.org/rfc/rfc7871) — Client Subnet in DNS Queries
+- [RFC 8914](https://www.rfc-editor.org/rfc/rfc8914) — Extended DNS Errors (echo pattern reference)
+- [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) — DNS-AID main spec
+- [draft-ietf-dnsop-svcb-https](https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/) — SVCB record type (RFC 9460)

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Annotated
 
 import typer
@@ -2480,6 +2481,119 @@ def dcv_revoke(
         else:
             error_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
+
+
+# ============================================================================
+# EXPERIMENTAL: edns-probe — demonstrate EDNS(0) agent-hint signaling
+# ============================================================================
+
+
+@app.command("edns-probe")
+def edns_probe(
+    domain: Annotated[str, typer.Argument(help="Domain to discover agents at")],
+    capabilities: Annotated[
+        str | None,
+        typer.Option("--capabilities", help="Comma-separated capabilities filter"),
+    ] = None,
+    intent: Annotated[str | None, typer.Option("--intent", help="Single intent tag filter")] = None,
+    transport: Annotated[
+        str | None,
+        typer.Option("--transport", help="Transport: mcp | a2a | https"),
+    ] = None,
+    auth_type: Annotated[
+        str | None,
+        typer.Option("--auth-type", help="Auth type: none | bearer | oauth2 | mtls"),
+    ] = None,
+    show_wire: Annotated[
+        bool,
+        typer.Option(
+            "--show-wire",
+            help="Print the EDNS option payload bytes (hex) for manual wire correlation.",
+        ),
+    ] = False,
+) -> None:
+    """[experimental] Demonstrate EDNS(0) agent-hint signaling end-to-end.
+
+    Constructs an AgentHint from the CLI flags, wraps the discovery resolver
+    with EdnsAwareResolver, performs two discover() calls back-to-back, and
+    reports the cache miss/hit behavior plus any AgentHintEcho the upstream
+    returned.
+
+    Requires DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 in the environment. Without the
+    flag, the command prints how to enable and exits non-zero.
+    """
+    import os
+    import sys
+
+    if os.environ.get("DNS_AID_EXPERIMENTAL_EDNS_HINTS", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        error_console.print(
+            "[yellow]Set DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 to enable this command.[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    print(
+        "[experimental] EDNS(0) agent-hint signaling is unstable; APIs may change.", file=sys.stderr
+    )
+
+    from dns_aid import discover
+    from dns_aid.experimental import AgentHint
+
+    caps_list = [c.strip() for c in capabilities.split(",") if c.strip()] if capabilities else None
+    hint = AgentHint(
+        capabilities=caps_list,
+        intent=intent,
+        transport=transport,
+        auth_type=auth_type,
+    )
+
+    console.print(
+        f"[bold]Probing {domain}[/bold] with hint signature: [cyan]{hint.signature() or '(empty)'}[/cyan]"
+    )
+    if show_wire:
+        payload = hint.encode()
+        console.print(f"  Wire payload ({len(payload)} bytes): [dim]{payload.hex()}[/dim]")
+
+    # First call — cold
+    console.print("\n[bold]Call 1[/bold] (expect upstream DNS query)")
+    t0 = time.perf_counter()
+    result1 = run_async(discover(domain, agent_hint=hint))
+    elapsed1_ms = (time.perf_counter() - t0) * 1000
+    console.print(
+        f"  agents={len(result1.agents)} dnssec={result1.dnssec_validated} "
+        f"elapsed={elapsed1_ms:.1f}ms"
+    )
+
+    # Second call — same hint, demonstrates that without an EdnsAwareResolver wrapping,
+    # the second call still hits DNS. The cache lives in EdnsAwareResolver itself;
+    # the standard discover() path doesn't share it. We demonstrate the cache
+    # separately below.
+    console.print("\n[bold]Call 2[/bold] via EdnsAwareResolver (in-process cache, Locus 1)")
+    from dns_aid.experimental import EdnsAwareResolver
+
+    resolver = EdnsAwareResolver()
+    fqdn_hint = f"_index._agents.{domain}"
+    t0 = time.perf_counter()
+    cached1 = run_async(resolver.resolve(fqdn_hint, "TXT", agent_hint=hint))
+    miss_ms = (time.perf_counter() - t0) * 1000
+    t0 = time.perf_counter()
+    cached2 = run_async(resolver.resolve(fqdn_hint, "TXT", agent_hint=hint))
+    hit_ms = (time.perf_counter() - t0) * 1000
+    console.print(f"  Cache miss: {miss_ms:.2f}ms — upstream resolve happened")
+    console.print(f"  Cache hit:  {hit_ms:.2f}ms — no upstream call")
+    if cached1.echo is not None:
+        applied = ",".join(str(c) for c in cached1.echo.applied_selectors)
+        console.print(f"  Upstream echoed applied selectors: [green]{applied}[/green]")
+    else:
+        console.print(
+            "  No echo from upstream — stock authoritative or stripped en route. "
+            "Local filtering is the only narrowing that happened."
+        )
+    # Reference cached2 so linters know it's intentional
+    _ = cached2
 
 
 # ============================================================================

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -2491,18 +2491,60 @@ def dcv_revoke(
 @app.command("edns-probe")
 def edns_probe(
     domain: Annotated[str, typer.Argument(help="Domain to discover agents at")],
-    capabilities: Annotated[
-        str | None,
-        typer.Option("--capabilities", help="Comma-separated capabilities filter"),
+    # Axis 1 — substrate filters
+    realm: Annotated[
+        str | None, typer.Option("--realm", help="[Axis 1] Multi-tenant scope identifier.")
     ] = None,
-    intent: Annotated[str | None, typer.Option("--intent", help="Single intent tag filter")] = None,
     transport: Annotated[
         str | None,
-        typer.Option("--transport", help="Transport: mcp | a2a | https"),
+        typer.Option("--transport", help="[Axis 1] Transport: mcp | a2a | https."),
     ] = None,
-    auth_type: Annotated[
+    policy_required: Annotated[
+        bool,
+        typer.Option(
+            "--policy-required",
+            help="[Axis 1] Only return records carrying a policy= URI.",
+        ),
+    ] = False,
+    min_trust: Annotated[
         str | None,
-        typer.Option("--auth-type", help="Auth type: none | bearer | oauth2 | mtls"),
+        typer.Option(
+            "--min-trust",
+            help="[Axis 1] Trust posture: signed | dnssec | signed+dnssec.",
+        ),
+    ] = None,
+    jurisdiction: Annotated[
+        str | None,
+        typer.Option("--jurisdiction", help="[Axis 1] ISO region tag (e.g. eu, us-east)."),
+    ] = None,
+    # Axis 2 — metering / lifecycle
+    intent_class: Annotated[
+        str | None,
+        typer.Option(
+            "--intent-class",
+            help="[Axis 2] Client intent: discovery | invocation.",
+        ),
+    ] = None,
+    max_age: Annotated[
+        int | None,
+        typer.Option(
+            "--max-age",
+            help="[Axis 2] Don't return cache entries older than this many seconds.",
+        ),
+    ] = None,
+    parallelism: Annotated[
+        int | None,
+        typer.Option(
+            "--parallelism",
+            help="[Axis 2] Expected sibling-query count (signals fan-out to caches).",
+        ),
+    ] = None,
+    deadline_ms: Annotated[
+        int | None,
+        typer.Option(
+            "--deadline-ms",
+            help="[Axis 2] Wait budget in milliseconds. Hint-only — auth cannot refuse for SLA in v0.",
+        ),
     ] = None,
     show_wire: Annotated[
         bool,
@@ -2542,12 +2584,18 @@ def edns_probe(
     from dns_aid import discover
     from dns_aid.experimental import AgentHint
 
-    caps_list = [c.strip() for c in capabilities.split(",") if c.strip()] if capabilities else None
     hint = AgentHint(
-        capabilities=caps_list,
-        intent=intent,
+        # Axis 1
+        realm=realm,
         transport=transport,
-        auth_type=auth_type,
+        policy_required=policy_required,
+        min_trust=min_trust,
+        jurisdiction=jurisdiction,
+        # Axis 2
+        client_intent_class=intent_class,
+        max_age=max_age,
+        parallelism=parallelism,
+        deadline_ms=deadline_ms,
     )
 
     console.print(

--- a/src/dns_aid/core/_edns_hint_ctx.py
+++ b/src/dns_aid/core/_edns_hint_ctx.py
@@ -1,0 +1,76 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Internal helper: per-call EDNS(0) ``agent-hint`` plumbing for the discovery layer.
+
+⚠ Experimental. See ``docs/experimental/edns-signaling.md``.
+
+This module is intentionally tiny and private (leading underscore in the name)
+because both ``discoverer.py`` and ``indexer.py`` need to read the same active
+hint without creating an import cycle (discoverer already imports from indexer).
+
+The contextvar is set by :func:`dns_aid.core.discoverer.discover` for the
+duration of the call, then reset in ``finally``. Helpers that build a
+``dns.asyncresolver.Resolver`` call :func:`apply_agent_hint_to_resolver` to
+attach the EDNS option when both the contextvar and the env flag are set.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+from typing import TYPE_CHECKING
+
+import dns.asyncresolver
+import structlog
+
+if TYPE_CHECKING:
+    from dns_aid.experimental.edns_hint import AgentHint
+
+logger = structlog.get_logger(__name__)
+
+_AGENT_HINT_CTX: contextvars.ContextVar[AgentHint | None] = contextvars.ContextVar(
+    "dns_aid_agent_hint", default=None
+)
+_EDNS_HINTS_ENV_FLAG = "DNS_AID_EXPERIMENTAL_EDNS_HINTS"
+
+
+def set_agent_hint(hint: AgentHint | None) -> contextvars.Token:
+    """Set the active hint and return a token for reset()."""
+    return _AGENT_HINT_CTX.set(hint)
+
+
+def reset_agent_hint(token: contextvars.Token) -> None:
+    """Restore the previous hint value."""
+    _AGENT_HINT_CTX.reset(token)
+
+
+def apply_agent_hint_to_resolver(resolver: dns.asyncresolver.Resolver) -> None:
+    """Attach the active agent-hint EDNS option to ``resolver`` if enabled.
+
+    No-op unless both: (a) a non-None hint is set on the contextvar, AND (b)
+    the ``DNS_AID_EXPERIMENTAL_EDNS_HINTS`` environment variable is truthy.
+    Import of the experimental module is lazy so non-experimental users never
+    load it.
+    """
+    if os.environ.get(_EDNS_HINTS_ENV_FLAG, "").lower() not in ("1", "true", "yes"):
+        return
+    hint = _AGENT_HINT_CTX.get()
+    if hint is None:
+        return
+    try:
+        import dns.edns
+
+        from dns_aid.experimental.edns_hint import AGENT_HINT_OPTION_CODE
+
+        option = dns.edns.GenericOption(dns.edns.OptionType(AGENT_HINT_OPTION_CODE), hint.encode())
+        resolver.use_edns(0, 0, 4096, options=[option])
+        logger.debug(
+            "experimental.agent_hint_attached",
+            option_code=AGENT_HINT_OPTION_CODE,
+            signature=hint.signature(),
+        )
+    except Exception as e:
+        # Experimental path must never break core discovery on failure.
+        logger.warning("experimental.agent_hint_attach_failed", error=str(e))

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -112,6 +112,9 @@ class A2AAgentCard:
     default_input_modes: list[str] = field(default_factory=lambda: ["text"])
     default_output_modes: list[str] = field(default_factory=lambda: ["text"])
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Experimental: publisher's EDNS(0) agent-hint advertisement. Stored as the
+    # raw dict from JSON. See docs/experimental/edns-signaling.md.
+    edns_signaling: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> A2AAgentCard:
@@ -134,6 +137,11 @@ class A2AAgentCard:
         if "authentication" in data and isinstance(data["authentication"], dict):
             auth = A2AAuthentication.from_dict(data["authentication"])
 
+        # Experimental: lift edns_signaling advertisement if present
+        edns_signaling = data.get("edns_signaling")
+        if not isinstance(edns_signaling, dict):
+            edns_signaling = None
+
         # Collect unknown fields as metadata
         known_keys = {
             "name",
@@ -145,6 +153,7 @@ class A2AAgentCard:
             "authentication",
             "defaultInputModes",
             "defaultOutputModes",
+            "edns_signaling",
         }
         metadata = {k: v for k, v in data.items() if k not in known_keys}
 
@@ -159,6 +168,7 @@ class A2AAgentCard:
             default_input_modes=data.get("defaultInputModes", ["text"]),
             default_output_modes=data.get("defaultOutputModes", ["text"]),
             metadata=metadata,
+            edns_signaling=edns_signaling,
         )
 
     @classmethod

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -46,6 +46,10 @@ class CapabilityDocument:
     use_cases: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
     raw_data: dict[str, Any] = field(default_factory=dict)
+    # Experimental: publisher's EDNS(0) agent-hint advertisement. Stored as the
+    # raw dict from the JSON to avoid coupling core to the experimental package.
+    # See docs/experimental/edns-signaling.md.
+    edns_signaling: dict[str, Any] | None = None
 
 
 def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bool:
@@ -178,7 +182,13 @@ async def fetch_cap_document(
         capabilities = _extract_capabilities_multi_format(data)
         use_cases = _extract_string_list(data, "use_cases")
 
-        known_keys = {"capabilities", "version", "description", "use_cases"}
+        # Experimental: lift the publisher's edns_signaling advertisement if present.
+        # Stored as a dict; forward-compat on unknown versions / shapes.
+        edns_signaling = data.get("edns_signaling")
+        if not isinstance(edns_signaling, dict):
+            edns_signaling = None
+
+        known_keys = {"capabilities", "version", "description", "use_cases", "edns_signaling"}
         metadata = {k: v for k, v in data.items() if k not in known_keys}
 
         doc = CapabilityDocument(
@@ -188,6 +198,7 @@ async def fetch_cap_document(
             use_cases=use_cases,
             metadata=metadata,
             raw_data=data,
+            edns_signaling=edns_signaling,
         )
 
         logger.debug(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -15,7 +15,7 @@ import base64
 import json
 import shlex
 import time
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 import dns.asyncresolver
@@ -23,11 +23,23 @@ import dns.rdatatype
 import dns.resolver
 import structlog
 
+from dns_aid.core._edns_hint_ctx import (
+    apply_agent_hint_to_resolver as _apply_agent_hint_to_resolver,
+)
+from dns_aid.core._edns_hint_ctx import (
+    reset_agent_hint as _reset_agent_hint,
+)
+from dns_aid.core._edns_hint_ctx import (
+    set_agent_hint as _set_agent_hint,
+)
 from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
 from dns_aid.core.filters import apply_filters
 from dns_aid.core.http_index import HttpIndexAgent, fetch_http_index_or_empty
 from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol
+
+if TYPE_CHECKING:
+    from dns_aid.experimental.edns_hint import AgentHint
 
 logger = structlog.get_logger(__name__)
 
@@ -122,6 +134,10 @@ async def discover(
     text_match: str | None = None,
     require_signed: bool = False,
     require_signature_algorithm: list[str] | None = None,
+    # Experimental: EDNS(0) agent-hint signaling. See docs/experimental/edns-signaling.md.
+    # Accepted unconditionally for forward-compat; only injected on the wire when
+    # DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 is set in the environment.
+    agent_hint: AgentHint | None = None,
 ) -> DiscoveryResult:
     """
     Discover AI agents at a domain using DNS-AID protocol.
@@ -179,6 +195,59 @@ async def discover(
         logger.debug("sdk.discover_implicit_verify_signatures", reason="require_signed=True")
 
     start_time = time.perf_counter()
+
+    # Experimental: stash agent_hint on the contextvar so DNS helpers below can
+    # attach it as an EDNS option without threading through every signature.
+    # try/finally guarantees the reset even on exception so the contextvar
+    # doesn't carry stale state across calls within the same async task.
+    _hint_token = _set_agent_hint(agent_hint)
+    try:
+        return await _discover_body(
+            domain,
+            protocol,
+            name,
+            require_dnssec,
+            use_http_index,
+            enrich_endpoints,
+            verify_signatures,
+            capabilities,
+            capabilities_any,
+            auth_type,
+            intent,
+            transport,
+            realm,
+            min_dnssec,
+            text_match,
+            require_signed,
+            require_signature_algorithm,
+            start_time,
+        )
+    finally:
+        _reset_agent_hint(_hint_token)
+
+
+async def _discover_body(
+    domain: str,
+    protocol: str | Protocol | None,
+    name: str | None,
+    require_dnssec: bool,
+    use_http_index: bool,
+    enrich_endpoints: bool,
+    verify_signatures: bool,
+    capabilities: list[str] | None,
+    capabilities_any: list[str] | None,
+    auth_type: str | None,
+    intent: str | None,
+    transport: str | None,
+    realm: str | None,
+    min_dnssec: bool,
+    text_match: str | None,
+    require_signed: bool,
+    require_signature_algorithm: list[str] | None,
+    start_time: float,
+) -> DiscoveryResult:
+    """Body of discover(), extracted so the public surface can wrap it in a
+    contextvar try/finally for the experimental agent_hint plumbing."""
 
     protocol = _normalize_protocol(protocol)
 
@@ -298,6 +367,7 @@ async def _query_single_agent(
 
     try:
         resolver = dns.asyncresolver.Resolver()
+        _apply_agent_hint_to_resolver(resolver)
 
         # Query SVCB record
         # Note: dnspython uses type 64 for SVCB
@@ -526,6 +596,7 @@ async def _query_capabilities(fqdn: str) -> list[str]:
 
     try:
         resolver = dns.asyncresolver.Resolver()
+        _apply_agent_hint_to_resolver(resolver)
         answers = await resolver.resolve(fqdn, "TXT")
 
         for rdata in answers:

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -116,6 +116,9 @@ class HttpIndexAgent:
     model_card: ModelCard | None = None
     capability: Capability | None = None
     cost: str | None = None
+    # Experimental: publisher's EDNS(0) agent-hint advertisement. Stored as the
+    # raw dict from JSON. See docs/experimental/edns-signaling.md.
+    edns_signaling: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, name: str, data: dict[str, Any]) -> HttpIndexAgent:
@@ -138,6 +141,11 @@ class HttpIndexAgent:
         model_card = ModelCard.from_dict(model_card_data)
         capability = Capability.from_dict(capability_data)
 
+        # Experimental: lift edns_signaling advertisement if present
+        edns_signaling = data.get("edns_signaling")
+        if not isinstance(edns_signaling, dict):
+            edns_signaling = None
+
         return cls(
             name=name,
             fqdn=location.get("fqdn", ""),
@@ -148,6 +156,7 @@ class HttpIndexAgent:
             model_card=model_card,
             capability=capability,
             cost=capability.cost,
+            edns_signaling=edns_signaling,
         )
 
     @property

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -171,6 +171,9 @@ async def read_index_via_dns(domain: str) -> list[IndexEntry]:
 
     try:
         resolver = dns.asyncresolver.Resolver()
+        from dns_aid.core._edns_hint_ctx import apply_agent_hint_to_resolver
+
+        apply_agent_hint_to_resolver(resolver)
         answers = await resolver.resolve(fqdn, "TXT")
 
         for rdata in answers:

--- a/src/dns_aid/experimental/__init__.py
+++ b/src/dns_aid/experimental/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experimental DNS-AID features.
+
+⚠ APIs in this subpackage are unstable. They may change shape, change behaviour,
+or disappear entirely in any release — including patch versions. They are NOT
+covered by the semver guarantees that apply to ``dns_aid.core`` and ``dns_aid.sdk``.
+
+By convention, experimental features are:
+
+- Never re-exported from the top-level ``dns_aid`` package. Callers import
+  explicitly: ``from dns_aid.experimental import AgentHint``.
+- Gated at runtime by a per-feature environment variable
+  (e.g. ``DNS_AID_EXPERIMENTAL_EDNS_HINTS=1``). Without the flag, the related
+  code paths remain dormant even if the symbols are imported.
+- Documented in ``docs/experimental/`` rather than ``docs/rfc/``.
+
+Currently exported:
+
+- :class:`AgentHint` — request-side EDNS(0) signal carrying selector filters
+- :class:`AgentHintEcho` — response-side echo from a hint-aware DNS hop
+- :class:`EdnsSignalingAdvertisement` — publisher advertisement model (JSON)
+- :class:`EdnsAwareResolver` — in-process programmable hop with hint-keyed cache
+
+See ``docs/experimental/edns-signaling.md`` for the design rationale and wire
+format.
+"""
+
+from __future__ import annotations
+
+from dns_aid.experimental.edns_cache import CachedAnswer, EdnsAwareResolver
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    EdnsSignalingAdvertisement,
+    HintSelector,
+    decode_agent_hint,
+    decode_agent_hint_echo,
+)
+
+__all__ = [
+    "AGENT_HINT_OPTION_CODE",
+    "AgentHint",
+    "AgentHintEcho",
+    "CachedAnswer",
+    "EdnsAwareResolver",
+    "EdnsSignalingAdvertisement",
+    "HintSelector",
+    "decode_agent_hint",
+    "decode_agent_hint_echo",
+]

--- a/src/dns_aid/experimental/edns_cache.py
+++ b/src/dns_aid/experimental/edns_cache.py
@@ -1,0 +1,175 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experimental ``EdnsAwareResolver`` — in-process programmable hop for ``agent-hint``.
+
+⚠ Experimental. See ``docs/experimental/edns-signaling.md``.
+
+This is the Locus 1 reference implementation: a thin wrapper around
+``dns.asyncresolver.Resolver`` that caches answers keyed by
+``(qname, qtype, hint_signature)``. When a query carries an :class:`AgentHint`
+that matches a previous fresh entry, the cached answer is returned without an
+upstream round trip.
+
+The cache is unconditionally per-process and in-memory. It is intentionally
+simple: no eviction policy beyond TTL expiry, no concurrency guards beyond what
+``asyncio`` provides natively (single event loop), no persistence. The point is
+to demonstrate the warm-cache behaviour described in the design doc, not to be
+a production cache.
+
+If the upstream response carries an :class:`AgentHintEcho`, it is surfaced on
+the :class:`CachedAnswer` so callers can see what filtering (if any) happened
+upstream.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import dns.asyncresolver
+import dns.edns
+import structlog
+
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    decode_agent_hint_echo,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_CACHE_TTL_SECONDS: float = 60.0
+
+
+@dataclass
+class CachedAnswer:
+    """A DNS answer captured by :class:`EdnsAwareResolver`.
+
+    Attributes:
+        answer:    The underlying ``dns.resolver.Answer`` (or anything the
+                   wrapped resolver returns).
+        cached_at: Monotonic timestamp of capture.
+        echo:      :class:`AgentHintEcho` if the upstream response carried one,
+                   else ``None``. Absence is meaningful — it tells the caller no
+                   upstream filtering happened.
+    """
+
+    answer: Any
+    cached_at: float
+    echo: AgentHintEcho | None = None
+
+
+CacheKey = tuple[str, str, str | None]
+
+
+class EdnsAwareResolver:
+    """In-process programmable hop that caches DNS answers by hint signature.
+
+    Usage::
+
+        resolver = EdnsAwareResolver()
+        result = await resolver.resolve(
+            "_chat._mcp._agents.example.com", "SVCB",
+            agent_hint=AgentHint(capabilities=["chat"]),
+        )
+        # result.answer is the dns answer; result.echo is the hop's applied selectors
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        upstream: dns.asyncresolver.Resolver | None = None,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._cache: dict[CacheKey, CachedAnswer] = {}
+        # Construct a default upstream resolver here so tests can swap it in.
+        self._upstream = upstream if upstream is not None else dns.asyncresolver.Resolver()
+        # Bypass OS cache so we observe upstream hits, not stale OS positives.
+        self._upstream.cache = None
+
+    async def resolve(
+        self,
+        qname: str,
+        qtype: str,
+        *,
+        agent_hint: AgentHint | None = None,
+    ) -> CachedAnswer:
+        """Resolve ``qname/qtype``, attaching ``agent_hint`` as an EDNS option.
+
+        Returns a :class:`CachedAnswer` containing the answer plus, if present,
+        the upstream :class:`AgentHintEcho`.
+        """
+        signature = agent_hint.signature() if agent_hint is not None else None
+        key: CacheKey = (qname, qtype, signature)
+
+        cached = self._cache.get(key)
+        if cached is not None and (time.monotonic() - cached.cached_at) < self._ttl:
+            logger.debug(
+                "edns-aware cache hit",
+                qname=qname,
+                qtype=qtype,
+                hint_signature=signature,
+            )
+            return cached
+
+        # Cache miss (or expired) — go upstream.
+        if agent_hint is not None:
+            option = dns.edns.GenericOption(
+                dns.edns.OptionType(AGENT_HINT_OPTION_CODE), agent_hint.encode()
+            )
+            # use_edns is sync on the resolver; options is the list of EDNS options to send.
+            self._upstream.use_edns(0, 0, 4096, options=[option])
+        else:
+            # Reset any previously-configured options so the next bare call doesn't leak hints.
+            self._upstream.use_edns(0, 0, 4096, options=[])
+
+        logger.debug(
+            "edns-aware cache miss; resolving upstream",
+            qname=qname,
+            qtype=qtype,
+            hint_signature=signature,
+        )
+        answer = await self._upstream.resolve(qname, qtype)
+        echo = _extract_echo(answer)
+
+        cached = CachedAnswer(answer=answer, cached_at=time.monotonic(), echo=echo)
+        self._cache[key] = cached
+        return cached
+
+    def invalidate(self) -> None:
+        """Drop all cached entries."""
+        self._cache.clear()
+
+
+def _extract_echo(answer: Any) -> AgentHintEcho | None:
+    """Return the :class:`AgentHintEcho` from a response, or ``None`` if absent.
+
+    Looks at ``answer.response.options`` (dnspython attaches EDNS options there
+    on the response message). Silently returns ``None`` for any structural
+    issue — the echo is non-mandatory.
+    """
+    response = getattr(answer, "response", None)
+    if response is None:
+        return None
+    options = getattr(response, "options", None) or []
+    for opt in options:
+        otype = getattr(opt, "otype", None)
+        if otype != AGENT_HINT_OPTION_CODE:
+            continue
+        # dnspython GenericOption stores payload in .data
+        data = getattr(opt, "data", None)
+        if not isinstance(data, (bytes, bytearray)):
+            return None
+        try:
+            return decode_agent_hint_echo(bytes(data))
+        except ValueError:
+            return None
+    return None

--- a/src/dns_aid/experimental/edns_hint.py
+++ b/src/dns_aid/experimental/edns_hint.py
@@ -1,0 +1,301 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Experimental EDNS(0) ``agent-hint`` option — request + response wire format.
+
+⚠ Experimental. See ``docs/experimental/edns-signaling.md`` for the full design.
+
+The ``agent-hint`` option carries a compact set of selector filters from the
+client to whichever hop on the resolution path is hint-aware:
+
+- Locus 1: the client's own resolver wrapper (in-process cache, see
+  :mod:`dns_aid.experimental.edns_cache`)
+- Locus 2: a hint-aware recursive resolver / forwarder
+- Locus 3: a hint-aware authoritative DNS server
+
+Stock authoritative servers treat the option as inert per RFC 6891. A hint-aware
+hop MAY include an :class:`AgentHintEcho` option in its response listing the
+selectors it actually applied — this lets the client know what upstream
+filtering happened.
+
+Wire format (request)::
+
+    +------------------+------------------+
+    |  VERSION (0x00)  |  SELECTOR-COUNT  |
+    +------------------+------------------+
+    |  selector-code (1B) | selector-len (1B) | selector-value (N B UTF-8) |
+    +------------------+------------------+
+                       ...
+
+Wire format (response echo)::
+
+    +------------------+------------------+
+    |  VERSION (0x80)  |  APPLIED-COUNT   |
+    +------------------+------------------+
+    |  selector-code (1B) | selector-code (1B) | ...                       |
+    +------------------+------------------+
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+from pydantic import BaseModel, Field, field_validator
+
+# Private-use EDNS(0) option-code range is 65001–65534 (RFC 6891 §6.1.1).
+# 65430 chosen arbitrarily within the range; subject to change before any IANA
+# coordination.
+AGENT_HINT_OPTION_CODE: int = 65430
+
+VERSION_REQUEST: int = 0x00
+VERSION_ECHO: int = 0x80
+ECHO_FLAG_MASK: int = 0x80
+VERSION_NUMBER_MASK: int = 0x7F
+
+MAX_SELECTOR_VALUE_LEN: int = 255  # 1-byte length prefix
+MAX_OPTION_PAYLOAD: int = 512  # soft cap to stay inside reasonable EDNS budget
+
+
+class HintSelector(IntEnum):
+    """Selector codes for ``agent-hint`` v0.
+
+    Codes 0x05–0xFF are reserved for future versions. Consumers MUST ignore
+    selector codes they do not recognise rather than rejecting the whole option.
+    """
+
+    CAPABILITIES = 0x01  # comma-separated list, e.g. "chat,code-review"
+    INTENT = 0x02  # single tag, e.g. "summarize"
+    TRANSPORT = 0x03  # "mcp" | "a2a" | "https"
+    AUTH_TYPE = 0x04  # "none" | "bearer" | "oauth2" | "mtls"
+
+
+# -----------------------------------------------------------------------------
+# Models
+# -----------------------------------------------------------------------------
+
+
+class AgentHint(BaseModel):
+    """Request-side EDNS(0) ``agent-hint`` payload.
+
+    Encodes a small set of selector filters that the client wants applied (by
+    whichever hop on the resolution path is hint-aware). Unrecognised selectors
+    on decode are silently dropped — forward compatibility.
+    """
+
+    capabilities: list[str] | None = Field(
+        default=None,
+        description="List of capability tags the client is looking for.",
+    )
+    intent: str | None = Field(
+        default=None,
+        description="Single intent tag, e.g. 'summarize'.",
+    )
+    transport: str | None = Field(
+        default=None,
+        description="Transport: 'mcp' | 'a2a' | 'https'.",
+    )
+    auth_type: str | None = Field(
+        default=None,
+        description="Auth type: 'none' | 'bearer' | 'oauth2' | 'mtls'.",
+    )
+
+    @field_validator("capabilities")
+    @classmethod
+    def _strip_empty_caps(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        cleaned = [c.strip() for c in v if c and c.strip()]
+        return cleaned or None
+
+    def encode(self) -> bytes:
+        """Encode this hint into the EDNS(0) option payload bytes.
+
+        Raises:
+            ValueError: if any selector value exceeds 255 bytes UTF-8, or the
+                total payload would exceed ``MAX_OPTION_PAYLOAD``.
+        """
+        selectors: list[tuple[int, bytes]] = []
+
+        if self.capabilities:
+            value = ",".join(self.capabilities).encode("utf-8")
+            selectors.append((HintSelector.CAPABILITIES.value, value))
+        if self.intent:
+            selectors.append((HintSelector.INTENT.value, self.intent.encode("utf-8")))
+        if self.transport:
+            selectors.append((HintSelector.TRANSPORT.value, self.transport.encode("utf-8")))
+        if self.auth_type:
+            selectors.append((HintSelector.AUTH_TYPE.value, self.auth_type.encode("utf-8")))
+
+        if len(selectors) > 255:
+            raise ValueError("agent-hint cannot carry more than 255 selectors")
+
+        parts: list[bytes] = [bytes([VERSION_REQUEST, len(selectors)])]
+        for code, value in selectors:
+            if len(value) > MAX_SELECTOR_VALUE_LEN:
+                raise ValueError(
+                    f"selector value for code 0x{code:02x} is {len(value)} bytes; "
+                    f"max is {MAX_SELECTOR_VALUE_LEN}"
+                )
+            parts.append(bytes([code, len(value)]))
+            parts.append(value)
+
+        payload = b"".join(parts)
+        if len(payload) > MAX_OPTION_PAYLOAD:
+            raise ValueError(
+                f"agent-hint payload is {len(payload)} bytes; max is {MAX_OPTION_PAYLOAD}"
+            )
+        return payload
+
+    def signature(self) -> str:
+        """Stable cache-key string for this hint.
+
+        Order-independent: two hints with the same selectors produce the same
+        signature regardless of construction order. ``capabilities`` values are
+        sorted to normalise.
+        """
+        parts: list[str] = []
+        if self.capabilities:
+            parts.append("cap:" + ",".join(sorted(self.capabilities)))
+        if self.intent:
+            parts.append(f"int:{self.intent}")
+        if self.transport:
+            parts.append(f"trn:{self.transport}")
+        if self.auth_type:
+            parts.append(f"aut:{self.auth_type}")
+        return "|".join(parts)
+
+
+class AgentHintEcho(BaseModel):
+    """Response-side echo from a hint-aware DNS hop.
+
+    Lists the selector codes the responder actually applied. Absence of an echo
+    on a response means no upstream filtering happened — the client should fall
+    back to local filtering against the returned record set.
+    """
+
+    applied_selectors: list[int] = Field(
+        default_factory=list,
+        description="Selector codes (HintSelector enum values) that the responder honoured.",
+    )
+
+    def encode(self) -> bytes:
+        """Encode this echo into the EDNS(0) option payload bytes."""
+        if len(self.applied_selectors) > 255:
+            raise ValueError("agent-hint echo cannot carry more than 255 selector codes")
+        for code in self.applied_selectors:
+            if not 0 <= code <= 255:
+                raise ValueError(f"selector code {code} out of range 0–255")
+        return bytes([VERSION_ECHO, len(self.applied_selectors)]) + bytes(self.applied_selectors)
+
+
+class EdnsSignalingAdvertisement(BaseModel):
+    """Publisher advertisement carried in well-known JSON blobs (cap-doc, agent-card).
+
+    Tells the client which selectors are *meaningful* for this publisher's
+    agents — i.e. the publisher has populated the matching metadata fields so
+    filtering on them will actually narrow results.
+
+    Channel-1 advertisement (out-of-band, JSON). Independent of whether any hop
+    on the DNS resolution path is hint-aware (which is the Channel-2 signal —
+    the OPT response echo).
+    """
+
+    version: int = Field(description="Hint protocol version this publisher supports.")
+    honored_selectors: list[str] = Field(
+        default_factory=list,
+        description="Selector names this publisher recommends populating, e.g. "
+        "['capabilities', 'intent', 'transport'].",
+    )
+    note: str | None = Field(
+        default=None,
+        description="Free-form human-readable note from the publisher.",
+    )
+
+
+# -----------------------------------------------------------------------------
+# Decoders
+# -----------------------------------------------------------------------------
+
+
+def decode_agent_hint(payload: bytes) -> AgentHint:
+    """Decode an EDNS(0) ``agent-hint`` request payload into :class:`AgentHint`.
+
+    Unrecognised selector codes are silently skipped (forward compat). Raises
+    :class:`ValueError` for structural malformations (truncated payload, echo
+    bit set, length overflow).
+    """
+    if len(payload) < 2:
+        raise ValueError("agent-hint payload too short (need at least version + count)")
+
+    version_byte = payload[0]
+    if version_byte & ECHO_FLAG_MASK:
+        raise ValueError("agent-hint payload has echo bit set (0x80); use decode_agent_hint_echo()")
+    version_number = version_byte & VERSION_NUMBER_MASK
+    if version_number != 0:
+        raise ValueError(f"unsupported agent-hint version {version_number}; only v0 is defined")
+
+    selector_count = payload[1]
+    cursor = 2
+
+    capabilities: list[str] | None = None
+    intent: str | None = None
+    transport: str | None = None
+    auth_type: str | None = None
+
+    for _ in range(selector_count):
+        if cursor + 2 > len(payload):
+            raise ValueError("agent-hint payload truncated mid-selector header")
+        code = payload[cursor]
+        length = payload[cursor + 1]
+        value_start = cursor + 2
+        value_end = value_start + length
+        if value_end > len(payload):
+            raise ValueError("agent-hint payload truncated mid-selector value")
+        try:
+            value = payload[value_start:value_end].decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError(f"selector code 0x{code:02x} value is not valid UTF-8") from e
+        cursor = value_end
+
+        if code == HintSelector.CAPABILITIES.value:
+            capabilities = [c.strip() for c in value.split(",") if c.strip()] or None
+        elif code == HintSelector.INTENT.value:
+            intent = value
+        elif code == HintSelector.TRANSPORT.value:
+            transport = value
+        elif code == HintSelector.AUTH_TYPE.value:
+            auth_type = value
+        # else: silently drop unknown selectors (forward compat)
+
+    return AgentHint(
+        capabilities=capabilities,
+        intent=intent,
+        transport=transport,
+        auth_type=auth_type,
+    )
+
+
+def decode_agent_hint_echo(payload: bytes) -> AgentHintEcho:
+    """Decode an EDNS(0) ``agent-hint`` response echo payload.
+
+    Raises :class:`ValueError` if the echo bit is not set, or if the payload is
+    truncated.
+    """
+    if len(payload) < 2:
+        raise ValueError("agent-hint echo payload too short (need at least version + count)")
+
+    version_byte = payload[0]
+    if not (version_byte & ECHO_FLAG_MASK):
+        raise ValueError("agent-hint echo payload missing echo bit (0x80)")
+    version_number = version_byte & VERSION_NUMBER_MASK
+    if version_number != 0:
+        raise ValueError(
+            f"unsupported agent-hint echo version {version_number}; only v0 is defined"
+        )
+
+    applied_count = payload[1]
+    if 2 + applied_count > len(payload):
+        raise ValueError("agent-hint echo payload truncated")
+    applied_selectors = list(payload[2 : 2 + applied_count])
+    return AgentHintEcho(applied_selectors=applied_selectors)

--- a/src/dns_aid/experimental/edns_hint.py
+++ b/src/dns_aid/experimental/edns_hint.py
@@ -6,42 +6,64 @@ Experimental EDNS(0) ``agent-hint`` option — request + response wire format.
 
 ⚠ Experimental. See ``docs/experimental/edns-signaling.md`` for the full design.
 
-The ``agent-hint`` option carries a compact set of selector filters from the
-client to whichever hop on the resolution path is hint-aware:
+The ``agent-hint`` option carries selector filters from the client toward
+whichever hop on the resolution path is hint-aware:
 
-- Locus 1: the client's own resolver wrapper (in-process cache, see
-  :mod:`dns_aid.experimental.edns_cache`)
+- Locus 1: an in-client programmable hop — today the
+  :class:`~dns_aid.experimental.edns_cache.EdnsAwareResolver`, long-term the
+  SDK growing into a real agentic cache or a co-located DNS-like cache process
 - Locus 2: a hint-aware recursive resolver / forwarder
 - Locus 3: a hint-aware authoritative DNS server
 
-Stock authoritative servers treat the option as inert per RFC 6891. A hint-aware
-hop MAY include an :class:`AgentHintEcho` option in its response listing the
-selectors it actually applied — this lets the client know what upstream
-filtering happened.
+Stock authoritative servers treat the option as inert per RFC 6891 §6.1.1.
+Hint-aware hops MAY include an :class:`AgentHintEcho` in their response
+listing the selectors they actually applied — absence is meaningful (no
+upstream filtering happened, client should fall back to local filtering).
+
+Two-axis selector taxonomy
+==========================
+
+Selector codes are split into two axes by code range. The split is structural,
+not advisory — Axis 1 and Axis 2 selectors have different cache semantics
+(see :meth:`AgentHint.signature`).
+
+**Axis 1 — substrate filters (codes 0x01–0x0F).**
+Things the auth/cache can decide on without dereferencing anything out-of-band.
+Different Axis-1 values mean different *answer* sets, so they participate in
+the cache key.
+
+**Axis 2 — metering / lifecycle (codes 0x10–0x1F).**
+Things about the request itself — rate-limit class, freshness budget, sibling
+count, deadline. Drive accept/reject/prefetch policy but should NOT fragment
+the cache: two queries differing only in ``parallelism`` should hit the same
+cache entry. Excluded from :meth:`AgentHint.signature`.
+
+Codes 0x20+ are reserved for future axes (e.g. cookies, correlation IDs).
 
 Wire format (request)::
 
-    +------------------+------------------+
-    |  VERSION (0x00)  |  SELECTOR-COUNT  |
-    +------------------+------------------+
-    |  selector-code (1B) | selector-len (1B) | selector-value (N B UTF-8) |
-    +------------------+------------------+
+    +----------------+----------------------+
+    | VERSION (0x00) | SELECTOR-COUNT (1B)  |
+    +----------------+----------------------+
+    | selector-code (1B) | selector-len (1B) | selector-value (N B UTF-8) |
+    +--------------------+-------------------+----------------------------+
                        ...
 
 Wire format (response echo)::
 
-    +------------------+------------------+
-    |  VERSION (0x80)  |  APPLIED-COUNT   |
-    +------------------+------------------+
-    |  selector-code (1B) | selector-code (1B) | ...                       |
-    +------------------+------------------+
+    +----------------+----------------------+
+    | VERSION (0x80) | APPLIED-COUNT (1B)   |
+    +----------------+----------------------+
+    | selector-code (1B) | selector-code (1B) | ...                       |
+    +--------------------+--------------------+----------------------+
 """
 
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 # Private-use EDNS(0) option-code range is 65001–65534 (RFC 6891 §6.1.1).
 # 65430 chosen arbitrarily within the range; subject to change before any IANA
@@ -56,18 +78,33 @@ VERSION_NUMBER_MASK: int = 0x7F
 MAX_SELECTOR_VALUE_LEN: int = 255  # 1-byte length prefix
 MAX_OPTION_PAYLOAD: int = 512  # soft cap to stay inside reasonable EDNS budget
 
+# Axis boundaries — encoded into the selector-code numbering so the wire
+# inspector can tell at a glance which axis a code belongs to.
+AXIS1_RANGE = range(0x01, 0x10)  # substrate filters: 0x01–0x0F
+AXIS2_RANGE = range(0x10, 0x20)  # metering / lifecycle: 0x10–0x1F
+
 
 class HintSelector(IntEnum):
     """Selector codes for ``agent-hint`` v0.
 
-    Codes 0x05–0xFF are reserved for future versions. Consumers MUST ignore
-    selector codes they do not recognise rather than rejecting the whole option.
+    Codes 0x05–0x0F (Axis 1 tail) and 0x14–0x1F (Axis 2 tail) are reserved
+    for future selectors within the same axis. Codes 0x20+ are reserved for
+    future axes. Consumers MUST ignore selector codes they do not recognise
+    rather than rejecting the whole option.
     """
 
-    CAPABILITIES = 0x01  # comma-separated list, e.g. "chat,code-review"
-    INTENT = 0x02  # single tag, e.g. "summarize"
-    TRANSPORT = 0x03  # "mcp" | "a2a" | "https"
-    AUTH_TYPE = 0x04  # "none" | "bearer" | "oauth2" | "mtls"
+    # Axis 1 — substrate filters
+    REALM = 0x01  # multi-tenant scope (SVCB realm= param)
+    TRANSPORT = 0x02  # "mcp" | "a2a" | "https"
+    POLICY_REQUIRED = 0x03  # "1" means only records carrying a policy= URI
+    MIN_TRUST = 0x04  # "signed" | "dnssec" | "signed+dnssec"
+    JURISDICTION = 0x05  # ISO region tag, e.g. "eu", "us-east"
+
+    # Axis 2 — metering / lifecycle
+    CLIENT_INTENT_CLASS = 0x10  # "discovery" | "invocation"
+    MAX_AGE = 0x11  # cache freshness in seconds (UTF-8 decimal)
+    PARALLELISM = 0x12  # expected sibling-query count (UTF-8 decimal uint)
+    DEADLINE_MS = 0x13  # client's wait budget in ms (UTF-8 decimal uint)
 
 
 # -----------------------------------------------------------------------------
@@ -78,35 +115,75 @@ class HintSelector(IntEnum):
 class AgentHint(BaseModel):
     """Request-side EDNS(0) ``agent-hint`` payload.
 
-    Encodes a small set of selector filters that the client wants applied (by
-    whichever hop on the resolution path is hint-aware). Unrecognised selectors
-    on decode are silently dropped — forward compatibility.
+    Two-axis structure (see module docstring):
+
+    - **Axis 1 (substrate filters)** — ``realm``, ``transport``,
+      ``policy_required``, ``min_trust``, ``jurisdiction``. Different values
+      → different answer sets → participate in the cache key.
+    - **Axis 2 (metering / lifecycle)** — ``client_intent_class``,
+      ``max_age``, ``parallelism``, ``deadline_ms``. Drive accept/reject/
+      prefetch policy but do NOT fragment the cache.
+
+    All fields are optional. Unrecognised selectors on decode are silently
+    dropped (forward compatibility).
+
+    Capabilities and intent are intentionally NOT DNS-layer selectors here —
+    they belong in the publisher's well-known JSON (the
+    :class:`EdnsSignalingAdvertisement` ``honored_selectors`` list) where
+    clients use them for post-fetch local filtering.
     """
 
-    capabilities: list[str] | None = Field(
+    # -- Axis 1: substrate filters --------------------------------------------
+
+    realm: str | None = Field(
         default=None,
-        description="List of capability tags the client is looking for.",
-    )
-    intent: str | None = Field(
-        default=None,
-        description="Single intent tag, e.g. 'summarize'.",
+        description="Multi-tenant scope identifier (matches SVCB realm= param).",
     )
     transport: str | None = Field(
         default=None,
         description="Transport: 'mcp' | 'a2a' | 'https'.",
     )
-    auth_type: str | None = Field(
+    policy_required: bool = Field(
+        default=False,
+        description="When True, only return records carrying a policy= URI.",
+    )
+    min_trust: str | None = Field(
         default=None,
-        description="Auth type: 'none' | 'bearer' | 'oauth2' | 'mtls'.",
+        description="Trust posture: 'signed' | 'dnssec' | 'signed+dnssec'.",
+    )
+    jurisdiction: str | None = Field(
+        default=None,
+        description="ISO region tag (e.g. 'eu', 'us-east'). Real compliance lever.",
     )
 
-    @field_validator("capabilities")
-    @classmethod
-    def _strip_empty_caps(cls, v: list[str] | None) -> list[str] | None:
-        if v is None:
-            return None
-        cleaned = [c.strip() for c in v if c and c.strip()]
-        return cleaned or None
+    # -- Axis 2: metering / lifecycle -----------------------------------------
+
+    client_intent_class: str | None = Field(
+        default=None,
+        description="'discovery' (browsing) vs 'invocation' (about to call).",
+    )
+    max_age: int | None = Field(
+        default=None,
+        ge=0,
+        description="Don't return cache entries older than this many seconds.",
+    )
+    parallelism: int | None = Field(
+        default=None,
+        ge=0,
+        description="Expected sibling-query count (signals fan-out to caches).",
+    )
+    deadline_ms: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Client's wait budget in milliseconds. Hint-only — DNS has no "
+            "refuse-for-SLA semantic in v0; auths may log it, choose a faster "
+            "code path, or serve a stale cache entry to meet it, but cannot "
+            "return a 'won't meet deadline' error."
+        ),
+    )
+
+    # -- Encode / decode ------------------------------------------------------
 
     def encode(self) -> bytes:
         """Encode this hint into the EDNS(0) option payload bytes.
@@ -117,15 +194,34 @@ class AgentHint(BaseModel):
         """
         selectors: list[tuple[int, bytes]] = []
 
-        if self.capabilities:
-            value = ",".join(self.capabilities).encode("utf-8")
-            selectors.append((HintSelector.CAPABILITIES.value, value))
-        if self.intent:
-            selectors.append((HintSelector.INTENT.value, self.intent.encode("utf-8")))
+        # Axis 1
+        if self.realm:
+            selectors.append((HintSelector.REALM.value, self.realm.encode("utf-8")))
         if self.transport:
             selectors.append((HintSelector.TRANSPORT.value, self.transport.encode("utf-8")))
-        if self.auth_type:
-            selectors.append((HintSelector.AUTH_TYPE.value, self.auth_type.encode("utf-8")))
+        if self.policy_required:
+            # Only emit when explicitly required — absence == "don't care".
+            selectors.append((HintSelector.POLICY_REQUIRED.value, b"1"))
+        if self.min_trust:
+            selectors.append((HintSelector.MIN_TRUST.value, self.min_trust.encode("utf-8")))
+        if self.jurisdiction:
+            selectors.append((HintSelector.JURISDICTION.value, self.jurisdiction.encode("utf-8")))
+
+        # Axis 2 — int fields encode as UTF-8 decimal
+        if self.client_intent_class:
+            selectors.append(
+                (HintSelector.CLIENT_INTENT_CLASS.value, self.client_intent_class.encode("utf-8"))
+            )
+        if self.max_age is not None:
+            selectors.append((HintSelector.MAX_AGE.value, str(self.max_age).encode("ascii")))
+        if self.parallelism is not None:
+            selectors.append(
+                (HintSelector.PARALLELISM.value, str(self.parallelism).encode("ascii"))
+            )
+        if self.deadline_ms is not None:
+            selectors.append(
+                (HintSelector.DEADLINE_MS.value, str(self.deadline_ms).encode("ascii"))
+            )
 
         if len(selectors) > 255:
             raise ValueError("agent-hint cannot carry more than 255 selectors")
@@ -150,28 +246,32 @@ class AgentHint(BaseModel):
     def signature(self) -> str:
         """Stable cache-key string for this hint.
 
-        Order-independent: two hints with the same selectors produce the same
-        signature regardless of construction order. ``capabilities`` values are
-        sorted to normalise.
+        Includes ONLY Axis 1 selectors (substrate filters). Axis 2 selectors
+        (metering, deadlines, parallelism) are intentionally excluded so two
+        queries that differ only in lifecycle parameters share the same cache
+        entry — the answer set is the same, the policy applied to the
+        request is different.
         """
         parts: list[str] = []
-        if self.capabilities:
-            parts.append("cap:" + ",".join(sorted(self.capabilities)))
-        if self.intent:
-            parts.append(f"int:{self.intent}")
+        if self.realm:
+            parts.append(f"rlm:{self.realm}")
         if self.transport:
             parts.append(f"trn:{self.transport}")
-        if self.auth_type:
-            parts.append(f"aut:{self.auth_type}")
+        if self.policy_required:
+            parts.append("plc:1")
+        if self.min_trust:
+            parts.append(f"trs:{self.min_trust}")
+        if self.jurisdiction:
+            parts.append(f"jur:{self.jurisdiction}")
         return "|".join(parts)
 
 
 class AgentHintEcho(BaseModel):
     """Response-side echo from a hint-aware DNS hop.
 
-    Lists the selector codes the responder actually applied. Absence of an echo
-    on a response means no upstream filtering happened — the client should fall
-    back to local filtering against the returned record set.
+    Lists the selector codes the responder actually applied. Absence of an
+    echo on a response means no upstream filtering happened — the client
+    should fall back to local filtering against the returned record set.
     """
 
     applied_selectors: list[int] = Field(
@@ -196,16 +296,22 @@ class EdnsSignalingAdvertisement(BaseModel):
     agents — i.e. the publisher has populated the matching metadata fields so
     filtering on them will actually narrow results.
 
-    Channel-1 advertisement (out-of-band, JSON). Independent of whether any hop
-    on the DNS resolution path is hint-aware (which is the Channel-2 signal —
-    the OPT response echo).
+    Channel-1 advertisement (out-of-band, JSON). Independent of whether any
+    hop on the DNS resolution path is hint-aware (which is the Channel-2
+    signal — the OPT response echo). Capabilities and intent live here, not
+    in the DNS-layer option, because they require dereferencing per-record
+    JSON which is not work the substrate can do.
     """
 
     version: int = Field(description="Hint protocol version this publisher supports.")
     honored_selectors: list[str] = Field(
         default_factory=list,
-        description="Selector names this publisher recommends populating, e.g. "
-        "['capabilities', 'intent', 'transport'].",
+        description=(
+            "Selector names this publisher recommends populating. "
+            "May include DNS-layer selector names (e.g. 'realm', 'transport') "
+            "OR JSON-only selectors the client should filter on locally after "
+            "fetch (e.g. 'capabilities', 'intent')."
+        ),
     )
     note: str | None = Field(
         default=None,
@@ -218,12 +324,25 @@ class EdnsSignalingAdvertisement(BaseModel):
 # -----------------------------------------------------------------------------
 
 
+def _decode_int_selector(code: int, value: str) -> int:
+    """Parse a UTF-8 decimal selector value into an int; fail-closed on garbage."""
+    try:
+        n = int(value, 10)
+    except ValueError as e:
+        raise ValueError(
+            f"selector code 0x{code:02x} expects a decimal integer, got {value!r}"
+        ) from e
+    if n < 0:
+        raise ValueError(f"selector code 0x{code:02x} must be non-negative, got {n}")
+    return n
+
+
 def decode_agent_hint(payload: bytes) -> AgentHint:
     """Decode an EDNS(0) ``agent-hint`` request payload into :class:`AgentHint`.
 
     Unrecognised selector codes are silently skipped (forward compat). Raises
     :class:`ValueError` for structural malformations (truncated payload, echo
-    bit set, length overflow).
+    bit set, unsupported version, length overflow, malformed numeric fields).
     """
     if len(payload) < 2:
         raise ValueError("agent-hint payload too short (need at least version + count)")
@@ -238,10 +357,11 @@ def decode_agent_hint(payload: bytes) -> AgentHint:
     selector_count = payload[1]
     cursor = 2
 
-    capabilities: list[str] | None = None
-    intent: str | None = None
-    transport: str | None = None
-    auth_type: str | None = None
+    fields: dict[str, Any] = {}
+    # First-wins on duplicate selector codes — defends against a hostile forwarder
+    # appending an overriding selector after a legitimate one. Mirrors the
+    # _parse_txt_value pattern in dcv.py (Igor's DCV review, S3 / ADV-006 class).
+    seen_codes: set[int] = set()
 
     for _ in range(selector_count):
         if cursor + 2 > len(payload):
@@ -258,29 +378,51 @@ def decode_agent_hint(payload: bytes) -> AgentHint:
             raise ValueError(f"selector code 0x{code:02x} value is not valid UTF-8") from e
         cursor = value_end
 
-        if code == HintSelector.CAPABILITIES.value:
-            capabilities = [c.strip() for c in value.split(",") if c.strip()] or None
-        elif code == HintSelector.INTENT.value:
-            intent = value
+        # First-wins: drop any duplicate occurrence of a code we've already seen.
+        # Applies to both known and unknown codes.
+        if code in seen_codes:
+            continue
+        seen_codes.add(code)
+
+        # For string-typed selectors, an empty value on the wire is treated as
+        # "field not set" — matches the encode-side semantics (encode skips empty
+        # strings) and avoids cache-key fragmentation under forged empty values.
+
+        # Axis 1
+        if code == HintSelector.REALM.value:
+            if value:
+                fields["realm"] = value
         elif code == HintSelector.TRANSPORT.value:
-            transport = value
-        elif code == HintSelector.AUTH_TYPE.value:
-            auth_type = value
+            if value:
+                fields["transport"] = value
+        elif code == HintSelector.POLICY_REQUIRED.value:
+            fields["policy_required"] = value == "1"
+        elif code == HintSelector.MIN_TRUST.value:
+            if value:
+                fields["min_trust"] = value
+        elif code == HintSelector.JURISDICTION.value:
+            if value:
+                fields["jurisdiction"] = value
+        # Axis 2
+        elif code == HintSelector.CLIENT_INTENT_CLASS.value:
+            if value:
+                fields["client_intent_class"] = value
+        elif code == HintSelector.MAX_AGE.value:
+            fields["max_age"] = _decode_int_selector(code, value)
+        elif code == HintSelector.PARALLELISM.value:
+            fields["parallelism"] = _decode_int_selector(code, value)
+        elif code == HintSelector.DEADLINE_MS.value:
+            fields["deadline_ms"] = _decode_int_selector(code, value)
         # else: silently drop unknown selectors (forward compat)
 
-    return AgentHint(
-        capabilities=capabilities,
-        intent=intent,
-        transport=transport,
-        auth_type=auth_type,
-    )
+    return AgentHint(**fields)
 
 
 def decode_agent_hint_echo(payload: bytes) -> AgentHintEcho:
     """Decode an EDNS(0) ``agent-hint`` response echo payload.
 
-    Raises :class:`ValueError` if the echo bit is not set, or if the payload is
-    truncated.
+    Raises :class:`ValueError` if the echo bit is not set, or if the payload
+    is truncated.
     """
     if len(payload) < 2:
         raise ValueError("agent-hint echo payload too short (need at least version + count)")

--- a/tests/testbed/agents/Dockerfile
+++ b/tests/testbed/agents/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa7
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsutils \
     curl \
+    tcpdump \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/tests/testbed/smoke_edns.sh
+++ b/tests/testbed/smoke_edns.sh
@@ -26,33 +26,37 @@ docker compose ps --status running | grep -q bind-orga || docker compose up -d b
 
 echo
 echo "--- [2] Start tcpdump on agent-a (background) ---"
-# 0xff96 in hex == 65430 decimal == AGENT_HINT_OPTION_CODE
-# Capturing for 5 seconds is plenty to see two probe calls.
+# 0xff96 in hex == 65430 decimal == AGENT_HINT_OPTION_CODE.
+# Capturing 20 packets is plenty to see one probe call's worth of queries.
+# tcpdump is pre-installed by the agent Dockerfile.
 docker exec -d agent-a bash -c \
-  'apt-get install -y -q tcpdump 2>/dev/null || true; tcpdump -i any -nn -X -c 20 host 172.28.0.10 and port 53 > /tmp/edns_capture.txt 2>&1 &'
+  'tcpdump -i any -nn -X -c 20 host 172.28.0.10 and port 53 > /tmp/edns_capture.txt 2>&1'
 sleep 1
 
 echo
 echo "--- [3] Run edns-probe with experimental flag on ---"
 docker exec -e DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 agent-a \
   dns-aid edns-probe orga.test \
-  --capabilities=chat,code \
-  --intent=summarize \
-  --transport=mcp \
-  --auth-type=bearer \
+  --realm prod \
+  --transport mcp \
+  --min-trust signed \
+  --intent-class invocation \
+  --parallelism 4 \
+  --deadline-ms 30000 \
   --show-wire
 
 echo
 echo "--- [4] Capture results ---"
 sleep 2
-docker exec agent-a cat /tmp/edns_capture.txt 2>/dev/null | head -80 || \
-  echo "  (tcpdump may not have been installed; install it inside the agent-a container manually)"
+docker exec agent-a cat /tmp/edns_capture.txt 2>/dev/null | head -80 || true
 
 echo
 echo "--- [5] Look for the agent-hint option code (0xff96) in the capture ---"
-docker exec agent-a grep -i "ff96\|ff 96" /tmp/edns_capture.txt 2>/dev/null && \
-  echo "  ✓ agent-hint option code 0xff96 (=65430) appeared on the wire" || \
+if docker exec agent-a grep -qi "ff96\|ff 96" /tmp/edns_capture.txt; then
+  echo "  ✓ agent-hint option code 0xff96 (=65430) appeared on the wire"
+else
   echo "  ✗ option code not found in capture — feature flag set? tcpdump captured the right packets?"
+fi
 
 echo
 echo "=== smoke_edns.sh complete ==="

--- a/tests/testbed/smoke_edns.sh
+++ b/tests/testbed/smoke_edns.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Manual wire-level verification for the experimental EDNS(0) agent-hint feature.
+#
+# What this does:
+#   1. Brings the testbed up (orga.test BIND9 authoritative + agent-a container)
+#   2. Starts a tcpdump on the agent-a container, listening for DNS traffic to bind-orga
+#   3. Runs `dns-aid edns-probe orga.test` with the experimental flag on
+#   4. Captures the wire and greps for the agent-hint option code (0xff96 = 65430)
+#
+# What you should see:
+#   - tcpdump shows the EDNS(0) OPT pseudo-RR carrying option-code 0xff96 in the
+#     outgoing query packet
+#   - The probe command prints cache miss + hit timings
+#   - No echo is expected: BIND9 stock treats unknown options as inert per RFC 6891
+#
+# Run from: tests/testbed/
+# Not in CI. tcpdump needs CAP_NET_RAW inside the container — works in compose
+# because docker-compose runs containers as root by default.
+set -euo pipefail
+
+echo "=== EDNS(0) agent-hint smoke test ==="
+echo
+
+echo "--- [1] Ensure testbed is up ---"
+docker compose ps --status running | grep -q bind-orga || docker compose up -d bind-orga agent-a
+
+echo
+echo "--- [2] Start tcpdump on agent-a (background) ---"
+# 0xff96 in hex == 65430 decimal == AGENT_HINT_OPTION_CODE
+# Capturing for 5 seconds is plenty to see two probe calls.
+docker exec -d agent-a bash -c \
+  'apt-get install -y -q tcpdump 2>/dev/null || true; tcpdump -i any -nn -X -c 20 host 172.28.0.10 and port 53 > /tmp/edns_capture.txt 2>&1 &'
+sleep 1
+
+echo
+echo "--- [3] Run edns-probe with experimental flag on ---"
+docker exec -e DNS_AID_EXPERIMENTAL_EDNS_HINTS=1 agent-a \
+  dns-aid edns-probe orga.test \
+  --capabilities=chat,code \
+  --intent=summarize \
+  --transport=mcp \
+  --auth-type=bearer \
+  --show-wire
+
+echo
+echo "--- [4] Capture results ---"
+sleep 2
+docker exec agent-a cat /tmp/edns_capture.txt 2>/dev/null | head -80 || \
+  echo "  (tcpdump may not have been installed; install it inside the agent-a container manually)"
+
+echo
+echo "--- [5] Look for the agent-hint option code (0xff96) in the capture ---"
+docker exec agent-a grep -i "ff96\|ff 96" /tmp/edns_capture.txt 2>/dev/null && \
+  echo "  ✓ agent-hint option code 0xff96 (=65430) appeared on the wire" || \
+  echo "  ✗ option code not found in capture — feature flag set? tcpdump captured the right packets?"
+
+echo
+echo "=== smoke_edns.sh complete ==="
+echo
+echo "Reminder: BIND9 stock will not emit an AgentHintEcho — its absence is correct"
+echo "and meaningful. A hint-aware authoritative would echo applied selectors back."

--- a/tests/unit/test_edns_cache.py
+++ b/tests/unit/test_edns_cache.py
@@ -54,7 +54,7 @@ async def test_first_call_misses_then_caches():
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    hint = AgentHint(capabilities=["chat"])
+    hint = AgentHint(realm="prod")
     result = await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
 
     assert result.answer is upstream.resolve.return_value
@@ -65,7 +65,7 @@ async def test_second_call_hits_cache_when_signature_matches():
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    hint = AgentHint(capabilities=["chat"], intent="summarize")
+    hint = AgentHint(realm="prod", transport="mcp")
     await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
     await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
 
@@ -73,16 +73,35 @@ async def test_second_call_hits_cache_when_signature_matches():
     upstream.resolve.assert_awaited_once()
 
 
-async def test_different_hint_signature_misses_cache():
+async def test_axis2_only_differences_still_hit_cache():
+    """Two queries differing only in Axis 2 fields must share a cache entry.
+
+    Locks in the design invariant: metering selectors (parallelism, deadline_ms,
+    etc.) do not fragment the cache because they describe the request, not the
+    answer set.
+    """
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    h1 = AgentHint(capabilities=["chat"])
-    h2 = AgentHint(capabilities=["code"])
+    h1 = AgentHint(realm="prod", parallelism=4, deadline_ms=5000)
+    h2 = AgentHint(realm="prod", parallelism=64, deadline_ms=1)
+    await resolver.resolve("example.com", "SVCB", agent_hint=h1)
+    await resolver.resolve("example.com", "SVCB", agent_hint=h2)
+
+    # One upstream call — second was a cache hit even with very different metering.
+    upstream.resolve.assert_awaited_once()
+
+
+async def test_different_axis1_signature_misses_cache():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    h1 = AgentHint(realm="prod")
+    h2 = AgentHint(realm="staging")
     await resolver.resolve("_x._mcp._agents.example.com", "SVCB", agent_hint=h1)
     await resolver.resolve("_x._mcp._agents.example.com", "SVCB", agent_hint=h2)
 
-    # Different hint signatures → both miss.
+    # Different Axis 1 values → different signatures → both miss.
     assert upstream.resolve.await_count == 2
 
 
@@ -92,7 +111,7 @@ async def test_no_hint_caches_separately_from_hinted():
     resolver = EdnsAwareResolver(upstream=upstream)
 
     await resolver.resolve("example.com", "SVCB", agent_hint=None)
-    await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"]))
+    await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(realm="prod"))
     await resolver.resolve("example.com", "SVCB", agent_hint=None)
 
     # Bare-first, hinted, bare-third → first and third should share a key (one upstream call
@@ -104,7 +123,7 @@ async def test_ttl_expiry_triggers_re_resolution():
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream, ttl_seconds=0.05)
 
-    hint = AgentHint(capabilities=["chat"])
+    hint = AgentHint(realm="prod")
     await resolver.resolve("example.com", "SVCB", agent_hint=hint)
     time.sleep(0.1)  # wait past TTL (sync sleep is fine — test doesn't depend on the loop)
     await resolver.resolve("example.com", "SVCB", agent_hint=hint)
@@ -116,7 +135,7 @@ async def test_invalidate_drops_cache():
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    hint = AgentHint(capabilities=["chat"])
+    hint = AgentHint(realm="prod")
     await resolver.resolve("example.com", "SVCB", agent_hint=hint)
     resolver.invalidate()
     await resolver.resolve("example.com", "SVCB", agent_hint=hint)
@@ -134,7 +153,7 @@ async def test_hint_passed_to_upstream_via_use_edns():
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    hint = AgentHint(capabilities=["chat"])
+    hint = AgentHint(realm="prod")
     await resolver.resolve("example.com", "SVCB", agent_hint=hint)
 
     upstream.use_edns.assert_called()
@@ -151,7 +170,7 @@ async def test_no_hint_clears_previous_options():
     upstream = _make_upstream()
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    await resolver.resolve("a.example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"]))
+    await resolver.resolve("a.example.com", "SVCB", agent_hint=AgentHint(realm="prod"))
     await resolver.resolve("b.example.com", "SVCB", agent_hint=None)
 
     # Last use_edns call (for the bare resolve) must have empty options.
@@ -166,25 +185,21 @@ async def test_no_hint_clears_previous_options():
 
 
 async def test_upstream_echo_surfaced_on_cached_answer():
-    echo = AgentHintEcho(applied_selectors=[HintSelector.CAPABILITIES.value])
+    echo = AgentHintEcho(applied_selectors=[HintSelector.REALM.value])
     upstream = _make_upstream(echo=echo)
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    result = await resolver.resolve(
-        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
-    )
+    result = await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(realm="prod"))
 
     assert result.echo is not None
-    assert result.echo.applied_selectors == [HintSelector.CAPABILITIES.value]
+    assert result.echo.applied_selectors == [HintSelector.REALM.value]
 
 
 async def test_absent_echo_means_no_upstream_filtering():
     upstream = _make_upstream(echo=None)
     resolver = EdnsAwareResolver(upstream=upstream)
 
-    result = await resolver.resolve(
-        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
-    )
+    result = await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(realm="prod"))
     assert result.echo is None
 
 
@@ -201,7 +216,5 @@ async def test_malformed_echo_in_response_returns_none():
     upstream.resolve = AsyncMock(return_value=mock_answer)
 
     resolver = EdnsAwareResolver(upstream=upstream)
-    result = await resolver.resolve(
-        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
-    )
+    result = await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(realm="prod"))
     assert result.echo is None

--- a/tests/unit/test_edns_cache.py
+++ b/tests/unit/test_edns_cache.py
@@ -1,0 +1,207 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.experimental.edns_cache — EdnsAwareResolver."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from dns_aid.experimental.edns_cache import EdnsAwareResolver
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    HintSelector,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_upstream(answer=None, echo: AgentHintEcho | None = None) -> MagicMock:
+    """Build a mock upstream resolver suitable for EdnsAwareResolver.
+
+    Uses MagicMock for the resolver instance so sync attrs (cache, use_edns,
+    nameservers) don't produce coroutine warnings; only resolve is AsyncMock.
+    """
+    mock = MagicMock()
+
+    response = MagicMock()
+    if echo is not None:
+        echo_opt = MagicMock()
+        echo_opt.otype = AGENT_HINT_OPTION_CODE
+        echo_opt.data = echo.encode()
+        response.options = [echo_opt]
+    else:
+        response.options = []
+
+    mock_answer = MagicMock()
+    mock_answer.response = response
+
+    mock.resolve = AsyncMock(return_value=answer if answer is not None else mock_answer)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Cache hit / miss
+# ---------------------------------------------------------------------------
+
+
+async def test_first_call_misses_then_caches():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"])
+    result = await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
+
+    assert result.answer is upstream.resolve.return_value
+    upstream.resolve.assert_awaited_once()
+
+
+async def test_second_call_hits_cache_when_signature_matches():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"], intent="summarize")
+    await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
+    await resolver.resolve("_chat._mcp._agents.example.com", "SVCB", agent_hint=hint)
+
+    # Two calls, one upstream resolve — second was a cache hit.
+    upstream.resolve.assert_awaited_once()
+
+
+async def test_different_hint_signature_misses_cache():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    h1 = AgentHint(capabilities=["chat"])
+    h2 = AgentHint(capabilities=["code"])
+    await resolver.resolve("_x._mcp._agents.example.com", "SVCB", agent_hint=h1)
+    await resolver.resolve("_x._mcp._agents.example.com", "SVCB", agent_hint=h2)
+
+    # Different hint signatures → both miss.
+    assert upstream.resolve.await_count == 2
+
+
+async def test_no_hint_caches_separately_from_hinted():
+    """A bare call (no hint) and a hinted call cache under different keys."""
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    await resolver.resolve("example.com", "SVCB", agent_hint=None)
+    await resolver.resolve("example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"]))
+    await resolver.resolve("example.com", "SVCB", agent_hint=None)
+
+    # Bare-first, hinted, bare-third → first and third should share a key (one upstream call
+    # between them). hinted is a separate key. Total: 2 upstream calls.
+    assert upstream.resolve.await_count == 2
+
+
+async def test_ttl_expiry_triggers_re_resolution():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream, ttl_seconds=0.05)
+
+    hint = AgentHint(capabilities=["chat"])
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+    time.sleep(0.1)  # wait past TTL (sync sleep is fine — test doesn't depend on the loop)
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+
+    assert upstream.resolve.await_count == 2
+
+
+async def test_invalidate_drops_cache():
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"])
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+    resolver.invalidate()
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+
+    assert upstream.resolve.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Upstream wire integration
+# ---------------------------------------------------------------------------
+
+
+async def test_hint_passed_to_upstream_via_use_edns():
+    """When a hint is supplied, the EDNS option must be attached on the upstream resolver."""
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    hint = AgentHint(capabilities=["chat"])
+    await resolver.resolve("example.com", "SVCB", agent_hint=hint)
+
+    upstream.use_edns.assert_called()
+    call = upstream.use_edns.call_args
+    options = call.kwargs.get("options") or (call.args[3] if len(call.args) >= 4 else None)
+    assert options is not None and len(options) == 1
+    opt = options[0]
+    assert opt.otype == AGENT_HINT_OPTION_CODE
+    assert opt.data == hint.encode()
+
+
+async def test_no_hint_clears_previous_options():
+    """A bare resolve must reset use_edns options so a prior hint doesn't leak."""
+    upstream = _make_upstream()
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    await resolver.resolve("a.example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"]))
+    await resolver.resolve("b.example.com", "SVCB", agent_hint=None)
+
+    # Last use_edns call (for the bare resolve) must have empty options.
+    last_call = upstream.use_edns.call_args
+    options = last_call.kwargs.get("options")
+    assert options == []
+
+
+# ---------------------------------------------------------------------------
+# AgentHintEcho surfacing
+# ---------------------------------------------------------------------------
+
+
+async def test_upstream_echo_surfaced_on_cached_answer():
+    echo = AgentHintEcho(applied_selectors=[HintSelector.CAPABILITIES.value])
+    upstream = _make_upstream(echo=echo)
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    result = await resolver.resolve(
+        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
+    )
+
+    assert result.echo is not None
+    assert result.echo.applied_selectors == [HintSelector.CAPABILITIES.value]
+
+
+async def test_absent_echo_means_no_upstream_filtering():
+    upstream = _make_upstream(echo=None)
+    resolver = EdnsAwareResolver(upstream=upstream)
+
+    result = await resolver.resolve(
+        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
+    )
+    assert result.echo is None
+
+
+async def test_malformed_echo_in_response_returns_none():
+    """A malformed echo option in the upstream response is silently treated as absent."""
+    upstream = MagicMock()
+    response = MagicMock()
+    bad_opt = MagicMock()
+    bad_opt.otype = AGENT_HINT_OPTION_CODE
+    bad_opt.data = b"\x80"  # truncated — too short to be a valid echo
+    response.options = [bad_opt]
+    mock_answer = MagicMock()
+    mock_answer.response = response
+    upstream.resolve = AsyncMock(return_value=mock_answer)
+
+    resolver = EdnsAwareResolver(upstream=upstream)
+    result = await resolver.resolve(
+        "example.com", "SVCB", agent_hint=AgentHint(capabilities=["chat"])
+    )
+    assert result.echo is None

--- a/tests/unit/test_edns_hint.py
+++ b/tests/unit/test_edns_hint.py
@@ -1,0 +1,240 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.experimental.edns_hint — wire format encode/decode."""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.experimental.edns_hint import (
+    AGENT_HINT_OPTION_CODE,
+    AgentHint,
+    AgentHintEcho,
+    EdnsSignalingAdvertisement,
+    HintSelector,
+    decode_agent_hint,
+    decode_agent_hint_echo,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_option_code_in_private_use_range():
+    """Sanity check: chosen option code is in RFC 6891 private-use range."""
+    assert 65001 <= AGENT_HINT_OPTION_CODE <= 65534
+
+
+# ---------------------------------------------------------------------------
+# AgentHint encode / decode — request
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_round_trip_all_selectors():
+    hint = AgentHint(
+        capabilities=["chat", "code-review"],
+        intent="summarize",
+        transport="mcp",
+        auth_type="bearer",
+    )
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.capabilities == ["chat", "code-review"]
+    assert decoded.intent == "summarize"
+    assert decoded.transport == "mcp"
+    assert decoded.auth_type == "bearer"
+
+
+def test_agent_hint_round_trip_partial_selectors():
+    hint = AgentHint(capabilities=["chat"])
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.capabilities == ["chat"]
+    assert decoded.intent is None
+    assert decoded.transport is None
+    assert decoded.auth_type is None
+
+
+def test_agent_hint_empty_hint_encodes_to_header_only():
+    """An AgentHint with no selectors encodes to just (version, count=0)."""
+    payload = AgentHint().encode()
+    assert payload == bytes([0x00, 0x00])
+    decoded = decode_agent_hint(payload)
+    assert decoded.capabilities is None and decoded.intent is None
+
+
+def test_agent_hint_capabilities_strip_empties():
+    """Empty/whitespace-only capability strings are stripped."""
+    hint = AgentHint(capabilities=["chat", "", "  ", "code"])
+    assert hint.capabilities == ["chat", "code"]
+
+
+def test_agent_hint_capabilities_all_empty_becomes_none():
+    """If every capability is empty after stripping, the field is None."""
+    hint = AgentHint(capabilities=["", "   "])
+    assert hint.capabilities is None
+
+
+def test_agent_hint_utf8_value_round_trip():
+    """Selector values are UTF-8 — non-ASCII survives the round trip."""
+    hint = AgentHint(intent="résumé-📝")
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.intent == "résumé-📝"
+
+
+# ---------------------------------------------------------------------------
+# AgentHint encode / decode — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_selector_value_too_long_rejected():
+    """Selector value over 255 bytes UTF-8 must be rejected at encode."""
+    hint = AgentHint(intent="x" * 256)
+    with pytest.raises(ValueError, match="max is 255"):
+        hint.encode()
+
+
+def test_agent_hint_decode_rejects_truncated_header():
+    with pytest.raises(ValueError, match="too short"):
+        decode_agent_hint(b"\x00")
+
+
+def test_agent_hint_decode_rejects_echo_bit_set():
+    """A payload with echo bit must be routed to decode_agent_hint_echo, not decode_agent_hint."""
+    echo_payload = bytes([0x80, 0x00])
+    with pytest.raises(ValueError, match="echo bit set"):
+        decode_agent_hint(echo_payload)
+
+
+def test_agent_hint_decode_rejects_unknown_version():
+    """Version bits 0–6 are the version number; non-zero rejected in v0."""
+    payload = bytes([0x01, 0x00])  # version 1, no selectors
+    with pytest.raises(ValueError, match="unsupported"):
+        decode_agent_hint(payload)
+
+
+def test_agent_hint_decode_rejects_truncated_selector_header():
+    """Payload claims a selector but lacks its 2-byte header."""
+    payload = bytes([0x00, 0x01, 0x01])  # version=0, count=1, then only 1B before EOF
+    with pytest.raises(ValueError, match="truncated mid-selector header"):
+        decode_agent_hint(payload)
+
+
+def test_agent_hint_decode_rejects_truncated_selector_value():
+    """Selector header says length=10 but only 3 bytes follow."""
+    payload = bytes([0x00, 0x01, 0x01, 0x0A, 0x61, 0x62, 0x63])
+    with pytest.raises(ValueError, match="truncated mid-selector value"):
+        decode_agent_hint(payload)
+
+
+def test_agent_hint_decode_silently_drops_unknown_selectors():
+    """Forward-compat: future selector codes must be skipped, not rejected."""
+    # version=0, count=2, selector(0xFE, "x"), selector(0x02, "intent-tag")
+    payload = bytes(
+        [0x00, 0x02]
+        + [0xFE, 0x01, ord("x")]
+        + [HintSelector.INTENT.value, 10]
+        + list(b"intent-tag")
+    )
+    decoded = decode_agent_hint(payload)
+    assert decoded.intent == "intent-tag"
+    # The unknown selector is silently dropped — no error.
+
+
+def test_agent_hint_decode_rejects_invalid_utf8():
+    payload = bytes(
+        [0x00, 0x01, HintSelector.INTENT.value, 0x02, 0xFF, 0xFE]
+    )  # 0xFF 0xFE is not valid UTF-8
+    with pytest.raises(ValueError, match="UTF-8"):
+        decode_agent_hint(payload)
+
+
+# ---------------------------------------------------------------------------
+# AgentHint signature() — cache-key stability
+# ---------------------------------------------------------------------------
+
+
+def test_signature_is_deterministic():
+    h1 = AgentHint(capabilities=["chat"], intent="summarize")
+    h2 = AgentHint(capabilities=["chat"], intent="summarize")
+    assert h1.signature() == h2.signature()
+
+
+def test_signature_is_order_independent_for_capabilities():
+    """Capabilities are sorted in the signature — ordering doesn't change the key."""
+    h1 = AgentHint(capabilities=["chat", "code", "search"])
+    h2 = AgentHint(capabilities=["search", "chat", "code"])
+    assert h1.signature() == h2.signature()
+
+
+def test_signature_differs_when_selectors_differ():
+    h1 = AgentHint(capabilities=["chat"])
+    h2 = AgentHint(capabilities=["search"])
+    assert h1.signature() != h2.signature()
+
+
+def test_signature_empty_hint_is_stable():
+    assert AgentHint().signature() == ""
+
+
+# ---------------------------------------------------------------------------
+# AgentHintEcho — response side
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_echo_round_trip():
+    echo = AgentHintEcho(
+        applied_selectors=[HintSelector.CAPABILITIES.value, HintSelector.INTENT.value]
+    )
+    decoded = decode_agent_hint_echo(echo.encode())
+    assert decoded.applied_selectors == [
+        HintSelector.CAPABILITIES.value,
+        HintSelector.INTENT.value,
+    ]
+
+
+def test_agent_hint_echo_empty_round_trip():
+    """An echo with no applied selectors is valid — means 'I saw the hint but applied nothing'."""
+    decoded = decode_agent_hint_echo(AgentHintEcho().encode())
+    assert decoded.applied_selectors == []
+
+
+def test_agent_hint_echo_decode_rejects_request_payload():
+    """A payload with the echo bit clear must NOT be decoded as an echo."""
+    request_payload = AgentHint(capabilities=["chat"]).encode()
+    with pytest.raises(ValueError, match="missing echo bit"):
+        decode_agent_hint_echo(request_payload)
+
+
+def test_agent_hint_echo_decode_rejects_truncated():
+    with pytest.raises(ValueError, match="truncated"):
+        decode_agent_hint_echo(bytes([0x80, 0x05, 0x01]))  # claims 5 selectors, has 1
+
+
+def test_agent_hint_echo_rejects_out_of_range_selector_code():
+    """Encoded selector codes must fit in one byte."""
+    with pytest.raises(ValueError, match="out of range"):
+        AgentHintEcho(applied_selectors=[300]).encode()
+
+
+# ---------------------------------------------------------------------------
+# EdnsSignalingAdvertisement — JSON publisher channel
+# ---------------------------------------------------------------------------
+
+
+def test_advertisement_round_trip_via_json():
+    """Pydantic model round trips through JSON without losing fields."""
+    adv = EdnsSignalingAdvertisement(
+        version=0,
+        honored_selectors=["capabilities", "intent"],
+        note="prefer pre-filtering",
+    )
+    restored = EdnsSignalingAdvertisement.model_validate_json(adv.model_dump_json())
+    assert restored.version == 0
+    assert restored.honored_selectors == ["capabilities", "intent"]
+    assert restored.note == "prefer pre-filtering"
+
+
+def test_advertisement_optional_note():
+    adv = EdnsSignalingAdvertisement(version=0, honored_selectors=["capabilities"])
+    assert adv.note is None

--- a/tests/unit/test_edns_hint.py
+++ b/tests/unit/test_edns_hint.py
@@ -9,6 +9,8 @@ import pytest
 
 from dns_aid.experimental.edns_hint import (
     AGENT_HINT_OPTION_CODE,
+    AXIS1_RANGE,
+    AXIS2_RANGE,
     AgentHint,
     AgentHintEcho,
     EdnsSignalingAdvertisement,
@@ -18,7 +20,7 @@ from dns_aid.experimental.edns_hint import (
 )
 
 # ---------------------------------------------------------------------------
-# Constants
+# Constants & taxonomy
 # ---------------------------------------------------------------------------
 
 
@@ -27,59 +29,152 @@ def test_option_code_in_private_use_range():
     assert 65001 <= AGENT_HINT_OPTION_CODE <= 65534
 
 
+def test_axis1_selectors_in_axis1_range():
+    """Substrate-filter selectors live in 0x01–0x0F."""
+    axis1 = {
+        HintSelector.REALM,
+        HintSelector.TRANSPORT,
+        HintSelector.POLICY_REQUIRED,
+        HintSelector.MIN_TRUST,
+        HintSelector.JURISDICTION,
+    }
+    for sel in axis1:
+        assert sel.value in AXIS1_RANGE, f"{sel.name} ({sel.value:#x}) not in Axis 1 range"
+
+
+def test_axis2_selectors_in_axis2_range():
+    """Metering/lifecycle selectors live in 0x10–0x1F."""
+    axis2 = {
+        HintSelector.CLIENT_INTENT_CLASS,
+        HintSelector.MAX_AGE,
+        HintSelector.PARALLELISM,
+        HintSelector.DEADLINE_MS,
+    }
+    for sel in axis2:
+        assert sel.value in AXIS2_RANGE, f"{sel.name} ({sel.value:#x}) not in Axis 2 range"
+
+
 # ---------------------------------------------------------------------------
-# AgentHint encode / decode — request
+# AgentHint encode / decode — Axis 1 (substrate filters)
 # ---------------------------------------------------------------------------
 
 
-def test_agent_hint_round_trip_all_selectors():
+def test_agent_hint_round_trip_all_axis1():
     hint = AgentHint(
-        capabilities=["chat", "code-review"],
-        intent="summarize",
+        realm="prod-tenant-42",
         transport="mcp",
-        auth_type="bearer",
+        policy_required=True,
+        min_trust="signed+dnssec",
+        jurisdiction="eu",
     )
     decoded = decode_agent_hint(hint.encode())
-    assert decoded.capabilities == ["chat", "code-review"]
-    assert decoded.intent == "summarize"
+    assert decoded.realm == "prod-tenant-42"
     assert decoded.transport == "mcp"
-    assert decoded.auth_type == "bearer"
+    assert decoded.policy_required is True
+    assert decoded.min_trust == "signed+dnssec"
+    assert decoded.jurisdiction == "eu"
 
 
-def test_agent_hint_round_trip_partial_selectors():
-    hint = AgentHint(capabilities=["chat"])
-    decoded = decode_agent_hint(hint.encode())
-    assert decoded.capabilities == ["chat"]
-    assert decoded.intent is None
-    assert decoded.transport is None
-    assert decoded.auth_type is None
-
-
-def test_agent_hint_empty_hint_encodes_to_header_only():
-    """An AgentHint with no selectors encodes to just (version, count=0)."""
-    payload = AgentHint().encode()
-    assert payload == bytes([0x00, 0x00])
+def test_agent_hint_policy_required_false_not_on_wire():
+    """policy_required=False is the default — absence must mean 'don't care', not 'forbid'."""
+    payload = AgentHint(realm="prod", policy_required=False).encode()
     decoded = decode_agent_hint(payload)
-    assert decoded.capabilities is None and decoded.intent is None
+    assert decoded.policy_required is False
+    # Wire payload should NOT carry the policy_required selector at all.
+    # version(1) + count(1) + realm-header(2) + "prod"(4) = 8 bytes
+    assert len(payload) == 8
 
 
-def test_agent_hint_capabilities_strip_empties():
-    """Empty/whitespace-only capability strings are stripped."""
-    hint = AgentHint(capabilities=["chat", "", "  ", "code"])
-    assert hint.capabilities == ["chat", "code"]
+def test_agent_hint_policy_required_true_emits_value_1():
+    payload = AgentHint(policy_required=True).encode()
+    decoded = decode_agent_hint(payload)
+    assert decoded.policy_required is True
 
 
-def test_agent_hint_capabilities_all_empty_becomes_none():
-    """If every capability is empty after stripping, the field is None."""
-    hint = AgentHint(capabilities=["", "   "])
-    assert hint.capabilities is None
+def test_agent_hint_partial_axis1():
+    hint = AgentHint(transport="a2a")
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.transport == "a2a"
+    assert decoded.realm is None
+    assert decoded.min_trust is None
 
 
 def test_agent_hint_utf8_value_round_trip():
     """Selector values are UTF-8 — non-ASCII survives the round trip."""
-    hint = AgentHint(intent="résumé-📝")
+    hint = AgentHint(realm="résumé-prod-📝")
     decoded = decode_agent_hint(hint.encode())
-    assert decoded.intent == "résumé-📝"
+    assert decoded.realm == "résumé-prod-📝"
+
+
+# ---------------------------------------------------------------------------
+# AgentHint encode / decode — Axis 2 (metering / lifecycle)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_round_trip_all_axis2():
+    hint = AgentHint(
+        client_intent_class="invocation",
+        max_age=300,
+        parallelism=4,
+        deadline_ms=30000,
+    )
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.client_intent_class == "invocation"
+    assert decoded.max_age == 300
+    assert decoded.parallelism == 4
+    assert decoded.deadline_ms == 30000
+
+
+def test_agent_hint_axis2_numeric_zero_round_trip():
+    """Zero is a valid value (means 'don't tolerate any stale cache')."""
+    hint = AgentHint(max_age=0, parallelism=0, deadline_ms=0)
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.max_age == 0
+    assert decoded.parallelism == 0
+    assert decoded.deadline_ms == 0
+
+
+def test_agent_hint_axis2_rejects_negative_at_model_layer():
+    """Pydantic field constraint (ge=0) rejects negatives before encode is even reached."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AgentHint(max_age=-1)
+    with pytest.raises(ValidationError):
+        AgentHint(deadline_ms=-100)
+
+
+# ---------------------------------------------------------------------------
+# AgentHint — combined Axis 1 + Axis 2
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hint_combined_axes_round_trip():
+    hint = AgentHint(
+        realm="prod",
+        transport="mcp",
+        min_trust="signed",
+        client_intent_class="invocation",
+        deadline_ms=5000,
+    )
+    decoded = decode_agent_hint(hint.encode())
+    assert decoded.realm == "prod"
+    assert decoded.transport == "mcp"
+    assert decoded.min_trust == "signed"
+    assert decoded.client_intent_class == "invocation"
+    assert decoded.deadline_ms == 5000
+
+
+def test_agent_hint_empty_hint_encodes_to_header_only():
+    """An AgentHint with nothing set encodes to just (version, count=0)."""
+    payload = AgentHint().encode()
+    assert payload == bytes([0x00, 0x00])
+    decoded = decode_agent_hint(payload)
+    # All fields default to None / False
+    assert decoded.realm is None
+    assert decoded.transport is None
+    assert decoded.policy_required is False
+    assert decoded.max_age is None
 
 
 # ---------------------------------------------------------------------------
@@ -89,7 +184,7 @@ def test_agent_hint_utf8_value_round_trip():
 
 def test_agent_hint_selector_value_too_long_rejected():
     """Selector value over 255 bytes UTF-8 must be rejected at encode."""
-    hint = AgentHint(intent="x" * 256)
+    hint = AgentHint(realm="x" * 256)
     with pytest.raises(ValueError, match="max is 255"):
         hint.encode()
 
@@ -114,67 +209,181 @@ def test_agent_hint_decode_rejects_unknown_version():
 
 
 def test_agent_hint_decode_rejects_truncated_selector_header():
-    """Payload claims a selector but lacks its 2-byte header."""
-    payload = bytes([0x00, 0x01, 0x01])  # version=0, count=1, then only 1B before EOF
+    payload = bytes([0x00, 0x01, 0x01])  # claims 1 selector, has only 1B of its 2B header
     with pytest.raises(ValueError, match="truncated mid-selector header"):
         decode_agent_hint(payload)
 
 
 def test_agent_hint_decode_rejects_truncated_selector_value():
     """Selector header says length=10 but only 3 bytes follow."""
-    payload = bytes([0x00, 0x01, 0x01, 0x0A, 0x61, 0x62, 0x63])
+    payload = bytes(
+        [0x00, 0x01, HintSelector.REALM.value, 0x0A, 0x61, 0x62, 0x63]
+    )  # claims 10-byte realm, has 3
     with pytest.raises(ValueError, match="truncated mid-selector value"):
         decode_agent_hint(payload)
 
 
 def test_agent_hint_decode_silently_drops_unknown_selectors():
     """Forward-compat: future selector codes must be skipped, not rejected."""
-    # version=0, count=2, selector(0xFE, "x"), selector(0x02, "intent-tag")
+    # version=0, count=2, selector(0xFE, "x"), selector(REALM, "prod")
     payload = bytes(
-        [0x00, 0x02]
-        + [0xFE, 0x01, ord("x")]
-        + [HintSelector.INTENT.value, 10]
-        + list(b"intent-tag")
+        [0x00, 0x02] + [0xFE, 0x01, ord("x")] + [HintSelector.REALM.value, 4] + list(b"prod")
     )
     decoded = decode_agent_hint(payload)
-    assert decoded.intent == "intent-tag"
-    # The unknown selector is silently dropped — no error.
+    assert decoded.realm == "prod"
 
 
 def test_agent_hint_decode_rejects_invalid_utf8():
     payload = bytes(
-        [0x00, 0x01, HintSelector.INTENT.value, 0x02, 0xFF, 0xFE]
+        [0x00, 0x01, HintSelector.REALM.value, 0x02, 0xFF, 0xFE]
     )  # 0xFF 0xFE is not valid UTF-8
     with pytest.raises(ValueError, match="UTF-8"):
         decode_agent_hint(payload)
 
 
+def test_agent_hint_decode_rejects_garbage_numeric_field():
+    """Axis 2 numeric fields must fail closed on non-decimal input."""
+    payload = bytes([0x00, 0x01, HintSelector.MAX_AGE.value, 0x03] + list(b"abc"))
+    with pytest.raises(ValueError, match="decimal integer"):
+        decode_agent_hint(payload)
+
+
 # ---------------------------------------------------------------------------
-# AgentHint signature() — cache-key stability
+# Adversarial regression: first-wins on duplicate selector codes
+# (Mirrors the DCV _parse_txt_value pattern — last-wins is exploitable
+#  via a hostile forwarder appending overriding selectors.)
 # ---------------------------------------------------------------------------
+
+
+def test_decode_first_wins_on_duplicate_axis1_string():
+    """Duplicate realm selector: the FIRST occurrence wins."""
+    payload = (
+        bytes([0x00, 0x02])
+        + bytes([HintSelector.REALM.value, 4])
+        + b"prod"
+        + bytes([HintSelector.REALM.value, 4])
+        + b"evil"
+    )
+    decoded = decode_agent_hint(payload)
+    assert decoded.realm == "prod"
+
+
+def test_decode_first_wins_on_duplicate_axis2_numeric():
+    """Duplicate max_age: first wins (5 seconds, not 999999)."""
+    payload = (
+        bytes([0x00, 0x02])
+        + bytes([HintSelector.MAX_AGE.value, 1])
+        + b"5"
+        + bytes([HintSelector.MAX_AGE.value, 6])
+        + b"999999"
+    )
+    decoded = decode_agent_hint(payload)
+    assert decoded.max_age == 5
+
+
+def test_decode_first_wins_on_duplicate_policy_required():
+    """Hostile forwarder cannot flip policy_required by appending an override."""
+    # First emits the True flavor, second tries to override with anything-not-"1".
+    payload = (
+        bytes([0x00, 0x02])
+        + bytes([HintSelector.POLICY_REQUIRED.value, 1])
+        + b"1"
+        + bytes([HintSelector.POLICY_REQUIRED.value, 1])
+        + b"0"
+    )
+    decoded = decode_agent_hint(payload)
+    assert decoded.policy_required is True
+
+
+# ---------------------------------------------------------------------------
+# Adversarial regression: empty Axis-1 string values treated as field-not-set
+# (Defense-in-depth: encode side already skips empty strings; decode must
+#  agree so a forged empty-value payload cannot fragment the cache key.)
+# ---------------------------------------------------------------------------
+
+
+def test_decode_empty_realm_treated_as_none():
+    """Forged payload with realm="" must decode to realm=None, not realm=""."""
+    payload = bytes([0x00, 0x01, HintSelector.REALM.value, 0x00])  # zero-length value
+    decoded = decode_agent_hint(payload)
+    assert decoded.realm is None
+
+
+def test_decode_empty_string_selectors_all_treated_as_none():
+    """All str-typed Axis-1 and the Axis-2 string field treat empty as not-set."""
+    payload = (
+        bytes([0x00, 0x05])
+        + bytes([HintSelector.REALM.value, 0x00])
+        + bytes([HintSelector.TRANSPORT.value, 0x00])
+        + bytes([HintSelector.MIN_TRUST.value, 0x00])
+        + bytes([HintSelector.JURISDICTION.value, 0x00])
+        + bytes([HintSelector.CLIENT_INTENT_CLASS.value, 0x00])
+    )
+    decoded = decode_agent_hint(payload)
+    assert decoded.realm is None
+    assert decoded.transport is None
+    assert decoded.min_trust is None
+    assert decoded.jurisdiction is None
+    assert decoded.client_intent_class is None
+
+
+def test_decode_empty_value_does_not_fragment_signature():
+    """Forged empty-value payload and the no-realm-at-all payload share a signature.
+
+    Encode side skips empty strings (`if self.realm:`); decode side must agree
+    so an attacker cannot construct a cache key under a value the legitimate
+    client would never produce.
+    """
+    empty_payload = bytes([0x00, 0x01, HintSelector.REALM.value, 0x00])
+    no_realm_payload = bytes([0x00, 0x00])
+    assert (
+        decode_agent_hint(empty_payload).signature()
+        == decode_agent_hint(no_realm_payload).signature()
+        == ""
+    )
+
+
+# ---------------------------------------------------------------------------
+# AgentHint.signature() — cache-key semantics
+# ---------------------------------------------------------------------------
+
+
+def test_signature_includes_axis1_only():
+    """Two queries differing only in Axis 2 fields must share a cache key.
+
+    This is the load-bearing design invariant: metering (parallelism, deadline,
+    intent_class, max_age) does NOT change what answer set you get — it only
+    changes policy applied to the request — so it MUST NOT fragment the cache.
+    """
+    h1 = AgentHint(realm="prod", transport="mcp", parallelism=4, deadline_ms=5000)
+    h2 = AgentHint(realm="prod", transport="mcp", parallelism=64, deadline_ms=1)
+    assert h1.signature() == h2.signature()
+
+
+def test_signature_changes_with_axis1():
+    """Different Axis 1 values → different signatures → different cache entries."""
+    assert AgentHint(realm="prod").signature() != AgentHint(realm="staging").signature()
+    assert AgentHint(transport="mcp").signature() != AgentHint(transport="a2a").signature()
+    assert (
+        AgentHint(policy_required=False).signature() != AgentHint(policy_required=True).signature()
+    )
 
 
 def test_signature_is_deterministic():
-    h1 = AgentHint(capabilities=["chat"], intent="summarize")
-    h2 = AgentHint(capabilities=["chat"], intent="summarize")
+    h1 = AgentHint(realm="prod", min_trust="signed")
+    h2 = AgentHint(realm="prod", min_trust="signed")
     assert h1.signature() == h2.signature()
-
-
-def test_signature_is_order_independent_for_capabilities():
-    """Capabilities are sorted in the signature — ordering doesn't change the key."""
-    h1 = AgentHint(capabilities=["chat", "code", "search"])
-    h2 = AgentHint(capabilities=["search", "chat", "code"])
-    assert h1.signature() == h2.signature()
-
-
-def test_signature_differs_when_selectors_differ():
-    h1 = AgentHint(capabilities=["chat"])
-    h2 = AgentHint(capabilities=["search"])
-    assert h1.signature() != h2.signature()
 
 
 def test_signature_empty_hint_is_stable():
     assert AgentHint().signature() == ""
+
+
+def test_signature_axis2_only_hint_has_empty_signature():
+    """A hint with only Axis 2 fields contributes nothing to the cache key —
+    structurally equivalent to no hint at all for caching purposes."""
+    hint = AgentHint(parallelism=8, deadline_ms=2000, client_intent_class="discovery")
+    assert hint.signature() == ""
 
 
 # ---------------------------------------------------------------------------
@@ -183,13 +392,11 @@ def test_signature_empty_hint_is_stable():
 
 
 def test_agent_hint_echo_round_trip():
-    echo = AgentHintEcho(
-        applied_selectors=[HintSelector.CAPABILITIES.value, HintSelector.INTENT.value]
-    )
+    echo = AgentHintEcho(applied_selectors=[HintSelector.REALM.value, HintSelector.TRANSPORT.value])
     decoded = decode_agent_hint_echo(echo.encode())
     assert decoded.applied_selectors == [
-        HintSelector.CAPABILITIES.value,
-        HintSelector.INTENT.value,
+        HintSelector.REALM.value,
+        HintSelector.TRANSPORT.value,
     ]
 
 
@@ -201,14 +408,14 @@ def test_agent_hint_echo_empty_round_trip():
 
 def test_agent_hint_echo_decode_rejects_request_payload():
     """A payload with the echo bit clear must NOT be decoded as an echo."""
-    request_payload = AgentHint(capabilities=["chat"]).encode()
+    request_payload = AgentHint(realm="prod").encode()
     with pytest.raises(ValueError, match="missing echo bit"):
         decode_agent_hint_echo(request_payload)
 
 
 def test_agent_hint_echo_decode_rejects_truncated():
     with pytest.raises(ValueError, match="truncated"):
-        decode_agent_hint_echo(bytes([0x80, 0x05, 0x01]))  # claims 5 selectors, has 1
+        decode_agent_hint_echo(bytes([0x80, 0x05, 0x01]))  # claims 5, has 1
 
 
 def test_agent_hint_echo_rejects_out_of_range_selector_code():
@@ -223,18 +430,17 @@ def test_agent_hint_echo_rejects_out_of_range_selector_code():
 
 
 def test_advertisement_round_trip_via_json():
-    """Pydantic model round trips through JSON without losing fields."""
     adv = EdnsSignalingAdvertisement(
         version=0,
-        honored_selectors=["capabilities", "intent"],
-        note="prefer pre-filtering",
+        honored_selectors=["realm", "transport", "capabilities"],
+        note="DNS-layer narrowing for realm/transport; client-side filter for capabilities",
     )
     restored = EdnsSignalingAdvertisement.model_validate_json(adv.model_dump_json())
     assert restored.version == 0
-    assert restored.honored_selectors == ["capabilities", "intent"]
-    assert restored.note == "prefer pre-filtering"
+    assert "capabilities" in restored.honored_selectors
+    assert "DNS-layer" in restored.note
 
 
 def test_advertisement_optional_note():
-    adv = EdnsSignalingAdvertisement(version=0, honored_selectors=["capabilities"])
+    adv = EdnsSignalingAdvertisement(version=0, honored_selectors=["realm"])
     assert adv.note is None

--- a/tests/unit/test_edns_hint_ctx.py
+++ b/tests/unit/test_edns_hint_ctx.py
@@ -1,0 +1,177 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.core._edns_hint_ctx — env-flag gating + contextvar plumbing.
+
+The contextvar/env-flag layer is the most security-relevant runtime gate in the
+experimental EDNS feature: it determines whether the agent-hint option is ever
+emitted on the wire. The cache tests already verify EdnsAwareResolver wires the
+option through use_edns when invoked directly; these tests cover the
+``_edns_hint_ctx`` helper that the core discoverer path uses instead.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dns_aid.core._edns_hint_ctx import (
+    apply_agent_hint_to_resolver,
+    reset_agent_hint,
+    set_agent_hint,
+)
+from dns_aid.experimental.edns_hint import AGENT_HINT_OPTION_CODE, AgentHint
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patched_env(value: str | None) -> dict:
+    """Build a patch.dict payload that sets or clears the EDNS flag."""
+    if value is None:
+        # Clearing via patch.dict requires pop after-entry; caller handles.
+        return {}
+    return {"DNS_AID_EXPERIMENTAL_EDNS_HINTS": value}
+
+
+# ---------------------------------------------------------------------------
+# Env-flag gate — no emission without the flag
+# ---------------------------------------------------------------------------
+
+
+def test_no_emission_when_flag_unset_even_with_active_hint():
+    """The most important regression: no wire emission without the env flag."""
+    resolver = MagicMock()
+    token = set_agent_hint(AgentHint(realm="prod"))
+    try:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DNS_AID_EXPERIMENTAL_EDNS_HINTS", None)
+            apply_agent_hint_to_resolver(resolver)
+        resolver.use_edns.assert_not_called()
+    finally:
+        reset_agent_hint(token)
+
+
+def test_no_emission_when_flag_set_but_no_hint():
+    """Flag on but no contextvar hint set → still nothing on the wire."""
+    resolver = MagicMock()
+    with patch.dict(os.environ, _patched_env("1")):
+        apply_agent_hint_to_resolver(resolver)
+    resolver.use_edns.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Env-flag truthy-value matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag_value", ["1", "true", "TRUE", "yes", "Yes", "True"])
+def test_truthy_env_flag_values_enable_emission(flag_value):
+    """1, true, yes (case-insensitive) all enable the wire emission."""
+    resolver = MagicMock()
+    token = set_agent_hint(AgentHint(realm="prod"))
+    try:
+        with patch.dict(os.environ, _patched_env(flag_value)):
+            apply_agent_hint_to_resolver(resolver)
+        resolver.use_edns.assert_called_once()
+    finally:
+        reset_agent_hint(token)
+
+
+@pytest.mark.parametrize("flag_value", ["0", "no", "false", "maybe", "", " ", "off"])
+def test_non_truthy_env_flag_values_keep_dormant(flag_value):
+    """Anything not in {1, true, yes} keeps the helper dormant."""
+    resolver = MagicMock()
+    token = set_agent_hint(AgentHint(realm="prod"))
+    try:
+        with patch.dict(os.environ, _patched_env(flag_value)):
+            apply_agent_hint_to_resolver(resolver)
+        resolver.use_edns.assert_not_called()
+    finally:
+        reset_agent_hint(token)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — flag + hint produces the right EDNS option
+# ---------------------------------------------------------------------------
+
+
+def test_emission_attaches_correct_option_code_and_payload():
+    resolver = MagicMock()
+    hint = AgentHint(realm="prod", transport="mcp")
+    token = set_agent_hint(hint)
+    try:
+        with patch.dict(os.environ, _patched_env("1")):
+            apply_agent_hint_to_resolver(resolver)
+        resolver.use_edns.assert_called_once()
+        call = resolver.use_edns.call_args
+        # Helper passes (edns, ednsflags, payload_size, options=...).
+        # We don't pin the positional shape; just check options[].
+        options = call.kwargs.get("options")
+        assert options is not None and len(options) == 1
+        opt = options[0]
+        assert int(opt.otype) == AGENT_HINT_OPTION_CODE
+        assert opt.data == hint.encode()
+    finally:
+        reset_agent_hint(token)
+
+
+# ---------------------------------------------------------------------------
+# Exception safety — experimental code must NEVER break core discovery
+# ---------------------------------------------------------------------------
+
+
+def test_helper_swallows_encode_exception():
+    """If hint.encode() raises, the helper must not propagate the exception.
+
+    Core discovery in discoverer.py calls this helper unconditionally inside the
+    DNS query path; an experimental-code crash here would take out a stable
+    feature. The helper's try/except is the seam that protects against that.
+    """
+    resolver = MagicMock()
+
+    bad_hint = MagicMock(spec=AgentHint)
+    bad_hint.encode.side_effect = ValueError("forced encode failure")
+    bad_hint.signature.return_value = "broken"
+
+    token = set_agent_hint(bad_hint)
+    try:
+        with patch.dict(os.environ, _patched_env("1")):
+            # Must not raise.
+            apply_agent_hint_to_resolver(resolver)
+        # use_edns never called because option construction failed.
+        resolver.use_edns.assert_not_called()
+    finally:
+        reset_agent_hint(token)
+
+
+# ---------------------------------------------------------------------------
+# Contextvar scoping
+# ---------------------------------------------------------------------------
+
+
+def test_reset_restores_previous_hint():
+    """set/reset must return the contextvar to its prior state."""
+    resolver = MagicMock()
+    outer_hint = AgentHint(realm="outer")
+    inner_hint = AgentHint(realm="inner")
+
+    outer_token = set_agent_hint(outer_hint)
+    try:
+        inner_token = set_agent_hint(inner_hint)
+        with patch.dict(os.environ, _patched_env("1")):
+            apply_agent_hint_to_resolver(resolver)
+        # The inner hint was active.
+        assert resolver.use_edns.call_args.kwargs["options"][0].data == inner_hint.encode()
+        reset_agent_hint(inner_token)
+
+        # After reset, the outer hint is active again.
+        resolver.use_edns.reset_mock()
+        with patch.dict(os.environ, _patched_env("1")):
+            apply_agent_hint_to_resolver(resolver)
+        assert resolver.use_edns.call_args.kwargs["options"][0].data == outer_hint.encode()
+    finally:
+        reset_agent_hint(outer_token)


### PR DESCRIPTION
## Summary

Experimental DNS-AID extension — an EDNS(0) option (`agent-hint`, code 65430 in the RFC 6891 private-use range) that lets clients attach selector filters to outgoing DNS queries. Any hop on the resolution path that understands the option may use the hint to narrow the response or short-circuit with a cached pre-filtered match. Stock authoritative servers treat the option as inert per RFC 6891 §6.1.1 — graceful degradation.

Forward-looking design + client-side reference implementation, not a shipping feature. The primary deliverable is the design doc at [docs/experimental/edns-signaling.md](docs/experimental/edns-signaling.md), written with section headers that map cleanly to future IETF-draft structure so content lifts when an LF spec home arrives.

## Two-axis selector taxonomy

**Axis 1 — substrate filters (0x01–0x0F).** What records to return. Participate in the cache key.

| Code | Name | Value | What it asks for |
|---|---|---|---|
| 0x01 | `realm` | UTF-8 | Match SVCB `realm=` param (multi-tenant scope) |
| 0x02 | `transport` | `mcp` / `a2a` / `https` | Encoded in `_{proto}._agents` + `alpn` |
| 0x03 | `policy_required` | `"1"` (or absent) | Only records carrying a `policy=` URI |
| 0x04 | `min_trust` | `signed` / `dnssec` / `signed+dnssec` | Gated on `sig` param + DNSSEC chain |
| 0x05 | `jurisdiction` | ISO region | Compliance lever |

**Axis 2 — metering / lifecycle (0x10–0x1F).** How to handle the request. Do NOT fragment the cache.

| Code | Name | Value | What it asks for |
|---|---|---|---|
| 0x10 | `client_intent_class` | `discovery` / `invocation` | Browsing vs imminent-call; rate-limit policy |
| 0x11 | `max_age` | seconds | Cache freshness budget |
| 0x12 | `parallelism` | uint | Sibling-query count; fan-out signal to caches |
| 0x13 | `deadline_ms` | uint | Wait budget. **Hint-only** — no SLA refuse in v0 |

**0x20+ reserved.** `client_cookie` (0x20) and `correlation_id` (0x21) are documented as future selectors with explicit privacy / threat-model caveats; not coded in v0.

**Not DNS-layer selectors.** `capabilities` and `intent` live in Channel 1 JSON advertisement (`edns_signaling.honored_selectors` in cap-doc / agent-card), used for **post-fetch local filtering**. The reason is layering: SVCB doesn't carry capability strings — those live in cap-doc JSON that an auth would have to dereference per-query, breaking DNS latency budgets.

## Load-bearing invariant: Axis 1 ⊆ cache key

`AgentHint.signature()` includes Axis 1 only. Two queries that differ only in metering — say one with `parallelism=4` and another with `parallelism=64` — hit the same cache entry. Same answer set, different request policy. Locked in by `test_axis2_only_differences_still_hit_cache` and `test_signature_includes_axis1_only`.

## Three loci of processing (forward-looking)

The wire format and advertisement schema support hint-aware processing at any hop along the resolution path:

1. **Locus 1** — in-client programmable hop. Today: `EdnsAwareResolver`. Long-term: the SDK growing into a real agentic cache, or a small DNS-like cache process co-located with the agent runtime. Always usable; ships in this PR.
2. **Locus 2** — hint-aware forwarder / recursive resolver. Future work.
3. **Locus 3** — hint-aware authoritative DNS server. Future work; the design treats this as a first-class deployment, not an aspiration.

## What's in this PR

**New `experimental/` namespace convention** (established here; documented in `docs/architecture.md`): code in `src/dns_aid/experimental/`, never re-exported from the top-level package, env-flag-gated runtime, `[experimental]` stderr banner on CLI commands, design docs in `docs/experimental/`.

**Code:**
- `src/dns_aid/experimental/{__init__,edns_hint,edns_cache}.py` — `AgentHint`, `AgentHintEcho`, `EdnsSignalingAdvertisement`, `EdnsAwareResolver`
- `src/dns_aid/core/_edns_hint_ctx.py` — private contextvar helper shared by `discoverer.py` and `indexer.py` (avoids circular import while keeping the hint threaded through discovery)
- `src/dns_aid/core/discoverer.py` — `agent_hint=` kwarg on `discover()`, body extracted so the contextvar `try/finally` wraps cleanly
- `src/dns_aid/core/indexer.py` — applies the hint on the `_index._agents.{domain}` TXT query path
- `src/dns_aid/core/{cap_fetcher,a2a_card,http_index}.py` — lift the optional `edns_signaling` advertisement from JSON (forward-compat on unknown shapes)
- `src/dns_aid/cli/main.py` — new `dns-aid edns-probe <domain>` command, env-flag-gated, `[experimental]` banner

**Tests (70 experimental):**
- `test_edns_hint.py` (40) — wire format round-trip both axes, malformed-input rejection, signature stability, Axis-1-only invariant, **first-wins on duplicate selector codes** (3 adversarial regression tests), **empty Axis-1 values treated as field-not-set** (3 tests)
- `test_edns_cache.py` (12) — cache hit/miss, TTL, hint-mismatch, echo surfacing, Axis-2-only-differences-still-hit-cache
- `test_edns_hint_ctx.py` (18) — env-flag gating, truthy/non-truthy matrix, exception-swallow (experimental crash MUST NOT propagate into stable core discovery), contextvar reset scoping

**End-to-end wire verification (local):** `tests/testbed/smoke_edns.sh` against the BIND9 testbed. `tcpdump` capture confirms the option (code 0xff96) reaches the authoritative on all three discovery query paths (index TXT / SVCB / capabilities TXT), with wire bytes matching the design doc bit-for-bit. Stock BIND9 returns no echo — correct behaviour for an inert authoritative, and the client's local-filter fallback engages cleanly. `tcpdump` is now pre-installed in the agent Dockerfile so the smoke script is self-contained.

**Docs:**
- `docs/experimental/edns-signaling.md` — full design doc (Overview / Motivation incl. async fan-out / Conceptual model / Wire format / Advertisement / Privacy / Security / Open Questions / Future Work)
- `docs/experimental/edns-signaling.abnf` — wire-format ABNF with axis-encoded code ranges
- `docs/experimental/README.md` — index + namespace conventions
- `README.md` — Experimental Features pointer
- `docs/api-reference.md` — new "Experimental: EDNS(0) signaling" section
- `docs/architecture.md` — new "Experimental namespace" section

## Self-audit against prior DCV review

| DCV pattern from prior review | EDNS feature status |
|---|---|
| First-wins on duplicate keys (mirroring `_parse_txt_value`) | ✓ Adversarial regression test: `realm=prod` + `realm=evil` → `realm=="prod"` |
| Empty-string vs None semantics | ✓ Empty Axis-1 values decode to `None`, matching encode-side `if self.realm:` skip |
| Fail-closed on malformed wire data | ✓ Truncated payload / invalid UTF-8 / garbage numeric → `ValueError` |
| Forward-compat on unknown codes | ✓ Silently skipped + test |
| DoS guards on parsed inputs | ✓ `MAX_OPTION_PAYLOAD=512`, `MAX_SELECTOR_VALUE_LEN=255` |
| Lazy imports of experimental from core | ✓ `TYPE_CHECKING` or function-body imports only |
| Doc coverage (README / api-ref / architecture) | ✓ All three updated |
| `MagicMock` (not `AsyncMock`) for resolver in tests | ✓ Enforced via `_make_upstream` helper |
| Pre-commit gates green | ✓ `ruff format`, `ruff check`, `mypy` all clean |

## CI gates verified locally

- `ruff format --check src/dns_aid` — clean
- `ruff check src/dns_aid` — clean
- `mypy src/dns_aid` — Success: no issues found in 84 source files
- `pytest tests/unit/` — 1569 passed; same 35 pre-existing CEL/ML-DSA failures, no new regressions
- `tests/testbed/smoke_edns.sh` — option appears on the wire to BIND9 (manual; requires Docker)

## Test plan

- [x] All 70 experimental tests pass
- [x] Full unit suite shows no regressions beyond pre-existing CEL/ML-DSA failures
- [x] `mypy`, `ruff format --check`, `ruff check` clean
- [x] Lazy import: `from dns_aid import discover` does not trigger `dns_aid.experimental` import
- [x] CLI gate respected: without `DNS_AID_EXPERIMENTAL_EDNS_HINTS=1`, `dns-aid edns-probe` prints env-var instruction and exits non-zero
- [x] First-wins on duplicate selector codes locked in by tests
- [x] Wire verification via `tests/testbed/smoke_edns.sh` — option 0xff96 appeared on the wire across all three discovery query paths

## Out of scope (forward work)

- Reference hint-aware authoritative server (wire format and advertisement schema designed to support it; building it is separate work)
- IANA option-code reservation (currently private-use)
- Recursive / forwarder reference implementation at Locus 2
- Echo authentication (DNSSEC doesn't cover OPT records — open question §9.4)
- `deadline_ms` enforcement (currently hint-only; structured SLA-refuse RCODE is §10 future work)

## Branch

Three commits on \`experimental/edns-signaling\`:

- \`ec51cb5\` — initial feature shape
- \`641068f\` — taxonomy reshape to two-axis + adversarial-review fixes
- \`64a44f2\` — testbed smoke-test polish (tcpdump in agent Dockerfile, v2 CLI flags)

Squash at merge time is fine if preferred.

## Acknowledgments

Thanks to **John Zinky** (Akamai) for design-level input on the experimental EDNS(0) `agent-hint` signaling work — particularly on how hint-aware hops could fit into the broader resolver ecosystem.
