### PR TITLE
docs: document v0.23.0 OpenTelemetry config surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,20 @@ ranked = await dns_aid.rank(result.agents, method="tools/list")
 for r in ranked:
     print(f"{r.agent_fqdn}: score={r.composite_score:.1f}")
 
-# Fetch community-wide rankings from telemetry API (v0.6.0+)
+# Fetch community-wide rankings from the directory API (v0.19.0+)
 from dns_aid.sdk import AgentClient, SDKConfig
 
-config = SDKConfig(telemetry_api_url="https://api.example.com")
+config = SDKConfig(directory_api_url="https://api.example.com")
 async with AgentClient(config) as client:
     rankings = await client.fetch_rankings(limit=10)
     for r in rankings:
         print(f"{r['agent_fqdn']}: {r['composite_score']}")
 ```
+
+**OpenTelemetry (v0.23.0+):** install `dns-aid[otel]` and set
+`otel_enabled=True` (or `DNS_AID_SDK_OTEL_ENABLED=true`) to emit spans +
+metrics per invoke and propagate W3C trace context to downstream agents.
+See [docs/integrations/opentelemetry.md](docs/integrations/opentelemetry.md).
 
 For advanced usage (connection reuse, OTEL export):
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1535,9 +1535,12 @@ config = SDKConfig(
     caller_id="my-app",              # Caller identifier for signals
     persist_signals=False,           # Auto-save signals to PostgreSQL
     database_url=None,               # DB URL (falls back to DATABASE_URL env)
-    otel_enabled=False,              # Enable OpenTelemetry export
-    otel_endpoint=None,              # OTLP endpoint URL
-    otel_export_format="otlp",       # "otlp" or "console"
+    otel_enabled=False,              # Enable OpenTelemetry export (v0.23.0+)
+    otel_endpoint=None,              # OTLP endpoint URL — use http:// (plaintext) or https:// (TLS)
+    otel_export_format="otlp",       # "otlp" | "console" | "noop"
+    otel_sampler=None,               # Sampler name; None = OTEL default (v0.23.0+)
+    otel_environment=None,           # deployment.environment resource attr (v0.23.0+)
+    otel_metric_labels=[],           # Opt-in high-cardinality labels: fqdn|caller|tool (v0.23.0+)
     http_push_url=None,              # POST signals to remote telemetry API
     directory_api_url=None,          # Base URL for AgentClient.search() and fetch_rankings()
     telemetry_api_url=None,          # Deprecated alias for directory_api_url
@@ -1556,11 +1559,21 @@ config = SDKConfig.from_env()
 | `DNS_AID_SDK_CALLER_ID` | None | Caller identifier |
 | `DNS_AID_SDK_PERSIST_SIGNALS` | false | Enable DB persistence |
 | `DATABASE_URL` | None | PostgreSQL connection URL |
-| `DNS_AID_SDK_OTEL_ENABLED` | false | Enable OpenTelemetry |
-| `DNS_AID_SDK_OTEL_ENDPOINT` | None | OTLP collector URL |
+| `DNS_AID_SDK_OTEL_ENABLED` | false | Enable OpenTelemetry (v0.23.0+) |
+| `DNS_AID_SDK_OTEL_ENDPOINT` | None | OTLP collector URL — `http://` plaintext, `https://` TLS |
+| `DNS_AID_SDK_OTEL_EXPORT_FORMAT` | otlp | `otlp` \| `console` \| `noop` |
+| `DNS_AID_SDK_OTEL_SAMPLER` | None | Sampler name; lower precedence than `OTEL_TRACES_SAMPLER` (v0.23.0+) |
+| `DNS_AID_SDK_OTEL_ENVIRONMENT` | None | Sets `deployment.environment` resource attr (v0.23.0+) |
+| `DNS_AID_SDK_OTEL_METRIC_LABELS` | None | Comma-separated opt-in labels: `fqdn,caller,tool` (v0.23.0+) |
 | `DNS_AID_SDK_HTTP_PUSH_URL` | None | POST signals to this URL |
 | `DNS_AID_SDK_DIRECTORY_API_URL` | None | Base URL for `AgentClient.search()` + `fetch_rankings()` (v0.19.0+) |
 | `DNS_AID_SDK_TELEMETRY_API_URL` | None | Deprecated alias for `DNS_AID_SDK_DIRECTORY_API_URL` |
+
+Standard OpenTelemetry env vars are also honored: `OTEL_TRACES_SAMPLER`,
+`OTEL_TRACES_SAMPLER_ARG`, `OTEL_PROPAGATORS`, `OTEL_RESOURCE_ATTRIBUTES`,
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_ENDPOINT`. See
+[docs/integrations/opentelemetry.md](integrations/opentelemetry.md) for the
+full guide (sampling, propagation, managed-collector auth, failure modes).
 
 The `resolved_directory_url` property returns `directory_api_url` when set, falling
 back to `telemetry_api_url` for backwards compatibility. Using the legacy alias

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1380,7 +1380,8 @@ from dns_aid.sdk import AgentClient, SDKConfig
 
 config = SDKConfig(
     persist_signals=True,      # Store signals in PostgreSQL
-    otel_enabled=True,         # Export to OpenTelemetry
+    otel_enabled=True,         # Export to OpenTelemetry (v0.23.0+)
+    otel_endpoint="http://localhost:4317",  # http:// plaintext, https:// TLS
     caller_id="my-app",
 )
 
@@ -1392,6 +1393,25 @@ async with AgentClient(config=config) as client:
     # Rank all invoked agents
     ranked = client.rank()
 ```
+
+**OpenTelemetry (v0.23.0+).** With `otel_enabled=True` the SDK emits a span
+per invoke, propagates W3C trace context (`traceparent`) to downstream
+agents, records metrics, and correlates structlog events with the active
+span. Configure via these env vars (no code change):
+
+```bash
+export DNS_AID_SDK_OTEL_ENABLED=true
+export DNS_AID_SDK_OTEL_ENDPOINT=http://collector:4317   # http:// plaintext, https:// TLS
+export DNS_AID_SDK_OTEL_SAMPLER=traceidratio             # optional sampler
+export DNS_AID_SDK_OTEL_ENVIRONMENT=production           # deployment.environment
+export DNS_AID_SDK_OTEL_METRIC_LABELS=fqdn,caller        # opt-in metric labels
+# Standard OTEL_* env vars also honored: OTEL_TRACES_SAMPLER,
+# OTEL_RESOURCE_ATTRIBUTES, OTEL_EXPORTER_OTLP_HEADERS, OTEL_PROPAGATORS.
+```
+
+Requires the `otel` extra: `pip install 'dns-aid[otel]'`. Full guide
+(sampling, propagation, managed-collector auth, runnable Jaeger example):
+[docs/integrations/opentelemetry.md](integrations/opentelemetry.md).
 
 ### Telemetry API
 


### PR DESCRIPTION
## Summary

FR-018 follow-up to #145 (v0.23.0 OTEL). `api-reference.md` and
`getting-started.md` didn't get the new OTEL config surface when v0.23.0
shipped; this closes that gap. Docs-only — no code, no version change.

## Changes
- `docs/api-reference.md` — `SDKConfig` example gains
  `otel_sampler`/`otel_environment`/`otel_metric_labels`; env-var table
  gains `DNS_AID_SDK_OTEL_{EXPORT_FORMAT,SAMPLER,ENVIRONMENT,METRIC_LABELS}`
  plus a note on the standard `OTEL_*` vars and a link to the integration
  guide.
- `docs/getting-started.md` — new OpenTelemetry subsection (enable flag,
  `http://`/`https://` endpoint scheme guidance, sampler/environment/
  metric-label env vars, `[otel]` extra) linking the integration guide.
- `README.md` — replace the deprecated `telemetry_api_url` example with
  `directory_api_url`; add a one-line OTEL pointer.

## Test plan
- [x] Docs-only; no code paths touched
- [x] Internal links resolve to `docs/integrations/opentelemetry.md`