### PR TITLE
fix(sdk/policy/guard): forward tool_name to PolicyContext (v0.21.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.3] - 2026-05-26
+
+### Fixed
+
+- **`check_target_policy()` dropped caller-supplied `tool_name`**:
+  `dns_aid.sdk.policy.guard.check_target_policy()` constructed a
+  `PolicyContext` but did not expose `tool_name` as a kwarg, so callers
+  who wanted tool-name-based policy enforcement (e.g., MCP servers gating
+  on `tools/call`) had to bypass the helper and build `PolicyContext`
+  directly. The data model already supported the field —
+  `PolicyContext.tool_name` has been present since the policy engine
+  shipped — the helper just didn't plumb it through.
+
+  **Fix**: add an optional `tool_name: str | None = None` kwarg to
+  `check_target_policy()` and forward it into the `PolicyContext`.
+  Strictly additive; existing call sites continue to work unchanged.
+  The denial log entry now also records `tool_name` for observability.
+
+  **Use case**: MCP servers integrating with `dns-aid` can now write:
+
+  ```python
+  from dns_aid.sdk.policy.guard import check_target_policy
+
+  result = await check_target_policy(
+      policy_uri=agent.policy_uri,
+      method="tools/call",
+      tool_name=tool_name,
+  )
+  if result.denied:
+      return {"error": "policy_denied", ...}
+  ```
+
+  No more shim wrappers in caller projects.
+
+### Tests
+
+- `tests/unit/mcp/test_policy_guard.py::TestCheckTargetPolicy::test_tool_name_forwarded_to_context`
+  captures the `PolicyContext` constructed inside the helper and asserts
+  the kwarg lands on `ctx.tool_name`.
+- `test_tool_name_defaults_to_none` pins the backward-compatibility
+  contract: callers that omit the new kwarg see `ctx.tool_name is None`,
+  matching pre-v0.21.3 behaviour.
+
 ## [0.21.2] - 2026-05-22
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.21.2"
-date-released: "2026-05-22"
+version: "0.21.3"
+date-released: "2026-05-26"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.21.2"
+version = "0.21.3"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/sdk/policy/guard.py
+++ b/src/dns_aid/sdk/policy/guard.py
@@ -40,6 +40,7 @@ async def check_target_policy(
     *,
     protocol: str = "mcp",
     method: str | None = None,
+    tool_name: str | None = None,
     caller_id: str = "dns-aid-mcp-server",
 ) -> PolicyResult:
     """Check target agent's policy before invocation.
@@ -49,6 +50,10 @@ async def check_target_policy(
                     or agent card). If None, returns allowed (no-policy).
         protocol: Protocol being used (mcp, a2a, https).
         method: Method being invoked (e.g., tools/call).
+        tool_name: For MCP tools/call, the name of the tool being invoked
+                   (e.g., "explore_network"). Forwarded to ``PolicyContext``
+                   so policy rules can match on tool name (e.g.,
+                   ``denied_tools`` or per-tool ``allowed_caller_domains``).
         caller_id: Identifier for the calling MCP server.
 
     Returns:
@@ -70,6 +75,7 @@ async def check_target_policy(
             caller_domain=os.getenv("DNS_AID_CALLER_DOMAIN"),
             protocol=protocol,
             method=method,
+            tool_name=tool_name,
         )
         result = evaluator.evaluate(
             policy_doc,
@@ -83,6 +89,7 @@ async def check_target_policy(
                 policy_uri=policy_uri,
                 protocol=protocol,
                 method=method,
+                tool_name=tool_name,
                 violations=[f"{v.rule}:{v.detail}" for v in result.violations],
                 mode=policy_mode,
             )

--- a/tests/unit/mcp/test_policy_guard.py
+++ b/tests/unit/mcp/test_policy_guard.py
@@ -175,3 +175,70 @@ class TestCheckTargetPolicy:
             )
             assert captured_ctx["protocol"] == "a2a"
             assert captured_ctx["method"] == "message/send"
+
+    @pytest.mark.asyncio
+    async def test_tool_name_forwarded_to_context(self) -> None:
+        """tool_name kwarg is forwarded to PolicyContext.
+
+        Regression test for v0.21.3: ``PolicyContext`` already had a
+        ``tool_name`` field, but ``check_target_policy()`` discarded any
+        caller-supplied value because it wasn't a kwarg. Callers wanting
+        per-tool policy enforcement had to bypass the helper entirely.
+        """
+        captured_ctx = {}
+
+        def capture_evaluate(doc, ctx, **kw):
+            captured_ctx["tool_name"] = ctx.tool_name
+            captured_ctx["method"] = ctx.method
+            return PolicyResult(allowed=True)
+
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(),
+        )
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(return_value=doc)
+        mock_eval.evaluate = capture_evaluate
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "permissive"}),
+        ):
+            await check_target_policy(
+                "https://example.com/policy.json",
+                protocol="mcp",
+                method="tools/call",
+                tool_name="explore_network",
+            )
+            assert captured_ctx["tool_name"] == "explore_network"
+            assert captured_ctx["method"] == "tools/call"
+
+    @pytest.mark.asyncio
+    async def test_tool_name_defaults_to_none(self) -> None:
+        """Backward compat: callers that omit tool_name see None in the context."""
+        captured_ctx = {}
+
+        def capture_evaluate(doc, ctx, **kw):
+            captured_ctx["tool_name"] = ctx.tool_name
+            return PolicyResult(allowed=True)
+
+        doc = PolicyDocument(
+            version="1.0",
+            agent="_test._mcp._agents.example.com",
+            rules=PolicyRules(),
+        )
+        mock_eval = AsyncMock()
+        mock_eval.fetch = AsyncMock(return_value=doc)
+        mock_eval.evaluate = capture_evaluate
+
+        with (
+            patch("dns_aid.sdk.policy.guard._get_evaluator", return_value=mock_eval),
+            patch.dict("os.environ", {"DNS_AID_POLICY_MODE": "permissive"}),
+        ):
+            await check_target_policy(
+                "https://example.com/policy.json",
+                protocol="mcp",
+                method="tools/call",
+            )
+            assert captured_ctx["tool_name"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.21.2"
+version = "0.21.3"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

`dns_aid.sdk.policy.guard.check_target_policy()` constructed a `PolicyContext` but did not accept `tool_name` as a kwarg, so callers wanting tool-name-based policy enforcement (e.g., MCP servers gating on `tools/call`) had to bypass the helper and build `PolicyContext` directly — typically via a small wrapper module in the caller project.

The data model already supported the field — `PolicyContext.tool_name` has been present since the policy engine shipped. The helper just discarded any caller-supplied value because it wasn't plumbed through.

## The fix

```diff
 async def check_target_policy(
     policy_uri: str | None,
     *,
     protocol: str = "mcp",
     method: str | None = None,
+    tool_name: str | None = None,
     caller_id: str = "dns-aid-mcp-server",
 ) -> PolicyResult:
     ...
         ctx = PolicyContext(
             caller_id=caller_id,
             caller_domain=os.getenv("DNS_AID_CALLER_DOMAIN"),
             protocol=protocol,
             method=method,
+            tool_name=tool_name,
         )
```

Plus a docstring entry for the new param and `tool_name` added to the `mcp.policy_denied` log fields for observability.

## Why this is a patch (not minor)

Functionally this is plumbing an existing data-model field through to the helper that owns it — not a new policy concept. `PolicyContext.tool_name` already exists; rules already reference it; the only missing piece was a kwarg on the public helper. Strictly additive, kwarg defaults to `None`, every existing call site continues to work without source change.

## Use case unblocked

MCP servers integrating with `dns-aid` can now write the canonical pattern without wrapper code:

```python
from dns_aid.sdk.policy.guard import check_target_policy

result = await check_target_policy(
    policy_uri=agent.policy_uri,
    method="tools/call",
    tool_name=tool_name,
)
if result.denied:
    return {"error": "policy_denied", "violations": [v.rule for v in result.violations]}
```

## Tests

- `tests/unit/mcp/test_policy_guard.py::TestCheckTargetPolicy::test_tool_name_forwarded_to_context` — captures the `PolicyContext` constructed inside the helper and asserts the kwarg lands on `ctx.tool_name`.
- `test_tool_name_defaults_to_none` — pins backward compatibility: callers that omit the new kwarg see `ctx.tool_name is None`, matching pre-v0.21.3 behaviour.

## Version bump

`0.21.2` → `0.21.3` (patch).

- `pyproject.toml`
- `CITATION.cff` (version + `date-released: 2026-05-26`)
- `CHANGELOG.md` (new `[0.21.3] - 2026-05-26` entry)
- `uv.lock` (regenerated)

## Breaking changes

None.

## Test plan

- [x] `uv run ruff check src/dns_aid/sdk/policy/guard.py` — passes
- [x] `uv run ruff format --check src/dns_aid/sdk/policy/guard.py tests/unit/mcp/test_policy_guard.py` — passes
- [x] `uv run mypy src/dns_aid/sdk/policy/guard.py` — passes
- [x] `uv run pytest tests/unit/mcp/test_policy_guard.py` — 10 passed (8 pre-existing + 2 new)
- [x] `uv run pytest tests/unit/mcp/ tests/unit/test_models.py` — 49 passed
- [x] Secrets scan — clean