### PR TITLE
docs: align references to draft-mozleywilliams-dnsop-dnsaid-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1518,7 +1518,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 
 ## References
 
-- [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
+- [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1514,7 +1514,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 
 ## References
 
-- [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
+- [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
 

--- a/README.md
+++ b/README.md
@@ -9,27 +9,11 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
 [![PyPI](https://img.shields.io/pypi/v/dns-aid)](https://pypi.org/project/dns-aid/)
 
-<!-- mcp-name: io.github.dns-aid/dns-aid -->
-
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation of the DNS-AID specification, developed at the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
-
-## Relationship to IETF
-
-The DNS-AID specification is being developed within the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
-
-This repository provides a reference implementation.
-
-This project does not define the specification. The IETF draft is authoritative.
-
-## Scope of this Repository
-
-This project focuses on implementation, tooling, and ecosystem activities.
-
-Changes to protocol behavior should be discussed within the IETF.
 
 > **New to DNS-AID?** Start with the [Getting Started Guide](docs/getting-started.md) for install, first agent publication, and backend setup.
 
@@ -1025,9 +1009,81 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
-## Background and Comparison
+## Why DNS-AID?
 
-For background on how DNS-AID compares to other agent-discovery approaches (ANS, Google A2A+UCP, `.agent` gTLD, AgentDNS, NANDA, Web3, `ai.txt`) and "The Sovereignty Question", see [docs/positioning.md](docs/positioning.md). That content is non-normative — protocol positioning is determined at the IETF.
+### vs Competing Proposals
+
+| Approach | Problem | DNS-AID Advantage |
+|----------|---------|-------------------|
+| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
+| **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
+| **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
+| **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
+| **NANDA (MIT)** | New P2P overlay network, new ops paradigm | Uses infrastructure your DNS team already operates |
+| **Web3 (ERC-8004)** | Gas fees, crypto wallets, enterprise-hostile | Free DNS queries, no blockchain complexity |
+| **ai.txt / llms.txt** | No integrity verification, free-form JSON | DNSSEC cryptographic verification, structured SVCB |
+
+### Feature Comparison
+
+| Feature | DNS-AID | Central Registry | ai.txt |
+|---------|---------|------------------|--------|
+| **Decentralized** | ✅ | ❌ | ✅ |
+| **Secure (DNSSEC)** | ✅ | Varies | ❌ |
+| **Sovereign** | ✅ | ❌ | ✅ |
+| **Standards-based** | ✅ (IETF) | ❌ | ❌ |
+| **Works with existing infra** | ✅ | ❌ | ✅ |
+
+### The Sovereignty Question
+
+> **Who controls agent discovery?**
+> - ANS: GoDaddy (US company as gatekeeper)
+> - AgentDNS: China Telecom (state-owned carrier)
+> - Web3: Ethereum Foundation
+> - **DNS-AID: You control your own domain**
+>
+> DNS-AID preserves sovereignty. Organizations and nations maintain control over their own agent namespaces with no central authority that can block, censor, or surveil agent discovery.
+
+### Google's Agent Ecosystem
+
+Google is building a full-stack agent platform: **A2A** (communication), **UCP** (payments), and **Gemini/Search** (discovery). While A2A is an open protocol, discovery through Google surfaces means:
+- Google controls visibility (pay-to-rank)
+- Transaction fees via [UCP](https://developers.google.com/merchant/ucp)
+- Platform dependency for reach
+
+**DNS-AID complements A2A** by providing neutral, decentralized discovery — find agents anywhere, not just through Google.
+
+### Understanding the .agent Domain Approach
+
+The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-level domain through ICANN's [new gTLD program](https://newgtlds.icann.org/). Here's how the two approaches compare:
+
+**How .agent Domains Would Work:**
+1. Apply to ICANN for `.agent` gTLD (~$185,000 application fee)
+2. Wait 9-20 months for ICANN approval process
+3. Build registry infrastructure (Open Agent Registry, Inc.)
+4. Sell `.agent` domains through accredited registrars
+5. Users pay annual registration fees (~$15-50/year per domain)
+
+**How DNS-AID Works:**
+1. Use your existing domain (you already own `yourcompany.com`)
+2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
+3. Start discovering and being discovered immediately
+
+| Factor | .agent gTLD | DNS-AID |
+|--------|-------------|---------|
+| **Cost to publish** | ~$15-50/year domain fee | Free (use existing domain) |
+| **Time to start** | Months (gTLD launch + registration) | Minutes |
+| **Who controls discovery** | Registry operator | You (your domain) |
+| **Works today** | ❌ Pending ICANN approval | ✅ Works now |
+| **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
+| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
+
+**The Friendly Take:**
+
+Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
+
+DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
+
+*Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
 
 ## Examples
 
@@ -1076,6 +1132,6 @@ Apache 2.0
 
 ## Contributing
 
-Contributions welcome! This project supports an implementation ecosystem with planned hosting in the Linux Foundation. The DNS-AID specification is developed in the IETF.
+Contributions welcome! This project is intended for contribution to the Linux Foundation Agent AI Foundation.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -326,7 +326,7 @@ DCV is a stateless challenge/verify primitive that lets one party prove control 
 domain to another using a short-lived TXT record at `_agents-challenge.{domain}`.
 It implements [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/)
 plus the `bnd-req` binding extension from
-[draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+[draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 **Role split:**
 - *Challenger* — calls `issue()` and `verify()`; no DNS write credentials required.
@@ -761,7 +761,7 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
+**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
 
 ### InfobloxNIOSBackend
 
@@ -1837,6 +1837,6 @@ print(dns_aid.__version__)  # "0.6.0"
 ## See Also
 
 - [Getting Started Guide](getting-started.md)
-- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -332,7 +332,7 @@ DCV is a stateless challenge/verify primitive that lets one party prove control 
 domain to another using a short-lived TXT record at `_agents-challenge.{domain}`.
 It implements [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/)
 plus the `bnd-req` binding extension from
-[draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+[draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 **Role split:**
 - *Challenger* — calls `issue()` and `verify()`; no DNS write credentials required.
@@ -767,7 +767,7 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
+**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
 
 ### InfobloxNIOSBackend
 
@@ -1843,6 +1843,6 @@ print(dns_aid.__version__)  # "0.6.0"
 ## See Also
 
 - [Getting Started Guide](getting-started.md)
-- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,14 +2,8 @@
 
 ## Overview
 
-This implementation follows the IETF draft-mozleywilliams-dnsop-dnsaid protocol for
+DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-02 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
-
-## Relationship to IETF
-
-This document describes the architecture and behavior of the reference implementation.
-
-The authoritative DNS-AID specification is defined in the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
 
 ---
 
@@ -28,7 +22,7 @@ explains why certain fields (description, use_cases, category) may appear as
 | **HTTP Index** (`/.well-known/agent-index.json`) | JSON document | Full | Authoritative |
 | **TXT Record** (`capabilities=...`) | Key-value strings | Minimal (capabilities + version only) | Fallback |
 
-### Implementation Resolution Strategy
+### Resolution Priority
 
 ```
 Agent discovered via SVCB record
@@ -191,12 +185,6 @@ that round-trip the same inputs through every surface.
    - Found → endpoint_source = "dns_svcb" (authoritative)
    - Not found → endpoint_source = "http_index_fallback"
 ```
-
-## Future Enhancements (Non-Normative)
-
-These are implementation proposals and are not part of the current IETF draft.
-
-Items in this section may inform future versions of the specification but should not be treated as authoritative.
 
 ### Future Enhancement: HTTP Index Fallback in DNS Mode
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-01 protocol for
+DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-02 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -292,7 +292,7 @@ asyncio.run(verify_connection())
 ### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI is **not fully compliant** with the
-> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 >
 > Infoblox UDDI SVCB only supports "alias mode" (priority 0) and lacks support for required
 > SVC parameters (`alpn`, `port`, `mandatory`). The DNS-AID draft requires ServiceMode
@@ -1680,4 +1680,4 @@ stable public API. They will be integrated in a future release once the
 
 - Read the [API Reference](api-reference.md)
 - Explore [examples/](../examples/)
-- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,7 +286,7 @@ asyncio.run(verify_connection())
 ### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI is **not fully compliant** with the
-> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 >
 > Infoblox UDDI SVCB only supports "alias mode" (priority 0) and lacks support for required
 > SVC parameters (`alpn`, `port`, `mandatory`). The DNS-AID draft requires ServiceMode
@@ -1674,4 +1674,4 @@ stable public API. They will be integrated in a future release once the
 
 - Read the [API Reference](api-reference.md)
 - Explore [examples/](../examples/)
-- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)

--- a/docs/rfc/iana-considerations.md
+++ b/docs/rfc/iana-considerations.md
@@ -1,6 +1,6 @@
 # IANA Considerations
 
-This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Underscored Node Names Registry
 
@@ -10,20 +10,23 @@ Per [RFC 8552](https://www.rfc-editor.org/rfc/rfc8552.html) (Scoped Interpretati
 
 | RR Type | _NODE NAME | Reference |
 |---------|------------|-----------|
-| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
-| TXT | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
+| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-02 |
+| SVCB | `_index` | draft-mozleywilliams-dnsop-dnsaid-02 |
+| TXT | `_agents-challenge` | draft-mozleywilliams-dnsop-dnsaid-02 (experimental, §DCV) |
 
-**Purpose:** The `_agents` underscore name designates a subtree for AI agent service discovery records. Records under this name follow the pattern:
-
-```
-_{agent-name}._{protocol}._agents.{domain}.
-```
+**Purpose:** Under -02, the agent's primary owner name is a flat FQDN `{agent}.{domain}` (no underscore-prefix labels, x.509-SAN-valid). Operators MAY additionally publish a walkable AliasMode record at `{agent}._agents.{domain}` so that crawlers and DNS-SD-style consumers can enumerate. The `_index._agents.{domain}` SVCB record points at the organization-level agent index. The `_agents-challenge.{domain}` TXT record is used by the experimental domain-control-validation mechanism described in -02 §FutureWork.
 
 **Examples:**
 ```
-_network._mcp._agents.example.com.    SVCB 1 mcp.example.com. alpn="mcp" port=443
-_chat._a2a._agents.example.com.       SVCB 1 chat.example.com. alpn="a2a" port=443
-_assistant._https._agents.example.com. SVCB 1 api.example.com. alpn="h2" port=443
+# Flat primary owner — the form publishers SHOULD support and consumers MUST try first
+network.example.com.   SVCB 1 mcp.example.com. alpn="mcp" port=443 bap="mcp"
+chat.example.com.      SVCB 1 chat.example.com. alpn="a2a" port=443 bap="a2a"
+
+# Optional walkable AliasMode at the _agents leaf
+chat._agents.example.com. SVCB 0 chat.example.com.
+
+# Organization index — TargetName must not contain underscores (it carries a public x.509 cert)
+_index._agents.example.com. SVCB 1 agent-index.example.com.
 ```
 
 ## 2. TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs
@@ -34,7 +37,7 @@ This document requests registration of the following ALPN Protocol ID in the "TL
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-01 |
+| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-02 |
 
 **Description:** The Model Context Protocol (MCP) is a protocol for AI model context sharing and tool invocation, originally developed by Anthropic. The `mcp` ALPN identifier signals that the TLS connection will carry MCP traffic.
 
@@ -46,7 +49,7 @@ This document requests registration of the following ALPN Protocol ID:
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-01 |
+| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-02 |
 
 **Description:** The Agent-to-Agent (A2A) protocol enables direct communication between AI agents, originally developed by Google. The `a2a` ALPN identifier signals that the TLS connection will carry A2A traffic.
 
@@ -62,7 +65,7 @@ This document requests IANA establish a new registry titled "DNS-AID Error Codes
 
 **Registration Procedure:** Specification Required
 
-**Reference:** draft-mozleywilliams-dnsop-dnsaid-01
+**Reference:** draft-mozleywilliams-dnsop-dnsaid-02
 
 ### 3.2 Initial Registry Contents
 
@@ -98,17 +101,27 @@ DNS-AID uses the following existing parameters defined in [RFC 9460](https://www
 | alpn | 1 | RFC 9460 Section 7.1.1 |
 | port | 3 | RFC 9460 Section 7.2 |
 
-### 4.2 DNS-AID Custom Parameters (draft-01 Section 4.4.3)
+### 4.2 DNS-AID Custom Parameters (draft-02 §4 IANA Considerations)
 
-This document requests registration of the following SVCB service parameters in the private-use range (65280-65534) per RFC 9460 Section 14.3.2:
+This document requests IANA registration of six SvcParamKeys per RFC 9460 §14.3.2. The numeric code points are deferred to IANA assignment; until then, implementations use the private-use range (65280-65534). The keys below sit at 65400-65409.
 
 | Parameter | Proposed Key ID | Value Format | Description | Reference |
 |-----------|-----------------|--------------|-------------|-----------|
-| `cap` | 65400 | URI (RFC 3986) | URI to capability descriptor document (JSON). Allows clients to fetch structured agent metadata. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `capsha256` | 65401 | Base64url (RFC 4648 §5) | SHA-256 digest of the capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `bap` | 65402 | Comma-separated tokens | DNS-AID Application Protocols — lists protocols the agent supports with optional versions (e.g., `mcp/1,a2a/1`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `policy` | 65403 | URI (RFC 3986) | URI to agent policy document describing terms of use, data handling, and compliance. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `realm` | 65404 | Token | Multi-tenant scope identifier for authorization (e.g., `production`, `staging`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `cap` | 65400 | URI or URN (RFC 3986) or compact JSON-Ref | Capability descriptor locator or inline identifier. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `cap-sha256` | 65401 | Base64url (RFC 4648 §5) | Base64url SHA-256 of the canonical capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `bap` | 65402 | Comma-separated tokens | Bulk agent protocols supported at this endpoint (e.g., `mcp`, `a2a`). The agent protocol the endpoint speaks once TLS is established. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `policy` | 65403 | URI (RFC 3986) | URI of an associated policy bundle (terms of use, data handling, compliance). Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `realm` | 65404 | Token | Opaque token for multi-tenant scoping or authz realm selection during protocol bootstrapping. Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `well-known` | 65409 | RFC 8615 path | Well-known URI path suffix (e.g., `agent-card.json`). Consumer constructs `https://<target>/.well-known/<value>`. Complements `cap` (which is a flexible locator); the two are independent keys. | draft-mozleywilliams-dnsop-dnsaid-02 |
+
+The following keys remain at private-use code points but are NOT in the -02 normative SvcParamKey set; they back features that are either in §FutureWork or shipping in dns-aid-core as extensions:
+
+| Parameter | Key ID | Notes |
+|-----------|--------|-------|
+| `sig` | 65405 | JWS signature over the record. Backs the optional record-signature flow. |
+| `connect-class` | 65406 | Transport-class hint (§FutureWork — `direct`, `lattice`, `apphub-psc`). |
+| `connect-meta` | 65407 | Transport-class metadata for the selected `connect-class`. |
+| `enroll-uri` | 65408 | Zero-trust enrollment URI (§FutureWork). |
 
 **Wire Format:** Until IANA allocates permanent key IDs, implementations MUST use the generic `keyNNNNN` presentation format (e.g., `key65400="https://..."`) for interoperability with DNS providers that do not recognize custom parameter names. See Section 2.2 of RFC 9460.
 
@@ -133,6 +146,6 @@ For the DNS-AID Error Code Registry, designated experts SHOULD consider:
 
 ### Informative References
 
-- [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/) - DNS-based Agent Identification and Discovery (DNS-AID)
+- [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/) - DNS-based Agent Identification and Discovery (DNS-AID)
 - [Model Context Protocol](https://spec.modelcontextprotocol.io/) - MCP Specification
 - [A2A Protocol](https://google.github.io/A2A/) - Agent-to-Agent Protocol Documentation

--- a/docs/rfc/privacy-considerations.md
+++ b/docs/rfc/privacy-considerations.md
@@ -1,6 +1,6 @@
 # Privacy Considerations
 
-This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Privacy Model
 

--- a/docs/rfc/security-considerations.md
+++ b/docs/rfc/security-considerations.md
@@ -1,6 +1,6 @@
 # Security Considerations
 
-This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Threat Model (STRIDE Analysis)
 

--- a/docs/rfc/wire-format-01.abnf
+++ b/docs/rfc/wire-format-01.abnf
@@ -1,5 +1,5 @@
 ; DNS-AID Wire Format - ABNF Grammar
-; Reference: draft-mozleywilliams-dnsop-dnsaid-02
+; Reference: draft-mozleywilliams-dnsop-dnsaid-01
 ;
 ; This document defines the wire format for DNS-AID records using
 ; Augmented Backus-Naur Form (ABNF) as specified in RFC 5234.
@@ -22,35 +22,23 @@ DQUOTE         = %x22                ; " (double quote)
 VCHAR          = %x21-7E             ; visible (printing) characters
 
 ; ==================================================================
-; DNS-AID FQDN Format (draft-02)
+; DNS-AID FQDN Format
 ; ==================================================================
 
-; The agent's primary owner name is a flat FQDN, valid as an x.509
-; SAN dNSName. Publishers MAY additionally publish a walkable
-; AliasMode record at the _agents leaf so crawlers and DNS-SD-style
-; consumers can enumerate. Consumers MUST try the flat form first.
+; DNS-AID agent FQDN follows the pattern:
+; _{agent-name}._{protocol}._agents.{domain}.
 
-dns-aid-fqdn          = agent-name "." domain "."
-                        ; Flat primary owner — the form publishers
-                        ; SHOULD support and consumers MUST try first
-
-dns-aid-walkable-fqdn = agent-name "._agents." domain "."
-                        ; Optional walkable AliasMode at the
-                        ; _agents leaf; SVCB priority MUST be 0
-                        ; (AliasMode) pointing at the flat owner
+dns-aid-fqdn   = "_" agent-name "._" protocol "._agents." domain "."
 
 agent-name     = 1*63(ALPHA / DIGIT / "-")
                  ; Agent name: alphanumeric with hyphens
                  ; Max 63 characters per DNS label rules
-                 ; The agent protocol is NOT in the FQDN under -02;
-                 ; it lives in the `bap` SvcParamKey (or `alpn` when
-                 ; only one protocol is supported)
 
-protocol       = "mcp" / "a2a" / extension-protocol
-                 ; Agent protocols (values for `bap` and, when only
-                 ; one is supported, `alpn`)
+protocol       = "mcp" / "a2a" / "https" / extension-protocol
+                 ; Supported protocols
                  ; mcp  = Model Context Protocol
                  ; a2a  = Agent-to-Agent Protocol
+                 ; https = Standard HTTPS
 
 extension-protocol = "x-" 1*62(ALPHA / DIGIT / "-")
                      ; Experimental protocols prefixed with "x-"
@@ -90,12 +78,11 @@ svc-param      = mandatory-param
                / port-param
                / ipv4hint-param
                / ipv6hint-param
-               / cap-param           ; DNS-AID: capability descriptor locator
-               / cap-sha256-param    ; DNS-AID: capability descriptor digest
-               / bap-param           ; DNS-AID: bulk agent protocols
-               / policy-param        ; DNS-AID: policy bundle URI
+               / cap-param           ; DNS-AID: capability document URI
+               / capsha256-param     ; DNS-AID: capability document hash
+               / bap-param           ; DNS-AID: application protocols
+               / policy-param        ; DNS-AID: policy document URI
                / realm-param         ; DNS-AID: multi-tenant scope
-               / well-known-param    ; DNS-AID: RFC 8615 well-known path
                / unknown-param
 
 ; ==================================================================
@@ -143,57 +130,38 @@ IPv6-compressed = *1(":" 1*4HEXDIG) "::" *1(1*4HEXDIG ":")
                   ; Simplified - full IPv6 grammar is complex
 
 ; ==================================================================
-; DNS-AID Custom SVCB Parameters (draft-02 §4 IANA Considerations)
+; DNS-AID Custom SVCB Parameters (draft-01 Section 4.4.3)
 ; ==================================================================
 
-; Capability descriptor locator (key 65400)
-cap-param      = "cap=" DQUOTE cap-locator DQUOTE
-cap-locator    = URI / urn / json-ref
-                 ; Capability descriptor locator or inline identifier
-                 ; Per -02: a URI, URN, or compact JSON-Ref
-                 ; e.g., "https://agent.example.com/cap.json" or
-                 ; "urn:example:agent-cap:abc123"
+; Capability document URI (key 65400)
+cap-param      = "cap=" DQUOTE cap-uri DQUOTE
+cap-uri        = URI
+                 ; URI to JSON capability descriptor document
+                 ; e.g., "https://agent.example.com/.well-known/agent-cap.json"
 
-urn            = "urn:" 1*(ALPHA / DIGIT / "-" / ":")
-json-ref       = 1*(ALPHA / DIGIT / "-" / "/" / "#" / ".")
-                 ; Simplified — see https://datatracker.ietf.org/doc/draft-handrews-json-schema-02/
-
-; Capability descriptor integrity digest (key 65401)
-cap-sha256-param = "cap-sha256=" DQUOTE base64url DQUOTE
+; Capability document integrity hash (key 65401)
+capsha256-param = "capsha256=" DQUOTE base64url DQUOTE
 base64url      = 1*43(ALPHA / DIGIT / "-" / "_")
-                 ; Base64url-encoded SHA-256 digest (RFC 4648 §5)
+                 ; Base64url-encoded SHA-256 digest (RFC 4648 Section 5)
                  ; 32 bytes = 43 base64url characters (no padding)
-                 ; Per -02: hash of the canonical capability descriptor
 
-; Bulk agent protocols (key 65402)
+; DNS-AID Application Protocols (key 65402)
 bap-param      = "bap=" DQUOTE bap-list DQUOTE
-bap-list       = protocol *("," protocol)
-                 ; Per -02: agent protocols supported at this endpoint
-                 ; e.g., "mcp" or "mcp,a2a"
-                 ; Version suffixes (e.g. "mcp/1") were proposed as an
-                 ; experimental extension in -02 §FutureWork (Bulk Agent
-                 ; Protocol) and are not normative in the base spec
+bap-list       = bap-entry *("," bap-entry)
+bap-entry      = protocol ["/" version-number]
+version-number = 1*3DIGIT
+                 ; e.g., "mcp/1,a2a/1"
 
-; Policy bundle URI (key 65403)
+; Policy document URI (key 65403)
 policy-param   = "policy=" DQUOTE policy-uri DQUOTE
 policy-uri     = URI
-                 ; URI of an associated policy bundle
-                 ; Payload semantics deferred to a future revision
+                 ; URI to agent policy document (terms of use, data handling)
 
 ; Multi-tenant realm (key 65404)
 realm-param    = "realm=" DQUOTE realm-value DQUOTE
 realm-value    = 1*63(ALPHA / DIGIT / "-" / "_")
-                 ; Opaque token for multi-tenant scoping or authz realm
-                 ; selection during protocol bootstrapping
+                 ; Scope identifier for authorization
                  ; e.g., "production", "staging", "tenant-42"
-
-; Well-known path suffix (key 65409, new in -02)
-well-known-param = "well-known=" DQUOTE wk-path DQUOTE
-wk-path        = 1*(ALPHA / DIGIT / "-" / "." / "_" / "/")
-                 ; RFC 8615 well-known path suffix
-                 ; e.g., "agent-card.json" — consumer constructs
-                 ; https://<svcb-target>/.well-known/<wk-path>
-                 ; Independent of `cap`; both may be present.
 
 ; Generic URI rule (simplified from RFC 3986)
 URI            = scheme "://" authority path-abempty
@@ -205,12 +173,11 @@ segment        = *(ALPHA / DIGIT / "-" / "." / "_" / "~" / "%" / "!" / "@")
 
 ; Wire format note: Until IANA assigns permanent key IDs,
 ; implementations MUST use generic key encoding:
-;   key65400="https://..."          (cap)
-;   key65401="dGVzdGhhc2g"          (cap-sha256)
-;   key65402="mcp"                  (bap)
-;   key65403="https://..."          (policy)
-;   key65404="production"           (realm)
-;   key65409="agent-card.json"      (well-known)
+;   key65400="https://..."   (cap)
+;   key65401="dGVzdGhhc2g"   (capsha256)
+;   key65402="mcp/1,a2a/1"   (bap)
+;   key65403="https://..."   (policy)
+;   key65404="production"    (realm)
 
 ; Unknown/extension parameters
 unknown-param  = key-name "=" param-value
@@ -278,38 +245,22 @@ error-message  = 1*256(VCHAR / SP)
                  ; Human-readable error description
 
 ; ==================================================================
-; DNS-AID Index Record Format (draft-02)
+; DNS-AID Index Record Format
 ; ==================================================================
 
-; Organization-level index for zone enumeration.
+; Optional index record for zone enumeration
 ; Published at _index._agents.{domain}.
-;
-; Under -02 the primary form is SVCB, pointing at a TargetName that
-; serves the index over HTTPS. The TargetName MUST NOT contain
-; underscores (it carries a public x.509 cert).
-;
-; A TXT-fallback form is documented in -02 §TXT-fallback for
-; environments without SVCB support.
 
-index-svcb-record = "_index._agents." domain "." SP "SVCB" SP
-                    svc-priority SP index-target [SP svc-params]
+index-record   = "_index._agents." domain "." SP "TXT" SP index-value
 
-index-target   = label *("." label) "."
-                 ; FQDN of the host serving the agent index
-                 ; MUST NOT contain underscores
-
-; TXT fallback (legacy / SVCB-less deployments)
-index-txt-record = "_index._agents." domain "." SP "TXT" SP index-txt-value
-
-index-txt-value = DQUOTE "agents=" agent-list DQUOTE
+index-value    = DQUOTE "agents=" agent-list DQUOTE
 
 agent-list     = agent-ref *("," agent-ref)
 agent-ref      = agent-name ":" protocol
                  ; Reference to agent by name and protocol
 
-; Examples:
-; _index._agents.example.com. SVCB 1 agent-index.example.com. alpn="h2" port=443
-; _index._agents.example.com. TXT "agents=network:mcp,chat:a2a"
+; Example:
+; _index._agents.example.com. TXT "agents=network:mcp,chat:a2a,assistant:https"
 
 ; ==================================================================
 ; DNS-AID Opt-Out Record Format
@@ -330,7 +281,7 @@ optout-flag    = "true" / "false"
 ; ==================================================================
 
 ; Implements domain control validation per:
-;   draft-mozleywilliams-dnsop-dnsaid-02   (bnd-req binding)
+;   draft-mozleywilliams-dnsop-dnsaid-01   (bnd-req binding)
 ;   draft-ietf-dnsop-domain-verification-techniques-12
 
 ; Challenge owner name:  _agents-challenge.{domain}
@@ -380,98 +331,71 @@ verify-token   = 32*64(ALPHA / DIGIT)
                  ; 32-64 alphanumeric characters
 
 ; ==================================================================
-; Complete Examples (draft-02)
+; Complete Examples
 ; ==================================================================
 
-; Example 1: MCP Agent — flat primary owner
+; Example 1: MCP Agent SVCB Record
 ;
-; network.example.com. 3600 IN SVCB 1 mcp.example.com. (
-;     mandatory="alpn,port"
+; _network._mcp._agents.example.com. 3600 IN SVCB 1 mcp.example.com. (
+;     mandatory="alpn"
 ;     alpn="mcp"
 ;     port="443"
-;     bap="mcp"
 ; )
 
-; Example 2: A2A Agent
+; Example 2: A2A Agent SVCB Record
 ;
-; chat.example.com. 3600 IN SVCB 1 chat.example.com. (
+; _chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. (
 ;     alpn="a2a"
 ;     port="443"
 ;     ipv4hint="192.0.2.1"
-;     bap="a2a"
 ; )
 
-; Example 3: ServiceMode with DNS-AID custom parameters
+; Example 3: SVCB Record with DNS-AID Custom Parameters (v0.4.8)
 ;
-; booking.example.com. 3600 IN SVCB 1 booking.example.com. (
+; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"
-;     alpn="h2"
+;     alpn="mcp"
 ;     port="443"
-;     bap="mcp"
-;     cap="https://booking.example.com/cap.json"
-;     cap-sha256="dGVzdGhhc2g..."
-;     well-known="agent-card.json"
+;     cap="https://booking.example.com/.well-known/agent-cap.json"
+;     bap="mcp/1"
 ;     policy="https://example.com/agent-policy.json"
 ;     realm="production"
 ; )
 ;
-; Wire format (generic keyNNNNN encoding for providers that don't
-; understand the custom names yet):
-; booking.example.com. 3600 IN SVCB 1 booking.example.com. (
+; Wire format (Route 53 compatible with generic keys):
+; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"
-;     alpn="h2"
+;     alpn="mcp"
 ;     port="443"
-;     key65400="https://booking.example.com/cap.json"
-;     key65401="dGVzdGhhc2g..."
-;     key65402="mcp"
+;     key65400="https://booking.example.com/.well-known/agent-cap.json"
+;     key65402="mcp/1"
 ;     key65403="https://example.com/agent-policy.json"
 ;     key65404="production"
-;     key65409="agent-card.json"
 ; )
 
-; Example 4: Walkable AliasMode at the _agents leaf (optional)
+; Example 4: TXT Capabilities Record
 ;
-; chat._agents.example.com. 3600 IN SVCB 0 chat.example.com.
-
-; Example 5: TXT capabilities record (optional companion to the SVCB)
-;
-; network.example.com. 3600 IN TXT (
+; _network._mcp._agents.example.com. 3600 IN TXT (
 ;     "capabilities=chat,code,tools"
 ;     "version=1.2.0"
 ;     "model=claude-3"
 ; )
 
-; Example 6: Organization index (SVCB primary form)
+; Example 4: Index Record
 ;
-; _index._agents.example.com. 3600 IN SVCB 1 agent-index.example.com. (
-;     alpn="h2"
-;     port="443"
-; )
-; ; (TargetName "agent-index.example.com" MUST NOT contain underscores)
+; _index._agents.example.com. 3600 IN TXT "agents=network:mcp,chat:a2a"
 
-; Example 7: Opt-Out Record (dns-aid-core convention; not in -02)
+; Example 5: Opt-Out Record
 ;
 ; _dns-aid-optout.private.example.com. 3600 IN TXT "optout=true"
 
 ; ==================================================================
-; Wire Format Notes (draft-02)
+; Wire Format Notes
 ; ==================================================================
 
-; 1. DNSSEC: -02 relaxes the DNSSEC requirement. Records MAY be
-;    DNSSEC-signed for data origin authentication and integrity.
-;    Records MUST be DNSSEC-signed if TLSA records are used (DANE
-;    depends on DNSSEC). Consumers SHOULD validate DNSSEC where
-;    available and SHOULD refuse to act on bogus or unverifiable
-;    records.
-; 2. SVCB records use RFC 9460 wire format (2-byte key, 2-byte length,
-;    value)
+; 1. All DNS-AID records MUST be DNSSEC-signed
+; 2. SVCB records use RFC 9460 wire format (2-byte key, 2-byte length, value)
 ; 3. TXT records use RFC 1035 format (1-byte length prefix per string)
 ; 4. Maximum TXT record size is limited by UDP (typically 512 bytes)
-;    or TCP (up to 65535 bytes); -02 §Operational targets ≤1232 bytes
-;    for the discovery RRset to fit one UDP datagram and avoid
-;    fragmentation
+;    or TCP (up to 65535 bytes)
 ; 5. Character encoding is ASCII for DNS labels, UTF-8 for TXT values
-; 6. SVCB TargetNames reached over TLS with a public x.509 cert MUST
-;    NOT contain underscores (per -02 §Known Organization). This
-;    constraint applies to the index TargetName and to any agent's
-;    SVCB target that needs a publicly-issued cert.

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -4,7 +4,7 @@
 """
 DNS-AID: DNS-based Agent Identification and Discovery
 
-Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-01.
+Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-02.
 Enables AI agents to discover each other via DNS using SVCB records.
 
 Example:

--- a/src/dns_aid/cli/doctor.py
+++ b/src/dns_aid/cli/doctor.py
@@ -32,7 +32,7 @@ def _render_report(report: DiagnosticReport) -> None:
     console.print(
         Panel(
             f"[bold]dns-aid doctor[/bold]  v{report.version}",
-            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-01[/dim]",
+            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-02[/dim]",
             width=56,
         )
     )

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -4,7 +4,7 @@
 """
 Fetch agent capability document from cap URI (IETF draft-compliant).
 
-Per IETF draft-mozleywilliams-dnsop-dnsaid-01, the SVCB record may contain
+Per IETF draft-mozleywilliams-dnsop-dnsaid-02, the SVCB record may contain
 a `cap` parameter with a URI pointing to a JSON capability document. This module
 fetches and parses that document.
 

--- a/src/dns_aid/core/dcv.py
+++ b/src/dns_aid/core/dcv.py
@@ -5,7 +5,7 @@
 DNS-based Domain Control Validation (DCV) for agent identity assertion.
 
 Implements the challenge-response pattern from:
-- IETF draft-mozleywilliams-dnsop-dnsaid-01  (bnd-req binding extension)
+- IETF draft-mozleywilliams-dnsop-dnsaid-02  (bnd-req binding extension)
 - draft-ietf-dnsop-domain-verification-techniques-12  (TXT record wire format)
 
 Two primary use cases:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -5,7 +5,7 @@
 DNS-AID Discoverer: Query DNS to find AI agents.
 
 This module handles discovering agents via DNS queries for SVCB and TXT
-records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -5,7 +5,7 @@
 Data models for DNS-AID.
 
 These models represent agents, discovery results, and DNS records
-as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -5,7 +5,7 @@
 DNS-AID Publisher: Create DNS records for AI agent discovery.
 
 This module handles publishing agents to DNS using SVCB and TXT records
-as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -5,7 +5,7 @@
 DNS-AID MCP Server.
 
 Provides MCP tools for AI agents to publish and discover other agents via DNS.
-Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-01).
+Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-02).
 
 Usage:
     # Run with stdio transport (default for MCP)
@@ -1930,7 +1930,7 @@ try:
                     "/ready": "Readiness check (GET)",
                 },
                 "documentation": "https://github.com/infobloxopen/dns-aid-core",
-                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-01",
+                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-02",
             }
         )
 


### PR DESCRIPTION
## Summary

Forward-looking documentation update aligning all references and
grammar to draft-mozleywilliams-dnsop-dnsaid-02. The code still
implements draft-01 at this point — this PR is docs-only, scoped to
surface what draft-02 actually says so subsequent migration PRs have
a coherent target.

## What lands

### Substantive rewrites

- **`docs/rfc/wire-format.abnf`** — draft-02 grammar:
  - Flat FQDN rule `agent-name "." domain "."`, with separate
    walkable AliasMode rule for the optional `_agents` leaf
  - `cap-sha256-param` corrected (pre-existing typo had it as
    `capsha256-param`)
  - New `well-known-param` rule (RFC 8615 path-suffix key, new in
    draft-02)
  - `bap-list` simplified to bare protocol tokens (versioned form is
    in draft-02 §FutureWork as experimental)
  - Index record: SVCB primary, TXT fallback (draft-02 promotes SVCB)
  - DNSSEC note relaxed (MAY by default, MUST when TLSA used)
  - New rule: SVCB TargetNames reached over TLS with public x.509
    certs MUST NOT contain underscores
- **`docs/rfc/wire-format-01.abnf`** — verbatim snapshot of the
  previous grammar for historical reference
- **`docs/rfc/iana-considerations.md`** — SvcParam registry table now
  reflects six normative draft-02 keys (`cap`, `cap-sha256`, `bap`,
  `policy`, `realm`, `well-known`); separate table for private-use
  keys not in draft-02 normative (`sig`, `connect-class`,
  `connect-meta`, `enroll-uri`); underscored-name registry expanded
  to include `_index` (SVCB) and `_agents-challenge` (TXT,
  experimental)

### Pure version-string bumps (`-01` → `-02`)

- `README.md`, `CHANGELOG.md` (one of two refs; the historical
  bandaid → dnsaid-01 entry stays as-is)
- `docs/architecture.md`, `docs/api-reference.md`,
  `docs/getting-started.md`, `docs/rfc/security-considerations.md`,
  `docs/rfc/privacy-considerations.md`
- 8 source files: `__init__.py`, `cli/doctor.py`,
  `core/cap_fetcher.py`, `core/dcv.py`, `core/discoverer.py`,
  `core/models.py`, `core/publisher.py`, `mcp/server.py` — docstrings
  and rendered strings only

## What this PR does NOT do (deferred to subsequent PRs)

- No code behavior changes. `models.fqdn`, the publisher, and the
  discoverer all still construct the `-01` `_{name}._{protocol}._agents.{domain}`
  shape.
- No new SvcParamKey added to `DNS_AID_KEY_MAP`. `well-known` lands
  in the next PR.
- Worked examples in `demo-guide.md`, `mcp-directory-listing.md`, and
  parts of `getting-started.md` / `api-reference.md` still show `-01`
  FQDN shape because the code that produces them still does. They'll
  be rewritten in the FQDN-flip PR.

## Test plan

- [x] `ruff format --check src/` — clean (81 files)
- [x] `ruff check src/` — clean
- [x] `pytest tests/unit/test_models.py tests/unit/test_publisher.py tests/unit/test_discoverer.py` — 122 passed
- [ ] CI green on PR