### PR TITLE
docs: correct Project Lead name to Igor Racic

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ Contributors who have earned the ability to merge pull requests. Committers are 
 
 | Name | GitHub | Role |
 |------|--------|------|
-| Ivan Racic | [@iracic82](https://github.com/iracic82) | Project Lead |
+| Igor Racic | [@iracic82](https://github.com/iracic82) | Project Lead |
 
 ### Project Lead
 


### PR DESCRIPTION
## Summary

The committer table in `GOVERNANCE.md` listed *"Ivan Racic"* for the `@iracic82` Project Lead entry. The correct first name is **Igor**. This single-line change brings the governance doc in line with the rest of the project — `MAINTAINERS.md`, `CITATION.cff`, and every other authoritative reference all use *Igor Racic*.

## Diff

\`\`\`diff
-| Ivan Racic | [@iracic82](https://github.com/iracic82) | Project Lead |
+| Igor Racic | [@iracic82](https://github.com/iracic82) | Project Lead |
\`\`\`

## Test plan

- [x] No code change; documentation only.
- [x] GitHub handle (`@iracic82`) unchanged.
- [x] No other occurrences of "Ivan" in governance docs (the remaining match in `MAINTAINERS.md` is Ingmar **Van** Glabbeek's GitHub handle, not a typo).