### PR TITLE
docs: IETF / LF wording edits (consolidating Chris Herbst's work)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to DNS-AID
 
-Thank you for your interest in contributing to DNS-AID! This project aims to be contributed to the Linux Foundation Agent AI Foundation.
+Thank you for your interest in contributing to DNS-AID! This project supports an implementation ecosystem, with planned hosting in the Linux Foundation. The DNS-AID specification is developed in the IETF.
 
 ## Quick Start
 
@@ -24,6 +24,22 @@ uv run pytest tests/unit/ -q
 > python -m venv .venv && source .venv/bin/activate
 > pip install -e ".[all]"
 > ```
+
+## Specification Alignment
+
+This repository implements the DNS-AID IETF draft (https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+
+Protocol changes should be discussed in the IETF before implementation.
+
+Implementation insights, deployment experience, and interoperability findings are encouraged here and may be fed back into the IETF process.
+
+## Experimental / Prototype Work
+
+This repository may include experimental features intended to inform the IETF draft.
+
+Experimental features are non-normative, are not part of the DNS-AID specification, and may change or be removed at any time.
+
+Experimental features should be clearly labeled in code comments, documentation, and CLI/SDK help text.
 
 ## Project Structure
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,12 @@
 # DNS-AID Governance
 
-This document describes the governance model for DNS-AID. The project is intended for contribution to the Linux Foundation and follows open governance principles.
+This project governs the DNS-AID reference implementation and supports an ecosystem with planned hosting in the Linux Foundation. The DNS-AID specification itself is defined in the IETF.
+
+## Scope
+
+This project governs the reference implementation and ecosystem activities, including tooling, examples, integrations, documentation, and operational guidance.
+
+The DNS-AID protocol specification is defined in the IETF. Protocol-level changes are out of scope for this project's governance.
 
 ## Roles
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@
 
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+Reference implementation of the DNS-AID specification, developed at the IETF: [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
+
+## Scope of this Repository
+
+This project focuses on implementation, tooling, and ecosystem activities.
+
+Changes to protocol behavior should be discussed within the IETF.
 
 > **New to DNS-AID?** Start with the [Getting Started Guide](docs/getting-started.md) for install, first agent publication, and backend setup.
 
@@ -1009,7 +1015,7 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
-## Why DNS-AID?
+## Background: Why DNS-AID?
 
 ### vs Competing Proposals
 
@@ -1132,6 +1138,6 @@ Apache 2.0
 
 ## Contributing
 
-Contributions welcome! This project is intended for contribution to the Linux Foundation Agent AI Foundation.
+Contributions welcome! This project supports an implementation ecosystem with planned hosting in the Linux Foundation. The DNS-AID specification is developed in the IETF.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,12 @@
 
 Complete API documentation for DNS-AID - DNS-based Agent Identification and Discovery.
 
+## Relationship to IETF
+
+This document describes the API of the DNS-AID reference implementation.
+
+The DNS-AID specification is defined in the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)
@@ -89,7 +95,7 @@ asyncio.run(main())
 
 ### publish()
 
-Publish an AI agent to DNS using the DNS-AID protocol.
+Publish an AI agent to DNS using this implementation of the DNS-AID specification.
 
 ```python
 async def publish(
@@ -169,7 +175,7 @@ else:
 
 ### discover()
 
-Discover AI agents at a domain using DNS-AID protocol (Path A — DNS substrate).
+Discover AI agents at a domain using this implementation of the DNS-AID specification (Path A — DNS substrate).
 
 ```python
 async def discover(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,12 @@
 DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-01 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
 
+## Relationship to IETF
+
+This document describes the architecture and behavior of the reference implementation.
+
+The authoritative DNS-AID specification is defined in the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
 ---
 
 ## Metadata Resolution Strategy
@@ -22,7 +28,7 @@ explains why certain fields (description, use_cases, category) may appear as
 | **HTTP Index** (`/.well-known/agent-index.json`) | JSON document | Full | Authoritative |
 | **TXT Record** (`capabilities=...`) | Key-value strings | Minimal (capabilities + version only) | Fallback |
 
-### Resolution Priority
+### Implementation Resolution Strategy
 
 ```
 Agent discovered via SVCB record
@@ -187,7 +193,8 @@ that round-trip the same inputs through every surface.
 ```
 
 ### Future Enhancement: HTTP Index Fallback in DNS Mode
-
+These are implementation proposals and are not part of the current IETF draft.
+Items in this section may inform future versions of the specification but should not be treated as authoritative.
 Currently the two discovery modes are independent — pure DNS never consults the
 HTTP index and vice versa. Per the DNS-AID draft, the HTTP well-known endpoint
 is a complementary discovery mechanism. A future enhancement should add an

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -1,6 +1,6 @@
 # DNS-AID Demo Guide
 
-This guide walks through demonstrating DNS-AID's end-to-end agent discovery capabilities. Perfect for conference calls, IETF presentations, and Linux Foundation demos.
+This guide demonstrates use of the DNS-AID reference implementation for agent discovery workflows. Perfect for conference calls, IETF presentations, and Linux Foundation demos.
 
 > **Version 0.6.0** - DNSSEC enforcement, DANE full certificate matching, Sigstore release signing, Route53/Cloudflare SVCB param demotion, JWS signatures for application-layer verification, Tier 1 Execution Telemetry SDK, and community rankings.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,12 @@ This guide will walk you through installing, configuring, and testing DNS-AID.
 
 > **Version 0.17.0** - Adds policy-to-RPZ compiler, Infoblox Threat Defense integration (`dns-aid enforce`), CEL-to-DNS compilation, bind-aid zone writer, and 4 new MCP tools for policy enforcement.
 
+## Relationship to IETF
+
+This guide describes usage of the reference implementation.
+
+The DNS-AID specification is defined in the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
 ## Prerequisites
 
 - Python 3.11 or higher


### PR DESCRIPTION
## Summary

Lands a set of documentation wording edits authored by @cherbst-IB
(legal counsel). All eight of Chris's open documentation PRs are being
closed in favor of this unified surface; the content from each is folded
in below. The underlying intent across every change is the same: sharpen
the line between the **IETF-defined DNS-AID specification** and **this
repository's reference implementation / ecosystem activities**, so
governance, contribution, and user-facing docs read consistently with
that scope.

Chris's wording is preserved **verbatim** — these are careful word
choices from legal counsel and have been applied without editorial
change. One single-character transcription fix was made on README.md
line 14 ("Reference implementationof" → "Reference implementation of",
where Chris's diff omitted a space). Every other line is exactly as he
submitted it.

## Content map

| File | Change |
|---|---|
| `README.md` | Opening line reworded; new "Scope of this Repository" section; "Why DNS-AID?" → "Background: Why DNS-AID?"; Contributing section rewording |
| `CONTRIBUTING.md` | IETF/LF opening rewording; new "Specification Alignment" and "Experimental / Prototype Work" sections |
| `GOVERNANCE.md` | Opening rewording; new "Scope" section explicitly excluding protocol-level changes from project governance |
| `docs/api-reference.md` | New "Relationship to IETF" section; two "this implementation of the DNS-AID specification" wording tweaks in the `publish()` / `discover()` headers |
| `docs/architecture.md` | New "Relationship to IETF" section; "Resolution Priority" → "Implementation Resolution Strategy"; non-normative caveat in the Future Enhancement subsection |
| `docs/getting-started.md` | New "Relationship to IETF" section |
| `docs/demo-guide.md` | Opening line reframed as demonstrating the reference implementation |

## Net diff

7 files, +57 / −10, docs-only.

## Verification

Local CI gates green on this branch:

- \`ruff check src/dns_aid\` → clean
- \`mypy src/dns_aid\` → 80 source files, no issues
- \`pytest tests/unit -q\` → 1537 passed

## Attribution

All wording changes in this PR are authored by **Chris Herbst**
(@cherbst-IB). The single transcription fix on README.md L14 is the only
edit that did not originate verbatim from his PRs.