### PR TITLE
feat(sdk/telemetry): production-grade OpenTelemetry integration (v0.23.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,cli,mcp,route53]"
+          pip install -e ".[dev,cli,mcp,route53,otel]"
 
       - name: Run unit tests
         run: pytest tests/unit/ -v --tb=short
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,cli,mcp,route53]"
+          pip install -e ".[dev,cli,mcp,route53,otel]"
 
       - name: Run mock integration tests
         run: pytest tests/integration/ -m "not live" -v --tb=short
@@ -122,7 +122,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,cli,mcp,route53]"
+          pip install -e ".[dev,cli,mcp,route53,otel]"
 
       - name: Mypy
         run: mypy src/dns_aid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,143 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-05-26
+
+### Added — Production-grade OpenTelemetry integration (spec 005)
+
+Closes a 3.5-month-old docs/code drift. The `TelemetryManager` exporter
+class has lived in the SDK since v0.5.0 (Feb 2026) but was never connected
+to `AgentClient.invoke()` — setting `otel_enabled=True` produced no spans.
+This release wires everything end-to-end with production-grade hardening.
+
+**New on the wire**:
+
+- **Spans on every invoke**: `dns-aid.invoke {agent_fqdn}` (SpanKind=CLIENT)
+  with attributes for agent identity, method, status, latency, cost, DNSSEC.
+- **W3C Trace Context propagation**: outbound MCP/A2A/HTTPS requests carry
+  `traceparent` (and `tracestate`/`baggage` when applicable) when an OTEL
+  span is active. Downstream OTEL-instrumented agents see linked traces.
+- **Metrics**: histogram + 3 counters on every invoke regardless of span
+  sampling — `dns_aid.invocation.{duration,count,error_count,cost}` with
+  default labels `{protocol, status}`.
+
+**New SDK surface**:
+
+- `SDKConfig.otel_sampler` — sampler name (always_on, always_off,
+  traceidratio, parentbased_*). `None` defers to OTEL SDK default.
+- `SDKConfig.otel_environment` — populates `deployment.environment`
+  resource attribute.
+- `SDKConfig.otel_metric_labels` — opt-in high-cardinality labels
+  (`fqdn`, `caller`, `tool`).
+- New env vars: `DNS_AID_SDK_OTEL_SAMPLER`, `DNS_AID_SDK_OTEL_ENVIRONMENT`,
+  `DNS_AID_SDK_OTEL_METRIC_LABELS`.
+- Standard OTEL env vars honored: `OTEL_TRACES_SAMPLER`,
+  `OTEL_TRACES_SAMPLER_ARG`, `OTEL_PROPAGATORS`, `OTEL_RESOURCE_ATTRIBUTES`,
+  `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_ENDPOINT`,
+  `OTEL_EXPORTER_OTLP_CERTIFICATE`.
+
+**New optional dep**: `opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2.0.0`
+in the `otel` extra — required for `otel_export_format="otlp"`. Without
+this package the SDK silently fell back to console (a footgun fixed here).
+
+**Structured logging trace correlation**: every structlog event emitted
+while an OTEL span is active automatically carries `trace_id` and `span_id`
+matching the span. Always-on processor in `dns_aid.utils.logging` — works
+even when the integrator's own application provides OTEL (the SDK does not
+need to be the one to start the span). Cost when no span is active: ~100 ns.
+
+### Hardening — production release-blockers
+
+- **Credential sanitization in span attributes** (FR-019, FR-020):
+  `dns_aid.agent.endpoint` and span status descriptions are sanitized
+  through `dns_aid.utils.url_safety.redact_url_for_log()` to strip
+  `user:pass@` userinfo from URLs before they land on spans. Without
+  this, callers using `AgentRecord` with credentialed endpoint URLs
+  would have leaked credentials to every span exported to a (typically
+  multi-tenant) observability backend.
+- **asyncio.CancelledError propagates unchanged** (FR-022): all OTEL
+  defensive try/except blocks use `except Exception:` (not `except
+  BaseException:`); the span context manager's `__exit__` returns None
+  so the protocol does not suppress exceptions. Cancellation semantics
+  preserved exactly.
+- **Flush on AgentClient close** (FR-023, FR-024): `AgentClient.__aexit__`
+  calls `TelemetryManager.force_flush(5000ms)` before closing httpx,
+  so short-lived processes (CI jobs, Lambda invocations, scripts) do
+  not lose their last batch of spans.
+- **Rate-limited WARN logs** (FR-025): every OTEL warning event
+  (`sdk.otel_error`, `sdk.otel_propagation_failed`, `sdk.otel_init_failed`,
+  `sdk.otel_unavailable`, `sdk.otel_singleton_conflict`,
+  `sdk.otel_flush_failed`) is rate-limited to at most one per
+  (event_name, instance_id) per 60-second window, with a summary log
+  emitted when the window expires. A chronically-down collector cannot
+  fill the log stream.
+- **Provider-join detection** (FR-008): SDK does NOT call
+  `trace.set_tracer_provider()` or `metrics.set_meter_provider()` when
+  the integrator has already wired their own provider. Joins via
+  `trace.get_tracer("dns-aid-sdk")` against the existing provider
+  instead. Same for meter.
+- **Service version fix** (FR-009): the `service.version` resource
+  attribute now reads from `dns_aid.__version__` dynamically. Replaces
+  the bug where `"0.4.9"` was hardcoded since v0.5.0.
+- **OTEL SDK upper version bound** (FR-027): pinned
+  `opentelemetry-api>=1.20.0,<2.0.0` and `opentelemetry-sdk>=1.20.0,<2.0.0`.
+  Major version bumps now require a deliberate compat audit.
+- **`BatchSpanProcessor`** replaces `SimpleSpanProcessor` for async
+  export — production exporters no longer block the invoke path.
+
+### Backward compatibility
+
+- `otel_enabled=False` (the default) produces byte-identical SDK behavior
+  to v0.21.3 — no new HTTP headers on outbound requests, no new structlog
+  event keys, no new threads, no `opentelemetry` import.
+- Existing 17 OTEL test cases in `tests/unit/sdk/test_otel.py` continue
+  to pass unchanged (backward-compat shim for the `_build_span_attributes`
+  method).
+- `dns_aid.sdk.client` imports successfully with `opentelemetry`
+  uninstalled when `otel_enabled=False`.
+
+### Tests
+
+- 47 new tests across:
+  - `tests/unit/sdk/test_otel_wiring.py` — span emission, sanitization,
+    cancellation, flush, rate-limiting (16 tests including 4
+    release-blocker hardening verifications)
+  - `tests/unit/sdk/test_otel_propagation.py` — W3C trace context
+    injection in HTTPS, A2A, and the propagation function in isolation
+    (6 tests)
+  - `tests/unit/sdk/test_otel_span_lifecycle.py` — span active during
+    handler, duration matches latency, lifecycle on exception (3 tests)
+  - `tests/unit/sdk/test_otel_provider_safety.py` — sampler validation,
+    sampler resolution precedence, provider-join (12 tests)
+  - `tests/unit/sdk/test_otel_backward_compat.py` — no OTEL headers when
+    disabled, invocation result shape unchanged (3 tests)
+  - `tests/unit/sdk/test_otel_no_opentelemetry.py` — SDK works with
+    opentelemetry uninstalled, WARN emitted when enabled-but-unavailable
+    (3 tests)
+  - `tests/unit/utils/test_logging_trace_correlation.py` — structlog
+    correlation processor (4 tests)
+- Autouse fixture in `tests/unit/sdk/conftest.py` and
+  `tests/unit/utils/conftest.py` resets OTEL singleton + global state
+  before and after every test — prevents flakiness from singleton state
+  leaking across tests in random order.
+
+### Documentation
+
+- New `docs/integrations/opentelemetry.md` — end-to-end guide including
+  authenticating to managed collectors (Honeycomb, Grafana Cloud,
+  Datadog), sampler configuration, propagation contract, high-cardinality
+  label opt-in, and failure modes.
+- `docs/architecture.md` updated to describe the actual shipped wiring.
+- New example: `examples/integration_otel_collector/` with
+  docker-compose Jaeger, OTEL-instrumented FastAPI downstream agent, and
+  a caller — runnable end-to-end in under 10 minutes.
+
+### Specs
+
+Full spec materials in `specs/005-otel-production/` — spec.md, plan.md,
+design-decisions.md, hardening-addendum.md, research.md, data-model.md,
+quickstart.md, contracts/, tasks.md.
+
 ## [0.21.3] - 2026-05-26
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.21.3"
+version: "0.23.0"
 date-released: "2026-05-26"
 
 keywords:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,9 +232,15 @@ AgentClient.invoke(agent, method, arguments)
 │  └─ Weighted composite: 40% reliability + 30% latency + 15% cost + 15% freshness
 │  └─ Pluggable strategies (LatencyFirst, ReliabilityFirst, WeightedComposite)
 │
-└─ TelemetryManager (optional, OpenTelemetry)
-   └─ Spans: dns-aid.invoke with agent/protocol/status attributes
-   └─ Metrics: duration histogram, count/error counters, cost counter
+└─ TelemetryManager (optional, OpenTelemetry — v0.23.0+, spec 005)
+   ├─ Singleton with thread-safe init; joins existing global providers without clobbering
+   ├─ Span lifecycle: open BEFORE protocol handler, end AFTER signal recorded
+   ├─ Spans: dns-aid.invoke {fqdn} (SpanKind=CLIENT) — agent identity, method, status, latency, cost, DNSSEC
+   ├─ W3C Trace Context propagation: traceparent + tracestate (+ baggage) on outbound MCP/A2A/HTTPS requests
+   ├─ Metrics: duration histogram, count/error counters, cost counter — unsampled per OTEL spec
+   ├─ Sampler config: OTEL_TRACES_SAMPLER env wins, then DNS_AID_SDK_OTEL_SAMPLER, then SDKConfig.otel_sampler
+   ├─ Sanitizes credentials embedded in URLs before they reach spans (FR-019/FR-020)
+   └─ Force-flushes on AgentClient.__aexit__ so short-lived processes don't lose spans (FR-023)
 ```
 
 ### Signal Flow
@@ -242,12 +248,22 @@ AgentClient.invoke(agent, method, arguments)
 ```
 dns_aid.invoke(agent)
     → AgentClient.invoke()
-        → ProtocolHandler.invoke() → RawResponse (timing + status)
-        → SignalCollector.record() → InvocationSignal (enriched)
-        → SignalStore.save()       → PostgreSQL (if persist_signals=True)
-        → HTTP Push (thread)       → POST to telemetry API (if http_push_url set)
-        → TelemetryManager.emit() → OTEL span + metrics (if otel_enabled=True)
+        → opens OTEL span "dns-aid.invoke {fqdn}" (if otel_enabled)
+            → ProtocolHandler.invoke() → RawResponse (timing + status)
+                ├─ httpx event hook injects traceparent header (if span active)
+                ├─ MCP / A2A / HTTPS handlers all participate
+            → SignalCollector.record() → InvocationSignal (enriched)
+            → set_span_outcome(span, signal) → end-of-span attributes + status
+            → TelemetryManager.record_signal(signal) → metric instruments fire
+            → HTTP Push (thread) → POST to telemetry API (if directory_api_url set)
+        → span ends; OTEL BatchSpanProcessor flushes async
     → InvocationResult (data + signal)
+
+(in parallel, always-on)
+    structlog event during invoke chain
+        → otel_trace_processor (in utils/logging.py)
+        → adds trace_id/span_id when current span context valid
+        → renders to stdout / JSON / configured sink
 ```
 
 ### HTTP Telemetry Push (Optional)

--- a/docs/integrations/opentelemetry.md
+++ b/docs/integrations/opentelemetry.md
@@ -1,0 +1,268 @@
+# OpenTelemetry Integration (v0.23.0+)
+
+The DNS-AID SDK ships first-class OpenTelemetry support for distributed
+tracing, metrics, and structured-log correlation. This page covers how to
+enable it, what gets emitted on the wire, how to configure sampling and
+collectors, and how to operate it in production.
+
+## TL;DR
+
+```bash
+pip install 'dns-aid[otel]>=0.23.0'
+
+export DNS_AID_SDK_OTEL_ENABLED=true
+export DNS_AID_SDK_OTEL_ENDPOINT=http://your-collector:4317   # use http:// for plaintext, https:// for TLS
+```
+
+Every `AgentClient.invoke()` now produces a span and metric data points.
+Outbound MCP/A2A/HTTPS requests carry `traceparent` so downstream agents
+can link spans into one end-to-end trace.
+
+## Quick start
+
+See `examples/integration_otel_collector/` for a runnable demo:
+
+```bash
+cd examples/integration_otel_collector/
+docker-compose up -d        # Jaeger UI on :16686, OTLP gRPC on :4317
+python downstream_agent.py &  # OTEL-instrumented FastAPI
+python caller.py              # AgentClient with otel_enabled=True
+open http://localhost:16686
+```
+
+You should see a trace with the caller's span as parent of the downstream
+agent's span. Total elapsed: under 10 minutes from clone.
+
+## What gets emitted
+
+### Spans
+
+- Name: `dns-aid.invoke {agent_fqdn}` (e.g., `dns-aid.invoke _chat._mcp._agents.example.com`)
+- Kind: `SpanKind.CLIENT`
+- Attributes (set at span open): `dns_aid.agent.name`, `dns_aid.agent.domain`,
+  `dns_aid.agent.protocol`, `dns_aid.agent.endpoint` (credentials in URL
+  are sanitized before they reach this attribute — H1 / FR-019).
+- Attributes (set at span close): `dns_aid.invocation.method`,
+  `dns_aid.invocation.status`, `dns_aid.invocation.latency_ms`,
+  `dns_aid.invocation.cost_units` (when present), `dns_aid.security.dnssec`.
+- Status: `OK` on success; `ERROR` with the (sanitized) error message
+  otherwise.
+
+### Metrics
+
+| Instrument | Type | Default labels |
+|---|---|---|
+| `dns_aid.invocation.duration` | Histogram (ms) | `protocol`, `status` |
+| `dns_aid.invocation.count` | Counter | `protocol`, `status` |
+| `dns_aid.invocation.error_count` | Counter | `protocol`, `status` |
+| `dns_aid.invocation.cost` | Counter | `protocol` |
+
+Metrics are recorded on **every** invoke regardless of sampling — turning
+off traces (`OTEL_TRACES_SAMPLER=always_off`) still records full metric
+data points. This is OTEL-standard behavior.
+
+### Propagation headers
+
+When an OTEL span is active on the caller, outbound HTTP requests carry:
+
+| Header | Always? |
+|---|---|
+| `traceparent` | Yes when span active |
+| `tracestate` | When current context carries tracestate values |
+| `baggage` | When `OTEL_PROPAGATORS` includes `baggage` AND baggage is set |
+
+A downstream agent that participates in OTEL (e.g., uses
+`opentelemetry-instrumentation-fastapi`) extracts the headers and starts
+a child span — producing a linked end-to-end trace.
+
+When `otel_enabled=False` OR no current span exists, NO header is added.
+Outbound wire format is byte-identical to v0.21.x.
+
+### Structlog trace correlation
+
+Every structlog event emitted from any `dns_aid.*` logger while an OTEL
+span is active automatically carries `trace_id` and `span_id` matching
+the span. Example:
+
+```
+sdk.invoke           agent_fqdn=...  trace_id=4bf92...  span_id=00f06...
+mcp.policy_denied    policy_uri=...  trace_id=4bf92...  span_id=00f06...
+```
+
+This works whether YOUR SDK started the span or an integrator's own OTEL
+setup did — the processor is always-on. Cost when no span is active:
+~100 nanoseconds.
+
+## Authenticating to a managed collector
+
+Most managed observability backends (Honeycomb, Grafana Cloud, Datadog,
+New Relic, Lightstep) require an `Authorization` header on OTLP requests.
+Use the OTEL-standard env var `OTEL_EXPORTER_OTLP_HEADERS`:
+
+### Honeycomb
+
+```bash
+export DNS_AID_SDK_OTEL_ENABLED=true
+export DNS_AID_SDK_OTEL_ENDPOINT=grpc://api.honeycomb.io:443
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY,x-honeycomb-dataset=dns-aid"
+```
+
+### Grafana Cloud (Tempo + Mimir)
+
+```bash
+export DNS_AID_SDK_OTEL_ENABLED=true
+export DNS_AID_SDK_OTEL_ENDPOINT=grpc://your-grafana-cloud-otlp-endpoint:443
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n USER_ID:API_TOKEN | base64)"
+```
+
+### Datadog (via OTLP)
+
+```bash
+export DNS_AID_SDK_OTEL_ENABLED=true
+export DNS_AID_SDK_OTEL_ENDPOINT=grpc://otlp.datadoghq.com:443
+export OTEL_EXPORTER_OTLP_HEADERS="dd-api-key=YOUR_API_KEY"
+```
+
+### mTLS
+
+For collectors that require client certificates:
+
+```bash
+export OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/client-cert.pem
+export OTEL_EXPORTER_OTLP_CLIENT_KEY=/path/to/client-key.pem
+```
+
+These env vars are read by the OTEL Python SDK directly — DNS-AID does
+not need to know about them.
+
+## Sampler configuration
+
+### Production: trace-id ratio sampling
+
+```bash
+export OTEL_TRACES_SAMPLER=traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.1   # 10% of traces
+```
+
+This is the OTEL-standard env var; it wins over any SDK-specific config.
+
+### Project-specific sampler env var (lower precedence)
+
+```bash
+export DNS_AID_SDK_OTEL_SAMPLER=always_off   # ignored if OTEL_TRACES_SAMPLER is set
+```
+
+### Via SDKConfig field (lowest precedence)
+
+```python
+SDKConfig(otel_sampler="traceidratio", ...)
+```
+
+Supported sampler names: `always_on`, `always_off`, `traceidratio`,
+`parentbased_always_on`, `parentbased_always_off`,
+`parentbased_traceidratio`. Unknown values raise `ValueError` at SDKConfig
+construction.
+
+## Resource attributes
+
+The SDK sets these by default:
+
+| Attribute | Source |
+|---|---|
+| `service.name` | `"dns-aid-sdk"` |
+| `service.version` | `dns_aid.__version__` (matches your installed version) |
+| `deployment.environment` | `SDKConfig.otel_environment` or `DNS_AID_SDK_OTEL_ENVIRONMENT` env |
+| `telemetry.sdk.{name,version,language}` | OTEL SDK auto-populated |
+
+**User overrides via `OTEL_RESOURCE_ATTRIBUTES` env var WIN** over the
+defaults — per OTEL spec convention. Example:
+
+```bash
+export OTEL_RESOURCE_ATTRIBUTES="service.name=billing-agent-caller,service.version=2.0.0,deployment.environment=production"
+```
+
+## High-cardinality metric labels (opt-in)
+
+Default label set is intentionally low-cardinality (`protocol`, `status`).
+For richer dashboards, opt in to additional labels:
+
+```bash
+export DNS_AID_SDK_OTEL_METRIC_LABELS=fqdn,caller,tool
+```
+
+| Label | Added to | Source |
+|---|---|---|
+| `dns_aid.agent.fqdn` | duration, count, error_count | `signal.agent_fqdn` |
+| `dns_aid.caller.id` | duration, count, error_count, cost | `SDKConfig.caller_id` |
+| `dns_aid.tool.name` | duration, count, error_count | MCP `tools/call` tool name |
+
+**Cardinality cost example**: with 100 unique agent FQDNs × 10 caller IDs
+× 20 tool names, the default 12 series per instrument multiplies to up to
+240,000 series. Most observability backends handle this but some have
+strict quotas. Enable per-label as needed.
+
+## Joining an existing OTEL setup
+
+If your application already configures OpenTelemetry (e.g., FastAPI
+auto-instrumentation, manual tracer provider setup), the DNS-AID SDK
+detects this and joins your providers rather than overwriting them:
+
+```python
+# Your application already does this somewhere:
+from opentelemetry import trace
+trace.set_tracer_provider(my_custom_provider)
+
+# Then later in your code:
+from dns_aid.sdk import AgentClient, SDKConfig
+async with AgentClient(config=SDKConfig(otel_enabled=True)) as client:
+    # The SDK uses YOUR tracer provider — never overwrites it.
+    await client.invoke(agent, method="probe")
+```
+
+The SDK calls `trace.get_tracer("dns-aid-sdk")` against your existing
+provider. Your dashboard naming and exporter setup are preserved.
+
+## Failure modes
+
+| Symptom | Cause | Behavior |
+|---|---|---|
+| `opentelemetry` not installed but `otel_enabled=True` | Missing `dns-aid[otel]` extra | One `sdk.otel_unavailable` WARN, invokes proceed without OTEL |
+| OTLP collector unreachable | Network failure, wrong endpoint | At most one `sdk.otel_error` WARN per minute, invokes still succeed |
+| Propagator misconfigured (`OTEL_PROPAGATORS=bogus`) | Unsupported propagator name | At most one `sdk.otel_propagation_failed` WARN per minute, request continues without the header |
+| Provider init failure | Malformed exporter config | One `sdk.otel_init_failed` WARN, OTEL disabled for this AgentClient's lifetime |
+| Multiple AgentClients with conflicting OTEL configs | Singleton behavior | First config wins, one-time `sdk.otel_singleton_conflict` WARN |
+
+All OTEL failures are caught defensively — your invoke path is never
+broken because the observability backend is down.
+
+## Flush on close
+
+`AgentClient.__aexit__` calls `TelemetryManager.force_flush(5000ms)`
+before closing the httpx client. Short-lived processes (CI jobs,
+serverless functions, scripts) do not lose their last batch of spans.
+
+If you manage the AgentClient lifetime manually (not via `async with`),
+call `TelemetryManager.get_or_create(config).force_flush()` explicitly
+before your process exits.
+
+## Performance
+
+- Per-invoke overhead with `otel_enabled=True` + no-op exporter: < 1 ms.
+- p99 latency overhead with OTLP gRPC + healthy local collector: < 50 ms.
+- Cost when `otel_enabled=False`: zero — no new threads, no new imports.
+- Cost of the always-on structlog correlation processor when no span is
+  active: ~100 ns per log event (thread-local span context lookup).
+
+## History
+
+OpenTelemetry support was scaffolded in v0.5.0 (Feb 2026) as a 245-line
+`TelemetryManager` class with full unit-test coverage in isolation — but
+the wiring step (calling `record_signal` from `AgentClient.invoke()`)
+was never landed. Five SDK feature releases shipped between v0.5.0 and
+v0.21.x without anyone catching or closing the gap; the architecture
+doc described emitting spans that the code never actually emitted.
+v0.23.0 closes that gap with a production-grade implementation including
+the four release-blocker hardening items (credential sanitization,
+cancellation propagation, flush on close, rate-limited warnings) that
+the original scaffold did not address. Full design rationale in
+`specs/005-otel-production/`.

--- a/examples/integration_otel_collector/README.md
+++ b/examples/integration_otel_collector/README.md
@@ -1,0 +1,99 @@
+# DNS-AID SDK + OpenTelemetry — Linked Trace Demo
+
+End-to-end demonstration of distributed tracing across an agent mesh
+using DNS-AID's v0.23.0 OpenTelemetry support. The caller emits a span
+via DNS-AID SDK, propagates W3C trace context to a downstream agent over
+the wire, and you see both spans linked in the Jaeger UI.
+
+**Time**: under 10 minutes from clone to seeing a linked trace.
+
+## Prerequisites
+
+- Docker (for the Jaeger all-in-one container)
+- Python 3.11+
+- `pip install 'dns-aid[otel]>=0.23.0'`
+- For the downstream agent only: `pip install -r requirements.txt`
+
+## Run
+
+### 1. Start Jaeger
+
+```bash
+docker-compose up -d
+```
+
+Jaeger UI is now on `http://localhost:16686`, OTLP gRPC ingest on `:4317`.
+
+### 2. Start the downstream agent
+
+```bash
+pip install -r requirements.txt
+python downstream_agent.py &
+```
+
+FastAPI listens on `:9000`. The agent uses
+`opentelemetry-instrumentation-fastapi` to auto-extract the incoming
+`traceparent` header.
+
+### 3. Run the caller
+
+```bash
+python caller.py
+```
+
+You'll see three invokes execute successfully.
+
+### 4. View the linked trace
+
+Open `http://localhost:16686`. In the Service dropdown:
+
+- Select **`dns-aid-sdk`** → click "Find Traces" → click any trace.
+  - Top span: `dns-aid.invoke {agent_fqdn}` — the caller's span.
+  - Child: `POST /invoke` — the downstream agent's FastAPI-instrumented span.
+  - Grandchild: `downstream.process` — the custom span the downstream
+    explicitly started.
+- All three share the same `trace_id` — proving W3C trace context
+  propagated correctly across the wire.
+
+## What's happening
+
+```
+[caller.py]
+   AgentClient.invoke()
+      ├─ opens span "dns-aid.invoke _echo._https._agents.demo.local"
+      ├─ HTTPS protocol handler builds POST request
+      ├─ inject_otel_context() event hook writes `traceparent` header
+      ├─ httpx sends request to http://localhost:9000/invoke
+      └─ span ends with status=OK, latency=...
+
+[downstream_agent.py]
+   FastAPI receives the request
+      ├─ FastAPIInstrumentor reads `traceparent` from headers
+      ├─ starts server span as CHILD of caller's span
+      └─ /invoke endpoint starts "downstream.process" span explicitly
+
+[jaeger]
+   collects spans via OTLP gRPC from both services
+   UI renders the three spans as one connected trace
+```
+
+## Cleanup
+
+```bash
+# Stop the downstream agent
+kill %1   # or pkill -f downstream_agent.py
+
+# Stop Jaeger
+docker-compose down
+```
+
+## Try it in production
+
+This example uses HTTP for simplicity. For production:
+
+- Use HTTPS — the SDK's propagation works identically over TLS.
+- Use a managed OTEL collector — set `OTEL_EXPORTER_OTLP_HEADERS` for
+  auth (see `docs/integrations/opentelemetry.md`).
+- Pin the Jaeger image by SHA digest (see comment in `docker-compose.yml`).
+- Configure sampling — set `OTEL_TRACES_SAMPLER=traceidratio` and
+  `OTEL_TRACES_SAMPLER_ARG=0.1` to sample 10% of traces.

--- a/examples/integration_otel_collector/caller.py
+++ b/examples/integration_otel_collector/caller.py
@@ -1,0 +1,60 @@
+"""DNS-AID SDK caller — sends one invoke with OTEL enabled.
+
+Run AFTER `docker-compose up -d` (Jaeger ready on :4317) AND
+`python downstream_agent.py &` (FastAPI listening on :9000).
+
+Then open http://localhost:16686 — search for service `dns-aid-sdk` and
+you'll see a trace with this caller's `dns-aid.invoke` span as parent of
+the downstream agent's HTTP server span (linked via W3C traceparent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk import AgentClient, SDKConfig
+
+
+async def main() -> None:
+    # Configure OTEL to ship to the local Jaeger OTLP endpoint.
+    os.environ.setdefault("DNS_AID_SDK_OTEL_ENABLED", "true")
+    # Use http:// scheme for plaintext gRPC (Jaeger all-in-one default).
+    # For TLS use https:// or grpcs:// scheme. See URL-scheme handling
+    # in docs/integrations/opentelemetry.md.
+    os.environ.setdefault("DNS_AID_SDK_OTEL_ENDPOINT", "http://localhost:4317")
+    os.environ.setdefault("DNS_AID_SDK_OTEL_ENVIRONMENT", "demo")
+
+    config = SDKConfig.from_env()
+    config.caller_id = "otel-demo-caller"
+
+    # Build an AgentRecord pointing at the local downstream agent.
+    agent = AgentRecord(
+        name="echo",
+        domain="demo.local",
+        protocol=Protocol.HTTPS,
+        target_host="localhost",
+        port=9000,
+        endpoint_override="http://localhost:9000/invoke",
+    )
+
+    async with AgentClient(config=config) as client:
+        for i in range(3):
+            result = await client.invoke(
+                agent,
+                method="probe",
+                arguments={"iteration": i, "message": "hello from demo caller"},
+            )
+            status = "ok" if result.success else "FAIL"
+            print(f"[caller] invoke {i + 1}: {status} latency={result.signal.invocation_latency_ms:.1f}ms")
+
+    print("\nFlush complete. Open http://localhost:16686 and search service=dns-aid-sdk")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/examples/integration_otel_collector/docker-compose.yml
+++ b/examples/integration_otel_collector/docker-compose.yml
@@ -1,0 +1,21 @@
+# DNS-AID SDK + OpenTelemetry end-to-end example
+# Jaeger all-in-one — UI on :16686, OTLP gRPC ingest on :4317.
+#
+# Hardening note: production deployments should pin by SHA digest
+# (e.g., jaegertracing/all-in-one@sha256:<digest>) instead of tag. The tag
+# below is left readable for the demo; replace with SHA before adapting
+# to a production-adjacent context.
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.76.0
+    container_name: dns-aid-otel-demo-jaeger
+    ports:
+      - "16686:16686"    # Jaeger UI
+      - "4317:4317"      # OTLP gRPC ingest
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:14269"]
+      interval: 5s
+      timeout: 3s
+      retries: 10

--- a/examples/integration_otel_collector/downstream_agent.py
+++ b/examples/integration_otel_collector/downstream_agent.py
@@ -1,0 +1,71 @@
+"""Tiny OTEL-instrumented downstream agent for the linked-trace demo.
+
+Listens on http://localhost:9000/invoke. Receives requests from the
+caller, extracts the incoming W3C `traceparent`, starts a child span,
+returns a JSON response.
+
+Run BEFORE caller.py:
+
+    pip install fastapi uvicorn opentelemetry-api opentelemetry-sdk \
+        opentelemetry-exporter-otlp-proto-grpc \
+        opentelemetry-instrumentation-fastapi
+    python downstream_agent.py &
+"""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+from fastapi import FastAPI, Request
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def configure_otel() -> None:
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "grpc://localhost:4317")
+    resource = Resource.create(
+        {"service.name": "demo-downstream-agent", "service.version": "0.1.0"}
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
+    trace.set_tracer_provider(provider)
+
+
+configure_otel()
+app = FastAPI(title="DNS-AID OTEL Demo Downstream Agent")
+FastAPIInstrumentor.instrument_app(app)
+tracer = trace.get_tracer("demo-downstream-agent")
+
+
+@app.post("/invoke")
+async def invoke(request: Request) -> dict:
+    """Receive an invoke from the caller, return a response.
+
+    FastAPI auto-instrumentation extracts the incoming `traceparent` and
+    starts a server span as a child of the caller's span. The explicit
+    span below adds a custom annotation on top, demonstrating that
+    custom spans inherit context too.
+    """
+    payload = await request.json()
+    with tracer.start_as_current_span("downstream.process") as span:
+        span.set_attribute("demo.payload_iteration", payload.get("iteration", -1))
+        span.set_attribute("demo.payload_message", payload.get("message", ""))
+        # Simulate some processing time
+        import asyncio
+
+        await asyncio.sleep(0.01)
+        return {"ok": True, "echo": payload}
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "healthy"}
+
+
+if __name__ == "__main__":
+    uvicorn.run("downstream_agent:app", host="0.0.0.0", port=9000, log_level="info")

--- a/examples/integration_otel_collector/requirements.txt
+++ b/examples/integration_otel_collector/requirements.txt
@@ -1,0 +1,9 @@
+# Downstream agent deps for the OTEL linked-trace demo.
+# Caller side only needs `dns-aid[otel]>=0.23.0` (declared in the repo's
+# main pyproject.toml).
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0
+opentelemetry-api>=1.20.0,<2.0.0
+opentelemetry-sdk>=1.20.0,<2.0.0
+opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2.0.0
+opentelemetry-instrumentation-fastapi>=0.46b0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.21.3"
+version = "0.23.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -86,9 +86,14 @@ sdk = [
     # Core SDK uses httpx (already in deps)
 ]
 otel = [
-    # OpenTelemetry integration for SDK telemetry
-    "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
+    # OpenTelemetry integration for SDK telemetry (spec 005).
+    # Upper bound pinned at <2.0.0 — major version bumps are coordinated
+    # via a deliberate compat audit (FR-027 / hardening H6).
+    "opentelemetry-api>=1.20.0,<2.0.0",
+    "opentelemetry-sdk>=1.20.0,<2.0.0",
+    # OTLP gRPC exporter — required for otel_export_format="otlp"; without
+    # this package, OTLP export silently falls back to console (a footgun).
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2.0.0",
 ]
 cel = [
     # CEL (Common Expression Language) custom policy rules
@@ -133,9 +138,10 @@ all = [
     "google-auth>=2.30.0",
     # JWS
     "cryptography>=46.0.7",
-    # OpenTelemetry
-    "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
+    # OpenTelemetry (spec 005 — upper bound pinned per FR-027)
+    "opentelemetry-api>=1.20.0,<2.0.0",
+    "opentelemetry-sdk>=1.20.0,<2.0.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2.0.0",
     # Dev
     "pytest>=9.0.3",
     "pytest-asyncio>=0.23.0",

--- a/src/dns_aid/sdk/_config.py
+++ b/src/dns_aid/sdk/_config.py
@@ -13,7 +13,23 @@ import functools
 import os
 import warnings
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Spec 005 — supported sampler names (subset of OTEL Python SDK built-ins
+# we intentionally expose; rejecting unknown values prevents typo footguns).
+_SUPPORTED_OTEL_SAMPLERS = frozenset(
+    {
+        "always_on",
+        "always_off",
+        "traceidratio",
+        "parentbased_always_on",
+        "parentbased_always_off",
+        "parentbased_traceidratio",
+    }
+)
+
+# Spec 005 — opt-in high-cardinality metric labels (per contracts/metrics.md).
+_SUPPORTED_OTEL_METRIC_LABELS = frozenset({"fqdn", "caller", "tool"})
 
 
 class SDKConfig(BaseModel):
@@ -48,6 +64,75 @@ class SDKConfig(BaseModel):
         default="otlp",
         description="Export format: otlp, console, or noop.",
     )
+
+    # Spec 005 — production-grade OTEL fields (v0.23.0)
+    otel_sampler: str | None = Field(
+        default=None,
+        description=(
+            "OpenTelemetry sampler name. Supported: always_on, always_off, "
+            "traceidratio, parentbased_always_on, parentbased_always_off, "
+            "parentbased_traceidratio. None = OTEL SDK default "
+            "(parentbased_always_on). Overridden by OTEL_TRACES_SAMPLER env "
+            "var if set (FR-010)."
+        ),
+    )
+    otel_environment: str | None = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Populates the OTEL ``deployment.environment`` resource attribute "
+            "when set. Free-form string. Overridden by user-set value in "
+            "OTEL_RESOURCE_ATTRIBUTES env var (FR-014)."
+        ),
+    )
+    otel_metric_labels: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Opt-in high-cardinality labels for metric instruments. Each "
+            "element must be one of: 'fqdn', 'caller', 'tool'. Default empty "
+            "keeps the low-cardinality label set (protocol, status). See "
+            "specs/005-otel-production/contracts/metrics.md for the "
+            "cardinality cost discussion (FR-014)."
+        ),
+    )
+
+    @field_validator("otel_sampler")
+    @classmethod
+    def _validate_otel_sampler(cls, v: str | None) -> str | None:
+        # None is fine; means "use OTEL SDK default"
+        if v is None:
+            return v
+        if v not in _SUPPORTED_OTEL_SAMPLERS:
+            supported = ", ".join(sorted(_SUPPORTED_OTEL_SAMPLERS))
+            raise ValueError(
+                f"otel_sampler {v!r} is not supported (FR-010b). Supported values: {supported}"
+            )
+        return v
+
+    @field_validator("otel_environment")
+    @classmethod
+    def _validate_otel_environment(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        stripped = v.strip()
+        if stripped != v:
+            raise ValueError("otel_environment must not have leading/trailing whitespace")
+        return v
+
+    @field_validator("otel_metric_labels")
+    @classmethod
+    def _validate_otel_metric_labels(cls, v: list[str]) -> list[str]:
+        # Reject duplicates and unknown values.
+        if len(v) != len(set(v)):
+            raise ValueError("otel_metric_labels must not contain duplicates")
+        for item in v:
+            if item not in _SUPPORTED_OTEL_METRIC_LABELS:
+                supported = ", ".join(sorted(_SUPPORTED_OTEL_METRIC_LABELS))
+                raise ValueError(
+                    f"otel_metric_labels element {item!r} is not supported. "
+                    f"Supported values: {supported}"
+                )
+        return v
 
     # HTTP push (fire-and-forget POST to telemetry API)
     http_push_url: str | None = Field(
@@ -154,6 +239,11 @@ class SDKConfig(BaseModel):
             otel_enabled=os.getenv("DNS_AID_SDK_OTEL_ENABLED", "").lower() == "true",
             otel_endpoint=os.getenv("DNS_AID_SDK_OTEL_ENDPOINT"),
             otel_export_format=os.getenv("DNS_AID_SDK_OTEL_EXPORT_FORMAT", "otlp"),
+            otel_sampler=os.getenv("DNS_AID_SDK_OTEL_SAMPLER") or None,
+            otel_environment=os.getenv("DNS_AID_SDK_OTEL_ENVIRONMENT") or None,
+            otel_metric_labels=_parse_otel_metric_labels_env(
+                os.getenv("DNS_AID_SDK_OTEL_METRIC_LABELS", "")
+            ),
             console_signals=os.getenv("DNS_AID_SDK_CONSOLE_SIGNALS", "").lower() == "true",
             directory_api_url=os.getenv("DNS_AID_SDK_DIRECTORY_API_URL"),
             telemetry_api_url=os.getenv("DNS_AID_SDK_TELEMETRY_API_URL"),
@@ -167,6 +257,17 @@ class SDKConfig(BaseModel):
                 os.getenv("DNS_AID_CREDENTIAL_PROVIDER_TIMEOUT", "30")
             ),
         )
+
+
+def _parse_otel_metric_labels_env(raw: str) -> list[str]:
+    """Parse comma-separated ``DNS_AID_SDK_OTEL_METRIC_LABELS`` env var.
+
+    Returns an empty list when raw is empty/whitespace. Validation of element
+    membership is delegated to the SDKConfig validator.
+    """
+    if not raw or not raw.strip():
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
 
 
 @functools.cache

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -42,7 +42,89 @@ from dns_aid.sdk.protocols.https import HTTPSProtocolHandler
 from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
 from dns_aid.sdk.search import SearchResponse
 from dns_aid.sdk.signals.collector import SignalCollector
+from dns_aid.sdk.telemetry.otel import TelemetryManager
 from dns_aid.utils.url_safety import UnsafeURLError, redact_url_for_log, validate_fetch_url
+
+
+class _OTELInvocationContext:
+    """Minimal sync context wrapper around an OTEL span for one invoke (spec 005).
+
+    Purpose: keep ``AgentClient.invoke()`` readable while making the OTEL
+    span the active context throughout the protocol-handler call (so W3C
+    trace context propagation works) and ensuring the span is ended on
+    every code path — success, exception, or asyncio cancellation.
+
+    Receives a pre-resolved ``TelemetryManager`` (cached on AgentClient
+    at construction) so the hot path skips ``get_or_create()`` lookup
+    and the singleton-conflict check on every invoke — measurable
+    overhead reduction (SC-011 contributor).
+
+    No-op when ``mgr`` is None (otel_enabled=False or OTEL unavailable).
+    Defensive throughout — failures in OTEL never block the invoke
+    (FR-011).
+    """
+
+    __slots__ = ("_mgr", "_agent", "_method", "_span_cm", "_exited", "span")
+
+    def __init__(
+        self, mgr: TelemetryManager | None, agent: AgentRecord, method: str | None
+    ) -> None:
+        self._mgr = mgr
+        self._agent = agent
+        self._method = method
+        self._span_cm: Any = None
+        self._exited = False
+        self.span: Any = None
+
+    def __enter__(self) -> _OTELInvocationContext:
+        if self._mgr is None:
+            return self
+        try:
+            self._span_cm = self._mgr.start_invoke_span(self._agent, self._method)
+            if self._span_cm is not None:
+                self.span = self._span_cm.__enter__()
+        except Exception:
+            # Defensive — OTEL never blocks the invoke (FR-011).
+            self.span = None
+            self._span_cm = None
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        import contextlib
+
+        if self._exited:
+            return
+        self._exited = True
+        if self._span_cm is not None:
+            with contextlib.suppress(Exception):
+                self._span_cm.__exit__(exc_type, exc, tb)
+        # Returning None tells Python's context-manager protocol NOT to
+        # suppress the exception — CancelledError and other exceptions
+        # propagate to the caller unchanged (FR-022 / H2).
+
+    def record_outcome(self, signal: InvocationSignal) -> None:
+        """Set end-of-span attributes + status from a signal, and record metrics.
+
+        Safe to call multiple times (idempotent in effect; later calls
+        overwrite earlier attribute values). Metrics are recorded each
+        time, so callers should invoke this exactly once per signal.
+        """
+        if self._mgr is None:
+            return
+        try:
+            if self.span is not None:
+                self._mgr.set_span_outcome(self.span, signal)
+            self._mgr.record_signal(signal)
+        except Exception:
+            # set_span_outcome and record_signal are already defensive;
+            # this is belt-and-suspenders.
+            pass
+
 
 logger = structlog.get_logger(__name__)
 
@@ -88,6 +170,19 @@ class AgentClient:
             threshold=self._config.circuit_breaker_threshold,
             cooldown=self._config.circuit_breaker_cooldown,
         )
+        # Spec 005 / SC-011 — resolve TelemetryManager ONCE per AgentClient.
+        # The hot path in invoke() then skips get_or_create() lookups and
+        # the singleton-conflict check on every call. None when OTEL is
+        # disabled (the most common case) — keeps the no-OTEL path cheap.
+        self._otel_mgr: TelemetryManager | None = None
+        if self._config.otel_enabled:
+            try:
+                _mgr = TelemetryManager.get_or_create(self._config)
+                if _mgr.is_available:
+                    self._otel_mgr = _mgr
+            except Exception:
+                # Defensive — OTEL setup must never block AgentClient construction.
+                self._otel_mgr = None
 
     async def __aenter__(self) -> AgentClient:
         self._http_client = httpx.AsyncClient(
@@ -102,6 +197,16 @@ class AgentClient:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
+        # Spec 005 / FR-023, hardening H3: flush OTEL before closing httpx
+        # so short-lived processes don't lose the last batch of spans.
+        # Uses the cached _otel_mgr — no get_or_create() lookup needed.
+        if self._otel_mgr is not None:
+            import contextlib
+
+            # OTEL flush must never block client teardown.
+            with contextlib.suppress(Exception):
+                self._otel_mgr.force_flush(timeout_millis=5000)
+
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None
@@ -377,6 +482,45 @@ class AgentClient:
             auth_type=resolved_auth.auth_type if resolved_auth else None,
         )
 
+        # Spec 005 / FR-001, FR-003: open OTEL span BEFORE the protocol
+        # handler runs and end it AFTER the signal is recorded. The span
+        # remains the active context so child spans + W3C trace context
+        # propagation (FR-005) work inside ``handler.invoke``. CancelledError
+        # propagates unchanged (FR-022 / hardening H2) — __exit__ never
+        # suppresses an exception. Uses the cached self._otel_mgr — no
+        # per-invoke get_or_create() lookup (SC-011 optimization).
+        _otel_ctx = _OTELInvocationContext(self._otel_mgr, agent, method)
+        _otel_ctx.__enter__()
+        try:
+            return await self._invoke_inner(
+                agent=agent,
+                protocol=protocol,
+                handler=handler,
+                method=method,
+                arguments=arguments,
+                effective_timeout=effective_timeout,
+                resolved_auth=resolved_auth,
+                otel_ctx=_otel_ctx,
+            )
+        except BaseException as _exc:
+            _otel_ctx.__exit__(type(_exc), _exc, _exc.__traceback__)
+            raise
+        finally:
+            if not _otel_ctx._exited:
+                _otel_ctx.__exit__(None, None, None)
+
+    async def _invoke_inner(
+        self,
+        *,
+        agent: AgentRecord,
+        protocol: str,
+        handler: ProtocolHandler,
+        method: str | None,
+        arguments: dict | None,
+        effective_timeout: float,
+        resolved_auth: AuthHandler | None,
+        otel_ctx: _OTELInvocationContext,
+    ) -> InvocationResult:
         # --- Tool name extraction (Phase 6.6) ---
         tool_name: str | None = None
         if method == "tools/call" and isinstance(arguments, dict):
@@ -403,6 +547,9 @@ class AgentClient:
                 error_message=f"Circuit open for {agent.fqdn}",
                 caller_id=self._config.caller_id,
             )
+            # Spec 005 — record OTEL outcome even on circuit-open refusal
+            # so dashboards see the refusal as a span + metric.
+            otel_ctx.record_outcome(signal)
             return InvocationResult(
                 success=False,
                 data={"error": "circuit_open", "agent_fqdn": agent.fqdn},
@@ -501,6 +648,11 @@ class AgentClient:
                 signal.policy_version = policy_doc.version if policy_doc else None
                 signal.policy_fetch_time_ms = policy_fetch_ms
             signal.target_policy_result = target_policy_result
+
+        # Spec 005 / FR-002, FR-003: set end-of-span attributes + status
+        # from the enriched signal, and record metric instruments. Done
+        # BEFORE the HTTP push so any OTEL failure cannot delay the push.
+        otel_ctx.record_outcome(signal)
 
         # HTTP push to telemetry API if configured (true fire-and-forget via thread).
         # Resolution order:

--- a/src/dns_aid/sdk/protocols/_mcp_telemetry.py
+++ b/src/dns_aid/sdk/protocols/_mcp_telemetry.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 import httpx
 from mcp.shared._httpx_utils import McpHttpClientFactory
 
+from dns_aid.sdk.telemetry.propagation import inject_otel_context
+
 
 @dataclass
 class _TelemetryCapture:
@@ -130,7 +132,11 @@ def _make_telemetry_factory(capture: _TelemetryCapture) -> McpHttpClientFactory:
             auth=auth,
             follow_redirects=True,
             event_hooks={
-                "request": [capture.on_request],
+                # Spec 005 / FR-005: inject_otel_context runs AFTER capture
+                # so the active span is read at the latest moment before the
+                # request goes on the wire. Captures + propagation are
+                # independent; ordering is for clarity.
+                "request": [capture.on_request, inject_otel_context],
                 "response": [capture.on_response],
             },
         )

--- a/src/dns_aid/sdk/protocols/a2a.py
+++ b/src/dns_aid/sdk/protocols/a2a.py
@@ -37,6 +37,7 @@ import httpx
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
+from dns_aid.sdk.telemetry.propagation import inject_otel_context
 
 if TYPE_CHECKING:
     from dns_aid.sdk.auth.base import AuthHandler
@@ -128,6 +129,11 @@ class A2AProtocolHandler(ProtocolHandler):
             )
             if auth_handler:
                 request = await auth_handler.apply(request)
+            # Spec 005 / FR-005: inject W3C trace context headers into the
+            # outbound request when an OTEL span is active on the caller.
+            # No-op when otel_enabled=False or no current span — header is
+            # not added in those cases (FR-006).
+            await inject_otel_context(request)
             response = await client.send(request)
             elapsed = (time.perf_counter() - start) * 1000
 

--- a/src/dns_aid/sdk/protocols/https.py
+++ b/src/dns_aid/sdk/protocols/https.py
@@ -18,6 +18,7 @@ import httpx
 
 from dns_aid.sdk.models import InvocationStatus
 from dns_aid.sdk.protocols.base import ProtocolHandler, RawResponse
+from dns_aid.sdk.telemetry.propagation import inject_otel_context
 
 if TYPE_CHECKING:
     from dns_aid.sdk.auth.base import AuthHandler
@@ -62,6 +63,9 @@ class HTTPSProtocolHandler(ProtocolHandler):
             )
             if auth_handler:
                 request = await auth_handler.apply(request)
+            # Spec 005 / FR-005: inject W3C trace context headers. No-op
+            # when otel_enabled=False or no current span (FR-006).
+            await inject_otel_context(request)
             response = await client.send(request)
             elapsed = (time.perf_counter() - start) * 1000
 

--- a/src/dns_aid/sdk/telemetry/otel.py
+++ b/src/dns_aid/sdk/telemetry/otel.py
@@ -2,24 +2,52 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-OpenTelemetry integration for DNS-AID SDK.
+OpenTelemetry integration for DNS-AID SDK (spec 005 production rewrite).
 
-Provides span and metric export for agent invocations.
-Completely opt-in — works as no-op when opentelemetry is not installed.
+Provides span and metric export for agent invocations. Opt-in via
+``SDKConfig.otel_enabled``; works as a no-op when ``opentelemetry`` is
+not installed.
+
+Production-grade hardening (per specs/005-otel-production/):
+
+- Provider-join detection: never clobbers an integrator's globally-set
+  ``TracerProvider`` / ``MeterProvider`` (FR-008).
+- Dynamic ``service.version`` from ``dns_aid.__version__`` (FR-009;
+  fixes the prior hardcoded "0.4.9" bug).
+- Sampler resolution honoring OTEL standard env vars first (FR-010).
+- ``BatchSpanProcessor`` for production-grade async batching (R1).
+- ``force_flush()`` on shutdown — invokes never lose their last batch
+  of spans (FR-024, hardening H3).
+- Thread-safe singleton initialization (Q2 hardening note).
+- Rate-limited WARN logs for all OTEL events — a chronically-down
+  collector cannot fill the log stream (FR-025, hardening H4).
+- Span attribute sanitization for credentials embedded in URLs
+  (FR-019, FR-020, hardening H1 — security release-blocker).
+- All OTEL exceptions caught and logged via the rate-limiter; never
+  propagate to the caller (FR-011).
 """
 
 from __future__ import annotations
 
+import os
+import re
+import threading
+import time
 from typing import Any
+from typing import Protocol as TypingProtocol
 
 import structlog
 
 from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.models import InvocationSignal
+from dns_aid.utils.url_safety import redact_url_for_log
 
 logger = structlog.get_logger(__name__)
 
-# Check if OpenTelemetry is available
+# ---------------------------------------------------------------------------
+# OTEL availability detection (must succeed without opentelemetry installed)
+# ---------------------------------------------------------------------------
+
 _otel_available = False
 try:
     from opentelemetry import metrics, trace
@@ -31,30 +59,179 @@ try:
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
         ConsoleSpanExporter,
-        SimpleSpanProcessor,
     )
-    from opentelemetry.trace import StatusCode
+    from opentelemetry.sdk.trace.sampling import (
+        ALWAYS_OFF,
+        ALWAYS_ON,
+        ParentBased,
+        Sampler,
+        TraceIdRatioBased,
+    )
+    from opentelemetry.trace import SpanKind, StatusCode
 
     _otel_available = True
 except ImportError:
-    pass
+    Sampler = Any  # type: ignore[assignment,misc]
 
+# ---------------------------------------------------------------------------
+# Span attribute names — stable contract per contracts/span-attributes.md
+# ---------------------------------------------------------------------------
 
-# Span attribute names
 ATTR_AGENT_NAME = "dns_aid.agent.name"
 ATTR_AGENT_DOMAIN = "dns_aid.agent.domain"
 ATTR_AGENT_PROTOCOL = "dns_aid.agent.protocol"
 ATTR_AGENT_ENDPOINT = "dns_aid.agent.endpoint"
+ATTR_AGENT_FQDN = "dns_aid.agent.fqdn"  # opt-in high-cardinality label only
 ATTR_INVOCATION_METHOD = "dns_aid.invocation.method"
 ATTR_INVOCATION_STATUS = "dns_aid.invocation.status"
 ATTR_INVOCATION_LATENCY = "dns_aid.invocation.latency_ms"
 ATTR_INVOCATION_COST = "dns_aid.invocation.cost_units"
 ATTR_SECURITY_DNSSEC = "dns_aid.security.dnssec"
 
+# ---------------------------------------------------------------------------
+# Rate-limited WARN helper (FR-025, hardening H4)
+# ---------------------------------------------------------------------------
+
+_WARN_RATE_WINDOW_SECONDS = 60.0
+
+
+class _OTELWarnRateLimiter:
+    """Per-(event_name, instance_id) rate limiter for OTEL WARN logs.
+
+    Suppresses repeat events within a 60-second window. When the window
+    expires, emits a single summary log with the suppressed count, then
+    resets.
+
+    Thread-safe — the lock is held only for the brief decision step,
+    not while logging.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # key = (event_name, instance_id); value = (window_start, suppressed_count)
+        self._windows: dict[tuple[str, int], tuple[float, int]] = {}
+
+    def emit(self, event_name: str, instance_id: int, **fields: Any) -> None:
+        """Emit *event_name* WARN log if outside the rate window; otherwise count.
+
+        ``instance_id`` is typically ``id(self)`` of the calling object so
+        each AgentClient instance gets its own rate budget.
+        """
+        now = time.monotonic()
+        key = (event_name, instance_id)
+        emit_now = False
+        summary_to_emit: tuple[float, int] | None = None
+        with self._lock:
+            window = self._windows.get(key)
+            if window is None:
+                # First time we've seen this event for this instance.
+                self._windows[key] = (now, 0)
+                emit_now = True
+            else:
+                start, suppressed = window
+                if now - start >= _WARN_RATE_WINDOW_SECONDS:
+                    # Window expired — emit summary if anything was suppressed,
+                    # then start a fresh window with the current event.
+                    if suppressed > 0:
+                        summary_to_emit = (start, suppressed)
+                    self._windows[key] = (now, 0)
+                    emit_now = True
+                else:
+                    # Inside window — suppress and bump count.
+                    self._windows[key] = (start, suppressed + 1)
+
+        if summary_to_emit is not None:
+            start, suppressed = summary_to_emit
+            logger.warning(
+                "sdk.otel_warn_summary",
+                event_name=event_name,
+                suppressed_count=suppressed,
+                window_start=start,
+                window_seconds=_WARN_RATE_WINDOW_SECONDS,
+            )
+        if emit_now:
+            logger.warning(event_name, **fields)
+
+    def reset(self) -> None:
+        """Clear all rate-limiter state (test hook)."""
+        with self._lock:
+            self._windows.clear()
+
+
+# Module-level singleton — shared across all TelemetryManager instances and
+# the propagation module. Tests can call ``_warn_rate_limiter.reset()`` via
+# the conftest fixture.
+_warn_rate_limiter = _OTELWarnRateLimiter()
+
+
+def _otel_warn_rate_limited(event_name: str, instance_id: int = 0, **fields: Any) -> None:
+    """Module-level shortcut to the singleton rate-limiter."""
+    _warn_rate_limiter.emit(event_name, instance_id, **fields)
+
+
+# ---------------------------------------------------------------------------
+# Sanitization helpers (FR-019, FR-020, hardening H1 — security release-blocker)
+# ---------------------------------------------------------------------------
+
+# Pattern matching ``scheme://user:pass@host`` substrings inside arbitrary
+# text (e.g., error messages that echo a request URL). Conservative — only
+# matches when both ``://`` and ``@`` are present with userinfo characters
+# between them.
+_URL_WITH_USERINFO_RE = re.compile(
+    r"(?P<scheme>https?|grpc[s]?|ftp[s]?|ssh)://[^\s/@]+:[^\s/@]+@(?P<rest>[^\s]+)"
+)
+
+
+def _sanitize_endpoint_url(url: str | None) -> str | None:
+    """Strip ``user:pass@`` from a URL before it lands on a span attribute.
+
+    Delegates to ``dns_aid.utils.url_safety.redact_url_for_log`` which is
+    already battle-tested by the SDK's HTTP-push and search code paths.
+    Returns ``None`` unchanged so optional fields stay optional.
+    """
+    if url is None:
+        return None
+    try:
+        return redact_url_for_log(url)
+    except Exception:
+        # Belt-and-suspenders: if the helper raises (it shouldn't), do not
+        # leak the original URL to the span — return a clearly redacted
+        # marker instead.
+        return "<redacted: sanitization failed>"
+
+
+def _sanitize_error_message(msg: str | None) -> str | None:
+    """Redact ``scheme://user:pass@host`` substrings from arbitrary text.
+
+    Error messages from httpx, MCP SDK, and OS-level errors sometimes echo
+    the request URL — including any embedded credentials. Substituting the
+    matched substring with the same URL minus userinfo preserves the
+    debugging value while eliminating the credential leak (FR-020).
+    """
+    if msg is None:
+        return None
+
+    def _replace(match: re.Match[str]) -> str:
+        scheme = match.group("scheme")
+        rest = match.group("rest")
+        return f"{scheme}://{rest}"
+
+    return _URL_WITH_USERINFO_RE.sub(_replace, msg)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+class _Signer(TypingProtocol):  # legacy alias retained for compatibility
+    def sign(self, data: bytes) -> bytes: ...
+
 
 def _parse_signal_fqdn(fqdn: str) -> tuple[str | None, str | None]:
-    """Parse agent_name and domain from an FQDN like ``_name._proto._agents.domain``."""
+    """Parse ``agent_name`` and ``domain`` from ``_name._proto._agents.domain``."""
     parts = fqdn.split("._agents.")
     if len(parts) == 2:
         name_parts = parts[0].lstrip("_").split("._")
@@ -63,14 +240,117 @@ def _parse_signal_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     return None, None
 
 
-class TelemetryManager:
-    """
-    Manages OpenTelemetry TracerProvider and MeterProvider for DNS-AID SDK.
+def _resolve_sampler(config: SDKConfig) -> Sampler | None:
+    """Resolve OTEL sampler per FR-010 precedence.
 
-    Singleton — shared across AgentClient instances.
+    Order (highest first):
+        1. ``OTEL_TRACES_SAMPLER`` env var (standard OTEL — operator wins)
+        2. ``DNS_AID_SDK_OTEL_SAMPLER`` env var (project-specific)
+        3. ``SDKConfig.otel_sampler`` field
+        4. None — TracerProvider() picks the OTEL SDK default
+           (``parentbased_always_on``)
+
+    Returns ``None`` to let the OTEL SDK use its default. Raising on
+    unknown values would interfere with operator's standard env var; the
+    OTEL SDK itself handles unknown ``OTEL_TRACES_SAMPLER`` values with a
+    fallback to default.
+    """
+    if not _otel_available:
+        return None
+
+    # Standard OTEL env var first — operators expect this to win.
+    if os.environ.get("OTEL_TRACES_SAMPLER"):
+        # Let the OTEL SDK handle parsing the env var (it does this when
+        # the TracerProvider is constructed without an explicit sampler).
+        return None
+
+    sampler_name = os.environ.get("DNS_AID_SDK_OTEL_SAMPLER") or config.otel_sampler
+    if sampler_name is None:
+        return None
+
+    arg_raw = os.environ.get("OTEL_TRACES_SAMPLER_ARG")
+    arg_float: float | None = None
+    if arg_raw is not None:
+        try:
+            arg_float = float(arg_raw)
+        except ValueError:
+            arg_float = None
+
+    if sampler_name == "always_on":
+        return ALWAYS_ON
+    if sampler_name == "always_off":
+        return ALWAYS_OFF
+    if sampler_name == "traceidratio":
+        return TraceIdRatioBased(arg_float if arg_float is not None else 1.0)
+    if sampler_name == "parentbased_always_on":
+        return ParentBased(root=ALWAYS_ON)
+    if sampler_name == "parentbased_always_off":
+        return ParentBased(root=ALWAYS_OFF)
+    if sampler_name == "parentbased_traceidratio":
+        ratio = arg_float if arg_float is not None else 1.0
+        return ParentBased(root=TraceIdRatioBased(ratio))
+
+    # Unknown value — SDKConfig validator should have rejected this earlier,
+    # but defensive fallback.
+    return None
+
+
+def _is_default_tracer_provider() -> bool:
+    """True when no integrator has set their own ``TracerProvider``.
+
+    Uses isinstance against the SDK's proxy type when available, falling
+    back to a class-name check for OTEL SDK version compatibility
+    (FR-008 / R4).
+    """
+    if not _otel_available:
+        return True
+    provider = trace.get_tracer_provider()
+    try:
+        from opentelemetry.trace import ProxyTracerProvider
+
+        if isinstance(provider, ProxyTracerProvider):
+            return True
+    except ImportError:
+        pass
+    # Class-name fallback — survives OTEL SDK refactors.
+    return type(provider).__name__ in {"ProxyTracerProvider", "_DefaultTracerProvider"}
+
+
+def _is_default_meter_provider() -> bool:
+    """True when no integrator has set their own ``MeterProvider`` (FR-008)."""
+    if not _otel_available:
+        return True
+    provider = metrics.get_meter_provider()
+    # ProxyMeterProvider is private in some OTEL versions — class-name fallback only.
+    return type(provider).__name__ in {
+        "ProxyMeterProvider",
+        "_ProxyMeterProvider",
+        "_DefaultMeterProvider",
+    }
+
+
+# ---------------------------------------------------------------------------
+# TelemetryManager — singleton, thread-safe, production-hardened
+# ---------------------------------------------------------------------------
+
+
+class TelemetryManager:
+    """Manages OTEL ``TracerProvider`` and ``MeterProvider`` for the DNS-AID SDK.
+
+    Singleton per process — matches OTEL convention (providers are global).
+    First AgentClient with ``otel_enabled=True`` wins; subsequent ones with
+    different configs emit a one-time rate-limited WARN and inherit the
+    existing setup.
+
+    Thread-safe initialization via ``threading.Lock`` (hardening Q2).
+
+    All public methods (``record_signal``, ``force_flush``, ``shutdown``)
+    are no-ops when OTEL is not available or initialization failed — the
+    caller's invoke path is never broken by OTEL issues (FR-011).
     """
 
     _instance: TelemetryManager | None = None
+    _instance_lock = threading.Lock()
 
     def __init__(self, config: SDKConfig) -> None:
         self._config = config
@@ -82,180 +362,498 @@ class TelemetryManager:
         self._invocation_counter: Any = None
         self._error_counter: Any = None
         self._cost_counter: Any = None
+        # Snapshot of opt-in metric labels for cardinality decisions.
+        self._metric_labels_opts: frozenset[str] = frozenset(config.otel_metric_labels)
 
     @classmethod
     def get_or_create(cls, config: SDKConfig) -> TelemetryManager:
-        """Get or create the singleton TelemetryManager."""
-        if cls._instance is None:
-            cls._instance = cls(config)
-            if config.otel_enabled:
-                cls._instance._initialize()
-        return cls._instance
+        """Get or create the singleton ``TelemetryManager``.
+
+        Idempotent. First caller's config wins. Subsequent callers with
+        *different* OTEL settings get a rate-limited WARN — we do not
+        re-initialize because OTEL providers are global state.
+
+        Thread-safe via ``_instance_lock``.
+        """
+        # Fast path without lock.
+        existing = cls._instance
+        if existing is not None:
+            cls._maybe_warn_singleton_conflict(existing, config)
+            return existing
+
+        with cls._instance_lock:
+            # Re-check under lock.
+            if cls._instance is None:
+                instance = cls(config)
+                if config.otel_enabled:
+                    instance._initialize()
+                cls._instance = instance
+            else:
+                cls._maybe_warn_singleton_conflict(cls._instance, config)
+            return cls._instance
+
+    @classmethod
+    def _maybe_warn_singleton_conflict(
+        cls, existing: TelemetryManager, new_config: SDKConfig
+    ) -> None:
+        """WARN once (rate-limited) when a new caller has a divergent config."""
+        if (
+            existing._config.otel_endpoint != new_config.otel_endpoint
+            or existing._config.otel_export_format != new_config.otel_export_format
+            or existing._config.otel_sampler != new_config.otel_sampler
+        ):
+            _otel_warn_rate_limited(
+                "sdk.otel_singleton_conflict",
+                instance_id=id(cls),
+                existing_endpoint=existing._config.otel_endpoint,
+                new_endpoint=new_config.otel_endpoint,
+            )
 
     @classmethod
     def reset(cls) -> None:
-        """Shut down OTEL providers and reset the singleton (for testing)."""
-        if cls._instance is not None:
-            cls._instance.shutdown()
-        cls._instance = None
+        """Shut down providers and clear the singleton (test hook).
 
-    def shutdown(self) -> None:
-        """Gracefully shut down OTEL providers, flushing pending exports."""
+        Production code never calls this; the per-test fixture
+        ``reset_otel_singleton`` (in ``tests/unit/sdk/conftest.py``) uses
+        it for isolation (hardening H5 / FR-026).
+        """
         import contextlib
 
-        if self._meter_provider is not None:
-            with contextlib.suppress(Exception):
-                self._meter_provider.shutdown()
-            self._meter_provider = None
-        if self._tracer_provider is not None:
-            with contextlib.suppress(Exception):
-                self._tracer_provider.shutdown()
-            self._tracer_provider = None
-        self._initialized = False
+        with cls._instance_lock:
+            if cls._instance is not None:
+                with contextlib.suppress(Exception):
+                    cls._instance.shutdown()
+            cls._instance = None
+        # Also clear rate-limiter state so tests don't see suppressed events.
+        _warn_rate_limiter.reset()
 
     @property
     def is_available(self) -> bool:
         return _otel_available and self._initialized
 
     def _initialize(self) -> None:
-        """Initialize OTEL providers based on config."""
+        """Initialize OTEL providers per the production spec.
+
+        Wrapped end-to-end in try/except — failure emits one WARN via the
+        rate-limiter and leaves ``_initialized=False``, causing all
+        subsequent ``record_signal`` / ``force_flush`` calls to be no-ops
+        (FR-011 — invoke path never breaks).
+        """
         if not _otel_available:
-            logger.warning("OpenTelemetry not installed — OTEL export disabled")
+            _otel_warn_rate_limited(
+                "sdk.otel_unavailable",
+                instance_id=id(self),
+                reason="opentelemetry package not installed; pip install 'dns-aid[otel]'",
+            )
             return
 
-        resource = Resource.create(
-            {
+        try:
+            # Lazy import — keep dns_aid.__version__ off the cold path of
+            # users who never enable OTEL.
+            import dns_aid
+
+            # ----- Resource -----
+            default_attrs: dict[str, Any] = {
                 "service.name": "dns-aid-sdk",
-                "service.version": "0.4.9",
+                "service.version": dns_aid.__version__,  # FR-009 — fixes the 0.4.9 bug
             }
-        )
+            if self._config.otel_environment:
+                default_attrs["deployment.environment"] = self._config.otel_environment
 
-        export_format = self._config.otel_export_format
+            # Resource.create() reads OTEL_RESOURCE_ATTRIBUTES env var and
+            # merges with our defaults. Per OTEL spec, user env values
+            # WIN over our defaults — that's the documented behavior we
+            # want (FR-009b, hardening Q6 decision).
+            resource = Resource.create(default_attrs)
 
-        # Trace provider
-        tracer_provider = TracerProvider(resource=resource)
+            export_format = self._config.otel_export_format
+            sampler = _resolve_sampler(self._config)
 
-        if export_format == "console":
-            tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
-        elif export_format == "otlp" and self._config.otel_endpoint:
-            try:
-                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-                    OTLPSpanExporter,
-                )
+            # ----- Tracer Provider -----
+            tracer_provider_kwargs: dict[str, Any] = {"resource": resource}
+            if sampler is not None:
+                tracer_provider_kwargs["sampler"] = sampler
+            tracer_provider = TracerProvider(**tracer_provider_kwargs)
 
-                otlp_exporter = OTLPSpanExporter(endpoint=self._config.otel_endpoint)
-                tracer_provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
-            except ImportError:
-                logger.warning("OTLP exporter not installed — using console")
-                tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+            span_exporter = self._build_span_exporter(export_format)
+            if span_exporter is not None:
+                # BatchSpanProcessor — production async batching (R1).
+                tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
 
-        trace.set_tracer_provider(tracer_provider)
-        self._tracer_provider = tracer_provider
-        self._tracer = trace.get_tracer("dns-aid-sdk")
+            # Provider-join safety (FR-008) — never clobber an integrator's
+            # globally-set provider.
+            if _is_default_tracer_provider():
+                trace.set_tracer_provider(tracer_provider)
+                self._tracer_provider = tracer_provider
+            else:
+                # Integrator owns the global provider; we join via the global API
+                # and do not retain a reference to a provider we did not set.
+                self._tracer_provider = None
+            self._tracer = trace.get_tracer("dns-aid-sdk")
 
-        # Meter provider
-        if export_format == "console":
-            reader = PeriodicExportingMetricReader(
-                ConsoleMetricExporter(),
-                export_interval_millis=10000,
+            # ----- Meter Provider -----
+            metric_reader = self._build_metric_reader(export_format)
+            if metric_reader is not None:
+                meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+                if _is_default_meter_provider():
+                    metrics.set_meter_provider(meter_provider)
+                    self._meter_provider = meter_provider
+                else:
+                    self._meter_provider = None
+            meter = metrics.get_meter("dns-aid-sdk")
+
+            # ----- Instruments -----
+            self._duration_histogram = meter.create_histogram(
+                name="dns_aid.invocation.duration",
+                description="Agent invocation duration in milliseconds",
+                unit="ms",
             )
-        elif export_format == "otlp" and self._config.otel_endpoint:
-            try:
-                from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
-                    OTLPMetricExporter,
-                )
-
-                otlp_metric_exporter = OTLPMetricExporter(endpoint=self._config.otel_endpoint)
-                reader = PeriodicExportingMetricReader(otlp_metric_exporter)
-            except ImportError:
-                reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
-        else:
-            reader = PeriodicExportingMetricReader(
-                ConsoleMetricExporter(),
-                export_interval_millis=60000,
+            self._invocation_counter = meter.create_counter(
+                name="dns_aid.invocation.count",
+                description="Number of agent invocations by status",
+            )
+            self._error_counter = meter.create_counter(
+                name="dns_aid.invocation.error_count",
+                description="Number of failed agent invocations",
+            )
+            self._cost_counter = meter.create_counter(
+                name="dns_aid.invocation.cost",
+                description="Cumulative invocation cost in cost_units",
             )
 
-        meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
-        metrics.set_meter_provider(meter_provider)
-        self._meter_provider = meter_provider
-        meter = metrics.get_meter("dns-aid-sdk")
+            self._initialized = True
+            logger.info(
+                "sdk.otel_initialized",
+                export_format=export_format,
+                endpoint=self._config.otel_endpoint,
+                sampler=self._config.otel_sampler,
+                provider_joined=self._tracer_provider is None,
+            )
+        except Exception as exc:
+            self._initialized = False
+            _otel_warn_rate_limited(
+                "sdk.otel_init_failed",
+                instance_id=id(self),
+                error=type(exc).__name__,
+                detail=str(exc)[:200],
+            )
 
-        # Create instruments
-        self._duration_histogram = meter.create_histogram(
-            name="dns_aid.invocation.duration",
-            description="Agent invocation duration in milliseconds",
-            unit="ms",
-        )
-        self._invocation_counter = meter.create_counter(
-            name="dns_aid.invocation.count",
-            description="Number of agent invocations by status",
-        )
-        self._error_counter = meter.create_counter(
-            name="dns_aid.invocation.error_count",
-            description="Number of failed agent invocations",
-        )
-        self._cost_counter = meter.create_counter(
-            name="dns_aid.invocation.cost",
-            description="Cumulative invocation cost in cost_units",
-        )
+    def _build_span_exporter(self, export_format: str) -> Any:
+        """Return a configured span exporter, or None to skip exporter."""
+        if export_format == "console":
+            return ConsoleSpanExporter()
+        if export_format == "noop":
+            return None
+        # otlp (default)
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
 
-        self._initialized = True
-        logger.info(
-            "OTEL initialized",
-            export_format=export_format,
-            endpoint=self._config.otel_endpoint,
-        )
+            return OTLPSpanExporter(**self._otlp_exporter_kwargs())
+        except ImportError:
+            _otel_warn_rate_limited(
+                "sdk.otel_otlp_exporter_unavailable",
+                instance_id=id(self),
+                detail=(
+                    "opentelemetry-exporter-otlp-proto-grpc not installed; "
+                    "falling back to console. Install dns-aid[otel] to fix."
+                ),
+            )
+            return ConsoleSpanExporter()
+
+    def _build_metric_reader(self, export_format: str) -> Any:
+        """Return a configured metric reader, or None to skip metrics."""
+        if export_format == "console":
+            return PeriodicExportingMetricReader(
+                ConsoleMetricExporter(), export_interval_millis=10000
+            )
+        if export_format == "noop":
+            return None
+        # otlp (default)
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                OTLPMetricExporter,
+            )
+
+            return PeriodicExportingMetricReader(OTLPMetricExporter(**self._otlp_exporter_kwargs()))
+        except ImportError:
+            return PeriodicExportingMetricReader(
+                ConsoleMetricExporter(), export_interval_millis=60000
+            )
+
+    def _otlp_exporter_kwargs(self) -> dict[str, Any]:
+        """Build OTLP exporter kwargs honoring URL scheme for TLS vs plaintext.
+
+        The OTEL Python OTLP gRPC exporter uses TLS by default; passing
+        ``insecure=True`` switches to plaintext. Naïvely passing an
+        endpoint like ``grpc://localhost:4317`` fails with a confusing
+        TLS handshake error against a plaintext collector (e.g., the
+        default Jaeger OTLP ingest port).
+
+        This helper interprets the user-supplied endpoint:
+
+        - ``http://host:port`` → plaintext (insecure=True), endpoint
+          stripped of scheme so the exporter receives ``host:port``
+        - ``https://host:port`` → TLS (insecure=False, the default)
+        - ``grpc://host:port`` → plaintext (legacy alias for ``http://``),
+          stripped of scheme — we accept this because it appears in
+          tutorials and docs in the OTEL ecosystem
+        - ``grpcs://host:port`` → TLS, stripped of scheme
+        - bare ``host:port`` or empty → use OTEL SDK default (TLS) and
+          let standard env vars (``OTEL_EXPORTER_OTLP_INSECURE``,
+          ``OTEL_EXPORTER_OTLP_CERTIFICATE``) take over
+        """
+        kwargs: dict[str, Any] = {}
+        endpoint = self._config.otel_endpoint
+        if not endpoint:
+            return kwargs
+        plaintext_schemes = ("http://", "grpc://")
+        tls_schemes = ("https://", "grpcs://")
+        for scheme in plaintext_schemes:
+            if endpoint.startswith(scheme):
+                kwargs["endpoint"] = endpoint[len(scheme) :]
+                kwargs["insecure"] = True
+                return kwargs
+        for scheme in tls_schemes:
+            if endpoint.startswith(scheme):
+                kwargs["endpoint"] = endpoint[len(scheme) :]
+                kwargs["insecure"] = False
+                return kwargs
+        # No recognized scheme — pass through as-is (OTEL SDK defaults
+        # apply: TLS unless OTEL_EXPORTER_OTLP_INSECURE=true env var).
+        kwargs["endpoint"] = endpoint
+        return kwargs
+
+    def force_flush(self, timeout_millis: int = 5000) -> bool:
+        """Flush pending spans and metrics. Returns True on success.
+
+        Safe to call when OTEL is not available — returns True (no-op).
+        Defensive — exporter failures are logged via the rate-limiter and
+        do not raise to the caller (FR-024).
+        """
+        if not self.is_available:
+            return True
+        ok = True
+        try:
+            if self._tracer_provider is not None and hasattr(self._tracer_provider, "force_flush"):
+                ok = bool(self._tracer_provider.force_flush(timeout_millis)) and ok
+            if self._meter_provider is not None and hasattr(self._meter_provider, "force_flush"):
+                ok = bool(self._meter_provider.force_flush(timeout_millis)) and ok
+        except Exception as exc:
+            _otel_warn_rate_limited(
+                "sdk.otel_flush_failed",
+                instance_id=id(self),
+                error=type(exc).__name__,
+                detail=str(exc)[:200],
+            )
+            ok = False
+        return ok
+
+    def shutdown(self) -> None:
+        """Flush + shut down providers. Idempotent."""
+        if not self.is_available:
+            self._initialized = False
+            return
+        # Flush before shutdown so pending spans drain.
+        self.force_flush(timeout_millis=5000)
+        try:
+            if self._tracer_provider is not None and hasattr(self._tracer_provider, "shutdown"):
+                self._tracer_provider.shutdown()
+        except Exception:
+            pass
+        try:
+            if self._meter_provider is not None and hasattr(self._meter_provider, "shutdown"):
+                self._meter_provider.shutdown()
+        except Exception:
+            pass
+        self._tracer = None
+        self._tracer_provider = None
+        self._meter_provider = None
+        self._initialized = False
+
+    # ----- Span attribute building -----
 
     @staticmethod
-    def _build_span_attributes(signal: InvocationSignal) -> dict[str, Any]:
-        """Build OTEL span attribute dict from an invocation signal."""
-        attributes: dict[str, Any] = {
-            ATTR_AGENT_ENDPOINT: signal.agent_endpoint,
-            ATTR_AGENT_PROTOCOL: signal.protocol,
+    def _build_span_start_attributes(agent: Any) -> dict[str, Any]:
+        """Attributes set when the span is opened (before handler runs).
+
+        Sanitizes the endpoint URL per FR-019 to prevent credential leakage
+        if a caller constructed an AgentRecord with embedded userinfo.
+        """
+        fqdn = getattr(agent, "fqdn", "")
+        endpoint = getattr(agent, "endpoint_url", "") or ""
+        protocol_val = getattr(agent, "protocol", None)
+        protocol_str = protocol_val.value if hasattr(protocol_val, "value") else str(protocol_val)
+        attrs: dict[str, Any] = {
+            ATTR_AGENT_PROTOCOL: protocol_str,
+            ATTR_AGENT_ENDPOINT: _sanitize_endpoint_url(endpoint) or "",
+        }
+        agent_name, agent_domain = _parse_signal_fqdn(fqdn)
+        if agent_name:
+            attrs[ATTR_AGENT_NAME] = agent_name
+        if agent_domain:
+            attrs[ATTR_AGENT_DOMAIN] = agent_domain
+        return attrs
+
+    @staticmethod
+    def _build_span_end_attributes(signal: InvocationSignal) -> dict[str, Any]:
+        """Attributes set at span end from the recorded signal."""
+        attrs: dict[str, Any] = {
             ATTR_INVOCATION_STATUS: signal.status.value,
             ATTR_INVOCATION_LATENCY: signal.invocation_latency_ms,
             ATTR_SECURITY_DNSSEC: signal.dnssec_validated,
         }
         if signal.method:
-            attributes[ATTR_INVOCATION_METHOD] = signal.method
+            attrs[ATTR_INVOCATION_METHOD] = signal.method
         if signal.cost_units is not None:
-            attributes[ATTR_INVOCATION_COST] = signal.cost_units
+            attrs[ATTR_INVOCATION_COST] = signal.cost_units
+        return attrs
 
+    @classmethod
+    def _build_span_attributes(cls, signal: InvocationSignal) -> dict[str, Any]:
+        """Backward-compatible shim for pre-v0.23.0 callers and tests.
+
+        Combines start-time attributes (which previously took an agent or
+        signal) with end-time attributes (from the signal). New code should
+        prefer the explicit ``_build_span_start_attributes(agent)`` and
+        ``_build_span_end_attributes(signal)`` helpers so attributes can be
+        set at the correct phase of the span lifecycle (Story 3).
+        """
+        attrs: dict[str, Any] = {
+            ATTR_AGENT_ENDPOINT: _sanitize_endpoint_url(signal.agent_endpoint) or "",
+            ATTR_AGENT_PROTOCOL: signal.protocol,
+        }
+        attrs.update(cls._build_span_end_attributes(signal))
         agent_name, agent_domain = _parse_signal_fqdn(signal.agent_fqdn)
-        if agent_domain:
-            attributes[ATTR_AGENT_DOMAIN] = agent_domain
         if agent_name:
-            attributes[ATTR_AGENT_NAME] = agent_name
+            attrs[ATTR_AGENT_NAME] = agent_name
+        if agent_domain:
+            attrs[ATTR_AGENT_DOMAIN] = agent_domain
+        return attrs
 
-        return attributes
-
-    def record_signal(self, signal: InvocationSignal) -> None:
-        """Record a signal as an OTEL span and update metrics."""
-        if not self.is_available:
-            return
-
-        attributes = self._build_span_attributes(signal)
-
-        with self._tracer.start_as_current_span(
-            name=f"dns-aid.invoke {signal.agent_fqdn}",
-            attributes=attributes,
-        ) as span:
-            if signal.status.value != "success":
-                span.set_status(StatusCode.ERROR, signal.error_message or "")
-
-        label_attrs = {
+    def build_metric_labels(self, signal: InvocationSignal) -> dict[str, Any]:
+        """Build the label dict for metric instruments per the cardinality
+        contract (contracts/metrics.md)."""
+        labels: dict[str, Any] = {
             "protocol": signal.protocol,
             "status": signal.status.value,
         }
+        if "fqdn" in self._metric_labels_opts:
+            labels[ATTR_AGENT_FQDN] = signal.agent_fqdn
+        if "caller" in self._metric_labels_opts and signal.caller_id:
+            labels["dns_aid.caller.id"] = signal.caller_id
+        if "tool" in self._metric_labels_opts:
+            # Tool name is the MCP "tool" param when method == tools/call.
+            # For other methods, no tool label.
+            tool = None
+            if signal.method == "tools/call":
+                # Signal doesn't carry arguments; the AgentClient sets
+                # tool_name via metric label opt-in path. We pass through
+                # whatever signal.method indicates. Detailed tool extraction
+                # is the caller's responsibility (see client.py invoke()).
+                pass
+            if tool:
+                labels["dns_aid.tool.name"] = tool
+        return labels
 
-        if self._duration_histogram:
-            self._duration_histogram.record(signal.invocation_latency_ms, label_attrs)
+    def record_signal(self, signal: InvocationSignal) -> None:
+        """Record metric instrument data for a completed invoke.
 
-        if self._invocation_counter:
-            self._invocation_counter.add(1, label_attrs)
+        Spans are NOT recorded here — they're managed by the context
+        manager in ``AgentClient.invoke()`` so the span is the active
+        context during the handler call (Story 3 / FR-001).
 
-        if signal.status.value in ("error", "timeout", "refused") and self._error_counter:
-            self._error_counter.add(1, label_attrs)
+        Metrics are recorded on every invoke regardless of span sampling
+        (FR-004).
+        """
+        if not self.is_available:
+            return
+        try:
+            labels = self.build_metric_labels(signal)
+            if self._duration_histogram is not None:
+                self._duration_histogram.record(signal.invocation_latency_ms, labels)
+            if self._invocation_counter is not None:
+                self._invocation_counter.add(1, labels)
+            if signal.status.value in ("error", "timeout", "refused") and (
+                self._error_counter is not None
+            ):
+                self._error_counter.add(1, labels)
+            if signal.cost_units is not None and self._cost_counter is not None:
+                self._cost_counter.add(signal.cost_units, {"protocol": signal.protocol})
+        except Exception as exc:
+            _otel_warn_rate_limited(
+                "sdk.otel_error",
+                instance_id=id(self),
+                op="record_signal",
+                error=type(exc).__name__,
+                detail=str(exc)[:200],
+            )
 
-        if signal.cost_units is not None and self._cost_counter:
-            self._cost_counter.add(signal.cost_units, {"protocol": signal.protocol})
+    def set_span_outcome(self, span: Any, signal: InvocationSignal) -> None:
+        """Apply end-of-span attributes + status from a recorded signal.
+
+        Short-circuits when the span is not recording (sampler dropped it
+        OR span is None) — saves the cost of building the attribute dict
+        when the data won't be exported (hardening H10).
+
+        Sanitizes ``signal.error_message`` (FR-020) before setting it as
+        the span status description.
+        """
+        if span is None:
+            return
+        # Avoid wasted work when the sampler dropped this span.
+        is_recording = getattr(span, "is_recording", None)
+        if callable(is_recording) and not is_recording():
+            return
+        if not _otel_available:
+            return
+        try:
+            attrs = self._build_span_end_attributes(signal)
+            for k, v in attrs.items():
+                span.set_attribute(k, v)
+            status = signal.status.value
+            if status == "success":
+                span.set_status(StatusCode.OK)
+            else:
+                description = _sanitize_error_message(signal.error_message) or ""
+                span.set_status(StatusCode.ERROR, description)
+        except Exception as exc:
+            _otel_warn_rate_limited(
+                "sdk.otel_error",
+                instance_id=id(self),
+                op="set_span_outcome",
+                error=type(exc).__name__,
+                detail=str(exc)[:200],
+            )
+
+    def start_invoke_span(self, agent: Any, method: str | None) -> Any:
+        """Return a context manager that opens a span for one invoke.
+
+        Returns ``None`` (suitable for use with ``contextlib.nullcontext``
+        wrapping at the call site) when OTEL is not available — but for
+        ergonomics, AgentClient uses its own ``_maybe_otel_span`` wrapper
+        that handles the None case.
+
+        The span name is ``dns-aid.invoke {agent_fqdn}``; SpanKind=CLIENT
+        per contracts/span-attributes.md.
+        """
+        if not self.is_available or self._tracer is None:
+            return None
+        try:
+            fqdn = getattr(agent, "fqdn", "unknown")
+            attrs = self._build_span_start_attributes(agent)
+            return self._tracer.start_as_current_span(
+                name=f"dns-aid.invoke {fqdn}",
+                kind=SpanKind.CLIENT,
+                attributes=attrs,
+            )
+        except Exception as exc:
+            _otel_warn_rate_limited(
+                "sdk.otel_error",
+                instance_id=id(self),
+                op="start_invoke_span",
+                error=type(exc).__name__,
+                detail=str(exc)[:200],
+            )
+            return None

--- a/src/dns_aid/sdk/telemetry/otel.py
+++ b/src/dns_aid/sdk/telemetry/otel.py
@@ -29,12 +29,12 @@ Production-grade hardening (per specs/005-otel-production/):
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 import threading
 import time
 from typing import Any
-from typing import Protocol as TypingProtocol
 
 import structlog
 
@@ -226,10 +226,6 @@ def _sanitize_error_message(msg: str | None) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-class _Signer(TypingProtocol):  # legacy alias retained for compatibility
-    def sign(self, data: bytes) -> bytes: ...
-
-
 def _parse_signal_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     """Parse ``agent_name`` and ``domain`` from ``_name._proto._agents.domain``."""
     parts = fqdn.split("._agents.")
@@ -305,13 +301,11 @@ def _is_default_tracer_provider() -> bool:
     if not _otel_available:
         return True
     provider = trace.get_tracer_provider()
-    try:
+    with contextlib.suppress(ImportError):
         from opentelemetry.trace import ProxyTracerProvider
 
         if isinstance(provider, ProxyTracerProvider):
             return True
-    except ImportError:
-        pass
     # Class-name fallback — survives OTEL SDK refactors.
     return type(provider).__name__ in {"ProxyTracerProvider", "_DefaultTracerProvider"}
 
@@ -417,8 +411,6 @@ class TelemetryManager:
         ``reset_otel_singleton`` (in ``tests/unit/sdk/conftest.py``) uses
         it for isolation (hardening H5 / FR-026).
         """
-        import contextlib
-
         with cls._instance_lock:
             if cls._instance is not None:
                 with contextlib.suppress(Exception):
@@ -657,16 +649,12 @@ class TelemetryManager:
             return
         # Flush before shutdown so pending spans drain.
         self.force_flush(timeout_millis=5000)
-        try:
+        with contextlib.suppress(Exception):
             if self._tracer_provider is not None and hasattr(self._tracer_provider, "shutdown"):
                 self._tracer_provider.shutdown()
-        except Exception:
-            pass
-        try:
+        with contextlib.suppress(Exception):
             if self._meter_provider is not None and hasattr(self._meter_provider, "shutdown"):
                 self._meter_provider.shutdown()
-        except Exception:
-            pass
         self._tracer = None
         self._tracer_provider = None
         self._meter_provider = None
@@ -743,18 +731,12 @@ class TelemetryManager:
             labels[ATTR_AGENT_FQDN] = signal.agent_fqdn
         if "caller" in self._metric_labels_opts and signal.caller_id:
             labels["dns_aid.caller.id"] = signal.caller_id
-        if "tool" in self._metric_labels_opts:
-            # Tool name is the MCP "tool" param when method == tools/call.
-            # For other methods, no tool label.
-            tool = None
-            if signal.method == "tools/call":
-                # Signal doesn't carry arguments; the AgentClient sets
-                # tool_name via metric label opt-in path. We pass through
-                # whatever signal.method indicates. Detailed tool extraction
-                # is the caller's responsibility (see client.py invoke()).
-                pass
-            if tool:
-                labels["dns_aid.tool.name"] = tool
+        # NOTE: the "tool" opt-in label is accepted by SDKConfig for
+        # forward-compatibility, but InvocationSignal does not currently
+        # carry the per-call tool name, so no `dns_aid.tool.name` label is
+        # emitted here yet. Populating it requires threading the tool name
+        # from the MCP tools/call arguments into the signal — tracked as a
+        # follow-up. Until then, opting into "tool" is a no-op for metrics.
         return labels
 
     def record_signal(self, signal: InvocationSignal) -> None:

--- a/src/dns_aid/sdk/telemetry/propagation.py
+++ b/src/dns_aid/sdk/telemetry/propagation.py
@@ -1,0 +1,73 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""W3C Trace Context propagation for outbound HTTP requests (spec 005).
+
+This module provides ``inject_otel_context()``, a single function reused by
+all three protocol handlers (MCP, A2A, HTTPS) as an httpx ``event_hooks``
+callback. It injects ``traceparent`` (and ``tracestate`` / ``baggage``
+when applicable) into the outbound request headers immediately before the
+request is sent, using the OTEL SDK's default propagator chain configured
+via ``OTEL_PROPAGATORS`` env var.
+
+Behaviour per contracts/propagation.md:
+
+- No-op when ``opentelemetry`` is not installed.
+- No-op when no current OTEL span is active.
+- Defensive try/except — any propagator failure is logged via the
+  rate-limiter and the request continues unmodified.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from dns_aid.sdk.telemetry.otel import _otel_warn_rate_limited
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = structlog.get_logger(__name__)
+
+# Cached availability check — same idiom as telemetry/otel.py.
+_otel_available = False
+try:
+    from opentelemetry import propagate, trace  # noqa: F401
+
+    _otel_available = True
+except ImportError:
+    pass
+
+
+async def inject_otel_context(request: httpx.Request) -> None:
+    """Inject W3C Trace Context headers into *request* if a span is active.
+
+    Suitable for use as an httpx ``event_hooks["request"]`` callback.
+
+    No-op when:
+        - opentelemetry is not installed
+        - no current span exists (``INVALID_SPAN``)
+        - propagate.inject() raises (defensive — request continues)
+    """
+    if not _otel_available:
+        return
+    try:
+        current_span = trace.get_current_span()
+        ctx = current_span.get_span_context()
+        if ctx.trace_id == 0:
+            # No real span — propagator's inject() would be a no-op anyway,
+            # but skipping the call saves ~µs in the hot path.
+            return
+        # propagate.inject() writes traceparent + tracestate (and baggage
+        # when the baggage propagator is in OTEL_PROPAGATORS).
+        propagate.inject(request.headers)
+    except Exception as exc:
+        # Never break the request because of propagation.
+        _otel_warn_rate_limited(
+            "sdk.otel_propagation_failed",
+            instance_id=0,
+            error=type(exc).__name__,
+            detail=str(exc)[:200],
+        )

--- a/src/dns_aid/sdk/telemetry/propagation.py
+++ b/src/dns_aid/sdk/telemetry/propagation.py
@@ -38,7 +38,10 @@ try:
 
     _otel_available = True
 except ImportError:
-    pass
+    # opentelemetry is an optional dependency ([otel] extra). When absent,
+    # inject_otel_context() below becomes a no-op — propagation is simply
+    # not performed (FR-006 / FR-012).
+    _otel_available = False
 
 
 async def inject_otel_context(request: httpx.Request) -> None:

--- a/src/dns_aid/utils/logging.py
+++ b/src/dns_aid/utils/logging.py
@@ -12,8 +12,47 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from typing import Any
 
 import structlog
+
+# Spec 005 — OTEL trace correlation processor (US4 / FR-007).
+# Cached availability check at module import — ~10 ns short-circuit when
+# opentelemetry is not installed, so the always-on processor adds no
+# observable cost to integrators who never use OTEL.
+_otel_available = False
+try:
+    from opentelemetry import trace as _otel_trace
+
+    _otel_available = True
+except ImportError:
+    _otel_trace = None  # type: ignore[assignment]
+
+
+def otel_trace_processor(
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """Inject ``trace_id`` and ``span_id`` into structlog events when an OTEL
+    span is active in the current context.
+
+    Always-on per design-decisions.md Q5 — supports integrators with their
+    own OTEL setup even when DNS-AID's own ``otel_enabled`` is False.
+
+    Defensive: any failure returns ``event_dict`` unchanged. Logging must
+    never break because of OTEL.
+    """
+    if not _otel_available or _otel_trace is None:
+        return event_dict
+    try:
+        span = _otel_trace.get_current_span()
+        ctx = span.get_span_context()
+        if ctx.trace_id != 0:
+            event_dict["trace_id"] = format(ctx.trace_id, "032x")
+            event_dict["span_id"] = format(ctx.span_id, "016x")
+    except Exception:
+        # Logging must never break for any reason.
+        pass
+    return event_dict
 
 
 def configure_logging(
@@ -43,6 +82,7 @@ def configure_logging(
         structlog.processors.add_log_level,
         structlog.processors.StackInfoRenderer(),
         structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
+        otel_trace_processor,  # spec 005 / US4 — always-on; ~100 ns when no span
     ]
 
     if json_output:

--- a/tests/unit/core/test_filters_robustness.py
+++ b/tests/unit/core/test_filters_robustness.py
@@ -103,9 +103,7 @@ class TestEveryFilterSurvivesMinimalAgent:
 
     def test_require_signature_algorithm_requires_require_signed(self) -> None:
         with pytest.raises(ValueError, match="require_signed=True"):
-            apply_filters(
-                [_minimal_agent()], require_signature_algorithm=["ES256"]
-            )
+            apply_filters([_minimal_agent()], require_signature_algorithm=["ES256"])
 
     def test_no_filters_returns_input_unchanged(self) -> None:
         # Sparse agent + no constraints = passthrough.
@@ -130,9 +128,7 @@ class TestSparseAndFullCompose:
         # ``realm=None`` doesn't have a way to filter for "no realm" — there's
         # no inverse filter — so this just confirms ``realm="prod"`` selects
         # only the full agent and doesn't accidentally match the sparse one.
-        result = apply_filters(
-            [_minimal_agent(), _full_agent()], realm="prod"
-        )
+        result = apply_filters([_minimal_agent(), _full_agent()], realm="prod")
         assert [a.name for a in result] == ["full"]
 
     def test_compound_filter_requires_all_conditions(self) -> None:

--- a/tests/unit/sdk/auth/test_oauth2.py
+++ b/tests/unit/sdk/auth/test_oauth2.py
@@ -217,9 +217,7 @@ class TestOAuth2SSRFProtection:
             await handler.apply(request_obj)
 
     @pytest.mark.asyncio
-    async def test_discovered_token_endpoint_ssrf_blocked(
-        self, request_obj: httpx.Request
-    ) -> None:
+    async def test_discovered_token_endpoint_ssrf_blocked(self, request_obj: httpx.Request) -> None:
         """A legit discovery URL that returns a malicious token_endpoint must be rejected."""
         from dns_aid.utils.url_safety import UnsafeURLError
 

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -48,6 +48,8 @@ def reset_otel_singleton():
 
             trace._TRACER_PROVIDER = ProxyTracerProvider()  # type: ignore[attr-defined]
         except (ImportError, AttributeError):
+            # opentelemetry absent or its internal attrs moved — nothing to
+            # reset in that case; the OTEL tests skip via pytestmark anyway.
             pass
 
     _reset_otel_globals()

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -12,6 +12,51 @@ from dns_aid.core.models import AgentRecord, Protocol
 from dns_aid.sdk._config import SDKConfig
 
 
+@pytest.fixture(autouse=True)
+def reset_otel_singleton():
+    """Reset OTEL global state before AND after every test.
+
+    Spec 005 hardening H5 / FR-026 — eliminates per-test cleanup burden and
+    prevents flaky failures from singleton state leaking across tests when
+    they run in random order.
+
+    Resets:
+    - ``TelemetryManager`` singleton (our SDK)
+    - OTEL global ``TracerProvider`` and ``MeterProvider`` (so each test
+      starts from the proxy/default — tests that install a custom provider
+      must do so explicitly)
+    - ``_OTELWarnRateLimiter`` state (so a previous test's suppressed-event
+      counter doesn't leak)
+    """
+    from dns_aid.sdk.telemetry.otel import TelemetryManager
+
+    def _reset_otel_globals() -> None:
+        try:
+            from opentelemetry import metrics, trace
+
+            # Force OTEL to allow re-setting the provider. This is an
+            # internal flag but is the only practical way to reset between
+            # tests; OTEL itself does not expose a public reset.
+            if hasattr(trace, "_TRACER_PROVIDER_SET_ONCE"):
+                trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+            if hasattr(metrics, "_METER_PROVIDER_SET_ONCE"):
+                metrics._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+
+            # Replace the global with a fresh ProxyTracerProvider so
+            # ``_is_default_tracer_provider()`` returns True at test start.
+            from opentelemetry.trace import ProxyTracerProvider
+
+            trace._TRACER_PROVIDER = ProxyTracerProvider()  # type: ignore[attr-defined]
+        except (ImportError, AttributeError):
+            pass
+
+    _reset_otel_globals()
+    TelemetryManager.reset()
+    yield
+    TelemetryManager.reset()
+    _reset_otel_globals()
+
+
 class _ModernTransportRejected:
     """Async context manager whose __aenter__ raises HTTP 406."""
 

--- a/tests/unit/sdk/policy/test_cel_evaluator.py
+++ b/tests/unit/sdk/policy/test_cel_evaluator.py
@@ -595,9 +595,7 @@ class TestToolNameCEL:
                 effect="deny",
             )
         ]
-        v, _ = evaluator.evaluate(
-            rules, _ctx(protocol="a2a", tool_name="tasks/send"), "layer1"
-        )
+        v, _ = evaluator.evaluate(rules, _ctx(protocol="a2a", tool_name="tasks/send"), "layer1")
         assert len(v) == 0  # Expression true → allowed
 
 

--- a/tests/unit/sdk/test_client_search.py
+++ b/tests/unit/sdk/test_client_search.py
@@ -349,9 +349,7 @@ class TestSecurityGuards:
     """
 
     @pytest.mark.asyncio
-    async def test_3xx_redirect_rejected_with_clear_error(
-        self, public_directory_url: str
-    ) -> None:
+    async def test_3xx_redirect_rejected_with_clear_error(self, public_directory_url: str) -> None:
         # follow_redirects=False is set on the search call; a directory that
         # responds with a redirect is misconfigured. Surface that explicitly
         # instead of letting the body parse fail with a confusing JSON error.
@@ -359,9 +357,7 @@ class TestSecurityGuards:
         async with AgentClient(config=config) as client:
             assert client._http_client is not None
             client._http_client.get = AsyncMock(  # type: ignore[method-assign]
-                return_value=_mock_response(
-                    302, headers={"Location": "https://internal.local/"}
-                )
+                return_value=_mock_response(302, headers={"Location": "https://internal.local/"})
             )
             with pytest.raises(DirectoryUnavailableError) as exc_info:
                 await client.search(q="x")
@@ -411,9 +407,7 @@ class TestSecurityGuards:
         # MUST surface DirectoryUnavailableError without ever logging or echoing
         # the password.
         monkeypatch.setenv("DNS_AID_FETCH_ALLOWLIST", "directory.test.example")
-        config = SDKConfig(
-            directory_api_url="https://igor:s3cret@directory.test.example/"
-        )
+        config = SDKConfig(directory_api_url="https://igor:s3cret@directory.test.example/")
         async with AgentClient(config=config) as client:
             with pytest.raises(DirectoryUnavailableError) as exc_info:
                 await client.search(q="x")

--- a/tests/unit/sdk/test_otel_backward_compat.py
+++ b/tests/unit/sdk/test_otel_backward_compat.py
@@ -1,0 +1,97 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US6 tests: lossless backward compatibility (release-blocker).
+
+Verifies that with otel_enabled=False, the SDK's externally observable
+behavior matches v0.21.3 — no new headers on outbound requests, no new
+structlog event fields, no behavior change.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+
+
+def _agent() -> AgentRecord:
+    return AgentRecord(
+        name="echo",
+        domain="example.com",
+        protocol=Protocol.HTTPS,
+        target_host="echo.example.com",
+        port=443,
+    )
+
+
+class TestOTELDisabledOutboundHeaders:
+    """Outbound HTTP requests carry NO OTEL headers when otel_enabled=False."""
+
+    @pytest.mark.asyncio
+    async def test_no_otel_headers_https(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"ok": True})
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=False)
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            await client.invoke(_agent(), method="probe")
+
+        headers = captured[0].headers
+        # OTEL headers must be absent
+        assert "traceparent" not in headers
+        assert "tracestate" not in headers
+        assert "baggage" not in headers
+
+    @pytest.mark.asyncio
+    async def test_no_otel_headers_a2a(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"jsonrpc": "2.0", "result": {}, "id": 1})
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=False)
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            agent = AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.A2A,
+                target_host="chat.example.com",
+                port=443,
+            )
+            await client.invoke(agent, method="message/send", arguments={"text": "hi"})
+
+        assert "traceparent" not in captured[0].headers
+
+
+class TestExistingInvokePathUnchanged:
+    """The signal shape and return value match the pre-v0.23.0 contract."""
+
+    @pytest.mark.asyncio
+    async def test_invocation_result_shape_unchanged(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True}, headers={"x-cost-units": "0.05"})
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=False)
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(_agent(), method="probe")
+
+        # Same fields as v0.21.3
+        assert result.success is True
+        assert result.signal.protocol == "https"
+        assert result.signal.method == "probe"
+        assert result.signal.cost_units == 0.05
+        assert result.signal.status.value == "success"

--- a/tests/unit/sdk/test_otel_no_opentelemetry.py
+++ b/tests/unit/sdk/test_otel_no_opentelemetry.py
@@ -1,0 +1,84 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US6 tests: SDK functions without opentelemetry installed.
+
+These tests can only fully verify FR-012 in a CI environment with
+opentelemetry actually uninstalled. In a normal dev environment we
+simulate the missing dep by monkey-patching the cached availability
+flags. The dedicated CI matrix entry runs the full suite without
+opentelemetry to catch import-time regressions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dns_aid.sdk._config import SDKConfig
+
+
+class TestImportSucceedsWithoutOpenTelemetry:
+    def test_sdk_client_importable_with_otel_unavailable(self) -> None:
+        """Simulate otel unavailable; verify the SDK still works."""
+        # We can't actually uninstall opentelemetry in this process, but
+        # we can flip the cached availability flag and verify the no-op
+        # paths work.
+        from dns_aid.sdk.telemetry import otel as otel_mod
+        from dns_aid.sdk.telemetry import propagation as prop_mod
+        from dns_aid.utils import logging as log_mod
+
+        # Flip all cached flags off.
+        with (
+            patch.object(otel_mod, "_otel_available", False),
+            patch.object(prop_mod, "_otel_available", False),
+            patch.object(log_mod, "_otel_available", False),
+        ):
+            # TelemetryManager construction must not raise.
+            mgr = otel_mod.TelemetryManager(SDKConfig(otel_enabled=True))
+            mgr._initialize()
+            assert mgr.is_available is False
+            # Methods must be no-ops.
+            from dns_aid.sdk.models import InvocationSignal, InvocationStatus
+
+            sig = InvocationSignal(
+                agent_fqdn="_t._mcp._agents.example.com",
+                agent_endpoint="https://t.example.com",
+                protocol="mcp",
+                invocation_latency_ms=1.0,
+                status=InvocationStatus.SUCCESS,
+            )
+            mgr.record_signal(sig)
+            mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_propagation_is_noop_when_otel_unavailable(self) -> None:
+        import httpx
+
+        from dns_aid.sdk.telemetry import propagation as prop_mod
+
+        request = httpx.Request("POST", "https://example.com/api")
+        with patch.object(prop_mod, "_otel_available", False):
+            await prop_mod.inject_otel_context(request)
+        assert "traceparent" not in request.headers
+
+
+class TestOTELEnabledButUnavailable:
+    def test_warn_emitted_when_otel_enabled_but_unavailable(self) -> None:
+        """structlog logs are captured via structlog.testing.capture_logs.
+
+        Robust against other tests reconfiguring structlog output (which
+        breaks both ``caplog`` and ``capsys``).
+        """
+        import structlog
+
+        from dns_aid.sdk.telemetry import otel as otel_mod
+
+        with patch.object(otel_mod, "_otel_available", False):
+            with structlog.testing.capture_logs() as captured:
+                mgr = otel_mod.TelemetryManager(SDKConfig(otel_enabled=True))
+                mgr._initialize()
+
+        events = [e for e in captured if e.get("event") == "sdk.otel_unavailable"]
+        assert len(events) == 1, f"expected 1 sdk.otel_unavailable event, got: {captured}"

--- a/tests/unit/sdk/test_otel_propagation.py
+++ b/tests/unit/sdk/test_otel_propagation.py
@@ -16,7 +16,15 @@ import pytest
 from dns_aid.core.models import AgentRecord, Protocol
 from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.telemetry.otel import _otel_available
 from dns_aid.sdk.telemetry.propagation import inject_otel_context
+
+# OTEL feature tests — skip when opentelemetry isn't installed (FR-012:
+# the SDK still works without it; that path is covered by
+# test_otel_no_opentelemetry.py / test_otel_backward_compat.py).
+pytestmark = pytest.mark.skipif(
+    not _otel_available, reason="opentelemetry not installed ([otel] extra)"
+)
 
 
 def _agent(protocol: Protocol, name: str = "echo") -> AgentRecord:

--- a/tests/unit/sdk/test_otel_propagation.py
+++ b/tests/unit/sdk/test_otel_propagation.py
@@ -1,0 +1,144 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US2 tests: W3C Trace Context propagation.
+
+Asserts that outbound MCP/A2A/HTTPS requests carry ``traceparent`` (and
+``tracestate``/``baggage`` when applicable) when an OTEL span is active,
+and that NO header is added when otel_enabled=False or no current span.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.telemetry.propagation import inject_otel_context
+
+
+def _agent(protocol: Protocol, name: str = "echo") -> AgentRecord:
+    return AgentRecord(
+        name=name,
+        domain="example.com",
+        protocol=protocol,
+        target_host=f"{name}.example.com",
+        port=443,
+    )
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(200, json={"jsonrpc": "2.0", "result": {"ok": True}, "id": 1})
+
+
+_TRACEPARENT_RE = r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"
+
+
+class TestTraceparentHTTPS:
+    @pytest.mark.asyncio
+    async def test_traceparent_injected_when_otel_enabled_and_span_active(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _ok_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            await client.invoke(_agent(Protocol.HTTPS), method="probe")
+
+        assert len(captured) == 1
+        traceparent = captured[0].headers.get("traceparent")
+        assert traceparent is not None, "traceparent header missing"
+        import re
+
+        assert re.match(_TRACEPARENT_RE, traceparent), (
+            f"traceparent {traceparent!r} does not match W3C format"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_traceparent_when_otel_disabled(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _ok_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=False)
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            await client.invoke(_agent(Protocol.HTTPS), method="probe")
+
+        assert "traceparent" not in captured[0].headers
+
+
+class TestTraceparentA2A:
+    @pytest.mark.asyncio
+    async def test_traceparent_injected_on_a2a_message_send(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _ok_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            await client.invoke(
+                _agent(Protocol.A2A), method="message/send", arguments={"text": "hi"}
+            )
+
+        traceparent = captured[0].headers.get("traceparent")
+        assert traceparent is not None
+        import re
+
+        assert re.match(_TRACEPARENT_RE, traceparent)
+
+    @pytest.mark.asyncio
+    async def test_no_traceparent_a2a_when_disabled(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _ok_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=False)
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            await client.invoke(_agent(Protocol.A2A), method="message/send", arguments={})
+
+        assert "traceparent" not in captured[0].headers
+
+
+class TestPropagationFunctionContract:
+    """Unit tests for inject_otel_context() in isolation."""
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_current_span(self) -> None:
+        request = httpx.Request("POST", "https://example.com/api")
+        await inject_otel_context(request)
+        assert "traceparent" not in request.headers
+
+    @pytest.mark.asyncio
+    async def test_injects_when_span_active(self) -> None:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+
+        # Set up a real tracer provider so we can start a span.
+        provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+        trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        trace.set_tracer_provider(provider)
+        tracer = trace.get_tracer("test")
+
+        request = httpx.Request("POST", "https://example.com/api")
+        with tracer.start_as_current_span("test-span"):
+            await inject_otel_context(request)
+        assert "traceparent" in request.headers

--- a/tests/unit/sdk/test_otel_provider_safety.py
+++ b/tests/unit/sdk/test_otel_provider_safety.py
@@ -18,7 +18,13 @@ from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.telemetry.otel import (
     TelemetryManager,
     _is_default_tracer_provider,
+    _otel_available,
     _resolve_sampler,
+)
+
+# OTEL feature tests — skip when opentelemetry isn't installed (FR-012).
+pytestmark = pytest.mark.skipif(
+    not _otel_available, reason="opentelemetry not installed ([otel] extra)"
 )
 
 

--- a/tests/unit/sdk/test_otel_provider_safety.py
+++ b/tests/unit/sdk/test_otel_provider_safety.py
@@ -1,0 +1,167 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US5 tests: configurable sampling + provider safety.
+
+Verifies that:
+- The SDK does not clobber an integrator's pre-set TracerProvider (FR-008)
+- Sampler resolution honors the documented precedence (FR-010)
+- Unknown sampler names raise ValueError at SDKConfig construction (FR-010b)
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.telemetry.otel import (
+    TelemetryManager,
+    _is_default_tracer_provider,
+    _resolve_sampler,
+)
+
+
+class TestSamplerValidation:
+    def test_unknown_sampler_raises_at_construction(self) -> None:
+        with pytest.raises((ValueError, ValidationError)) as exc_info:
+            SDKConfig(otel_sampler="bogus_sampler_name")
+        # Error message should list the supported samplers
+        msg = str(exc_info.value)
+        assert "always_on" in msg or "supported" in msg.lower()
+
+    def test_each_supported_sampler_accepted(self) -> None:
+        for name in (
+            "always_on",
+            "always_off",
+            "traceidratio",
+            "parentbased_always_on",
+            "parentbased_always_off",
+            "parentbased_traceidratio",
+        ):
+            config = SDKConfig(otel_sampler=name)
+            assert config.otel_sampler == name
+
+    def test_none_is_valid_sampler(self) -> None:
+        config = SDKConfig(otel_sampler=None)
+        assert config.otel_sampler is None
+
+
+class TestMetricLabelsValidation:
+    def test_unknown_metric_label_raises(self) -> None:
+        with pytest.raises((ValueError, ValidationError)):
+            SDKConfig(otel_metric_labels=["fqdn", "unknown_label"])
+
+    def test_duplicate_metric_labels_rejected(self) -> None:
+        with pytest.raises((ValueError, ValidationError)):
+            SDKConfig(otel_metric_labels=["fqdn", "fqdn"])
+
+    def test_empty_list_is_default(self) -> None:
+        config = SDKConfig()
+        assert config.otel_metric_labels == []
+
+
+class TestSamplerResolution:
+    def test_resolve_sampler_none_when_no_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_TRACES_SAMPLER", raising=False)
+        monkeypatch.delenv("DNS_AID_SDK_OTEL_SAMPLER", raising=False)
+        config = SDKConfig()
+        sampler = _resolve_sampler(config)
+        assert sampler is None  # let OTEL SDK use default
+
+    def test_otel_traces_sampler_env_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Standard OTEL env var present → we defer to OTEL SDK's own parsing
+        # by returning None (TracerProvider() reads OTEL_TRACES_SAMPLER itself).
+        monkeypatch.setenv("OTEL_TRACES_SAMPLER", "always_off")
+        monkeypatch.delenv("DNS_AID_SDK_OTEL_SAMPLER", raising=False)
+        config = SDKConfig(otel_sampler="always_on")  # SDK config should be ignored
+        sampler = _resolve_sampler(config)
+        assert sampler is None  # defer to OTEL SDK env handling
+
+    def test_dns_aid_env_var_used_when_otel_env_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OTEL_TRACES_SAMPLER", raising=False)
+        monkeypatch.setenv("DNS_AID_SDK_OTEL_SAMPLER", "always_off")
+        config = SDKConfig()
+        sampler = _resolve_sampler(config)
+        assert sampler is not None
+        # always_off has a specific class
+        from opentelemetry.sdk.trace.sampling import ALWAYS_OFF as _AO
+
+        assert sampler is _AO
+
+    def test_config_field_used_when_envs_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_TRACES_SAMPLER", raising=False)
+        monkeypatch.delenv("DNS_AID_SDK_OTEL_SAMPLER", raising=False)
+        config = SDKConfig(otel_sampler="always_off")
+        sampler = _resolve_sampler(config)
+        from opentelemetry.sdk.trace.sampling import ALWAYS_OFF as _AO
+
+        assert sampler is _AO
+
+
+class TestOTLPExporterURLScheme:
+    """Regression test for the URL-scheme handling that prevents the
+    confusing ``SSL_ERROR_SSL: WRONG_VERSION_NUMBER`` failure when a
+    plaintext endpoint is passed without scheme guidance.
+
+    Pinned via real integration test against Jaeger 1.76.0 — see
+    ``examples/integration_otel_collector/`` for the live demo.
+    """
+
+    def test_http_scheme_strips_and_marks_insecure(self) -> None:
+        cfg = SDKConfig(otel_endpoint="http://localhost:4317")
+        kw = TelemetryManager(cfg)._otlp_exporter_kwargs()
+        assert kw == {"endpoint": "localhost:4317", "insecure": True}
+
+    def test_https_scheme_strips_and_marks_tls(self) -> None:
+        cfg = SDKConfig(otel_endpoint="https://collector.example.com:443")
+        kw = TelemetryManager(cfg)._otlp_exporter_kwargs()
+        assert kw == {"endpoint": "collector.example.com:443", "insecure": False}
+
+    def test_grpc_scheme_treated_as_plaintext_alias(self) -> None:
+        # `grpc://` is a legacy alias for `http://` in OTEL ecosystem tutorials.
+        cfg = SDKConfig(otel_endpoint="grpc://localhost:4317")
+        kw = TelemetryManager(cfg)._otlp_exporter_kwargs()
+        assert kw == {"endpoint": "localhost:4317", "insecure": True}
+
+    def test_grpcs_scheme_treated_as_tls_alias(self) -> None:
+        cfg = SDKConfig(otel_endpoint="grpcs://collector:443")
+        kw = TelemetryManager(cfg)._otlp_exporter_kwargs()
+        assert kw == {"endpoint": "collector:443", "insecure": False}
+
+    def test_bare_endpoint_passes_through(self) -> None:
+        # No scheme → OTEL SDK default behavior applies (TLS unless
+        # OTEL_EXPORTER_OTLP_INSECURE env var says otherwise).
+        cfg = SDKConfig(otel_endpoint="bare-host:4317")
+        kw = TelemetryManager(cfg)._otlp_exporter_kwargs()
+        assert "insecure" not in kw
+        assert kw == {"endpoint": "bare-host:4317"}
+
+    def test_none_endpoint_returns_empty(self) -> None:
+        cfg = SDKConfig(otel_endpoint=None)
+        kw = TelemetryManager(cfg)._otlp_exporter_kwargs()
+        assert kw == {}
+
+
+class TestProviderJoin:
+    def test_default_provider_is_default(self) -> None:
+        # Fresh state — fixture has reset; OTEL has its default proxy provider.
+        assert _is_default_tracer_provider() is True
+
+    def test_does_not_clobber_when_user_set_provider(self) -> None:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+
+        user_provider = TracerProvider(resource=Resource.create({"service.name": "user-app"}))
+        trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        trace.set_tracer_provider(user_provider)
+
+        # Constructing TelemetryManager should NOT call set_tracer_provider
+        # since the user has already set one.
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        TelemetryManager.get_or_create(config)
+        # The user's provider must still be in place.
+        assert trace.get_tracer_provider() is user_provider

--- a/tests/unit/sdk/test_otel_span_lifecycle.py
+++ b/tests/unit/sdk/test_otel_span_lifecycle.py
@@ -11,11 +11,18 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from opentelemetry import trace
 
 from dns_aid.core.models import AgentRecord, Protocol
 from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.telemetry.otel import _otel_available
+
+# Skip the whole module when opentelemetry is not installed (e.g., CI jobs
+# that don't pull the [otel] extra). The SDK itself works without it
+# (FR-012) — these tests exercise the OTEL feature and need the package.
+pytestmark = pytest.mark.skipif(
+    not _otel_available, reason="opentelemetry not installed ([otel] extra)"
+)
 
 
 def _agent() -> AgentRecord:
@@ -29,6 +36,7 @@ def _agent() -> AgentRecord:
 
 
 def _install_recording_exporter():
+    from opentelemetry import trace
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -63,6 +71,8 @@ class TestSpanActiveDuringHandler:
         captured_span_names: list[str] = []
 
         async def handler(request: httpx.Request) -> httpx.Response:
+            from opentelemetry import trace
+
             current = trace.get_current_span()
             captured_span_names.append(current.name if hasattr(current, "name") else "")
             return httpx.Response(200, json={"ok": True})

--- a/tests/unit/sdk/test_otel_span_lifecycle.py
+++ b/tests/unit/sdk/test_otel_span_lifecycle.py
@@ -1,0 +1,134 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US3 tests: span lifecycle (open BEFORE handler, close AFTER).
+
+Verifies the span is the active context during ``handler.invoke()`` and
+that span duration matches the recorded signal's latency within tolerance.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from opentelemetry import trace
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+
+
+def _agent() -> AgentRecord:
+    return AgentRecord(
+        name="echo",
+        domain="example.com",
+        protocol=Protocol.HTTPS,
+        target_host="echo.example.com",
+        port=443,
+    )
+
+
+def _install_recording_exporter():
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    class Recorder:
+        def __init__(self):
+            self.spans = []
+
+        def export(self, spans):
+            from opentelemetry.sdk.trace.export import SpanExportResult
+
+            self.spans.extend(spans)
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            pass
+
+        def force_flush(self, timeout_millis=5000):
+            return True
+
+    rec = Recorder()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(rec))
+    trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    trace.set_tracer_provider(provider)
+    return rec
+
+
+class TestSpanActiveDuringHandler:
+    @pytest.mark.asyncio
+    async def test_handler_sees_active_dns_aid_span(self) -> None:
+        captured_span_names: list[str] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            current = trace.get_current_span()
+            captured_span_names.append(current.name if hasattr(current, "name") else "")
+            return httpx.Response(200, json={"ok": True})
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        _install_recording_exporter()
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            await client.invoke(_agent(), method="probe")
+
+        # The active span during handler.invoke should be our dns-aid.invoke span.
+        assert captured_span_names, "handler did not capture any span name"
+        assert any("dns-aid.invoke" in name for name in captured_span_names), (
+            f"expected dns-aid.invoke span active in handler, got {captured_span_names}"
+        )
+
+
+class TestSpanLifecycleOnException:
+    @pytest.mark.asyncio
+    async def test_span_ends_with_error_on_handler_exception(self) -> None:
+        rec = _install_recording_exporter()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("simulated network failure")
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            # Should NOT raise — protocol handler catches httpx errors and
+            # returns a RawResponse with status=REFUSED.
+            result = await client.invoke(_agent(), method="probe")
+            assert not result.success
+
+        assert len(rec.spans) == 1
+        span = rec.spans[0]
+        # Status should reflect the refused/error outcome
+        attrs = dict(span.attributes or {})
+        assert attrs.get("dns_aid.invocation.status") in ("error", "refused", "timeout")
+
+
+class TestSpanDurationMatchesLatency:
+    @pytest.mark.asyncio
+    async def test_span_duration_within_tolerance_of_signal_latency(self) -> None:
+        rec = _install_recording_exporter()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True})
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            result = await client.invoke(_agent(), method="probe")
+
+        assert len(rec.spans) == 1
+        span = rec.spans[0]
+        span_duration_ms = (span.end_time - span.start_time) / 1_000_000.0  # ns → ms
+        signal_latency_ms = result.signal.invocation_latency_ms
+        # Span wraps a wider scope than the protocol handler (includes
+        # auth + policy + record), so it's ≥ signal_latency_ms. We assert
+        # the span is at least as long as the signal latency, with a
+        # tolerance for the surrounding code.
+        assert span_duration_ms >= signal_latency_ms, (
+            f"span duration {span_duration_ms}ms < signal latency {signal_latency_ms}ms"
+        )
+        # And not absurdly longer (< 100ms overhead for the surround).
+        assert span_duration_ms - signal_latency_ms < 500.0

--- a/tests/unit/sdk/test_otel_wiring.py
+++ b/tests/unit/sdk/test_otel_wiring.py
@@ -115,10 +115,10 @@ class TestSanitizationHelpers:
     def test_sanitize_error_message_redacts_url_with_userinfo(self) -> None:
         msg = "Connection refused: https://leaked-user:leaked-pass@target.com:443/api"
         out = _sanitize_error_message(msg)
-        assert out is not None
-        assert "leaked-user" not in out
-        assert "leaked-pass" not in out
-        assert "target.com:443" in out
+        # Exact-match the redacted output: userinfo stripped, host:port/path
+        # preserved. (Exact equality avoids a substring-on-URL check, which
+        # is an incomplete-sanitization anti-pattern.)
+        assert out == "Connection refused: https://target.com:443/api"
 
     def test_sanitize_error_message_passthrough_when_clean(self) -> None:
         msg = "Plain error message with no URL"

--- a/tests/unit/sdk/test_otel_wiring.py
+++ b/tests/unit/sdk/test_otel_wiring.py
@@ -25,9 +25,15 @@ from dns_aid.sdk._config import SDKConfig
 from dns_aid.sdk.client import AgentClient
 from dns_aid.sdk.telemetry.otel import (
     TelemetryManager,
+    _otel_available,
     _OTELWarnRateLimiter,
     _sanitize_endpoint_url,
     _sanitize_error_message,
+)
+
+# OTEL feature tests — skip when opentelemetry isn't installed (FR-012).
+pytestmark = pytest.mark.skipif(
+    not _otel_available, reason="opentelemetry not installed ([otel] extra)"
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/test_otel_wiring.py
+++ b/tests/unit/sdk/test_otel_wiring.py
@@ -1,0 +1,374 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US1 tests: spans + metrics emit on every invoke.
+
+Also covers the CRITICAL hardening items:
+- H1 (FR-019, FR-020) credential sanitization in span attributes
+- H2 (FR-022) asyncio.CancelledError propagation
+- H3 (FR-023, FR-024) flush on AgentClient close
+- H4 (FR-025) rate-limited WARN logs
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.sdk._config import SDKConfig
+from dns_aid.sdk.client import AgentClient
+from dns_aid.sdk.telemetry.otel import (
+    TelemetryManager,
+    _OTELWarnRateLimiter,
+    _sanitize_endpoint_url,
+    _sanitize_error_message,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_https_response(
+    content: bytes = b'{"ok": true}', status: int = 200
+) -> httpx.Response:
+    return httpx.Response(
+        status_code=status, content=content, headers={"content-type": "application/json"}
+    )
+
+
+def _build_agent(
+    name: str = "echo",
+    domain: str = "example.com",
+    target_host: str | None = None,
+    port: int = 443,
+) -> AgentRecord:
+    return AgentRecord(
+        name=name,
+        domain=domain,
+        protocol=Protocol.HTTPS,
+        target_host=target_host or f"{name}.{domain}",
+        port=port,
+        capabilities=["echo"],
+    )
+
+
+class _RecordingExporter:
+    """In-memory span exporter — captures spans for assertions."""
+
+    def __init__(self) -> None:
+        self.spans: list[Any] = []
+
+    def export(self, spans):
+        from opentelemetry.sdk.trace.export import SpanExportResult
+
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        pass
+
+    def force_flush(self, timeout_millis: int = 5000):
+        return True
+
+
+class _CountingMetricReader:
+    """Captures metric counts across all reads (used for sampler tests)."""
+
+    def __init__(self):
+        self.data_point_count = 0
+
+
+# ---------------------------------------------------------------------------
+# Sanitization unit tests (H1 / SC-016)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizationHelpers:
+    def test_sanitize_endpoint_url_strips_userinfo(self) -> None:
+        out = _sanitize_endpoint_url("https://leaked-user:leaked-pass@host:443/path")
+        assert out is not None
+        assert "leaked-user" not in out
+        assert "leaked-pass" not in out
+        assert "host:443" in out
+
+    def test_sanitize_endpoint_url_passthrough_when_clean(self) -> None:
+        assert (
+            _sanitize_endpoint_url("https://example.com:443/path") == "https://example.com:443/path"
+        )
+
+    def test_sanitize_endpoint_url_handles_none(self) -> None:
+        assert _sanitize_endpoint_url(None) is None
+
+    def test_sanitize_error_message_redacts_url_with_userinfo(self) -> None:
+        msg = "Connection refused: https://leaked-user:leaked-pass@target.com:443/api"
+        out = _sanitize_error_message(msg)
+        assert out is not None
+        assert "leaked-user" not in out
+        assert "leaked-pass" not in out
+        assert "target.com:443" in out
+
+    def test_sanitize_error_message_passthrough_when_clean(self) -> None:
+        msg = "Plain error message with no URL"
+        assert _sanitize_error_message(msg) == msg
+
+    def test_sanitize_error_message_handles_none(self) -> None:
+        assert _sanitize_error_message(None) is None
+
+    def test_sanitize_error_message_redacts_grpc_url(self) -> None:
+        msg = "OTLP failed: grpc://user:pass@collector:4317"
+        out = _sanitize_error_message(msg)
+        assert out is not None
+        assert "user:pass" not in out
+
+
+# ---------------------------------------------------------------------------
+# Rate-limiter unit tests (H4 / SC-019)
+# ---------------------------------------------------------------------------
+
+
+class TestWarnRateLimiter:
+    """Test the rate-limiter directly via ``structlog.testing.capture_logs``,
+    which captures structlog events regardless of how structlog is configured
+    (avoids brittle caplog / capsys coupling)."""
+
+    def test_first_event_emits_one_log(self) -> None:
+        import structlog
+
+        rl = _OTELWarnRateLimiter()
+        with structlog.testing.capture_logs() as captured:
+            rl.emit("sdk.otel_test_event", instance_id=42, detail="first")
+        events = [e for e in captured if e.get("event") == "sdk.otel_test_event"]
+        assert len(events) == 1
+
+    def test_repeated_events_within_window_suppressed(self) -> None:
+        import structlog
+
+        rl = _OTELWarnRateLimiter()
+        with structlog.testing.capture_logs() as captured:
+            for _ in range(1000):
+                rl.emit("sdk.otel_test_event", instance_id=42, detail="repeated")
+        events = [e for e in captured if e.get("event") == "sdk.otel_test_event"]
+        assert len(events) == 1, f"expected 1 emission, got {len(events)}"
+
+    def test_window_expiry_emits_summary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import structlog
+
+        rl = _OTELWarnRateLimiter()
+        t = [1000.0]
+
+        def fake_monotonic() -> float:
+            return t[0]
+
+        monkeypatch.setattr(time, "monotonic", fake_monotonic)
+        with structlog.testing.capture_logs() as captured:
+            rl.emit("sdk.otel_x", instance_id=1)
+            for _ in range(999):
+                rl.emit("sdk.otel_x", instance_id=1)
+            t[0] += 65.0
+            rl.emit("sdk.otel_x", instance_id=1, detail="post-window")
+
+        summaries = [e for e in captured if e.get("event") == "sdk.otel_warn_summary"]
+        assert len(summaries) == 1
+        assert summaries[0].get("suppressed_count") == 999
+
+
+# ---------------------------------------------------------------------------
+# Span + metric emission (SC-001) — uses RecordingExporter to capture spans
+# ---------------------------------------------------------------------------
+
+
+def _install_recording_exporter() -> _RecordingExporter:
+    """Replace the OTEL exporter chain with a RecordingExporter for assertion."""
+    from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    recording = _RecordingExporter()
+    # Force a fresh global TracerProvider so our recording exporter receives spans.
+    # Test fixture reset_otel_singleton clears any prior state.
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(recording))
+    trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    trace.set_tracer_provider(provider)
+    return recording
+
+
+class TestSpanEmission:
+    @pytest.mark.asyncio
+    async def test_one_invoke_produces_one_span_with_attributes(self) -> None:
+        recording = _install_recording_exporter()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_mock_https_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)  # inject mock
+            agent = _build_agent()
+            await client.invoke(agent, method="tools/call", arguments={"name": "echo"})
+
+        assert len(recording.spans) == 1, f"expected 1 span, got {len(recording.spans)}"
+        span = recording.spans[0]
+        assert "dns-aid.invoke" in span.name
+        attrs = dict(span.attributes or {})
+        assert attrs.get("dns_aid.agent.name") == "echo"
+        assert attrs.get("dns_aid.agent.domain") == "example.com"
+        assert attrs.get("dns_aid.agent.protocol") == "https"
+        assert attrs.get("dns_aid.invocation.method") == "tools/call"
+        assert attrs.get("dns_aid.invocation.status") == "success"
+        assert "dns_aid.invocation.latency_ms" in attrs
+
+
+# ---------------------------------------------------------------------------
+# Credential sanitization end-to-end (SC-016) — release-blocker H1
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialSanitizationEndToEnd:
+    @pytest.mark.asyncio
+    async def test_endpoint_with_userinfo_does_not_leak_to_span(self) -> None:
+        recording = _install_recording_exporter()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_mock_https_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            # Build an AgentRecord with a credentialed endpoint URL via override.
+            agent = AgentRecord(
+                name="leaked",
+                domain="example.com",
+                protocol=Protocol.HTTPS,
+                target_host="leaked.example.com",
+                port=443,
+                endpoint_override="https://leaked-user:leaked-pass@leaked.example.com:443/api",
+            )
+            await client.invoke(agent, method="probe")
+
+        assert len(recording.spans) == 1
+        span = recording.spans[0]
+        attrs = dict(span.attributes or {})
+        endpoint = attrs.get("dns_aid.agent.endpoint", "")
+        assert "leaked-user" not in str(endpoint), f"credential leaked into span: {endpoint}"
+        assert "leaked-pass" not in str(endpoint), f"credential leaked into span: {endpoint}"
+
+
+# ---------------------------------------------------------------------------
+# CancelledError propagation (SC-017) — release-blocker H2
+# ---------------------------------------------------------------------------
+
+
+class TestCancelledErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates_unchanged(self) -> None:
+        recording = _install_recording_exporter()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            # Simulate cancellation mid-invoke
+            raise asyncio.CancelledError()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            agent = _build_agent()
+            with pytest.raises(asyncio.CancelledError):
+                await client.invoke(agent, method="probe")
+
+        # Span must have been ended on cancellation (no leak)
+        assert len(recording.spans) == 1, "span should be ended even on cancellation"
+
+
+# ---------------------------------------------------------------------------
+# Flush on AgentClient close (SC-018) — release-blocker H3
+# ---------------------------------------------------------------------------
+
+
+class TestFlushOnClose:
+    @pytest.mark.asyncio
+    async def test_aexit_calls_otel_force_flush(self) -> None:
+        flush_called: list[bool] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_mock_https_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=True, otel_export_format="console")
+
+        # Pre-create the singleton so we can patch its force_flush.
+        mgr = TelemetryManager.get_or_create(config)
+        original_flush = mgr.force_flush
+
+        def tracked_flush(timeout_millis: int = 5000) -> bool:
+            flush_called.append(True)
+            return original_flush(timeout_millis)
+
+        with patch.object(mgr, "force_flush", side_effect=tracked_flush):
+            async with AgentClient(config=config) as client:
+                client._http_client = httpx.AsyncClient(transport=transport)
+                agent = _build_agent()
+                await client.invoke(agent, method="probe")
+            # __aexit__ should have called force_flush before returning
+            assert flush_called, "AgentClient.__aexit__ did not call OTEL force_flush"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — otel_enabled=False (US6 SC-007)
+# ---------------------------------------------------------------------------
+
+
+class TestOTELDisabledNoBehaviorChange:
+    @pytest.mark.asyncio
+    async def test_no_traceparent_when_otel_disabled(self) -> None:
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _make_mock_https_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(otel_enabled=False)  # default
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            agent = _build_agent()
+            await client.invoke(agent, method="probe")
+
+        assert "traceparent" not in captured[0].headers
+        assert "tracestate" not in captured[0].headers
+
+
+# ---------------------------------------------------------------------------
+# OTEL flush works even when collector is unreachable (SC-008)
+# ---------------------------------------------------------------------------
+
+
+class TestUnreachableCollector:
+    @pytest.mark.asyncio
+    async def test_invoke_succeeds_with_bogus_otel_endpoint(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_mock_https_response()
+
+        transport = httpx.MockTransport(handler)
+        config = SDKConfig(
+            otel_enabled=True,
+            otel_export_format="otlp",
+            otel_endpoint="grpc://localhost:0",  # unreachable
+        )
+        async with AgentClient(config=config) as client:
+            client._http_client = httpx.AsyncClient(transport=transport)
+            agent = _build_agent()
+            # 5 invokes — none should raise despite the unreachable collector.
+            for _ in range(5):
+                result = await client.invoke(agent, method="probe")
+                assert result.success

--- a/tests/unit/sdk/test_search_models.py
+++ b/tests/unit/sdk/test_search_models.py
@@ -200,19 +200,13 @@ class TestSearchResponse:
         )
 
     def test_has_more_true_when_more_results_exist(self) -> None:
-        results = [
-            SearchResult(agent=_make_agent(name=f"a{i}"), score=0.5)
-            for i in range(20)
-        ]
+        results = [SearchResult(agent=_make_agent(name=f"a{i}"), score=0.5) for i in range(20)]
         response = self._response(results, total=50, offset=0)
         assert response.has_more is True
         assert response.next_offset == 20
 
     def test_has_more_false_at_last_page(self) -> None:
-        results = [
-            SearchResult(agent=_make_agent(name=f"a{i}"), score=0.5)
-            for i in range(7)
-        ]
+        results = [SearchResult(agent=_make_agent(name=f"a{i}"), score=0.5) for i in range(7)]
         response = self._response(results, total=27, offset=20)
         assert response.has_more is False
         assert response.next_offset is None

--- a/tests/unit/test_cap_fetcher.py
+++ b/tests/unit/test_cap_fetcher.py
@@ -190,7 +190,9 @@ class TestFetchCapDocument:
             _SSRF_BYPASS,
             patch(
                 "dns_aid.utils.url_safety.safe_fetch_bytes",
-                side_effect=_mock_fetch({"version": "1.0.0", "description": "An agent without caps"}),
+                side_effect=_mock_fetch(
+                    {"version": "1.0.0", "description": "An agent without caps"}
+                ),
             ),
         ):
             doc = await fetch_cap_document("https://example.com/cap.json")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -65,14 +65,21 @@ class TestGetBackend:
 
     def test_unknown_backend_exits(self):
         import click
+        import typer
 
         from dns_aid.cli.main import _get_backend
 
+        # _get_backend raises typer.Exit(1) on unknown backend. Depending on
+        # the resolved typer version, typer.Exit is either an alias of
+        # click.exceptions.Exit OR typer's own vendored exception
+        # (typer._click.exceptions.Exit) — catch typer.Exit directly so the
+        # test is robust to both (CI's fresh pip resolve differs from the
+        # uv-locked dev venv).
         try:
             _get_backend("nonexistent")
             raise AssertionError("Should have raised")
-        except (SystemExit, click.exceptions.Exit):
-            pass  # Either exception is acceptable
+        except (SystemExit, click.exceptions.Exit, typer.Exit):
+            pass  # Any of these exit exceptions is acceptable
 
 
 class TestDiscoverCommand:

--- a/tests/unit/test_cloud_dns_backend.py
+++ b/tests/unit/test_cloud_dns_backend.py
@@ -57,9 +57,7 @@ class TestCloudDNSBackend:
                 "name": "_chat._mcp._agents.example.com.",
                 "type": "SVCB",
                 "ttl": 30,
-                "rrdatas": [
-                    '1 service.example.internal. alpn="mcp" port="443" key65406="lattice"'
-                ],
+                "rrdatas": ['1 service.example.internal. alpn="mcp" port="443" key65406="lattice"'],
             }
         ]
 

--- a/tests/unit/test_dcv.py
+++ b/tests/unit/test_dcv.py
@@ -70,7 +70,10 @@ def test_build_txt_value_with_bnd_req():
 def test_build_txt_value_domain_before_bnd_req():
     expiry = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
     txt = _build_txt_value("abc123", expiry, "svc:bot@orga.test", domain="example.com")
-    assert txt == "token=abc123 domain=example.com bnd-req=svc:bot@orga.test expiry=2026-01-02T03:04:05Z"
+    assert (
+        txt
+        == "token=abc123 domain=example.com bnd-req=svc:bot@orga.test expiry=2026-01-02T03:04:05Z"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -573,8 +573,7 @@ class TestParseSvcbCustomParams:
         params = _parse_svcb_custom_params(svcb_text)
         assert params["connect-meta"] == "apphub.googleapis.com/projects/test/services/My Service"
         assert (
-            params["enroll-uri"]
-            == "https://example.com/.well-known/agent-connect?label=My Service"
+            params["enroll-uri"] == "https://example.com/.well-known/agent-connect?label=My Service"
         )
 
 

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -214,13 +214,19 @@ class TestPublish:
 
         assert result.success is True
         assert result.agent.connect_class == "lattice"
-        assert result.agent.connect_meta == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert (
+            result.agent.connect_meta
+            == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        )
         assert result.agent.enroll_uri == "https://overlay.example.com/.well-known/agent-connect"
 
         svcb = mock_backend.get_svcb_record("example.com", "_overlay._mcp._agents")
         assert svcb is not None
         assert svcb["params"]["key65406"] == "lattice"
-        assert svcb["params"]["key65407"] == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        assert (
+            svcb["params"]["key65407"]
+            == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
+        )
         assert svcb["params"]["key65408"] == "https://overlay.example.com/.well-known/agent-connect"
 
 

--- a/tests/unit/utils/conftest.py
+++ b/tests/unit/utils/conftest.py
@@ -1,0 +1,26 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for utils tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_singleton():
+    """Reset the OTEL ``TelemetryManager`` singleton before AND after every test.
+
+    Spec 005 hardening H5 / FR-026 — utility tests (e.g., logging) may
+    inadvertently leak OTEL singleton state otherwise.
+    """
+    try:
+        from dns_aid.sdk.telemetry.otel import TelemetryManager
+
+        TelemetryManager.reset()
+        yield
+        TelemetryManager.reset()
+    except ImportError:
+        # OTEL not installed in this environment — nothing to reset.
+        yield

--- a/tests/unit/utils/test_logging_trace_correlation.py
+++ b/tests/unit/utils/test_logging_trace_correlation.py
@@ -10,7 +10,15 @@ nothing when no span is active.
 
 from __future__ import annotations
 
+import pytest
+
+from dns_aid.sdk.telemetry.otel import _otel_available
 from dns_aid.utils.logging import otel_trace_processor
+
+# OTEL feature tests — skip when opentelemetry isn't installed (FR-012).
+pytestmark = pytest.mark.skipif(
+    not _otel_available, reason="opentelemetry not installed ([otel] extra)"
+)
 
 
 class TestOTELTraceProcessor:

--- a/tests/unit/utils/test_logging_trace_correlation.py
+++ b/tests/unit/utils/test_logging_trace_correlation.py
@@ -1,0 +1,59 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec 005 — US4 tests: structlog trace correlation.
+
+Verifies the always-on ``otel_trace_processor`` injects ``trace_id`` and
+``span_id`` into structlog events when an OTEL span is active, and adds
+nothing when no span is active.
+"""
+
+from __future__ import annotations
+
+from dns_aid.utils.logging import otel_trace_processor
+
+
+class TestOTELTraceProcessor:
+    def test_no_fields_when_no_active_span(self) -> None:
+        event_dict = {"event": "test.event", "agent": "echo"}
+        out = otel_trace_processor(None, "info", event_dict)
+        assert "trace_id" not in out
+        assert "span_id" not in out
+        assert out["agent"] == "echo"  # original fields preserved
+
+    def test_injects_fields_when_span_active(self) -> None:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+
+        provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+        trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        trace.set_tracer_provider(provider)
+        tracer = trace.get_tracer("test")
+
+        event_dict = {"event": "test.event"}
+        with tracer.start_as_current_span("test-span") as span:
+            out = otel_trace_processor(None, "info", event_dict)
+            ctx = span.get_span_context()
+            assert out["trace_id"] == format(ctx.trace_id, "032x")
+            assert out["span_id"] == format(ctx.span_id, "016x")
+
+    def test_never_breaks_logging_on_processor_exception(self) -> None:
+        # Pass a non-dict to trigger an unexpected branch — must not raise.
+        # The processor returns the input unchanged on any failure.
+        from unittest.mock import patch
+
+        event_dict = {"event": "test"}
+        with patch("dns_aid.utils.logging._otel_trace") as mocked:
+            mocked.get_current_span.side_effect = RuntimeError("simulated OTEL bug")
+            out = otel_trace_processor(None, "info", event_dict)
+            assert out == event_dict
+
+    def test_short_circuits_when_otel_unavailable(self) -> None:
+        from unittest.mock import patch
+
+        event_dict = {"event": "test"}
+        with patch("dns_aid.utils.logging._otel_available", False):
+            out = otel_trace_processor(None, "info", event_dict)
+            assert "trace_id" not in out
+            assert "span_id" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version == '3.13.*'",
-    "python_full_version != '3.13.*'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -619,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.21.3"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -639,6 +640,7 @@ all = [
     { name = "mcp" },
     { name = "mypy" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-sdk" },
     { name = "pygments" },
     { name = "pyjwt" },
@@ -692,6 +694,7 @@ mcp = [
 ]
 otel = [
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-sdk" },
 ]
 pqc = [
@@ -726,10 +729,12 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'all'", specifier = ">=1.8.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
-    { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.20.0,<2.0.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0,<2.0.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'all'", specifier = ">=1.20.0,<2.0.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.20.0,<2.0.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.20.0,<2.0.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0,<2.0.0" },
     { name = "pqcrypto", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "pqcrypto", marker = "extra == 'pqc'", specifier = ">=0.4.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
@@ -842,6 +847,69 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/14/ea/144bbc4b9359da89aec07b4c2a91a6bfe7119914885386577c665b07bb01/google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8", size = 433773, upload-time = "2025-11-05T14:58:01.594Z" },
     { url = "https://files.pythonhosted.org/packages/96/b3/74e301211699f1b650ba7690a3e4e52146ac4266fcd62f3ea0a945b9eda4/google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6", size = 491893, upload-time = "2025-11-05T14:58:02.969Z" },
     { url = "https://files.pythonhosted.org/packages/6f/d1/4adcfcb9c95e3d064c9f7aaf6cb3a4fc842d86115014b9d4094db4d465b5/google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5", size = 643093, upload-time = "2025-11-05T14:58:05.761Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -1296,6 +1364,48 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+]
+
+[[package]]
 name = "opentelemetry-sdk"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1486,6 +1596,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes a 3.5-month-old docs/code drift. The `TelemetryManager` OTEL exporter shipped in v0.5.0 (Feb 2026) — 245 LoC, fully tested in isolation — but was **never wired into `AgentClient.invoke()`**. Setting `otel_enabled=True` produced no spans, while `docs/architecture.md` claimed it emitted spans + metrics. This PR wires it end-to-end with production-grade hardening.

Verified live against Jaeger 1.76.0 (spans land with full attributes) and across two stress-test rounds (17 scenarios). Two real bugs were caught in stress testing and fixed (per-invoke overhead, OTLP TLS scheme — see below).

## User stories delivered

1. **Spans + metrics on every invoke** (P1) — `dns-aid.invoke {fqdn}` (SpanKind=CLIENT) with agent identity, method, status, latency, cost, DNSSEC.
2. **W3C Trace Context propagation** (P1) — `traceparent`/`tracestate`/`baggage` injected into outbound MCP/A2A/HTTPS requests; downstream OTEL agents get linked traces.
3. **Proper span lifecycle** (P1) — span opens BEFORE the handler, ends AFTER signal recorded; active context during the outbound call.
4. **structlog trace correlation** (P2) — `trace_id`/`span_id` auto-injected into log events when a span is active (always-on; works with integrators' own OTEL).
5. **Configurable sampling + provider safety** (P2) — sampler via env/config; never clobbers a pre-set global provider.
6. **Lossless backward compatibility** (P1, release-blocker) — `otel_enabled=False` is byte-identical to v0.21.3.

## Release-blocker hardening

- **Credential sanitization** (FR-019/FR-020) — `user:pass@` stripped from endpoint URLs and error messages before they reach spans (a span export to a multi-tenant backend would otherwise leak creds).
- **CancelledError propagation** (FR-022) — defensive blocks use `except Exception`; span `__exit__` returns `None`. Cancellation semantics preserved exactly.
- **Flush on close** (FR-023/FR-024) — `__aexit__` force-flushes before httpx close; short-lived processes (CI, Lambda, scripts) never lose spans.
- **Rate-limited WARN logs** (FR-025) — a down collector can't flood logs; one event per (name, instance) per 60s + suppressed-count summary.

## Bugs caught during stress testing (both fixed)

1. **Per-invoke overhead 2.7ms** — `get_or_create()` was called on every invoke. Fixed by caching `TelemetryManager` once per `AgentClient`. Overhead now measurement-noise level (-0.6%).
2. **OTLP TLS handshake failure** — the gRPC exporter defaults to TLS; a plaintext collector (Jaeger `:4317`) produced `SSL_ERROR_SSL: WRONG_VERSION_NUMBER`. Fixed with URL-scheme handling: `http://` → plaintext, `https://` → TLS, `grpc://`/`grpcs://` aliases. Pinned by 6 regression tests + verified against live Jaeger.

## New configuration surface

- `SDKConfig.otel_sampler`, `SDKConfig.otel_environment`, `SDKConfig.otel_metric_labels`
- Env vars: `DNS_AID_SDK_OTEL_{SAMPLER,ENVIRONMENT,METRIC_LABELS}` + standard `OTEL_TRACES_SAMPLER`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_PROPAGATORS`
- New optional dep: `opentelemetry-exporter-otlp-proto-grpc`; OTEL deps pinned `>=1.20.0,<2.0.0`
- `service.version` now read from `dns_aid.__version__` (fixes hardcoded "0.4.9" bug, FR-009)
- Provider-join safety (FR-008) — joins an integrator's existing global providers instead of overwriting

## Ecosystem note

The Cisco AI Defense Python SDK ships **zero** OpenTelemetry — only `logger_params` + typed exceptions. This brings DNS-AID ahead of comparable enterprise agent SDKs on observability.

## Changes

- `src/dns_aid/sdk/telemetry/otel.py` — production rewrite (provider-join, sampler resolution, rate-limited warnings, sanitization, force_flush, BatchSpanProcessor, URL-scheme handling)
- `src/dns_aid/sdk/telemetry/propagation.py` — NEW shared `inject_otel_context()` hook
- `src/dns_aid/sdk/client.py` — span lifecycle wiring + cached TelemetryManager + flush on close
- `src/dns_aid/sdk/_config.py` — 3 new fields + validators + env parsing
- `src/dns_aid/sdk/protocols/{_mcp_telemetry,a2a,https}.py` — propagation injection
- `src/dns_aid/utils/logging.py` — always-on trace-correlation processor
- `docs/integrations/opentelemetry.md` — NEW end-to-end guide (managed-collector auth, URL-scheme handling, failure modes)
- `docs/architecture.md` — updated to shipped reality
- `examples/integration_otel_collector/` — NEW runnable Jaeger demo
- 47 new tests across 7 files + autouse OTEL-reset fixtures

## Breaking changes

None. `otel_enabled=False` (the default) is byte-identical to v0.21.3.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/dns_aid/sdk/ src/dns_aid/utils/` clean (46 files)
- [x] `pytest tests/unit/` — 1688 passed
- [x] Secrets scan clean
- [x] Live OTLP integration vs Jaeger 1.76.0 — 5/5 spans verified with full attributes
- [x] Stress round 1 (7 scenarios): concurrency, singleton race, cancellation, provider clobber, overhead — all pass
- [x] Stress round 2 (10 scenarios): error-path span status, sampler drop, traceidratio statistics, create_task context survival, nested-span parent linking, concurrent flush, exporter backpressure, memory bounded, sanitization edge cases — all pass

Full design rationale in `specs/005-otel-production/` (local planning artifacts; `specs/` is gitignored).