### PR TITLE
ci: pin CI deps via uv.lock + clear code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,cli,mcp,route53,otel]"
+        run: uv sync --frozen --extra dev --extra cli --extra mcp --extra route53 --extra otel
 
       - name: Run unit tests
-        run: pytest tests/unit/ -v --tb=short
+        run: uv run pytest tests/unit/ -v --tb=short
 
       - name: Run tests with coverage
-        run: pytest tests/unit/ --cov=dns_aid --cov-report=xml --cov-report=term-missing
+        run: uv run pytest tests/unit/ --cov=dns_aid --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage artifact
         if: matrix.python-version == '3.12'
@@ -76,13 +77,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,cli,mcp,route53,otel]"
+        run: uv sync --frozen --extra dev --extra cli --extra mcp --extra route53 --extra otel
 
       - name: Run mock integration tests
-        run: pytest tests/integration/ -m "not live" -v --tb=short
+        run: uv run pytest tests/integration/ -m "not live" -v --tb=short
 
   lint:
     name: Lint
@@ -96,16 +98,17 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+        run: uv sync --frozen --extra dev
 
       - name: Ruff check
-        run: ruff check src/
+        run: uv run ruff check src/
 
       - name: Ruff format check
-        run: ruff format --check src/
+        run: uv run ruff format --check src/
 
   typecheck:
     name: Type Check
@@ -119,10 +122,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,cli,mcp,route53,otel]"
+        run: uv sync --frozen --extra dev --extra cli --extra mcp --extra route53 --extra otel
 
       - name: Mypy
-        run: mypy src/dns_aid
+        run: uv run mypy src/dns_aid

--- a/tests/unit/sdk/policy/test_bindaid_writer.py
+++ b/tests/unit/sdk/policy/test_bindaid_writer.py
@@ -79,8 +79,9 @@ class TestNSRecord:
 class TestActionDirectives:
     def test_nxdomain_txt(self, result_with_directives: CompilationResult) -> None:
         zone = write_bindaid_zone(result_with_directives, "policy.example.com", serial=1)
-        assert "evil.com" in zone
-        assert "ACTION:nxdomain" in zone
+        # Assert the full record line, not a bare host substring (avoids the
+        # incomplete-URL-substring anti-pattern and is a stronger check).
+        assert 'evil.com  300  IN  TXT  "ACTION:nxdomain"' in zone
 
     def test_passthru_txt(self, result_with_directives: CompilationResult) -> None:
         zone = write_bindaid_zone(result_with_directives, "policy.example.com", serial=1)


### PR DESCRIPTION
## Summary
Clears the open code-scanning alerts on `main` (CodeQL + OpenSSF Scorecard). These predate / are unrelated to recent dependency work — surfaced on each push-to-main re-scan.

## Changes
- `.github/workflows/ci.yml` — replace unpinned `pip install -e ".[extras]"` with SHA-pinned `astral-sh/setup-uv` + `uv sync --frozen`, installing exactly from the hash-pinned `uv.lock`. Test/lint/typecheck now run via `uv run`. Closes the 6 **Scorecard Pinned-Dependencies** (error) alerts. (GitHub Actions were already SHA-pinned.)
- `tests/unit/sdk/policy/test_bindaid_writer.py` — replace the bare `"evil.com" in zone` host-substring check with a full record-line assertion. Closes the **CodeQL `py/incomplete-url-substring-sanitization`** (high) alert and is a stronger test.

## Not in scope
The remaining ~27 alerts are CodeQL `note`-severity quality lint (unused-import, empty-except, etc.), mostly in test files — left for separate triage.

## Test plan (mirrors CI exactly)
- [x] `uv sync --frozen --extra dev --extra cli --extra mcp --extra route53 --extra otel`
- [x] `uv run pytest tests/unit/` — 1688 passed
- [x] `uv run ruff check src/` + `ruff format --check src/` — clean
- [x] `uv run mypy src/dns_aid` — no issues (81 files)
- [x] ci.yml valid YAML
- [x] secrets scan — clean