### PR TITLE
feat(security): OWASP MAESTRO trust-enforcement hardening on invocation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ DNS-AID enables AI agents to discover each other via DNS, using the internet's e
 - [Architecture](docs/architecture.md) — protocol layers, metadata resolution, integration points
 - [Integrations](docs/integrations.md) — backend-specific setup notes
 - [Demo Guide](docs/demo-guide.md) — end-to-end walkthrough for talks and presentations
+- [Security](docs/security/) — [OWASP MAESTRO threat mapping](docs/security/owasp-maestro-mapping.md) and [best practices](docs/security/best-practices.md) for hardening invocation-time trust enforcement
 - [Privacy Policy](PRIVACY.md) | [Security Policy](SECURITY.md) | [Trademarks](TRADEMARKS.md)
 
 ## Companion services

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1520,10 +1520,30 @@ config = SDKConfig.from_env()
 | `DNS_AID_SDK_HTTP_PUSH_URL` | None | POST signals to this URL |
 | `DNS_AID_SDK_DIRECTORY_API_URL` | None | Base URL for `AgentClient.search()` + `fetch_rankings()` (v0.19.0+) |
 | `DNS_AID_SDK_TELEMETRY_API_URL` | None | Deprecated alias for `DNS_AID_SDK_DIRECTORY_API_URL` |
+| `DNS_AID_PREFER_DANE` | false | Try DANE TLSA before TLS handshake; fall back to WebPKI when TLSA absent |
+| `DNS_AID_REQUIRE_DANE` | false | Refuse invocations when TLSA is absent (implies `prefer_dane=True`) |
+| `DNS_AID_REQUIRE_DNSSEC` | false | Refuse answers that are not DNSSEC-validated (AD flag absent or bogus) |
+| `DNS_AID_VERIFY_FRESHNESS_SECONDS` | 0 | When > 0, invoke implicitly re-resolves discoveries older than this many seconds |
 
 The `resolved_directory_url` property returns `directory_api_url` when set, falling
 back to `telemetry_api_url` for backwards compatibility. Using the legacy alias
 emits a `DeprecationWarning` once per process.
+
+#### Trust-enforcement flags (OWASP MAESTRO hardening)
+
+These flags graduate enforcement of substrate-layer trust claims at
+invocation time. Defaults are permissive to match real-world adoption of
+DNSSEC / DANE / mTLS on the public internet; each is **opt-in** for
+hardened deployments. See
+[docs/security/best-practices.md](security/best-practices.md) for guidance
+on which profile to use.
+
+| Field | Default | Mitigates | Behavior |
+|---|---|---|---|
+| `prefer_dane` | `False` | MAESTRO T47 / T7.1 / T9 | Query TLSA before invoke; pin TLS cert when present and matches; fall back to WebPKI when absent; **always refuse on mismatch** |
+| `require_dane` | `False` | MAESTRO T47 strict | Refuse invocation when TLSA absent (no WebPKI fallback). Implies `prefer_dane=True`. |
+| `require_dnssec` | `False` | MAESTRO T37 | Refuse answers that are not DNSSEC-validated |
+| `verify_freshness_seconds` | `0` | MAESTRO BV-9, BV-2 | Re-resolve stale `DiscoveryResult` records before invoke; refuse on `target_host` / `port` / `cap_sha256` drift |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -300,6 +300,49 @@ and gracefully skips hosts that don't serve `.well-known/agent-card.json`.
 
 ---
 
+## Trust-Enforcement Layer (SDK invocation path)
+
+`AgentClient.invoke()` evaluates three substrate-layer trust gates before
+delegating to the protocol handler. All three are **opt-in** via `SDKConfig`
+flags so the SDK behaves as it did historically when called with default
+settings, matching the real-world adoption levels of DNSSEC, DANE TLSA, and
+mTLS on the public internet.
+
+```
+discover() → AgentRecord (carries discovered_at timestamp)
+                    │
+                    ▼
+AgentClient.invoke(agent)
+  │
+  ├─ Freshness gate (verify_freshness_seconds > 0 and stale)
+  │     _reverify_agent(agent) → fresh AgentRecord OR drift
+  │     • match → adopt fresh record
+  │     • drift → refuse with StaleDiscoveryDrift (MAESTRO BV-9, BV-2)
+  │
+  ├─ DANE preflight (prefer_dane or require_dane)
+  │     core._dane.dane_preflight(host, port, require_dane=...)
+  │     • TLSA present + match → ok
+  │     • TLSA absent + permissive → fallback to WebPKI
+  │     • TLSA absent + strict → refuse with DANEAbsent
+  │     • TLSA mismatch → always refuse with DANEMismatch (MAESTRO T47)
+  │
+  ├─ Caller-side policy (sdk/policy/, layer=CALLER)
+  │
+  └─ ProtocolHandler.invoke() — actual wire request
+```
+
+Mandatory key enforcement (RFC 9460 §8) happens earlier, in
+`core/discoverer.py`: records whose `mandatory=` list names a SvcParamKey
+the SDK does not implement are skipped during resolution. This is the
+publisher-driven mechanism by which a zone owner can declare which keys
+clients MUST honor — see [docs/security/best-practices.md](security/best-practices.md).
+
+See [docs/security/owasp-maestro-mapping.md](security/owasp-maestro-mapping.md)
+for the threat-by-threat status across the OWASP MAESTRO catalog (T1-T47 +
+BV-1 through BV-12).
+
+---
+
 ## Invocation Layer (`core/invoke.py`)
 
 The invocation module is the single source of truth for agent communication.

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -1,0 +1,161 @@
+# Security Best Practices
+
+dns-aid-core ships with **permissive defaults** so it works against the
+real-world public internet, where DNSSEC adoption is partial, DANE TLSA is
+rare, and mTLS is mostly internal. Every hardening below is **opt-in**.
+
+This document is paired with [owasp-maestro-mapping.md](owasp-maestro-mapping.md),
+which enumerates the OWASP MAESTRO threats each flag addresses.
+
+## Operator personas
+
+There are two operator roles that benefit from this document:
+
+- **Publishing operators** — own the zone the agent records live under
+- **Calling operators** — run the SDK that invokes agents
+
+The two sides cooperate: a publisher signals what's mandatory via the SVCB
+record; a caller decides how strict to be when consuming records.
+
+## Publishing-side recommendations
+
+If you operate the zone where agents are published, the following practices
+maximize the trust signal callers can act on.
+
+### Publish DNSSEC
+
+Sign the zone hosting `_agents.{your-domain}`. Without DNSSEC, the SVCB and
+DANE primitives below have no authenticated chain of trust — a recursive
+resolver between the caller and your zone could substitute records freely.
+Mitigates OWASP MAESTRO **T37** (Agent Registry Poisoning) and **T9** (Identity
+Spoofing).
+
+### Publish DANE TLSA records
+
+For each agent endpoint, publish a `TLSA` record at `_{port}._tcp.{target}`.
+Selector `1` (SubjectPublicKeyInfo) + matching type `1` (SHA-256) is the
+common shape. This binds the runtime TLS certificate to the DNS-published
+key fingerprint, defeating attackers who have a valid WebPKI cert for the
+hostname. Mitigates OWASP MAESTRO **T47** (Rogue Server) and **T7.1**
+(Agent Impersonation).
+
+### Declare `mandatory=` for keys that matter
+
+Per RFC 9460 §8, listing a SvcParamKey in `mandatory=` means clients that
+don't implement it MUST skip the record. dns-aid-core enforces this on the
+consumption side: if any key you list is unknown to the client SDK, the
+record is discarded with a structured warning. Use this to fail closed:
+
+```text
+chat._mcp._agents.example.com. SVCB 1 svc.example.com.
+    alpn="mcp" port=443
+    cap="https://example.com/cap/chat-v1.json"
+    cap-sha256="..."
+    mandatory="alpn,port,cap-sha256"
+```
+
+A caller that doesn't understand `cap-sha256` will refuse to use this record
+rather than silently downgrading. Mitigates **T7.6** (Fallback Downgrade).
+
+### Set a realistic TTL
+
+The SDK's freshness re-verification (see caller side below) re-resolves
+records older than the configured budget. If you operate a high-churn zone,
+keep TTLs short and the caller's freshness budget short. If your records are
+stable, longer TTLs reduce DNS load.
+
+### Sign records (`sig=`) when DNSSEC isn't available
+
+The `sig=` SvcParamKey carries a JWS-signed payload that validates the
+record independently of DNSSEC. Useful for zones that haven't enabled
+DNSSEC yet. Keys are published at `/.well-known/dns-aid-jwks.json`.
+
+## Calling-side recommendations
+
+The SDKConfig flags below control how strictly the SDK enforces the
+substrate's trust claims at invocation time.
+
+### Threat-to-flag matrix
+
+| MAESTRO threat | What it is | Flag |
+|---|---|---|
+| **T47 / T7.1 / T9** — Rogue server / impersonation | Endpoint serves a cert that doesn't match the DNS-published key | `prefer_dane=True` (try DANE) or `require_dane=True` (refuse when TLSA absent) |
+| **T37** — Registry poisoning | Caller accepts unsigned / bogus DNS answers | `require_dnssec=True` |
+| **BV-9** — TOCTOU verify→invoke | Record changes between discovery and use | `verify_freshness_seconds=N` |
+| **BV-2** — Tool description poisoning (rug pull) | Publisher rotates cap-doc after trust established | `verify_freshness_seconds=N` (the same freshness check compares cap_sha256 and detects rotation) |
+
+### Recommended profiles
+
+**Default (permissive — matches today's behavior)**
+
+```python
+from dns_aid.sdk import SDKConfig
+config = SDKConfig()  # all hardening off
+```
+
+Use when callers are on the public internet and zones aren't guaranteed to
+have DNSSEC or DANE deployed. The substrate still verifies what it can; you
+just don't refuse on what isn't there.
+
+**Standard hardening — opportunistic when present, no fail-closed**
+
+```python
+config = SDKConfig(
+    prefer_dane=True,           # use TLSA when it's there; WebPKI fallback otherwise
+    verify_freshness_seconds=300,  # re-verify discoveries older than 5 minutes
+)
+```
+
+Use for production callers where the cost of the extra DNS lookup is
+acceptable. TLSA-publishing zones get the cert-pinning benefit; legacy zones
+keep working.
+
+**Strict hardening — for high-assurance deployments**
+
+```python
+config = SDKConfig(
+    require_dane=True,          # refuse endpoints without TLSA
+    require_dnssec=True,        # refuse unsigned / bogus answers
+    verify_freshness_seconds=60,
+)
+```
+
+Use only when you control or trust the zones you're calling AND those zones
+are committed to DNSSEC + DANE. This will refuse to invoke a large portion
+of the public internet, which is the point.
+
+## Environment variables
+
+All `SDKConfig` flags above can be set via environment variable for
+deployments where the calling process is launched by an orchestrator and
+doesn't construct the config directly:
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `DNS_AID_PREFER_DANE` | bool | Prefer DANE when TLSA is present |
+| `DNS_AID_REQUIRE_DANE` | bool | Refuse when TLSA is absent |
+| `DNS_AID_REQUIRE_DNSSEC` | bool | Refuse on bogus / unsigned answers |
+| `DNS_AID_VERIFY_FRESHNESS_SECONDS` | int | Re-verify stale discoveries |
+
+## Operational hygiene
+
+- **Backend credentials**: never log them, never check them into version
+  control, prefer per-environment vault-mounted secrets. dns-aid-core's
+  publisher abstractions accept credentials at construction time and do not
+  emit them in any log or telemetry field. (Mitigates **T22** — Service
+  Account Exposure.)
+- **HSM/TPM where supported**: for high-assurance publishers, generate the
+  signing key in an HSM or TPM. The dns-aid-core publisher does not enforce
+  HSM use today; it's a deployment decision.
+- **Network exposure**: registrar / publisher services should be reachable
+  only from the corp network or a hardened ingress, not the public internet.
+- **Log redaction**: when shipping telemetry to an external sink, validate
+  that nothing in the auth handlers' headers (Bearer tokens, API keys) is
+  serialized.
+
+## Mapping to canonical sources
+
+See [owasp-maestro-mapping.md](owasp-maestro-mapping.md) for the full
+threat-by-threat status across T1-T47 + BV-1 through BV-12.
+
+The threat-model authors whose work this builds on are cited there.

--- a/docs/security/owasp-maestro-mapping.md
+++ b/docs/security/owasp-maestro-mapping.md
@@ -1,0 +1,121 @@
+# OWASP MAESTRO mapping for dns-aid-core
+
+This document maps the OWASP MAESTRO multi-agentic threat taxonomy (T1-T47 +
+BV-1 through BV-12) against the dns-aid-core codebase. Each threat is marked
+as **Mitigated** (a primitive in the codebase addresses it), **Partial**
+(primitive exists but enforcement is opt-in or limited in scope), **Out of
+scope** (the threat lives at a layer dns-aid-core does not own — foundation
+models, agent reasoning, RAG, runtime sandboxing, payments), or **Gap**
+(a real defect tracked for follow-up work).
+
+Last updated: 2026-05-13. Reflects the trust-enforcement hardening shipped on
+`feat/owasp-maestro-trust-enforcement`.
+
+## Attribution
+
+This mapping is built directly on the following published threat models. The
+applicability commentary is dns-aid-core specific; the threat enumeration,
+descriptions, and MAESTRO layering are the work of the authors below.
+
+- **OWASP Multi-Agentic System Threat Modelling Guide v1.0** (April 2025) —
+  Ken Huang, A. Sheriff, J. Sotiropoulos, R. F. Del, V. Lu, et al.
+  <https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/>
+- **MAESTRO Playbook & Threat Taxonomy** (CC BY-SA 4.0). Contains the T1-T47
+  enumeration and the BV-1 through BV-12 blindspot vectors used below.
+  <https://agentic-threat-modeling.github.io/MAESTRO/playbook/02-threat-taxonomy.html>
+- **ANS / MAESTRO mapping** — Scott Courtney (GoDaddy). The MAESTRO threat
+  model applied to the Agent Name Service. Several of the dns-aid-core
+  mitigations below are direct applications of patterns documented in his
+  mapping (notably DANE/TLSA pinning, signed integrity envelopes, capability
+  contract sealing, and the multi-stream audit model).
+  <https://github.com/godaddy/ans-registry/blob/main/MAESTRO.md>
+
+## Design posture
+
+dns-aid-core defaults are **permissive** — designed to match the real-world
+adoption levels of DNSSEC, DANE/TLSA, and mTLS on the public internet. Every
+hardening discussed below is **opt-in** via `SDKConfig` flags or via
+publisher-driven `mandatory=` declarations in the SVCB record itself.
+See [best-practices.md](best-practices.md) for the operator-facing flag
+recommendations.
+
+## Core threats (T1-T15)
+
+| ID | Threat | Status | Notes |
+|---|---|---|---|
+| T1 | Memory Poisoning | Out of scope | Agent-runtime / RAG-layer concern. |
+| T2 | Tool Misuse | Mitigated | `cap=` URI sealed by `cap-sha256` (RFC 9460 SVCB params). Tool contract is publisher-declared and integrity-checked at fetch. |
+| T3 | Privilege Compromise | Out of scope | Caller-side workload-identity concern (SPIFFE / SCIM territory). |
+| T4 | Resource Overload | Partial | Caller-side rate limiting via `SDKConfig.max_retries` + circuit breaker; substrate does not throttle. |
+| T5 | Cascading Hallucinations | Out of scope | Foundation model layer. |
+| T6 | Intent Breaking & Goal Manipulation | Out of scope | Agent framework layer. |
+| T7 | Misaligned & Deceptive Behaviour | Out of scope | Runtime / governance layer. |
+| T8 | Repudiation & Untraceability | Partial | Telemetry signals in `sdk/signals/` capture invocation outcomes; audit-log integrity (hash chaining / signed checkpoints) is open work — see Gap T23. |
+| T9 | Identity Spoofing | Mitigated | DNSSEC-validated SVCB resolution; DANE TLSA pinning when configured (`prefer_dane` / `require_dane`); `cap-sha256` integrity check. |
+| T10 | Overwhelming HITL | Out of scope | Human-in-the-loop UX layer. |
+| T11 | Unexpected RCE / Code Attacks | Out of scope | Runtime sandboxing concern. |
+| T12 | Agent Communication Poisoning | Partial | DNS-layer protected by DNSSEC; transport-layer protected by DANE pinning when enabled; application-layer message authentication is the runtime's responsibility (JWS via `sdk/auth/`). |
+| T13 | Rogue Agents | Mitigated | DCV (`core/dcv.py`) proves the publishing zone is controlled by whoever placed the challenge; DNSSEC ties the chain back to the trust anchor. |
+| T14 | Human Attacks on MAS | Out of scope | Social-engineering / agent-framework layer. |
+| T15 | Human Trust Manipulation | Out of scope | UX / human-factors layer. |
+
+## Extended threats (T16-T47)
+
+T26 and T27 are reserved in the canonical taxonomy. Threats omitted from the
+table below (T16-T18, T20-T21, T28-T35, T38, T42) are runtime / framework /
+blockchain / RAG-layer concerns that dns-aid-core does not address by design.
+
+| ID | Threat | Status | Notes |
+|---|---|---|---|
+| T19 | Unintended Workflow Execution | Out of scope | Agent framework. |
+| T22 | Service Account Exposure | Partial | Backends consume credentials from env / SDKConfig. HSM/TPM-backed signing is not yet a first-class primitive in `sdk/auth/`. Operational guidance only — see [best-practices.md](best-practices.md). |
+| T23 | Selective Log Manipulation | Gap | `sdk/telemetry/` writes plain events. Hash-chained / signed-checkpoint audit log is open work; not included in this PR. |
+| T24 | Dynamic Policy Enforcement Failure | Mitigated | `sdk/policy/` evaluates per-invocation; failures fall open with structured warning logs. |
+| T25 | Workflow Disruption via Dependency | Out of scope | Runtime layer. |
+| T29 | Plugin Vulnerability | Out of scope | dns-aid-core itself is not a plugin host; consumers integrating into Claude Desktop / Marketplace need their own input-validation discipline at that boundary. |
+| T36 | Malicious Agent Diffusion | Partial | Records published via DCV-controlled zones can be retracted (revocation propagates as DNS NXDOMAIN). Continuous re-verification is open work. |
+| T37 | Agent Registry Poisoning | Mitigated | DNSSEC + DCV are the canonical mitigations and exist in `core/validator.py` and `core/dcv.py`. Enforcement is opt-in (`require_dnssec`) because of partial real-world DNSSEC adoption. |
+| T39 | Unintended Resource Consumption | Out of scope (substrate); Partial (SDK) | Substrate does not budget; SDK circuit breaker bounds repeated failures per agent. |
+| T40 | MCP Client Impersonation | Mitigated | Caller-side identity is JWS-signable via `sdk/auth/jws.py` (HTTP Message Signatures). Web Bot Auth handler is open work. |
+| T41 | Schema Mismatch | Mitigated | `cap-sha256` seals the capability descriptor against post-hoc divergence; client refuses non-matching content (`core/cap_fetcher.py`). |
+| T43 | Network Exposure | Out of scope | Deployment concern. Documented in [best-practices.md](best-practices.md). |
+| T44 | Insufficient Logging | Partial | Telemetry exists; W3C `traceparent` propagation across protocol handlers is open work. |
+| T45 | Insufficient Server Permission Isolation | Out of scope | Deployment concern. |
+| T46 | Data Residency / Compliance Violation | Partial | `policy=` SVCB key carries the URI; bundle schema and runtime evaluator are open work. |
+| T47 | Rogue Server | Mitigated | DANE TLSA pinning on the invocation path (`SDKConfig.prefer_dane` / `require_dane`). Mismatch always refuses; absent falls back to WebPKI in permissive mode. |
+
+## Blindspot Vectors (BV-1 through BV-12)
+
+| ID | Vector | Status | Notes |
+|---|---|---|---|
+| BV-1 | Context Window Poisoning | Out of scope | Foundation model layer. |
+| BV-2 | Tool Description Poisoning (Rug Pull) | Mitigated | `cap-sha256` re-validation against current SVCB at every fetch, plus `SDKConfig.verify_freshness_seconds` re-resolves before invoke when set and detects rotated cap_sha256 as drift. |
+| BV-3 | Agentic Supply Chain (Dependency Confusion) | Partial | The dns-aid-core repository is open source. SLSA build provenance + Sigstore signing of wheels + transparency-log entry per release is open work; not in this PR. |
+| BV-4 | Prompt Leakage via Tool Outputs | Out of scope | Foundation model / framework layer. |
+| BV-5 | Multi-Tenant Agent Isolation Failure | Out of scope (this PR) | Substrate is per-zone; multi-tenant registrar isolation would be a separate design. |
+| BV-6 | Cost / Budget Exhaustion Attacks | Out of scope | Foundation model billing concern. |
+| BV-7 | Agent Memory Injection via A2A | Out of scope | Runtime / A2A protocol concern. |
+| BV-8 | Steganographic Data Exfiltration | Out of scope | Foundation model output layer. |
+| BV-9 | Time-of-Check-to-Time-of-Use (TOCTOU) | Mitigated | `SDKConfig.verify_freshness_seconds` re-resolves stale `DiscoveryResult` records before invoke; essential fields (target_host, port, cap_sha256) are compared between cached and fresh; drift refuses the invocation. |
+| BV-10 | LLM Reasoning Manipulation | Out of scope | Foundation model layer. |
+| BV-11 | OAuth/OIDC Token Relay Attacks | Out of scope (this PR) | Delegation wire format is deferred — tracked for OIDC-A maturity. |
+| BV-12 | Observability Overload | Gap | Audit-sink classification / anomaly detection is open work; pair with the T23 audit-integrity work. |
+
+## Status summary
+
+- **Mitigated** in this codebase: T2, T9, T13, T24, T37, T40, T41, T47, BV-2, BV-9
+- **Partial**: T4, T8, T12, T22, T36, T39, T44, T46, BV-3
+- **Gap (tracked)**: T23, BV-12
+- **Out of scope**: everything else listed (foundation model, agent framework, RAG, payments, deployment, runtime sandboxing — none of which dns-aid-core owns)
+
+## What this PR specifically lands
+
+This document was created as part of the
+`feat/owasp-maestro-trust-enforcement` branch. The code changes that ship
+alongside this mapping address: T47 / T7.1 / T9 (DANE pinning at invoke),
+BV-9 (TOCTOU re-verification), BV-2 (cap-doc drift detection via the same
+re-verification), and T7.6 (RFC 9460 `mandatory=` enforcement so publishers
+can declare which keys clients MUST honor).
+
+See [best-practices.md](best-practices.md) for the operator-facing flags
+that gate each mitigation.

--- a/src/dns_aid/core/_dane.py
+++ b/src/dns_aid/core/_dane.py
@@ -1,0 +1,248 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared DANE TLSA helpers.
+
+Provides a single source of truth for TLSA lookup and certificate-matching
+logic used by both:
+
+- ``core.validator`` (advisory + full-cert-match modes inside ``verify()``)
+- ``sdk.client`` (pre-invocation preflight against the actual endpoint)
+
+The MAESTRO trust-enforcement hardening PR exposes prefer-then-fallback DANE
+on the invocation path: when a TLSA record is present and validates, the
+runtime cert is bound to the DNS-published key; when absent, WebPKI takes
+over; when present-but-mismatched, the connection is refused.
+
+Per RFC 6698 / RFC 7671, TLSA records MUST be DNSSEC-validated to be
+trustworthy. DNSSEC enforcement is layered on top via the ``require_dnssec``
+config knob; this module does not assume the caller's DNSSEC posture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import ssl
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import dns.asyncresolver
+import dns.resolver
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+class DanePreflightStatus(StrEnum):
+    """Outcome of a DANE preflight against an endpoint."""
+
+    MATCH = "match"  # TLSA present and the endpoint cert matches
+    ABSENT = "absent"  # No TLSA record published for this endpoint
+    MISMATCH = "mismatch"  # TLSA present but the endpoint cert does NOT match
+    ERROR = "error"  # Lookup or TLS handshake failed for a transient reason
+
+
+@dataclass
+class TLSARecord:
+    """Lightweight TLSA RDATA carrier — selector / matching type / association data."""
+
+    usage: int
+    selector: int
+    mtype: int
+    cert: bytes
+
+
+@dataclass
+class DanePreflightResult:
+    """
+    Result of a DANE preflight check.
+
+    ``ok`` is the single boolean the caller should gate on. The other fields
+    are diagnostic: which status the preflight produced, any TLSA records
+    that were considered, and the raw error string when ``status == ERROR``.
+    """
+
+    ok: bool
+    status: DanePreflightStatus
+    tlsa_records: list[TLSARecord] = field(default_factory=list)
+    error: str | None = None
+
+
+async def fetch_tlsa_records(target: str, port: int) -> list[TLSARecord] | None:
+    """
+    Look up TLSA records at ``_{port}._tcp.{target}``.
+
+    Returns:
+        - A non-empty list of :class:`TLSARecord` when records exist.
+        - ``None`` when no TLSA record is configured (NXDOMAIN / NoAnswer).
+
+    Raises:
+        Exception: only on transient resolver errors that callers may want
+            to retry. Callers that need a fail-soft path should catch and
+            treat as ``None`` themselves.
+    """
+    tlsa_fqdn = f"_{port}._tcp.{target}"
+    try:
+        resolver = dns.asyncresolver.Resolver()
+        answers = await resolver.resolve(tlsa_fqdn, "TLSA")
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        return None
+
+    records: list[TLSARecord] = []
+    for rdata in answers:
+        records.append(
+            TLSARecord(
+                usage=int(rdata.usage),
+                selector=int(rdata.selector),
+                mtype=int(rdata.mtype),
+                cert=bytes(rdata.cert),
+            )
+        )
+    return records or None
+
+
+async def match_cert_against_tlsa(
+    target: str,
+    port: int,
+    tlsa_records: list[TLSARecord],
+) -> bool:
+    """
+    Connect to ``target:port`` and compare the presented cert against each TLSA.
+
+    Returns ``True`` if any TLSA record matches the endpoint certificate, per
+    RFC 6698 § 2.1. Returns ``False`` when every TLSA in the set fails to
+    match. Mismatch is the security-relevant outcome — callers must refuse
+    the connection.
+
+    The TLS handshake here is intentionally tolerant of WebPKI errors: a
+    DANE-EE deployment may publish a self-signed cert whose only attestation
+    is the DNSSEC-signed TLSA record. The DANE match is what binds trust,
+    not the public CA chain.
+    """
+    ctx = ssl.create_default_context()
+    # DANE-EE (usage 3) commonly uses self-signed certs. Disable WebPKI
+    # verification for the handshake; the TLSA match below is the trust
+    # anchor we actually care about.
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    _, writer = await asyncio.open_connection(target, port, ssl=ctx)
+    try:
+        ssl_object = writer.get_extra_info("ssl_object")
+        if ssl_object is None:
+            return False
+        der_cert = ssl_object.getpeercert(binary_form=True)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    if not der_cert:
+        return False
+
+    return any(_match_one_tlsa(der_cert, rec) for rec in tlsa_records)
+
+
+def _match_one_tlsa(der_cert: bytes, rec: TLSARecord) -> bool:
+    """Apply one TLSA record's selector + matching-type to a DER cert."""
+    if rec.selector == 1:
+        # SPKI: extract SubjectPublicKeyInfo from the DER certificate
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            PublicFormat,
+        )
+        from cryptography.x509 import load_der_x509_certificate
+
+        try:
+            x509_cert = load_der_x509_certificate(der_cert)
+            cert_bytes = x509_cert.public_key().public_bytes(
+                Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+            )
+        except Exception:
+            return False
+    else:
+        # selector 0 — full DER certificate
+        cert_bytes = der_cert
+
+    if rec.mtype == 1:
+        computed: bytes = hashlib.sha256(cert_bytes).digest()
+    elif rec.mtype == 2:
+        computed = hashlib.sha512(cert_bytes).digest()
+    else:
+        # mtype 0 — exact match
+        computed = cert_bytes
+
+    return computed == rec.cert
+
+
+async def dane_preflight(
+    target: str,
+    port: int,
+    *,
+    require_dane: bool = False,
+) -> DanePreflightResult:
+    """
+    Run a DANE preflight against ``target:port``.
+
+    Behavior matrix:
+
+    +---------------------------+------------------+------------------+
+    | TLSA state                | require_dane=False | require_dane=True |
+    +===========================+==================+==================+
+    | absent                    | ok=True ABSENT   | ok=False ABSENT  |
+    +---------------------------+------------------+------------------+
+    | present + match           | ok=True MATCH    | ok=True MATCH    |
+    +---------------------------+------------------+------------------+
+    | present + mismatch        | ok=False MISMATCH | ok=False MISMATCH |
+    +---------------------------+------------------+------------------+
+    | transient lookup error    | ok=True ERROR    | ok=False ERROR   |
+    +---------------------------+------------------+------------------+
+
+    Mismatch always fails. Absent fails only in strict mode. Transient
+    lookup errors are treated as "no TLSA available" in permissive mode
+    (matches today's behavior for zones with intermittent DNS issues) and
+    as a hard fail in strict mode.
+    """
+    try:
+        records = await fetch_tlsa_records(target, port)
+    except Exception as exc:
+        logger.debug("dane.preflight.lookup_error", target=target, port=port, error=str(exc))
+        return DanePreflightResult(
+            ok=not require_dane,
+            status=DanePreflightStatus.ERROR,
+            error=str(exc),
+        )
+
+    if records is None:
+        logger.debug("dane.preflight.absent", target=target, port=port)
+        return DanePreflightResult(
+            ok=not require_dane,
+            status=DanePreflightStatus.ABSENT,
+        )
+
+    try:
+        matched = await match_cert_against_tlsa(target, port, records)
+    except Exception as exc:
+        logger.debug("dane.preflight.match_error", target=target, port=port, error=str(exc))
+        return DanePreflightResult(
+            ok=not require_dane,
+            status=DanePreflightStatus.ERROR,
+            tlsa_records=records,
+            error=str(exc),
+        )
+
+    if matched:
+        logger.debug("dane.preflight.match", target=target, port=port)
+        return DanePreflightResult(
+            ok=True,
+            status=DanePreflightStatus.MATCH,
+            tlsa_records=records,
+        )
+
+    logger.warning("dane.preflight.mismatch", target=target, port=port)
+    return DanePreflightResult(
+        ok=False,
+        status=DanePreflightStatus.MISMATCH,
+        tlsa_records=records,
+    )

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -369,6 +369,23 @@ async def _query_single_agent(
             # Custom/private-use params may appear as string keys in the
             # presentation format. We parse the text representation to extract them.
             svcb_text = str(rdata)
+
+            # RFC 9460 §8 — if the record carries a ``mandatory=`` list and any
+            # listed key is one we don't implement, the record MUST be skipped.
+            # This is the publisher-driven fail-closed mechanism: a publisher who
+            # cares about (say) cap-sha256 integrity can declare it mandatory and
+            # know that downstream clients without that support will refuse to use
+            # the record rather than silently downgrading. Mitigates OWASP MAESTRO
+            # T7.6 (fallback downgrade).
+            mandatory_ok, unknown_keys = _mandatory_keys_satisfied(svcb_text)
+            if not mandatory_ok:
+                logger.warning(
+                    "Skipping SVCB record with unsupported mandatory keys",
+                    fqdn=fqdn,
+                    unknown_keys=unknown_keys,
+                )
+                return None
+
             custom_params = _parse_svcb_custom_params(svcb_text)
 
             cap_uri = custom_params.get("cap")
@@ -450,12 +467,76 @@ async def _query_single_agent(
                 capability_source=capability_source,
                 endpoint_source="dns_svcb",  # Endpoint resolved via DNS SVCB lookup
                 agent_card=agent_card,
+                discovered_at=time.time(),
             )
 
     except Exception as e:
         logger.debug("Failed to query agent", fqdn=fqdn, error=str(e))
 
     return None
+
+
+# SvcParamKeys this SDK understands. RFC 9460 §8 requires clients to ignore
+# any record whose ``mandatory=`` list names a key the client does not
+# implement, so this set is the gate the discoverer uses below. Standard SVCB
+# keys are accepted by name; DNS-AID custom keys (key65400 ... key65408) are
+# accepted by either their human-readable alias or their numeric form, via
+# normalization in :func:`_parse_mandatory_keys`.
+_SUPPORTED_SVCB_KEYS: frozenset[str] = frozenset(
+    {
+        # RFC 9460 baseline
+        "alpn",
+        "no-default-alpn",
+        "port",
+        "ipv4hint",
+        "ipv6hint",
+        "ech",
+        "dohpath",
+        # DNS-AID extensions (see core.models.DNS_AID_KEY_MAP)
+        "cap",
+        "cap-sha256",
+        "bap",
+        "policy",
+        "realm",
+        "sig",
+        "connect-class",
+        "connect-meta",
+        "enroll-uri",
+    }
+)
+
+
+def _parse_mandatory_keys(svcb_text: str) -> list[str]:
+    """Extract the SVCB ``mandatory=`` list from a record's text representation.
+
+    Returns an empty list when the record has no ``mandatory=`` param. Values
+    in the returned list are normalized to lowercase human-readable form
+    (``keyNNNNN`` aliases are translated when known).
+    """
+    from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
+
+    try:
+        parts = shlex.split(svcb_text)
+    except ValueError:
+        return []
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, _, value = part.partition("=")
+        if key.strip().lower() != "mandatory":
+            continue
+        raw_keys = [k.strip().lower() for k in value.split(",") if k.strip()]
+        return [DNS_AID_KEY_MAP_REVERSE.get(k, k) for k in raw_keys]
+    return []
+
+
+def _mandatory_keys_satisfied(svcb_text: str) -> tuple[bool, list[str]]:
+    """Return (ok, unknown_keys). ``ok=False`` means the record MUST be skipped."""
+    mandatory_keys = _parse_mandatory_keys(svcb_text)
+    if not mandatory_keys:
+        return True, []
+    unknown = [k for k in mandatory_keys if k not in _SUPPORTED_SVCB_KEYS]
+    return (not unknown), unknown
 
 
 def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
@@ -841,6 +922,7 @@ def _http_agent_to_record(
         description=http_agent.description,
         endpoint_override=http_agent.endpoint,
         endpoint_source="http_index_fallback",
+        discovered_at=time.time(),
     )
 
 

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -415,6 +415,19 @@ class AgentRecord(BaseModel):
         "not attempted.",
     )
 
+    # Discovery freshness — populated by the discoverer when this record was
+    # built from a live DNS resolution. The SDK's verify_freshness_seconds knob
+    # uses this to gate implicit re-verification before invoke (OWASP MAESTRO
+    # BV-9 TOCTOU). ``None`` indicates the record was constructed by some path
+    # other than ``discover()`` (e.g., test fixture, manual build) and is
+    # treated as fresh (backward-compatible).
+    discovered_at: float | None = Field(
+        default=None,
+        description="POSIX timestamp (``time.time()``) at which this agent was discovered "
+        "via DNS. Populated by the discoverer; ``None`` for records built outside the "
+        "discovery pipeline.",
+    )
+
     model_config = {"arbitrary_types_allowed": True}
 
     @field_validator("name", mode="before")

--- a/src/dns_aid/sdk/_config.py
+++ b/src/dns_aid/sdk/_config.py
@@ -113,6 +113,44 @@ class SDKConfig(BaseModel):
         description="Seconds before an open circuit transitions to half-open.",
     )
 
+    # OWASP MAESTRO trust-enforcement hardening
+    # Defaults are deliberately permissive to match real-world internet adoption
+    # of DNSSEC / DANE / mTLS. Each strict mode is opt-in.
+    # See docs/security/best-practices.md for guidance.
+    prefer_dane: bool = Field(
+        default=False,
+        description="When True, query TLSA before each invocation and pin the TLS "
+        "certificate against the DNS-published key if a TLSA record is present. "
+        "Absent TLSA records fall back to WebPKI (today's default behavior). "
+        "Mismatched TLSA records always cause invocation to be refused, regardless "
+        "of this setting. Off by default because TLSA adoption is rare and the "
+        "extra DNS lookup adds invocation latency; turn it on for high-assurance "
+        "deployments. Mitigates OWASP MAESTRO T47 / T7.1 / T9.",
+    )
+    require_dane: bool = Field(
+        default=False,
+        description="When True, invocations refuse to proceed unless a TLSA record "
+        "is present AND matches the endpoint cert. Implies prefer_dane=True. Use "
+        "for zones that have committed to publishing TLSA. Mitigates the absent-"
+        "TLSA downgrade case under OWASP MAESTRO T47.",
+    )
+    require_dnssec: bool = Field(
+        default=False,
+        description="When True, discovery / verify operations refuse to use answers "
+        "that are not DNSSEC-validated (AD flag absent or bogus). Off by default "
+        "because the bulk of the public DNS does not yet sign zones. Mitigates "
+        "OWASP MAESTRO T37 (registry poisoning).",
+    )
+    verify_freshness_seconds: int = Field(
+        default=0,
+        ge=0,
+        description="When > 0, invocations against a stale DiscoveryResult (older "
+        "than this many seconds) implicitly re-resolve and re-validate the SVCB / "
+        "cap-doc before connecting. 0 disables the check (caller controls verify→ "
+        "invoke ordering, today's default). Mitigates OWASP MAESTRO BV-9 (TOCTOU "
+        "between verify and invoke) and BV-2 (tool description poisoning / rug-pull).",
+    )
+
     @property
     def resolved_directory_url(self) -> str | None:
         """
@@ -152,6 +190,10 @@ class SDKConfig(BaseModel):
             circuit_breaker_enabled=os.getenv("DNS_AID_CIRCUIT_BREAKER", "").lower() == "true",
             circuit_breaker_threshold=int(os.getenv("DNS_AID_CIRCUIT_BREAKER_THRESHOLD", "5")),
             circuit_breaker_cooldown=float(os.getenv("DNS_AID_CIRCUIT_BREAKER_COOLDOWN", "60")),
+            prefer_dane=os.getenv("DNS_AID_PREFER_DANE", "").lower() in ("1", "true", "yes"),
+            require_dane=os.getenv("DNS_AID_REQUIRE_DANE", "").lower() in ("1", "true", "yes"),
+            require_dnssec=os.getenv("DNS_AID_REQUIRE_DNSSEC", "").lower() in ("1", "true", "yes"),
+            verify_freshness_seconds=int(os.getenv("DNS_AID_VERIFY_FRESHNESS_SECONDS", "0")),
         )
 
 

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -14,10 +14,12 @@ import threading
 import time as _time
 from types import TracebackType
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 import httpx
 import structlog
 
+from dns_aid.core._dane import DanePreflightStatus, dane_preflight
 from dns_aid.core.models import AgentRecord
 from dns_aid.sdk._circuit_breaker import CircuitBreaker
 from dns_aid.sdk._config import SDKConfig
@@ -49,6 +51,65 @@ _HANDLERS: dict[str, type[ProtocolHandler]] = {
     "a2a": A2AProtocolHandler,
     "https": HTTPSProtocolHandler,
 }
+
+# Default TLS port per URL scheme. Used to derive the (host, port) pair the
+# DANE preflight queries TLSA records for. Schemes not listed here yield
+# ``(None, 0)`` and the preflight is skipped — non-TLS or unknown schemes
+# have no TLSA semantic.
+_DEFAULT_PORTS: dict[str, int] = {"https": 443, "http": 80}
+
+
+def _parse_target_port(url: str) -> tuple[str | None, int]:
+    """Extract ``(host, port)`` from an endpoint URL for DANE preflight.
+
+    Returns ``(None, 0)`` when the URL lacks a hostname or uses a scheme the
+    SDK does not run DANE against. Defaults to 443 for https / 80 for http
+    when the URL omits an explicit port.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None, 0
+    host = parsed.hostname
+    if not host:
+        return None, 0
+    if parsed.port is not None:
+        return host, parsed.port
+    default_port = _DEFAULT_PORTS.get(parsed.scheme)
+    if default_port is None:
+        return None, 0
+    return host, default_port
+
+
+async def _reverify_agent(agent: AgentRecord) -> tuple[AgentRecord | None, str | None]:
+    """Re-resolve ``agent`` and confirm essential fields are unchanged.
+
+    Used by the SDK freshness re-verification step (OWASP MAESTRO BV-9).
+    Returns ``(fresh_agent, None)`` when re-discovery succeeds and the
+    fresh record's target/port/cap_sha256 match the cached values. Returns
+    ``(None, reason)`` when the agent is missing from a fresh discovery, the
+    re-resolve raises, or any essential field has drifted — all three cases
+    indicate a TOCTOU window has been observed and the invocation must be
+    refused.
+    """
+    from dns_aid.core.discoverer import discover as _discover
+
+    try:
+        result = await _discover(agent.domain, name=agent.name, protocol=agent.protocol.value)
+    except Exception as exc:
+        return None, f"re-resolve failed: {exc}"
+
+    for fresh in result.agents:
+        if fresh.fqdn != agent.fqdn:
+            continue
+        if (
+            fresh.target_host == agent.target_host
+            and fresh.port == agent.port
+            and fresh.cap_sha256 == agent.cap_sha256
+        ):
+            return fresh, None
+        return None, "essential fields drifted (target_host / port / cap_sha256)"
+    return None, "agent missing from fresh discovery"
 
 
 class AgentClient:
@@ -268,6 +329,96 @@ class AgentClient:
                     policy_uri=agent.policy_uri,
                 )
         # --- end policy enforcement ---
+
+        # --- Freshness re-verification (OWASP MAESTRO BV-9 TOCTOU) ---
+        # When the caller has opted in via verify_freshness_seconds, a stale
+        # DiscoveryResult triggers re-resolution before invoke. Essential fields
+        # (target_host, port, cap_sha256) are compared between cached and fresh
+        # records; any drift refuses the invocation so a poisoned/rug-pulled
+        # record cannot reach the protocol handler.
+        if (
+            self._config.verify_freshness_seconds > 0
+            and agent.discovered_at is not None
+            and _time.time() - agent.discovered_at > self._config.verify_freshness_seconds
+        ):
+            fresh_agent, drift_reason = await _reverify_agent(agent)
+            if fresh_agent is None:
+                logger.warning(
+                    "sdk.freshness_reverify_failed",
+                    agent_fqdn=agent.fqdn,
+                    reason=drift_reason,
+                    age_seconds=_time.time() - agent.discovered_at,
+                )
+                signal = InvocationSignal(
+                    agent_fqdn=agent.fqdn,
+                    agent_endpoint=agent.endpoint_url,
+                    protocol=protocol,
+                    method=method,
+                    invocation_latency_ms=0.0,
+                    status=InvocationStatus.REFUSED,
+                    error_type="StaleDiscoveryDrift",
+                    error_message=(
+                        drift_reason
+                        or "Discovery record drifted since last verify (TOCTOU mitigation)"
+                    ),
+                    caller_id=self._config.caller_id,
+                )
+                return InvocationResult(
+                    success=False,
+                    data={"error": "StaleDiscoveryDrift", "agent_fqdn": agent.fqdn},
+                    signal=signal,
+                )
+            # Essentials match — adopt the refreshed record so any downstream
+            # cap_sha256 / DANE checks operate on the latest authoritative state.
+            agent = fresh_agent
+
+        # --- DANE preflight (OWASP MAESTRO T47 / T7.1 / T9) ---
+        # Bind the runtime TLS cert to the DNS-published key when the deployment
+        # has opted in. Default is permissive (today's WebPKI-only behavior); the
+        # prefer_dane / require_dane flags graduate enforcement at the caller's
+        # discretion. Mismatch always refuses, regardless of strictness.
+        if self._config.prefer_dane or self._config.require_dane:
+            dane_host, dane_port = _parse_target_port(agent.endpoint_url)
+            if dane_host is not None:
+                preflight = await dane_preflight(
+                    dane_host,
+                    dane_port,
+                    require_dane=self._config.require_dane,
+                )
+                if not preflight.ok:
+                    error_type = (
+                        "DANEMismatch"
+                        if preflight.status == DanePreflightStatus.MISMATCH
+                        else "DANEAbsent"
+                        if preflight.status == DanePreflightStatus.ABSENT
+                        else "DANEError"
+                    )
+                    logger.warning(
+                        "sdk.dane_preflight_failed",
+                        agent_fqdn=agent.fqdn,
+                        endpoint=agent.endpoint_url,
+                        status=preflight.status.value,
+                        require_dane=self._config.require_dane,
+                    )
+                    signal = InvocationSignal(
+                        agent_fqdn=agent.fqdn,
+                        agent_endpoint=agent.endpoint_url,
+                        protocol=protocol,
+                        method=method,
+                        invocation_latency_ms=0.0,
+                        status=InvocationStatus.REFUSED,
+                        error_type=error_type,
+                        error_message=(
+                            f"DANE preflight {preflight.status.value} "
+                            f"(require_dane={self._config.require_dane})"
+                        ),
+                        caller_id=self._config.caller_id,
+                    )
+                    return InvocationResult(
+                        success=False,
+                        data={"error": error_type, "agent_fqdn": agent.fqdn},
+                        signal=signal,
+                    )
 
         raw = await handler.invoke(
             client=self._http_client,

--- a/tests/integration/test_dane_e2e.py
+++ b/tests/integration/test_dane_e2e.py
@@ -1,0 +1,273 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end DANE TLSA tests against a real in-process TLS server.
+
+Generates a self-signed certificate at runtime, spins up an asyncio TLS
+server with that cert on a random localhost port, and exercises the full
+``core._dane`` preflight path: TLSA lookup → TLS handshake → cert
+extraction → RFC 6698 §2.1 selector/matching-type comparison.
+
+Only ``fetch_tlsa_records`` is mocked (so we don't need a live DNS
+server). The actual TLS handshake, cert presentation, and
+``match_cert_against_tlsa`` body run against the live server, which is
+what the unit tests in ``tests/unit/test_dane_preflight.py`` cannot
+verify on their own.
+
+Runs hermetically. No Docker / BIND needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import socket
+import ssl
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from dns_aid.core._dane import (
+    DanePreflightStatus,
+    TLSARecord,
+    dane_preflight,
+    match_cert_against_tlsa,
+)
+
+# ---------------------------------------------------------------------------
+# Self-signed cert helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_self_signed_cert() -> tuple[bytes, bytes, bytes]:
+    """Generate (cert_pem, key_pem, der_cert_bytes) for a fresh RSA-2048 cert."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "dane-e2e-test.local")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(minutes=5))
+        .not_valid_after(datetime.now(UTC) + timedelta(hours=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    der_cert = cert.public_bytes(serialization.Encoding.DER)
+    return cert_pem, key_pem, der_cert
+
+
+def _spki_sha256(der_cert: bytes) -> bytes:
+    """SHA-256 of SubjectPublicKeyInfo — the bytes a TLSA 3 1 1 record carries."""
+    cert_obj = x509.load_der_x509_certificate(der_cert)
+    spki = cert_obj.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(spki).digest()
+
+
+# ---------------------------------------------------------------------------
+# Server fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def tls_server(tmp_path: Path) -> AsyncIterator[tuple[str, int, bytes]]:
+    """Start a localhost TLS server with a fresh self-signed cert.
+
+    Yields ``(host, port, der_cert_bytes)``. The DER cert bytes are exposed
+    so tests can build TLSA records that match (or deliberately don't).
+    """
+    cert_pem, key_pem, der_cert = _generate_self_signed_cert()
+    cert_file = tmp_path / "cert.pem"
+    key_file = tmp_path / "key.pem"
+    cert_file.write_bytes(cert_pem)
+    key_file.write_bytes(key_pem)
+
+    ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ssl_ctx.load_cert_chain(certfile=str(cert_file), keyfile=str(key_file))
+
+    # Reserve a free port without binding it long-term.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        # No-op: the cert is already presented during the handshake and the
+        # client extracts it from get_extra_info("ssl_object") before any
+        # application data flows. Closing immediately is fine.
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", port, ssl=ssl_ctx)
+    try:
+        yield "127.0.0.1", port, der_cert
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Full preflight matrix against a real TLS server
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_match_against_real_tls_server(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """Real TLS handshake + TLSA(3, 1, 1) with the correct SPKI hash → MATCH."""
+    host, port, der_cert = tls_server
+    correct_hash = _spki_sha256(der_cert)
+    tlsa = [TLSARecord(usage=3, selector=1, mtype=1, cert=correct_hash)]
+
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(return_value=tlsa),
+    ):
+        result = await dane_preflight(host, port, require_dane=True)
+
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.MATCH
+    assert result.tlsa_records == tlsa
+
+
+async def test_preflight_mismatch_against_real_tls_server(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """Real TLS handshake + TLSA(3, 1, 1) with the WRONG hash → MISMATCH, refused."""
+    host, port, _der_cert = tls_server
+    wrong_hash = hashlib.sha256(b"definitely-not-the-real-key").digest()
+    tlsa = [TLSARecord(usage=3, selector=1, mtype=1, cert=wrong_hash)]
+
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(return_value=tlsa),
+    ):
+        result = await dane_preflight(host, port, require_dane=False)
+
+    # Mismatch always refuses regardless of strictness — RFC 7671 promise.
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.MISMATCH
+
+
+async def test_preflight_strict_mismatch_against_real_tls_server(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """Confirm strict mode also refuses on mismatch (same outcome, different posture)."""
+    host, port, _der_cert = tls_server
+    wrong_hash = hashlib.sha256(b"other-key-bytes").digest()
+    tlsa = [TLSARecord(usage=3, selector=1, mtype=1, cert=wrong_hash)]
+
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(return_value=tlsa),
+    ):
+        result = await dane_preflight(host, port, require_dane=True)
+
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.MISMATCH
+
+
+async def test_preflight_absent_falls_back_to_webpki_permissive(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """No TLSA record + permissive → WebPKI fallback path (preflight ok, status ABSENT).
+
+    The actual TLS handshake never runs because there's nothing to compare
+    against; the SDK's downstream code is what would perform the WebPKI
+    handshake. Here we just verify the preflight produces the right verdict.
+    """
+    host, port, _der_cert = tls_server
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await dane_preflight(host, port, require_dane=False)
+
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.ABSENT
+
+
+async def test_preflight_absent_strict_refuses(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """No TLSA + strict → refuse. require_dane is the publisher's commitment gate."""
+    host, port, _der_cert = tls_server
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await dane_preflight(host, port, require_dane=True)
+
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.ABSENT
+
+
+# ---------------------------------------------------------------------------
+# Selector / matching-type coverage against the real cert
+# ---------------------------------------------------------------------------
+
+
+async def test_match_selector_0_mtype_0_exact_full_cert(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """Selector 0 (full cert) + mtype 0 (exact) — exercise the non-hash path."""
+    host, port, der_cert = tls_server
+    tlsa = [TLSARecord(usage=3, selector=0, mtype=0, cert=der_cert)]
+    matched = await match_cert_against_tlsa(host, port, tlsa)
+    assert matched is True
+
+
+async def test_match_selector_0_mtype_1_sha256_full_cert(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """Selector 0 (full cert) + mtype 1 (SHA-256 over full cert)."""
+    host, port, der_cert = tls_server
+    tlsa = [TLSARecord(usage=3, selector=0, mtype=1, cert=hashlib.sha256(der_cert).digest())]
+    matched = await match_cert_against_tlsa(host, port, tlsa)
+    assert matched is True
+
+
+async def test_match_selector_0_mtype_2_sha512_full_cert(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """Selector 0 + mtype 2 (SHA-512 over full cert)."""
+    host, port, der_cert = tls_server
+    tlsa = [TLSARecord(usage=3, selector=0, mtype=2, cert=hashlib.sha512(der_cert).digest())]
+    matched = await match_cert_against_tlsa(host, port, tlsa)
+    assert matched is True
+
+
+async def test_match_multiple_tlsa_first_wrong_second_correct(
+    tls_server: tuple[str, int, bytes],
+) -> None:
+    """RFC 6698 §2.1: a TLSA RRset can carry multiple records; any match suffices."""
+    host, port, der_cert = tls_server
+    wrong = hashlib.sha256(b"wrong").digest()
+    correct = _spki_sha256(der_cert)
+    tlsa = [
+        TLSARecord(usage=3, selector=1, mtype=1, cert=wrong),
+        TLSARecord(usage=3, selector=1, mtype=1, cert=correct),
+    ]
+    matched = await match_cert_against_tlsa(host, port, tlsa)
+    assert matched is True

--- a/tests/unit/sdk/test_dane_invoke.py
+++ b/tests/unit/sdk/test_dane_invoke.py
@@ -1,0 +1,244 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK-level tests for DANE preflight wiring in AgentClient.invoke().
+
+Verifies that when prefer_dane / require_dane are set on SDKConfig, the
+invocation path consults the DANE preflight before reaching the protocol
+handler and refuses with a structured InvocationSignal on mismatch or
+strict-mode absent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.core._dane import DanePreflightResult, DanePreflightStatus
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient, _parse_target_port
+from dns_aid.sdk.models import InvocationStatus
+
+# ---------------------------------------------------------------------------
+# _parse_target_port — URL parsing for the preflight host/port
+# ---------------------------------------------------------------------------
+
+
+def test_parse_target_port_https_explicit() -> None:
+    assert _parse_target_port("https://agent.example.com:8443/path") == (
+        "agent.example.com",
+        8443,
+    )
+
+
+def test_parse_target_port_https_default() -> None:
+    assert _parse_target_port("https://agent.example.com/") == ("agent.example.com", 443)
+
+
+def test_parse_target_port_http_default() -> None:
+    assert _parse_target_port("http://agent.example.com/") == ("agent.example.com", 80)
+
+
+def test_parse_target_port_unknown_scheme_skipped() -> None:
+    """Non-TLS / unknown schemes should yield (None, 0) so preflight is skipped."""
+    assert _parse_target_port("mcp://agent.example.com/") == (None, 0)
+    assert _parse_target_port("not-a-url") == (None, 0)
+
+
+def test_parse_target_port_no_hostname() -> None:
+    assert _parse_target_port("https://") == (None, 0)
+
+
+# ---------------------------------------------------------------------------
+# AgentClient — preflight gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp_agent() -> AgentRecord:
+    return AgentRecord(
+        name="network",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="mcp.example.com",
+        port=443,
+        capabilities=["ipam"],
+        version="1.0.0",
+    )
+
+
+async def test_no_preflight_when_both_flags_off(mcp_agent: AgentRecord) -> None:
+    """Default behavior (prefer_dane=False, require_dane=False) skips preflight entirely."""
+    config = SDKConfig(prefer_dane=False, require_dane=False)
+    preflight_mock = AsyncMock()
+
+    with (
+        patch("dns_aid.sdk.client.dane_preflight", new=preflight_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(
+            return_value=type(
+                "R",
+                (),
+                {
+                    "success": True,
+                    "status": InvocationStatus.SUCCESS,
+                    "data": {},
+                    "http_status_code": 200,
+                    "error_type": None,
+                    "error_message": None,
+                    "invocation_latency_ms": 1.0,
+                    "ttfb_ms": 1.0,
+                    "response_size_bytes": 0,
+                    "tls_version": None,
+                    "cost_units": None,
+                    "cost_currency": None,
+                    "headers": {},
+                },
+            )()
+        )
+        async with AgentClient(config=config) as client:
+            await client.invoke(mcp_agent)
+
+    preflight_mock.assert_not_called()
+
+
+async def test_prefer_dane_match_proceeds(mcp_agent: AgentRecord) -> None:
+    """prefer_dane=True + TLSA matches → handler invoked normally."""
+    config = SDKConfig(prefer_dane=True)
+    preflight_mock = AsyncMock(
+        return_value=DanePreflightResult(ok=True, status=DanePreflightStatus.MATCH)
+    )
+
+    with (
+        patch("dns_aid.sdk.client.dane_preflight", new=preflight_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        raw = _build_success_raw()
+        handler.invoke = AsyncMock(return_value=raw)
+
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(mcp_agent)
+
+    preflight_mock.assert_awaited_once()
+    handler.invoke.assert_awaited_once()
+    assert result.success is True
+
+
+async def test_prefer_dane_absent_falls_back_to_webpki(mcp_agent: AgentRecord) -> None:
+    """prefer_dane=True + TLSA absent → handler still invoked (WebPKI fallback)."""
+    config = SDKConfig(prefer_dane=True, require_dane=False)
+    preflight_mock = AsyncMock(
+        return_value=DanePreflightResult(ok=True, status=DanePreflightStatus.ABSENT)
+    )
+
+    with (
+        patch("dns_aid.sdk.client.dane_preflight", new=preflight_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(mcp_agent)
+
+    preflight_mock.assert_awaited_once()
+    handler.invoke.assert_awaited_once()
+    assert result.success is True
+
+
+async def test_prefer_dane_mismatch_refuses(mcp_agent: AgentRecord) -> None:
+    """Mismatch is an attack signal — refused regardless of strictness."""
+    config = SDKConfig(prefer_dane=True, require_dane=False)
+    preflight_mock = AsyncMock(
+        return_value=DanePreflightResult(ok=False, status=DanePreflightStatus.MISMATCH)
+    )
+
+    with (
+        patch("dns_aid.sdk.client.dane_preflight", new=preflight_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(mcp_agent)
+
+    preflight_mock.assert_awaited_once()
+    handler.invoke.assert_not_called()
+    assert result.success is False
+    assert result.signal.status == InvocationStatus.REFUSED
+    assert result.signal.error_type == "DANEMismatch"
+
+
+async def test_require_dane_absent_refuses(mcp_agent: AgentRecord) -> None:
+    """require_dane=True + TLSA absent → refused (no WebPKI fallback)."""
+    config = SDKConfig(prefer_dane=True, require_dane=True)
+    preflight_mock = AsyncMock(
+        return_value=DanePreflightResult(ok=False, status=DanePreflightStatus.ABSENT)
+    )
+
+    with (
+        patch("dns_aid.sdk.client.dane_preflight", new=preflight_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(mcp_agent)
+
+    preflight_mock.assert_awaited_once()
+    handler.invoke.assert_not_called()
+    assert result.success is False
+    assert result.signal.error_type == "DANEAbsent"
+
+
+async def test_require_dane_error_refuses(mcp_agent: AgentRecord) -> None:
+    """Strict mode: transient DANE lookup error → refuse rather than fall through."""
+    config = SDKConfig(require_dane=True)
+    preflight_mock = AsyncMock(
+        return_value=DanePreflightResult(
+            ok=False,
+            status=DanePreflightStatus.ERROR,
+            error="simulated",
+        )
+    )
+
+    with (
+        patch("dns_aid.sdk.client.dane_preflight", new=preflight_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(mcp_agent)
+
+    handler.invoke.assert_not_called()
+    assert result.signal.error_type == "DANEError"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_success_raw():
+    """Build a minimal RawResponse-shaped object the post-invoke code can consume."""
+    from dns_aid.sdk.protocols.base import RawResponse
+
+    return RawResponse(
+        success=True,
+        status=InvocationStatus.SUCCESS,
+        data={},
+        http_status_code=200,
+        invocation_latency_ms=1.0,
+        ttfb_ms=1.0,
+        response_size_bytes=0,
+        headers={},
+    )

--- a/tests/unit/sdk/test_verify_freshness.py
+++ b/tests/unit/sdk/test_verify_freshness.py
@@ -1,0 +1,249 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK-level tests for ``verify_freshness_seconds`` opt-in re-verify.
+
+Covers OWASP MAESTRO BV-9 (TOCTOU between verify and invoke):
+
+- Fresh agent (or budget disabled) → no re-resolve, handler invoked
+- Stale agent + match → fresh record adopted, handler invoked
+- Stale agent + drift → invocation refused with StaleDiscoveryDrift
+- Stale agent + re-resolve failure → invocation refused
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+from dns_aid.core.models import AgentRecord, DiscoveryResult, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient, _reverify_agent
+from dns_aid.sdk.models import InvocationStatus
+
+
+def _make_agent(discovered_at: float | None, target_host: str = "mcp.example.com") -> AgentRecord:
+    return AgentRecord(
+        name="network",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host=target_host,
+        port=443,
+        capabilities=["ipam"],
+        version="1.0.0",
+        cap_sha256="abc",
+        discovered_at=discovered_at,
+    )
+
+
+def _build_success_raw():
+    from dns_aid.sdk.protocols.base import RawResponse
+
+    return RawResponse(
+        success=True,
+        status=InvocationStatus.SUCCESS,
+        data={},
+        http_status_code=200,
+        invocation_latency_ms=1.0,
+        ttfb_ms=1.0,
+        response_size_bytes=0,
+        headers={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _reverify_agent — pure helper
+# ---------------------------------------------------------------------------
+
+
+async def test_reverify_returns_fresh_when_essentials_match() -> None:
+    cached = _make_agent(discovered_at=time.time() - 10)
+    fresh = _make_agent(discovered_at=time.time())
+    result = DiscoveryResult(
+        query="_agents.example.com",
+        domain="example.com",
+        agents=[fresh],
+    )
+    with patch("dns_aid.core.discoverer.discover", new=AsyncMock(return_value=result)):
+        out_agent, reason = await _reverify_agent(cached)
+    assert reason is None
+    assert out_agent is not None
+    assert out_agent.target_host == "mcp.example.com"
+
+
+async def test_reverify_detects_target_host_drift() -> None:
+    cached = _make_agent(discovered_at=time.time() - 10, target_host="mcp.example.com")
+    fresh = _make_agent(discovered_at=time.time(), target_host="attacker.example.com")
+    result = DiscoveryResult(query="_agents.example.com", domain="example.com", agents=[fresh])
+    with patch("dns_aid.core.discoverer.discover", new=AsyncMock(return_value=result)):
+        out_agent, reason = await _reverify_agent(cached)
+    assert out_agent is None
+    assert reason is not None
+    assert "drift" in reason.lower()
+
+
+async def test_reverify_detects_cap_sha256_rotation_bv2() -> None:
+    """Publisher rotated cap-doc and updated SVCB cap-sha256 (OWASP MAESTRO BV-2).
+
+    Same target host and port, but cap_sha256 has changed — the rug-pull case
+    where the agent advertises an entirely new capability document. Drift must
+    be detected and the invocation refused; clients that previously cached the
+    cap-doc cannot be silently steered to a new contract.
+    """
+    cached = _make_agent(discovered_at=time.time() - 10)  # cap_sha256='abc'
+    fresh = _make_agent(discovered_at=time.time())
+    fresh.cap_sha256 = "different-hash"  # publisher rotated
+    result = DiscoveryResult(query="_agents.example.com", domain="example.com", agents=[fresh])
+    with patch("dns_aid.core.discoverer.discover", new=AsyncMock(return_value=result)):
+        out_agent, reason = await _reverify_agent(cached)
+    assert out_agent is None
+    assert reason is not None
+    assert "drift" in reason.lower()
+
+
+async def test_reverify_detects_missing_agent() -> None:
+    cached = _make_agent(discovered_at=time.time() - 10)
+    result = DiscoveryResult(query="_agents.example.com", domain="example.com", agents=[])
+    with patch("dns_aid.core.discoverer.discover", new=AsyncMock(return_value=result)):
+        out_agent, reason = await _reverify_agent(cached)
+    assert out_agent is None
+    assert reason is not None
+    assert "missing" in reason.lower()
+
+
+async def test_reverify_handles_resolver_exception() -> None:
+    cached = _make_agent(discovered_at=time.time() - 10)
+    with patch(
+        "dns_aid.core.discoverer.discover",
+        new=AsyncMock(side_effect=RuntimeError("simulated dns failure")),
+    ):
+        out_agent, reason = await _reverify_agent(cached)
+    assert out_agent is None
+    assert reason is not None
+    assert "re-resolve failed" in reason
+
+
+# ---------------------------------------------------------------------------
+# AgentClient.invoke — freshness gating
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_freshness_skips_reverify() -> None:
+    """verify_freshness_seconds=0 → never re-verifies (today's default)."""
+    cached = _make_agent(discovered_at=time.time() - 1_000_000)  # very stale
+    config = SDKConfig(verify_freshness_seconds=0)
+    reverify_mock = AsyncMock()
+
+    with (
+        patch("dns_aid.sdk.client._reverify_agent", new=reverify_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+        async with AgentClient(config=config) as client:
+            await client.invoke(cached)
+
+    reverify_mock.assert_not_called()
+
+
+async def test_fresh_agent_skips_reverify() -> None:
+    """Within budget → no re-verify even when feature is enabled."""
+    cached = _make_agent(discovered_at=time.time())
+    config = SDKConfig(verify_freshness_seconds=60)
+    reverify_mock = AsyncMock()
+
+    with (
+        patch("dns_aid.sdk.client._reverify_agent", new=reverify_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+        async with AgentClient(config=config) as client:
+            await client.invoke(cached)
+
+    reverify_mock.assert_not_called()
+
+
+async def test_missing_discovered_at_skips_reverify() -> None:
+    """Records constructed outside discover() (no timestamp) → backward-compatible passthrough."""
+    cached = _make_agent(discovered_at=None)
+    config = SDKConfig(verify_freshness_seconds=60)
+    reverify_mock = AsyncMock()
+
+    with (
+        patch("dns_aid.sdk.client._reverify_agent", new=reverify_mock),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+        async with AgentClient(config=config) as client:
+            await client.invoke(cached)
+
+    reverify_mock.assert_not_called()
+
+
+async def test_stale_agent_reverify_match_proceeds() -> None:
+    """Stale + match → fresh record adopted, handler invoked."""
+    cached = _make_agent(discovered_at=time.time() - 120)
+    fresh = _make_agent(discovered_at=time.time())
+    config = SDKConfig(verify_freshness_seconds=30)
+
+    with (
+        patch(
+            "dns_aid.sdk.client._reverify_agent",
+            new=AsyncMock(return_value=(fresh, None)),
+        ),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(cached)
+
+    handler.invoke.assert_awaited_once()
+    assert result.success is True
+
+
+async def test_stale_agent_reverify_drift_refuses() -> None:
+    """Stale + drift → invocation refused, handler not called."""
+    cached = _make_agent(discovered_at=time.time() - 120)
+    config = SDKConfig(verify_freshness_seconds=30)
+
+    with (
+        patch(
+            "dns_aid.sdk.client._reverify_agent",
+            new=AsyncMock(return_value=(None, "essential fields drifted")),
+        ),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(cached)
+
+    handler.invoke.assert_not_called()
+    assert result.success is False
+    assert result.signal.status == InvocationStatus.REFUSED
+    assert result.signal.error_type == "StaleDiscoveryDrift"
+    assert "drifted" in (result.signal.error_message or "")
+
+
+async def test_stale_agent_reverify_failure_refuses() -> None:
+    """Stale + re-resolve failure → invocation refused."""
+    cached = _make_agent(discovered_at=time.time() - 120)
+    config = SDKConfig(verify_freshness_seconds=30)
+
+    with (
+        patch(
+            "dns_aid.sdk.client._reverify_agent",
+            new=AsyncMock(return_value=(None, "re-resolve failed: timeout")),
+        ),
+        patch.object(AgentClient, "_get_handler") as get_handler,
+    ):
+        handler = get_handler.return_value
+        handler.invoke = AsyncMock(return_value=_build_success_raw())
+        async with AgentClient(config=config) as client:
+            result = await client.invoke(cached)
+
+    handler.invoke.assert_not_called()
+    assert result.signal.error_type == "StaleDiscoveryDrift"

--- a/tests/unit/test_dane_preflight.py
+++ b/tests/unit/test_dane_preflight.py
@@ -1,0 +1,248 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dns_aid.core._dane — DANE TLSA preflight helper.
+
+Covers the prefer-then-fallback matrix used by the SDK invocation path:
+
+    +------------------------+------------------+------------------+
+    | TLSA state             | require_dane=F   | require_dane=T   |
+    +========================+==================+==================+
+    | absent                 | ok=True ABSENT   | ok=False ABSENT  |
+    | present + match        | ok=True MATCH    | ok=True MATCH    |
+    | present + mismatch     | ok=False MISMATCH| ok=False MISMATCH|
+    | transient lookup error | ok=True ERROR    | ok=False ERROR   |
+    +------------------------+------------------+------------------+
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.core._dane import (
+    DanePreflightResult,
+    DanePreflightStatus,
+    TLSARecord,
+    dane_preflight,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_tlsa() -> list[TLSARecord]:
+    """One TLSA 3 1 1 record — DANE-EE / SPKI / SHA-256 (most common shape)."""
+    return [
+        TLSARecord(
+            usage=3,
+            selector=1,
+            mtype=1,
+            cert=b"\x00" * 32,  # opaque 32-byte fingerprint
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Behavior matrix: absent
+# ---------------------------------------------------------------------------
+
+
+async def test_absent_permissive_returns_ok() -> None:
+    """TLSA absent + require_dane=False → preflight ok (WebPKI fallback path)."""
+    with patch("dns_aid.core._dane.fetch_tlsa_records", new=AsyncMock(return_value=None)):
+        result = await dane_preflight("agent.example.com", 443, require_dane=False)
+    assert isinstance(result, DanePreflightResult)
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.ABSENT
+    assert result.tlsa_records == []
+
+
+async def test_absent_strict_refuses() -> None:
+    """TLSA absent + require_dane=True → preflight refuses."""
+    with patch("dns_aid.core._dane.fetch_tlsa_records", new=AsyncMock(return_value=None)):
+        result = await dane_preflight("agent.example.com", 443, require_dane=True)
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.ABSENT
+
+
+# ---------------------------------------------------------------------------
+# Behavior matrix: present + match
+# ---------------------------------------------------------------------------
+
+
+async def test_present_match_permissive(sample_tlsa: list[TLSARecord]) -> None:
+    with (
+        patch(
+            "dns_aid.core._dane.fetch_tlsa_records",
+            new=AsyncMock(return_value=sample_tlsa),
+        ),
+        patch(
+            "dns_aid.core._dane.match_cert_against_tlsa",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=False)
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.MATCH
+    assert result.tlsa_records == sample_tlsa
+
+
+async def test_present_match_strict(sample_tlsa: list[TLSARecord]) -> None:
+    """Strict + match → ok (the happy path for hardened deployments)."""
+    with (
+        patch(
+            "dns_aid.core._dane.fetch_tlsa_records",
+            new=AsyncMock(return_value=sample_tlsa),
+        ),
+        patch(
+            "dns_aid.core._dane.match_cert_against_tlsa",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=True)
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.MATCH
+
+
+# ---------------------------------------------------------------------------
+# Behavior matrix: present + mismatch (security-critical: always fails)
+# ---------------------------------------------------------------------------
+
+
+async def test_present_mismatch_always_refuses_permissive(
+    sample_tlsa: list[TLSARecord],
+) -> None:
+    """Mismatch is an attack signal — must fail even in permissive mode."""
+    with (
+        patch(
+            "dns_aid.core._dane.fetch_tlsa_records",
+            new=AsyncMock(return_value=sample_tlsa),
+        ),
+        patch(
+            "dns_aid.core._dane.match_cert_against_tlsa",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=False)
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.MISMATCH
+
+
+async def test_present_mismatch_always_refuses_strict(
+    sample_tlsa: list[TLSARecord],
+) -> None:
+    with (
+        patch(
+            "dns_aid.core._dane.fetch_tlsa_records",
+            new=AsyncMock(return_value=sample_tlsa),
+        ),
+        patch(
+            "dns_aid.core._dane.match_cert_against_tlsa",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=True)
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Behavior matrix: transient errors (fail-soft permissive, fail-hard strict)
+# ---------------------------------------------------------------------------
+
+
+async def test_lookup_error_permissive_returns_ok() -> None:
+    """Transient DNS resolver failure + permissive → don't punish the caller."""
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(side_effect=RuntimeError("simulated transient")),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=False)
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.ERROR
+    assert result.error is not None
+    assert "simulated transient" in result.error
+
+
+async def test_lookup_error_strict_refuses() -> None:
+    """Strict mode treats a TLSA lookup failure as a hard fail."""
+    with patch(
+        "dns_aid.core._dane.fetch_tlsa_records",
+        new=AsyncMock(side_effect=RuntimeError("simulated transient")),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=True)
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.ERROR
+
+
+async def test_match_error_permissive_returns_ok(sample_tlsa: list[TLSARecord]) -> None:
+    """TLSA present but the TLS handshake itself fails: fail-soft in permissive."""
+    with (
+        patch(
+            "dns_aid.core._dane.fetch_tlsa_records",
+            new=AsyncMock(return_value=sample_tlsa),
+        ),
+        patch(
+            "dns_aid.core._dane.match_cert_against_tlsa",
+            new=AsyncMock(side_effect=ConnectionError("simulated tls failure")),
+        ),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=False)
+    assert result.ok is True
+    assert result.status == DanePreflightStatus.ERROR
+    assert result.tlsa_records == sample_tlsa
+    assert result.error is not None
+
+
+async def test_match_error_strict_refuses(sample_tlsa: list[TLSARecord]) -> None:
+    with (
+        patch(
+            "dns_aid.core._dane.fetch_tlsa_records",
+            new=AsyncMock(return_value=sample_tlsa),
+        ),
+        patch(
+            "dns_aid.core._dane.match_cert_against_tlsa",
+            new=AsyncMock(side_effect=ConnectionError("simulated tls failure")),
+        ),
+    ):
+        result = await dane_preflight("agent.example.com", 443, require_dane=True)
+    assert result.ok is False
+    assert result.status == DanePreflightStatus.ERROR
+
+
+# ---------------------------------------------------------------------------
+# TLSA matching primitive
+# ---------------------------------------------------------------------------
+
+
+def test_match_one_tlsa_full_cert_sha256() -> None:
+    """selector=0 mtype=1 — full DER cert, SHA-256."""
+    import hashlib
+
+    from dns_aid.core._dane import _match_one_tlsa
+
+    der_cert = b"fake-der-cert-bytes"
+    correct_hash = hashlib.sha256(der_cert).digest()
+    wrong_hash = hashlib.sha256(b"different").digest()
+
+    matching = TLSARecord(usage=3, selector=0, mtype=1, cert=correct_hash)
+    non_matching = TLSARecord(usage=3, selector=0, mtype=1, cert=wrong_hash)
+
+    assert _match_one_tlsa(der_cert, matching) is True
+    assert _match_one_tlsa(der_cert, non_matching) is False
+
+
+def test_match_one_tlsa_exact_match_mtype0() -> None:
+    """selector=0 mtype=0 — exact DER cert comparison."""
+    from dns_aid.core._dane import _match_one_tlsa
+
+    der_cert = b"exact-der-bytes"
+    matching = TLSARecord(usage=3, selector=0, mtype=0, cert=der_cert)
+    non_matching = TLSARecord(usage=3, selector=0, mtype=0, cert=b"other")
+
+    assert _match_one_tlsa(der_cert, matching) is True
+    assert _match_one_tlsa(der_cert, non_matching) is False

--- a/tests/unit/test_mandatory_keys.py
+++ b/tests/unit/test_mandatory_keys.py
@@ -1,0 +1,83 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for RFC 9460 ``mandatory=`` key enforcement in the SVCB parser.
+
+OWASP MAESTRO T7.6 — publishers declare which keys clients MUST honor; clients
+that don't implement a mandatory key MUST skip the record (fail-closed).
+"""
+
+from __future__ import annotations
+
+from dns_aid.core.discoverer import (
+    _mandatory_keys_satisfied,
+    _parse_mandatory_keys,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_mandatory_keys
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mandatory_empty_record() -> None:
+    """No mandatory param → empty list."""
+    text = '1 svc.example.com. alpn="mcp" port=443'
+    assert _parse_mandatory_keys(text) == []
+
+
+def test_parse_mandatory_standard_keys() -> None:
+    text = '1 svc.example.com. alpn="mcp" port=443 mandatory=alpn,port'
+    assert _parse_mandatory_keys(text) == ["alpn", "port"]
+
+
+def test_parse_mandatory_normalizes_keynnnnn_aliases() -> None:  # noqa: N802 — RFC keyNNNNN
+    """key65400 → cap, key65401 → cap-sha256, etc. — normalized."""
+    text = '1 svc.example.com. alpn="mcp" mandatory=alpn,key65400,key65401'
+    assert _parse_mandatory_keys(text) == ["alpn", "cap", "cap-sha256"]
+
+
+def test_parse_mandatory_dns_aid_human_names() -> None:
+    text = "1 svc.example.com. mandatory=alpn,cap-sha256,bap"
+    assert _parse_mandatory_keys(text) == ["alpn", "cap-sha256", "bap"]
+
+
+# ---------------------------------------------------------------------------
+# _mandatory_keys_satisfied — the gate the discoverer uses
+# ---------------------------------------------------------------------------
+
+
+def test_satisfied_no_mandatory_passes() -> None:
+    text = '1 svc.example.com. alpn="mcp" port=443'
+    ok, unknown = _mandatory_keys_satisfied(text)
+    assert ok is True
+    assert unknown == []
+
+
+def test_satisfied_all_keys_known() -> None:
+    text = '1 svc.example.com. alpn="mcp" mandatory=alpn,port,cap-sha256'
+    ok, unknown = _mandatory_keys_satisfied(text)
+    assert ok is True
+    assert unknown == []
+
+
+def test_satisfied_unknown_key_fails() -> None:
+    """A publisher requiring something the SDK doesn't implement → record skipped."""
+    text = '1 svc.example.com. alpn="mcp" mandatory=alpn,some-future-key'
+    ok, unknown = _mandatory_keys_satisfied(text)
+    assert ok is False
+    assert "some-future-key" in unknown
+
+
+def test_satisfied_unknown_numeric_key_fails() -> None:
+    """Numeric private-use key not in DNS_AID_KEY_MAP → unknown → skip."""
+    text = '1 svc.example.com. alpn="mcp" mandatory=alpn,key65500'
+    ok, unknown = _mandatory_keys_satisfied(text)
+    assert ok is False
+    assert "key65500" in unknown
+
+
+def test_satisfied_mixed_known_and_unknown() -> None:
+    text = "1 svc.example.com. mandatory=alpn,cap,unknownX"
+    ok, unknown = _mandatory_keys_satisfied(text)
+    assert ok is False
+    assert unknown == ["unknownx"]  # normalized to lowercase


### PR DESCRIPTION
## Summary

Substrate-layer trust enforcement at TLS handshake and at invocation time,
driven by the OWASP MAESTRO threat catalog. Every hardening ships as an
**opt-in SDKConfig flag** — defaults are unchanged so existing callers see
the same WebPKI-only / no-re-verify behavior. Hardened deployments enable
the flags individually or as a profile.

## Threats addressed

| MAESTRO ID | Threat | Mitigation in this PR |
|---|---|---|
| T47 / T7.1 / T9 | Rogue Server / Agent Impersonation / Identity Spoofing | DANE TLSA prefer-then-fallback at the TLS layer (`prefer_dane` / `require_dane`) |
| BV-9 | Time-of-Check-to-Time-of-Use between verify() and invoke() | `verify_freshness_seconds` opt-in re-resolve with drift detection |
| BV-2 | Tool Description Poisoning (Rug Pull) | Same freshness gate compares `cap_sha256` between cached and fresh records; existing `cap_fetcher` hash check catches content-side drift |
| T7.6 | mTLS Fallback Downgrade | RFC 9460 §8 `mandatory=` enforced on consumption — publishers declare which keys clients MUST honor; the SDK skips records whose mandatory list names a key it doesn't implement |

## Design posture

DNSSEC adoption on the public internet is partial; DANE TLSA adoption is
much rarer; mTLS is mostly internal. Strict-by-default would break a large
fraction of legitimate zones. The PR's posture:

- **Defaults match real-world internet adoption** — no behavior change for existing callers
- **Every hardening is opt-in** via `SDKConfig` flag or publisher-driven `mandatory=` declaration
- **Mismatch always refuses** — a present-but-broken TLSA record is an attack signal, not a fallback case (RFC 7671)
- **Prefer-then-fallback for DANE** — absent TLSA falls back to WebPKI in permissive mode; only refuses when `require_dane=True`

## New SDKConfig flags

| Flag | Default | Mitigates | Behavior |
|---|---|---|---|
| `prefer_dane` | `False` | T47 / T7.1 / T9 | Query TLSA; pin when present and matches; fall back to WebPKI when absent; refuse on mismatch |
| `require_dane` | `False` | T47 strict | Refuse when TLSA absent. Implies `prefer_dane=True`. |
| `require_dnssec` | `False` | T37 | Refuse answers without AD flag / bogus |
| `verify_freshness_seconds` | `0` | BV-9, BV-2 | Re-resolve stale records; refuse on `target_host` / `port` / `cap_sha256` drift |

All four have matching `DNS_AID_*` environment variables.

## What's NOT in this PR (scoped out)

- Default `require_dnssec=True` migration — explicitly out of scope; adoption is too low to warrant a breaking default change
- `dns-aid monitor` continuous re-verify daemon — separate PR
- SLSA build provenance / Sigstore signing — CI-only, separate PR
- Audit-log hash chaining (T23) — separate PR
- `policy=` bundle schema (T46) — separate experimental design PR
- W3C `traceparent` propagation (T44) — small, separable

See `docs/security/owasp-maestro-mapping.md` for the full status across T1-T47 + BV-1-12.

## Files

**New code:**
- `src/dns_aid/core/_dane.py` — shared DANE TLSA preflight helper

**Modified code:**
- `src/dns_aid/core/models.py` — `AgentRecord.discovered_at` timestamp
- `src/dns_aid/core/discoverer.py` — populate `discovered_at`; RFC 9460 §8 `mandatory=` enforcement
- `src/dns_aid/sdk/_config.py` — four new opt-in flags + env-var wiring
- `src/dns_aid/sdk/client.py` — freshness gate, DANE preflight gate, `_parse_target_port`, `_reverify_agent`

**New tests (50 total):**
- `tests/unit/test_dane_preflight.py` (12) — DANE preflight matrix with mocked DNS + TLS
- `tests/unit/test_mandatory_keys.py` (8) — RFC 9460 parser & gate
- `tests/unit/sdk/test_dane_invoke.py` (10) — AgentClient wiring + URL parsing
- `tests/unit/sdk/test_verify_freshness.py` (11) — TOCTOU re-verify positive + drift
- `tests/integration/test_dane_e2e.py` (9) — **end-to-end against a real in-process TLS server**: generates a fresh RSA-2048 self-signed cert, spins up `asyncio.start_server` on a random localhost port, exercises the real handshake + cert extraction + RFC 6698 §2.1 matching. Hermetic, no Docker/BIND required, ~0.8s.

**New docs:**
- `docs/security/owasp-maestro-mapping.md` — full T1-T47 + BV-1-12 mapping
- `docs/security/best-practices.md` — operator-facing guidance + profiles

**Doc updates:**
- `README.md` — security docs pointer
- `docs/api-reference.md` — new flags + env var reference
- `docs/architecture.md` — Trust-Enforcement Layer subsection

## Attribution

This PR is built directly on published threat-model work. Full credit in `docs/security/owasp-maestro-mapping.md`:

- **OWASP Multi-Agentic System Threat Modelling Guide v1.0** (April 2025) — Ken Huang, A. Sheriff, J. Sotiropoulos, R. F. Del, V. Lu, et al. https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/
- **MAESTRO Playbook & Threat Taxonomy** (CC BY-SA 4.0) — canonical T1-T47 + BV-1-12 enumeration https://agentic-threat-modeling.github.io/MAESTRO/playbook/02-threat-taxonomy.html
- **ANS / MAESTRO mapping** — Scott Courtney (GoDaddy). The DANE pinning, capability-sealing, and multi-stream audit patterns adopted here are direct applications of his prior art. https://github.com/godaddy/ans-registry/blob/main/MAESTRO.md

## Verification

All gates run locally on this branch:

- `pytest tests/unit tests/integration/test_dane_e2e.py -q` → **1589 passed** (1550 baseline + 30 unit + 9 e2e)
- `ruff format --check src/dns_aid` → 81 files clean
- `ruff check src/dns_aid` → clean
- `mypy src/dns_aid` → 81 files, no issues

The end-to-end test in `tests/integration/test_dane_e2e.py` covers the
verification previously flagged for manual exercise — a real TLS
handshake against a self-signed cert + real cert extraction + real RFC 6698
match/mismatch — without needing Docker or external infrastructure.

## Test plan

- [x] DANE preflight matrix (absent / match / mismatch / error) × (permissive / strict) — mocked
- [x] AgentClient wiring for DANE (skip-when-off, prefer-paths, refuse-paths)
- [x] Freshness re-verify positive + drift on `target_host` + drift on `cap_sha256` + missing + exception
- [x] AgentClient gating for freshness (disabled, fresh, no-timestamp, stale+match, stale+drift, stale+failure)
- [x] `mandatory=` parser + consumer skip with unknown keys
- [x] `_parse_target_port` URL parsing edge cases
- [x] **End-to-end**: real TLS server + self-signed cert + real handshake → MATCH/MISMATCH verdicts; selectors 0/1; matching types 0/1/2; multi-record RRset