### PR TITLE
fix(backends/route53): honor ROUTE53_ZONE_ID env var (v0.21.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2] - 2026-05-22
+
+### Fixed
+
+- **Route 53 backend ignored `ROUTE53_ZONE_ID` env var**: `Route53Backend.__init__`
+  read `AWS_REGION` from the environment but silently dropped `ROUTE53_ZONE_ID`,
+  even though `dns_aid/cli/backends.py` advertised the variable as "auto-detected
+  if omitted." The CLI (`dns-aid publish`) and the MCP server both construct the
+  backend via `create_backend("route53")`, which calls `Route53Backend()` with no
+  keyword arguments — so callers who set only the env var always fell through to
+  a `ListHostedZones` paginated API call, requiring the broader
+  `route53:ListHostedZones` IAM permission and adding an avoidable round-trip to
+  every publish.
+
+  Route 53 was the only backend with this gap — every other backend
+  (`Cloudflare`, `NS1`, `Cloud DNS`, `BloxOne`, `NIOS`, `DDNS`) already used the
+  `kwarg or os.environ.get(VAR)` pattern. The fix brings Route 53 into line.
+
+  **Fix**: `self._zone_id = zone_id or os.environ.get("ROUTE53_ZONE_ID")` in
+  `src/dns_aid/backends/route53.py`. Explicit `zone_id=` kwarg continues to take
+  precedence; env var is consulted only when the kwarg is unset. No API change,
+  no behavior change for callers who already passed `zone_id` explicitly.
+
+  **Operational benefit**: callers who set `ROUTE53_ZONE_ID` can now scope their
+  IAM policy to `route53:ChangeResourceRecordSets` on the specific zone and skip
+  the `route53:ListHostedZones` grant. The fallback path (no kwarg, no env var)
+  still works unchanged — `_get_zone_id()` discovers the zone via API when
+  `self._zone_id` is unset.
+
+### Tests
+
+- New `tests/unit/test_route53_backend.py` cases pin the contract:
+  `test_init_no_zone_id_no_env`, `test_init_zone_id_from_env`,
+  `test_init_kwarg_wins_over_env` (precedence), plus a new test class
+  `TestRoute53GetZoneIdEnvShortCircuit::test_get_zone_id_short_circuits_on_env_var`
+  that asserts no boto3 client is constructed when the env var alone supplies
+  the zone ID.
+- `TestRoute53FactoryWiring::test_factory_with_env_var` /
+  `test_factory_without_env_var` cover the `create_backend("route53")` factory
+  path the CLI and MCP server both use.
+- `TestRoute53AdvertisedEnvContract::test_route53_zone_id_in_optional_env_registry`
+  pins the docs/code contract — if a future change drops `ROUTE53_ZONE_ID` from
+  `BACKEND_REGISTRY` or stops honoring it, the test fails.
+- Live integration verified against AWS Route 53: CLI (`dns-aid publish`), MCP
+  server (`publish_agent_to_dns` tool), and direct SDK use all honor the env
+  var; control case without the env var still falls through to API discovery.
+
 ## [0.21.1] - 2026-05-20
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.21.1"
-date-released: "2026-05-20"
+version: "0.21.2"
+date-released: "2026-05-22"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.21.1"
+version = "0.21.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/backends/route53.py
+++ b/src/dns_aid/backends/route53.py
@@ -64,12 +64,16 @@ class Route53Backend(DNSBackend):
 
         Args:
             zone_id: Optional hosted zone ID (e.g., "ZEXAMPLEZONEID").
-                     If not provided, will be looked up by domain name.
+                     If omitted, falls back to the ``ROUTE53_ZONE_ID``
+                     environment variable; if neither is set, the zone is
+                     looked up by domain name via ``ListHostedZonesByName``
+                     (which requires the ``route53:ListHostedZones`` IAM
+                     permission).
             region: AWS region (defaults to us-east-1 for Route 53)
             aws_access_key_id: AWS access key (defaults to env/credentials)
             aws_secret_access_key: AWS secret key (defaults to env/credentials)
         """
-        self._zone_id = zone_id
+        self._zone_id = zone_id or os.environ.get("ROUTE53_ZONE_ID")
         self._region = region or os.environ.get("AWS_REGION", "us-east-1")
         self._aws_access_key_id = aws_access_key_id
         self._aws_secret_access_key = aws_secret_access_key

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -45,6 +45,35 @@ class TestRoute53BackendInit:
             backend = Route53Backend()
             assert backend._region == "eu-west-1"
 
+    # -----------------------------------------------------------------
+    # ROUTE53_ZONE_ID env var (regression — bug fix v0.21.2)
+    # -----------------------------------------------------------------
+    # Prior to v0.21.2 the constructor read AWS_REGION but ignored
+    # ROUTE53_ZONE_ID even though `cli/backends.py` advertised it as
+    # "auto-detected if omitted". The CLI and MCP server both flow
+    # through `create_backend("route53")` which calls `cls()` with no
+    # kwargs, so a caller with only ROUTE53_ZONE_ID set always fell
+    # through to ListHostedZones — requiring broader IAM than necessary
+    # and adding an avoidable API call to every publish. Pin the fix.
+
+    def test_init_no_zone_id_no_env(self, monkeypatch):
+        """Bare construction with no env var leaves zone_id unset."""
+        monkeypatch.delenv("ROUTE53_ZONE_ID", raising=False)
+        backend = Route53Backend()
+        assert backend._zone_id is None
+
+    def test_init_zone_id_from_env(self, monkeypatch):
+        """ROUTE53_ZONE_ID env var is honoured when no kwarg is supplied."""
+        monkeypatch.setenv("ROUTE53_ZONE_ID", "ZFROMENVVAR")
+        backend = Route53Backend()
+        assert backend._zone_id == "ZFROMENVVAR"
+
+    def test_init_kwarg_wins_over_env(self, monkeypatch):
+        """Explicit zone_id kwarg takes precedence over ROUTE53_ZONE_ID env."""
+        monkeypatch.setenv("ROUTE53_ZONE_ID", "ZFROMENVVAR")
+        backend = Route53Backend(zone_id="ZEXPLICITKWARG")
+        assert backend._zone_id == "ZEXPLICITKWARG"
+
 
 class TestRoute53BackendProperties:
     """Tests for Route53Backend properties."""
@@ -681,3 +710,70 @@ class TestRoute53PublishAgentParamDemotion:
         assert "dnsaid_key65402" in txt_strings  # bap
         assert "dnsaid_key65403" in txt_strings  # policy
         assert "dnsaid_key65404" in txt_strings  # realm
+
+
+# ---------------------------------------------------------------------------
+# ROUTE53_ZONE_ID end-to-end wiring (regression — bug fix v0.21.2)
+# ---------------------------------------------------------------------------
+
+
+class TestRoute53GetZoneIdEnvShortCircuit:
+    """``_get_zone_id`` returns the env-supplied zone ID without an AWS call.
+
+    Prior to the bug fix, the constructor ignored ROUTE53_ZONE_ID so the
+    CLI / MCP construction shape ``Route53Backend()`` always fell through
+    to ListHostedZones. Pin the end-to-end behaviour: env var alone is
+    sufficient to skip the API call entirely.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_zone_id_short_circuits_on_env_var(self, monkeypatch):
+        monkeypatch.setenv("ROUTE53_ZONE_ID", "ZSHORTCIRCUITENV")
+        backend = Route53Backend()  # no kwargs — CLI / MCP construction shape
+
+        # If _get_client were invoked, this would raise — proving no API
+        # round-trip happened. That's the operational improvement.
+        backend._get_client = MagicMock(
+            side_effect=AssertionError("boto3 client must not be created")
+        )
+
+        result = await backend._get_zone_id("example.com")
+        assert result == "ZSHORTCIRCUITENV"
+        backend._get_client.assert_not_called()
+
+
+class TestRoute53FactoryWiring:
+    """``create_backend("route53")`` honours ROUTE53_ZONE_ID.
+
+    This is the path the CLI (``cli/main.py``) and the MCP server
+    (``mcp/server.py``) both take: a factory call with no kwargs. Pin
+    that the factory shape delivers the env var through to the backend.
+    """
+
+    def test_factory_with_env_var(self, monkeypatch):
+        from dns_aid.backends import create_backend
+
+        monkeypatch.setenv("ROUTE53_ZONE_ID", "ZFACTORYENV")
+        backend = create_backend("route53")
+        assert backend._zone_id == "ZFACTORYENV"  # type: ignore[attr-defined]
+
+    def test_factory_without_env_var(self, monkeypatch):
+        from dns_aid.backends import create_backend
+
+        monkeypatch.delenv("ROUTE53_ZONE_ID", raising=False)
+        backend = create_backend("route53")
+        assert backend._zone_id is None  # type: ignore[attr-defined]
+
+
+class TestRoute53AdvertisedEnvContract:
+    """The env var advertised in ``cli/backends.py`` is honoured by the code.
+
+    The original bug was a docs/code drift: the registry entry advertised
+    ROUTE53_ZONE_ID but no code read it. Pin the contract so future
+    contributors can't reintroduce the drift silently.
+    """
+
+    def test_route53_zone_id_in_optional_env_registry(self):
+        from dns_aid.cli.backends import BACKEND_REGISTRY
+
+        assert "ROUTE53_ZONE_ID" in BACKEND_REGISTRY["route53"].optional_env

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

`Route53Backend.__init__` ignored `ROUTE53_ZONE_ID` even though `dns_aid/cli/backends.py:54` advertised it as auto-honored. The CLI (`dns-aid publish`) and the MCP server both construct the backend via `create_backend("route53")`, which calls `Route53Backend()` with no kwargs — so callers who set only the env var always fell through to a `ListHostedZones` paginated API call, requiring the broader `route53:ListHostedZones` IAM permission and adding an avoidable round-trip to every publish.

Route 53 was the only backend with this gap. Every other backend (`Cloudflare`, `NS1`, `Cloud DNS`, `BloxOne`, `NIOS`, `DDNS`) already used the `kwarg or os.environ.get(VAR)` pattern. This PR brings Route 53 into line.

## The fix

```diff
-        self._zone_id = zone_id
+        self._zone_id = zone_id or os.environ.get("ROUTE53_ZONE_ID")
```

- Explicit `zone_id=` kwarg continues to take precedence; env var is consulted only when the kwarg is unset.
- The fallback path (no kwarg, no env var) is unchanged — `_get_zone_id()` discovers the zone via the `ListHostedZones` API when `self._zone_id` is falsy.
- No API surface change, no behavior change for callers who already passed `zone_id` explicitly.

## Why tests didn't catch it

`tests/unit/test_route53_backend.py` had coverage for `AWS_REGION` env fallback but no test for `ROUTE53_ZONE_ID`. The factory-level test only verified construction succeeded, not env-var consumption. This PR adds 7 targeted tests including a registry-contract test that prevents this class of docs/code drift from recurring.

## Tests added

- `test_init_no_zone_id_no_env` — bare construction leaves `_zone_id` unset
- `test_init_zone_id_from_env` — regression test for the bug
- `test_init_kwarg_wins_over_env` — precedence
- `TestRoute53GetZoneIdEnvShortCircuit::test_get_zone_id_short_circuits_on_env_var` — pins the end-to-end short-circuit (no boto3 client created when env var alone supplies the zone)
- `TestRoute53FactoryWiring::test_factory_with_env_var` / `test_factory_without_env_var` — the `create_backend("route53")` path the CLI and MCP server both use
- `TestRoute53AdvertisedEnvContract::test_route53_zone_id_in_optional_env_registry` — pins the `BACKEND_REGISTRY` / constructor alignment

## Live verification

End-to-end tested against AWS Route 53 on the `highvelocitynetworking.com` zone:

| Path | With `ROUTE53_ZONE_ID` set | Without env var |
|---|---|---|
| Python SDK direct (`Route53Backend()`) | 0 `ListHostedZones` paginator calls; uses env value | 1 paginator call; falls through to API discovery |
| CLI (`dns-aid publish`) | "Found zone ID" debug log absent; record created | "Found zone ID" debug log present; record created |
| MCP server (`publish_agent_to_dns` tool) | 0 `list_hosted_zones_by_name` paginator calls; record created | (control case via SDK) |

DNS resolution confirmed via `dig +short ... SVCB @8.8.8.8` after publish. All test records were cleaned up.

## Operational benefit

Callers who set `ROUTE53_ZONE_ID` can now scope their IAM policy to `route53:ChangeResourceRecordSets` on the specific zone and drop the `route53:ListHostedZones` grant. This was the contract advertised in `cli/backends.py` from day one — this PR delivers on it.

## Version bump

`0.21.1` → `0.21.2` (patch). Bug fix only, no API changes, aligns implementation with already-advertised behavior.

- `pyproject.toml`
- `CITATION.cff` (version + `date-released: 2026-05-22`)
- `CHANGELOG.md` (new `[0.21.2] - 2026-05-22` entry)
- `uv.lock` (regenerated)

## Breaking changes

None.

## Test plan

- [x] `uv run ruff check src/` — passes
- [x] `uv run ruff format --check src/` — passes (80 files already formatted)
- [x] `uv run mypy src/dns_aid/backends/route53.py` — passes
- [x] `uv run pytest tests/unit/test_route53_backend.py` — 40 passed (33 pre-existing + 7 new)
- [x] `uv run pytest tests/unit/` — 1615 passed (the 9 failures are in an untracked WIP file outside this PR)
- [x] Secrets scan — clean
- [x] Live integration test against real Route 53 — CLI + MCP + SDK paths verified