### PR TITLE
fix(ddns): yield list[str] values not singular data string (#137, v0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-05-20
+
+### Fixed
+
+- **DDNS backend `list_records()` yield shape ([#137](https://github.com/infobloxopen/dns-aid-core/issues/137))**:
+  `DDNSBackend.list_records()` previously yielded one dict per rdata with a
+  singular `data: str(rdata)` key, diverging from every other backend
+  (Route53, Cloudflare, NS1, Cloud DNS, BloxOne, NIOS, Mock) which yield
+  one dict per RRset with a `values: list[str]` key per the documented
+  contract. `core.indexer.read_index()` reads `values` per the contract,
+  so the divergent shape made existing index entries invisible to
+  DDNS-backed zones — each `publish_agent()` call overwrote the index TXT
+  record with only its own entry instead of merging.
+
+  Discovered and diagnosed by external contributor
+  [@yiyuandao](https://github.com/yiyuandao). The DDNS multi-agent +
+  `read_index()` scenario was never exercised by the existing BIND9
+  integration test, which only published single agents.
+
+  Fix: DDNS now groups all rdata at a `(name, type)` tuple into a single
+  yielded dict with `values: list[str]`, matching the contract.
+
+### Tests
+
+- Two new unit tests in
+  `tests/unit/test_ddns_backend.py::TestDDNSBackendListRecords`:
+  `test_list_records_yields_values_list_not_data_string` (pins the
+  yield-shape contract) and `test_list_records_groups_multiple_rdata_into_one_dict`
+  (pins the grouping behavior — N rdata at one (name, type) → 1 yielded
+  dict, not N).
+- New live integration test
+  `tests/integration/test_ddns.py::TestDDNSBackend::test_multi_agent_index_merging`
+  publishes two agents through DDNS and asserts the merged index TXT
+  record contains both. Closes the test-matrix hole that allowed #137 to
+  ship in the first commit (2026-01-16) and survive every release since.
+
 ## [0.21.0] - 2026-05-19
 
 > Lazy credential resolution via `credential_provider` callback — enables RFC 8693

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.21.0"
-date-released: "2026-05-19"
+version: "0.21.1"
+date-released: "2026-05-20"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.21.0"
+version = "0.21.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/backends/ddns.py
+++ b/src/dns_aid/backends/ddns.py
@@ -354,13 +354,22 @@ class DDNSBackend(DNSBackend):
             for rtype in types_to_query:
                 try:
                     answers = dns.resolver.resolve(fqdn, rtype)
-                    for rdata in answers:
+                    # Group all rdata at this (name, type) into the documented
+                    # ``values`` list — one dict per RRset, NOT one dict per
+                    # rdata. Matches the contract used by every other backend
+                    # (Route53, Cloudflare, NS1, CloudDNS, BloxOne, NIOS, Mock).
+                    # The previous shape (``data``: singular string, one dict
+                    # per rdata) caused ``read_index()`` to skip existing
+                    # entries, overwriting the index on each subsequent
+                    # publish (issue #137).
+                    values = [str(rdata) for rdata in answers]
+                    if values:
                         yield {
                             "name": name_pattern,
                             "fqdn": fqdn,
                             "type": rtype,
                             "ttl": answers.rrset.ttl,
-                            "data": str(rdata),
+                            "values": values,
                         }
                 except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
                     pass

--- a/tests/integration/test_ddns.py
+++ b/tests/integration/test_ddns.py
@@ -253,3 +253,101 @@ class TestDDNSBackend:
 
         finally:
             await ddns_backend.delete_record(DDNS_ZONE, name, "SVCB")
+
+    @pytest.mark.asyncio
+    async def test_multi_agent_index_merging(self, ddns_backend):
+        """Regression for #137: calling ``update_index()`` for two agents in
+        sequence must result in an index TXT record listing BOTH, not just
+        the most recent.
+
+        The bug: ``DDNSBackend.list_records()`` yielded a singular ``data``
+        string per rdata, but ``read_index()`` reads the documented
+        ``values`` list. So ``read_index()`` returned empty for any DDNS
+        zone, and the second ``update_index()`` call's read-modify-write
+        sequence saw no existing entries — overwriting the index with
+        only the latest agent.
+
+        This is the CLI flow the reporter used (``dns-aid publish``):
+        each publish triggers ``update_index()`` which does read → merge
+        → write. With the bug, "read" returned empty; without the bug,
+        "read" returns the previously-published agent so the merge
+        preserves it.
+        """
+        from dns_aid.core.indexer import IndexEntry, read_index, update_index
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent_a = AgentRecord(
+            name="multi-a",
+            domain=DDNS_ZONE,
+            protocol=Protocol.A2A,
+            target_host="a.test.dns-aid.local",
+            port=443,
+            capabilities=["multi-test"],
+            ttl=300,
+        )
+        agent_b = AgentRecord(
+            name="multi-b",
+            domain=DDNS_ZONE,
+            protocol=Protocol.A2A,
+            target_host="b.test.dns-aid.local",
+            port=443,
+            capabilities=["multi-test"],
+            ttl=300,
+        )
+
+        # DDNSBackend.list_records() uses the default dns.resolver, which
+        # consults the host's resolver config. Pin it to the test BIND for
+        # the duration of this test so reads hit the container directly.
+        import dns.resolver as _dnsresolver
+
+        original_nameservers = _dnsresolver.get_default_resolver().nameservers[:]
+        original_port = _dnsresolver.get_default_resolver().port
+        _dnsresolver.get_default_resolver().nameservers = [DDNS_SERVER]
+        _dnsresolver.get_default_resolver().port = DDNS_PORT
+
+        try:
+            # Publish agent A + write it into the index.
+            await ddns_backend.publish_agent(agent_a)
+            await update_index(
+                DDNS_ZONE,
+                ddns_backend,
+                add=[IndexEntry(name="multi-a", protocol="a2a")],
+                ttl=300,
+            )
+            await asyncio.sleep(1)
+
+            # Publish agent B + merge it into the index. With the bug,
+            # update_index's read step returns empty (because DDNS yields
+            # the wrong shape), so B's write overwrites A. With the fix,
+            # the read sees A and the write merges both.
+            await ddns_backend.publish_agent(agent_b)
+            await update_index(
+                DDNS_ZONE,
+                ddns_backend,
+                add=[IndexEntry(name="multi-b", protocol="a2a")],
+                ttl=300,
+            )
+            await asyncio.sleep(1)
+
+            # Read the merged index and assert BOTH agents survived.
+            entries = await read_index(DDNS_ZONE, ddns_backend)
+            names = sorted(e.name for e in entries)
+
+            assert "multi-a" in names, (
+                f"Agent A missing from merged index — read_index() returned "
+                f"empty during agent B's update_index() call, causing B to "
+                f"overwrite A. This is the original #137 bug. "
+                f"Got entries: {names!r}"
+            )
+            assert "multi-b" in names, f"Agent B missing from merged index. Got entries: {names!r}"
+
+        finally:
+            _dnsresolver.get_default_resolver().nameservers = original_nameservers
+            _dnsresolver.get_default_resolver().port = original_port
+            # Cleanup
+            for agent_name in ("multi-a", "multi-b"):
+                name = f"_{agent_name}._a2a._agents"
+                await ddns_backend.delete_record(DDNS_ZONE, name, "SVCB")
+                await ddns_backend.delete_record(DDNS_ZONE, name, "TXT")
+            # Reset the index TXT record so re-runs start clean.
+            await ddns_backend.delete_record(DDNS_ZONE, "_index._agents", "TXT")

--- a/tests/unit/test_ddns_backend.py
+++ b/tests/unit/test_ddns_backend.py
@@ -367,6 +367,73 @@ class TestDDNSBackendListRecords:
         # DDNS can't list without specific name pattern
         assert len(records) == 0
 
+    @pytest.mark.asyncio
+    async def test_list_records_yields_values_list_not_data_string(self, backend):
+        """Regression for #137: ``list_records`` MUST yield ``values`` as a
+        list (matching every other backend's documented contract), NOT a
+        singular ``data`` string. ``read_index()`` reads ``values`` per the
+        contract; the previous shape made it invisible to DDNS records,
+        causing the index to be overwritten on multi-agent publish."""
+        mock_answer = MagicMock()
+        mock_answer.rrset.ttl = 3600
+        mock_rdata = MagicMock()
+        mock_rdata.__str__ = lambda self: '"agents=alpha:mcp,beta:a2a"'
+        mock_answer.__iter__ = lambda self: iter([mock_rdata])
+
+        with patch("dns.resolver.resolve", return_value=mock_answer):
+            records = []
+            async for record in backend.list_records(
+                zone="example.com",
+                name_pattern="_index._agents",
+                record_type="TXT",
+            ):
+                records.append(record)
+
+        assert len(records) == 1
+        record = records[0]
+        # The contract: ``values`` is a list of strings.
+        assert "values" in record, (
+            f"DDNS must yield 'values' key per the documented contract; got {record!r}"
+        )
+        assert isinstance(record["values"], list), (
+            f"'values' must be a list, got {type(record['values']).__name__}"
+        )
+        assert record["values"] == ['"agents=alpha:mcp,beta:a2a"']
+        # And NOT the legacy ``data`` singular string key.
+        assert "data" not in record, (
+            f"'data' key from the broken pre-fix shape must not appear; got {record!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_records_groups_multiple_rdata_into_one_dict(self, backend):
+        """Multiple rdata at the same (name, type) MUST be grouped into one
+        yielded dict with a multi-element ``values`` list — NOT yielded as
+        separate dicts. Matches Route53/Cloudflare/NS1 grouping behavior."""
+        mock_answer = MagicMock()
+        mock_answer.rrset.ttl = 3600
+        r1 = MagicMock()
+        r1.__str__ = lambda self: "value-one"
+        r2 = MagicMock()
+        r2.__str__ = lambda self: "value-two"
+        r3 = MagicMock()
+        r3.__str__ = lambda self: "value-three"
+        mock_answer.__iter__ = lambda self: iter([r1, r2, r3])
+
+        with patch("dns.resolver.resolve", return_value=mock_answer):
+            records = []
+            async for record in backend.list_records(
+                zone="example.com",
+                name_pattern="_some._agents",
+                record_type="TXT",
+            ):
+                records.append(record)
+
+        # One dict, three values — NOT three dicts.
+        assert len(records) == 1, (
+            f"3 rdata must group into 1 dict, got {len(records)} dicts: {records!r}"
+        )
+        assert records[0]["values"] == ["value-one", "value-two", "value-three"]
+
 
 class TestDDNSBackendZoneExists:
     """Tests for zone existence check."""

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Closes #137.

`DDNSBackend.list_records()` yielded a non-conforming dict shape — one dict per rdata with a singular `data: str(rdata)` key — diverging from every other backend (Route53, Cloudflare, NS1, Cloud DNS, BloxOne, NIOS, Mock), which yield one dict per RRset with `values: list[str]` per the documented `DNSBackend.list_records()` contract.

`core.indexer.read_index()` correctly reads `values` per the documented contract. The divergent DDNS shape made existing index entries invisible to `read_index()` on DDNS-backed zones, so the read-modify-write sequence in `core.indexer.update_index()` consistently returned empty for the "read" step. Each subsequent `dns-aid publish` overwrote the `_index._agents` TXT record with only the most-recently-published agent, instead of merging the new entry into the existing list.

This bug has been present since the initial commit (2026-01-16) and survived every release because no integration test exercised the multi-agent publish + `read_index()` scenario — the existing BIND9 integration test only published single agents.

## Acknowledgement

Thanks to [@yiyuandao](https://github.com/yiyuandao) for filing the bug with a complete reproduction, an environment listing, and code archaeology that identified the exact offending line (`src/dns_aid/core/indexer.py:114`). The diagnostic work in the issue made the fix straightforward.

## Fix layer — note on divergence from the reporter's proposed patch

The issue proposed a workaround in `src/dns_aid/core/indexer.py` where `read_index()` would fall back to reading the `data` key if `values` was absent. The reporter explicitly flagged this approach as potentially having "side effects for other backends".

This PR fixes the bug at the root cause instead: `DDNSBackend.list_records()` now conforms to the same `values: list[str]` contract every other backend already satisfies. `core.indexer.read_index()` is untouched, and every other consumer of `list_records()` (`cli.main.list_records`, `mcp.server.list_published_agents`, the default `DNSBackend.get_record()` implementation) continues to rely on the uniform documented contract.

The reporter's diagnosis was correct; the patch is placed at the producer side rather than the consumer side so that the documented `DNSBackend.list_records()` contract retains a single canonical shape.

## Changes

| File | Change |
|---|---|
| `src/dns_aid/backends/ddns.py` | Group all rdata at a `(name, type)` tuple into a single yielded dict with `values: list[str]`. 13-line delta. |
| `tests/unit/test_ddns_backend.py` | Two new regression tests in `TestDDNSBackendListRecords`: one pins the `values` key (asserts `data` is absent); one pins the grouping behavior (N rdata at one `(name, type)` → 1 yielded dict, not N). |
| `tests/integration/test_ddns.py` | New live test `test_multi_agent_index_merging` publishes two agents through real BIND9, calls `update_index()` for each (mirroring the CLI flow), and asserts the merged `_index._agents` TXT record contains both. Closes the test-matrix hole that allowed this bug to ship in the initial commit. |
| `CHANGELOG.md` | New `[0.21.1]` section under "Fixed". |
| `pyproject.toml`, `CITATION.cff`, `uv.lock` | Version bump `0.21.0` → `0.21.1` (patch release: bug fix only, no API changes). |

## Backwards compatibility

This change is fully backwards-compatible at the public API level:

- `DDNSBackend.list_records()` now returns the documented contract shape. No consumer in this repository read the previous `data` key; the only consumer (`core.indexer.read_index()`) reads `values`, which is what every other backend already provides.
- No public API signatures changed.
- No new dependencies.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/` — clean
- [x] `uv run mypy src/dns_aid/` — clean (80 source files)
- [x] `uv run pytest tests/unit/test_ddns_backend.py` — 29 passed (27 existing + 2 new)
- [x] `uv run pytest tests/unit/test_indexer.py` — 41 passed (no regression on the consumer side)
- [x] `DDNS_TEST_ENABLED=1 uv run pytest tests/integration/test_ddns.py` — 6 passed against real BIND9 (5 existing + 1 new multi-agent merging test), reproducing the original CLI flow from the issue end-to-end

## Release

Patch release `v0.21.1` follows immediately after merge, triggered by tag push per the existing release workflow.
