### PR TITLE
feat(core): scalar bap per draft-02 §FutureWork (Bulk Agent Protocol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1518,7 +1518,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 
 ## References
 
-- [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
+- [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `to_params()` reads `DNS_AID_SVCB_STRING_KEYS` once per call (was up
   to 11× per serialization).
 
+### BREAKING CHANGE — `bap` SvcParamKey is now a single scalar
+
+The `bap` SvcParamKey value type changed from `list[str] | None` to
+`str | None` across the public API: `publish()`, the CLI `--bap`
+flag, the MCP `publish_agent_to_dns` tool, and the `AgentRecord` /
+`SvcbRecord` Pydantic models.
+
+The value form follows draft-02 §5.1: bare (`mcp`, `a2a`) or
+versioned with the draft's `=` delimiter (`mcp=1.0`, `a2a=1.1`).
+
+- `AgentRecord(bap=["mcp"])` now raises `ValidationError`. Field
+  validators on both models reject the list form at the type
+  boundary so the break direction is pinned.
+- `--bap mcp,a2a` no longer auto-splits — the CLI passes the value
+  through verbatim and the validator rejects the comma. Operators
+  who want both protocols publish two SVCB records, one per
+  protocol.
+- The MCP tool's input schema for `bap` changed from `array` to
+  `string`. Clients that bind to the JSON schema need updates.
+- The previous concatenated form (`mcp2.1`, `a2a1.0`) is rejected
+  because it is ambiguous to parse back into protocol and version.
+
+This is experimental territory in the draft (§FutureWork), but the
+public-API shape change still warrants the version bump. A new
+shared `dns_aid.core.bap.normalize_bap` helper coerces legacy
+comma-strings and list inputs into the canonical scalar on the
+discover / SDK / indexer paths so existing wire data on the network
+keeps deserializing without operator intervention.
+
+### Security
+
+- **`bap` field validator closes a SvcParamKey injection
+  vulnerability.** A crafted value such as `mcp" key65500="x` used
+  to round-trip verbatim through `to_params()` and the backend
+  formatters; dnspython would then parse two SvcParamKeys, with the
+  second attacker-controlled. On a multi-tenant publish path that is
+  server-side parameter injection. The new validator rejects
+  quotes, spaces, commas, and any character that could break SVCB
+  SvcParam quoting at every construction path.
+
 ### BREAKING CHANGE — draft-02 flat FQDN + walkable AliasMode
 
 This release flips the wire-format default from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Repository moved to the vendor-neutral `dns-aid` GitHub organization** (`github.com/dns-aid/dns-aid-core`), ahead of Linux Foundation graduation. Previous `infobloxopen/dns-aid-core` URLs redirect automatically, so existing clones, links, and badges continue to work. Contributors should update their git remotes (`git remote set-url <remote> https://github.com/dns-aid/dns-aid-core.git`). The PyPI Trusted Publisher and MCP Registry namespace are being updated to match the new organization.
 
+### Added — `well-known` SvcParamKey and TargetName validator (draft-02)
+
+- **New `well-known` SvcParamKey** at the project's interim private-use
+  code point `key65409` (final IANA assignment deferred per draft §7.1).
+  Carries an RFC 8615 path the discoverer reconstructs as
+  `https://<svcb-target>/.well-known/<value>` and fetches as the
+  capability descriptor. Independent of `cap`; both may be present.
+- **Absolute-path well-known values** (per draft Figure 3) — values
+  starting with `/` (e.g. `/.well-known/agent-card.json`,
+  `/not-well-known/other-card.json`) are used as origin-relative paths
+  without double-prefixing. Bare suffixes still get the `/.well-known/`
+  prefix.
+- **`validate_well_known_path`** constrains the value to a safe
+  character class (`[A-Za-z0-9._-]` per segment, length-bounded, no
+  `..` traversal, no `?` / `#` / control chars). Enforced on both
+  publish and discover; field-validator on `SvcbRecord.well_known_path`
+  and `AgentRecord.well_known_path` so direct model construction can't
+  bypass.
+- **`cap_sha256_verified: bool`** field on `AgentRecord` / `SvcbRecord`.
+  True only when the discoverer actually fetched the descriptor AND
+  the SHA-256 of its bytes matched `cap_sha256`. Consumers keying
+  trust off the integrity pin MUST check this flag — the mere presence
+  of `cap_sha256` is no longer a sufficient signal. Dangling case
+  (pin declared, never applied) logs a structured WARN with
+  `warning_class="dns_aid.dangling_cap_sha256"`.
+- **`validate_no_underscore_in_target`** — TargetName underscore
+  validator with operator-only bypass. The bypass requires both the
+  per-call `allow_underscore=True` flag AND
+  `DNS_AID_ALLOW_UNDERSCORE_TARGET=1` in the environment. Field
+  validators on `SvcbRecord.target` and `AgentRecord.target_host`
+  honour the same env gate so the rule fires at the type boundary.
+
+### Changed — correctness
+
+- **Non-HTTPS `cap` (URN, JSON-Ref) falls back to `well-known`** at
+  fetch time. Earlier `cap` presence was terminal, silently disabling
+  a perfectly good `well-known` and downgrading discovery to
+  unauthenticated TXT.
+- **`cap > well-known` precedence** now proven at fetch time, not
+  just at serialization. When both are set and `cap` is https-fetchable,
+  the cap URL drives the fetch and `capability_source="cap_uri"`.
+- **DNSSEC docstring on `validator.py`** rewritten to quote the
+  draft's actual SHOULD posture (§6.2) instead of the earlier
+  MAY/MUST framing. Also no longer overstates what the code does on
+  this branch — the fail-closed DANE demotion ships separately on
+  #155.
+
+### Security
+
+- **pyjwt 2.12.1 → 2.13.0** clears PYSEC-2026-175 / 177 / 178 / 179.
+
+### Internal
+
+- Validation logger migrated from stdlib `logging` to project-standard
+  `structlog`.
+- `_parse_svcb_custom_params` derives its recognised key set from
+  `DNS_AID_KEY_MAP` (was a hand-maintained literal that needed three-
+  file edits per new key).
+- `to_params()` reads `DNS_AID_SVCB_STRING_KEYS` once per call (was up
+  to 11× per serialization).
+
 ## [0.23.0] - 2026-05-26
 
 ### Added — Production-grade OpenTelemetry integration (spec 005)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,111 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `to_params()` reads `DNS_AID_SVCB_STRING_KEYS` once per call (was up
   to 11× per serialization).
 
+### BREAKING CHANGE — draft-02 flat FQDN + walkable AliasMode
+
+This release flips the wire-format default from
+draft-mozleywilliams-dnsop-dnsaid-01 to -02. The primary agent owner is
+now the flat FQDN `{name}.{domain}` (valid as an x.509 SAN dNSName); the
+agent protocol no longer travels in the FQDN — it lives in the SVCB
+`bap` SvcParamKey (or `alpn` when only one protocol is supported).
+
+Anyone with -01 records in production will need to either republish or
+opt into a per-call legacy fallback. See **Migrating from -01** below.
+
+### Added
+
+- **Flat primary owner record** at `{name}.{domain}`. SVCB + companion
+  TXT are written at this name on every publish.
+- **Optional walkable AliasMode** at `{name}._agents.{domain}` pointing
+  at the flat primary owner. **Off by default** under -02 to avoid an
+  enumeration handle — see `docs/privacy-considerations.md`. Opt in
+  per-publish via `publish_walkable_alias=True`, the CLI `--walkable`
+  flag, or the MCP `publish_walkable_alias=true` kwarg.
+- **Per-call legacy fallback** kwarg `allow_legacy: bool | None` on
+  `discover()` / `discover_at_fqdn()`. When set, a flat-FQDN miss falls
+  back to the -01 shape; the resulting `AgentRecord` is stamped
+  `legacy_resolved=True` so downstream filters can down-weight it.
+  The env-flag form `DNS_AID_LEGACY_01_FALLBACK=1` is preserved as a
+  process-wide back-compat for callers that can't easily thread the
+  kwarg; it now also logs a warning on each use and stamps the result.
+- **Per-agent DNSSEC validation** under flat-FQDN. Each agent's owner
+  is checked independently; the result-level `dnssec_validated` is
+  True only when every agent's check passed.
+- **`legacy_resolved: bool`** field on `AgentRecord` for filter-side
+  visibility into legacy-shape records.
+- **`docs/privacy-considerations.md`** — explains the enumeration vs.
+  discovery trade-off and when to enable the walkable record.
+- **`SVCB_ALIAS_MODE` / `SVCB_SERVICE_MODE`** constants in
+  `dns_aid.core.models` so backend code reads `priority=SVCB_ALIAS_MODE`
+  instead of a bare integer.
+- **`dns_aid.core.fqdn.parse_dnsaid_fqdn`** — a single FQDN parser
+  recognising all three shapes; the discoverer's `_parse_fqdn` and the
+  telemetry's `_parse_signal_fqdn` are thin projections over it.
+
+### Changed — Security
+
+- **JWS signature now binds to the record.** `signature_verified` is
+  True only when the signed `RecordPayload` fields (`fqdn`, `target`,
+  `port`, `alpn`) match the AgentRecord — closing a hole where a
+  validly-signed `sig` could be lifted off one record and pasted onto
+  a spoofed SVCB pointing at an attacker host.
+- **`cap-sha256` mismatch now refuses the record** instead of silently
+  downgrading to TXT fallback. `fetch_cap_document` raises
+  `CapDigestMismatchError` on digest mismatch (distinct from network
+  failure); the discoverer catches it and drops the affected record.
+  TXT-fallback records no longer carry `cap_sha256` because the pin
+  doesn't apply to the data we ended up using.
+- **`well-known` SvcParamKey value is now validated** to a safe
+  RFC 8615 single-segment suffix (`^[A-Za-z0-9._-]+$`, length-bounded,
+  no `..` traversal) on both publish and discover. Prevents path
+  traversal, query-string injection, and fragment injection through
+  the SVCB → URL reconstruction.
+- **Walkable AliasMode target is the flat primary owner.** Was the
+  endpoint host, which only coincided with the flat owner when those
+  names happened to match.
+- **DANE score gates on DNSSEC.** A TLSA record without a DNSSEC chain
+  has no integrity guarantee (RFC 6698 §10.1); the validator now
+  demotes `dane_valid` to `None` in that case, and `security_score`'s
+  +15 for DANE is gated on `dnssec_valid` as a second-line guard.
+- **`unpublish()` reports success only when the primary record was
+  deleted (or was already absent and cleanup ran).** Earlier the
+  success boolean OR'd in walkable / legacy cleanup, so a primary
+  delete that silently failed on Route53 / Cloudflare could be masked
+  by an unrelated cleanup succeeding — the MCP server would then
+  de-index a still-live agent.
+- **Agent name is validated at publish.** `validate_agent_name()` is
+  now called on the publisher path (previously only on the MCP path),
+  so SDK / CLI callers can't land records whose flat-FQDN SAN would
+  be unrepresentable.
+- **Underscore-target bypass log is now structured `WARN`** with a
+  `warning_class="dns_aid.underscore_bypass"` key so log aggregators
+  can count and alert on deliberate opt-ins per zone.
+
+### Changed — Code quality
+
+- `sync_index` performs a single backend enumeration instead of two
+  (the second was a subset of the first; doubled API quota burn on
+  every sync).
+- `discover_at_fqdn` for flat / walkable shapes resolves DNS once and
+  reads the actual protocol from the record's `bap` (preferred) or
+  `alpn` field instead of firing MCP-then-A2A back-to-back.
+- Validation logger migrated from stdlib `logging` to project-standard
+  `structlog`.
+
+### Migrating from -01
+
+1. **Re-publish your agents.** The publisher writes the flat shape by
+   default; nothing else to do for new records.
+2. **Existing -01 records keep resolving** when consumers set
+   `allow_legacy=True` on `discover()` or set the env-flag form
+   `DNS_AID_LEGACY_01_FALLBACK=1`. The returned `AgentRecord` will
+   have `legacy_resolved=True` so filters can down-weight.
+3. **`unpublish()` cleans up both shapes** in one call. No flag needed.
+4. **Walkable record is now opt-in.** Operators relying on
+   DNS-SD-style enumeration need to pass `--walkable` (CLI) /
+   `publish_walkable_alias=True` (SDK/MCP) — see
+   `docs/privacy-considerations.md`.
+
 ## [0.23.0] - 2026-05-26
 
 ### Added — Production-grade OpenTelemetry integration (spec 005)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING
+
+- **SVCB TargetName underscore validator is strict by default.**
+  `dns_aid.publish()` and direct `SvcbRecord` / `AgentRecord`
+  construction now reject endpoints containing any underscored DNS
+  label, because the CA/Browser Forum Baseline Requirements and
+  RFC 5280 dNSName SANs forbid underscored labels — a publicly-issued
+  x.509 certificate cannot cover such a name. This is a deliberate,
+  versioned tightening per draft-mozleywilliams-dnsop-dnsaid-02
+  §3.2 (Known Organization, Unknown Agent).
+
+  **Migration from 0.23.0** for deployments that intentionally
+  publish underscored internal endpoints (not behind public PKI):
+
+  1. Preferred: rename the endpoint to use only LDH labels (letters,
+     digits, hyphens). This is the long-term spec-conformant path.
+  2. Operator opt-in: set `DNS_AID_ALLOW_UNDERSCORE_TARGET=1` on the
+     publishing process AND pass `allow_underscore_target=True` to
+     `publish()`. Both are required — the env gate prevents a calling
+     LLM or MCP client from unilaterally downgrading the MUST.
+  3. The opt-in surfaces `dns_aid.underscore_bypass` on
+     `PublishResult.warnings` (caller-visible structured signal) and
+     in structlog with `warning_class="dns_aid.underscore_bypass"`,
+     so operators can count and alert per zone.
+
+  Downstream wrappers and controllers that call `publish()` will
+  need to thread the new flag through their own config surface (CRD
+  field, CLI flag, env var) to preserve any intentional
+  underscored-endpoint behaviour. Until that wiring lands, those
+  deployments must rename the endpoint to LDH labels.
+
 ### Changed
 
 - **Repository moved to the vendor-neutral `dns-aid` GitHub organization** (`github.com/dns-aid/dns-aid-core`), ahead of Linux Foundation graduation. Previous `infobloxopen/dns-aid-core` URLs redirect automatically, so existing clones, links, and badges continue to work. Contributors should update their git remotes (`git remote set-url <remote> https://github.com/dns-aid/dns-aid-core.git`). The PyPI Trusted Publisher and MCP Registry namespace are being updated to match the new organization.
@@ -36,6 +67,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `cap_sha256` is no longer a sufficient signal. Dangling case
   (pin declared, never applied) logs a structured WARN with
   `warning_class="dns_aid.dangling_cap_sha256"`.
+- **`PublishResult.warnings: list[str]`** — non-fatal advisories
+  raised during the publish path, surfaced as stable warning-class
+  identifiers (e.g. `dns_aid.underscore_bypass`) so consumers can
+  match exactly without log-string parsing.
+- **`capability_source="descriptor_unreachable"`** — distinct
+  provenance value when a record declares a `cap` or `well-known`
+  locator but the descriptor fetch fails (timeout, TLS error, 5xx).
+  Lets consumers tell transient outages from mis-configurations
+  without scraping log lines.
+- **`CapabilitySource` `Literal` consolidated in `core.models`** —
+  single source of truth for provenance values; the discoverer,
+  SDK, indexer, and `AgentRecord` all import the same symbol.
+- **Per-agent descriptor-fetch budget** — descriptor fetches are
+  now bounded by `asyncio.wait_for` with a 12-second total budget.
+  A single slow endpoint can no longer stall a bulk-discovery loop;
+  the agent records `capability_source="descriptor_unreachable"`.
 - **`validate_no_underscore_in_target`** — TargetName underscore
   validator with operator-only bypass. The bypass requires both the
   per-call `allow_underscore=True` flag AND

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1514,7 +1514,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 
 ## References
 
-- [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
+- [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ result = await dns_aid.discover(
 )
 
 # Verify an agent's DNS records
-result = await dns_aid.verify("_my-agent._mcp._agents.example.com")
+result = await dns_aid.verify("my-agent.example.com")
 print(f"Security Score: {result.security_score}/100")
 ```
 
@@ -262,7 +262,7 @@ dns-aid discover example.com --use-http-index
 dns-aid discover example.com --json
 
 # Verify DNS records
-dns-aid verify _my-agent._mcp._agents.example.com
+dns-aid verify my-agent.example.com
 
 # List DNS-AID records in a zone
 dns-aid list example.com
@@ -381,7 +381,7 @@ agents = await dns_aid.discover("example.com", use_http_index=True)
 | **DNS (default)** | Maximum decentralization, offline caching, minimal round trips |
 | **HTTP Index** | Rich metadata upfront, ANS compatibility, model cards, capabilities, direct endpoints |
 
-**FQDN as Source of Truth (v0.4.7):** The HTTP index only needs to provide each agent's FQDN (e.g., `_booking._mcp._agents.example.com`). Agent name and protocol are extracted from the FQDN — no separate `protocols` field needed. DNS SVCB lookup then resolves the authoritative endpoint.
+**FQDN as Source of Truth (v0.4.7):** The HTTP index only needs to provide each agent's FQDN (e.g., `booking.example.com`). Agent name and protocol are extracted from the FQDN — no separate `protocols` field needed. DNS SVCB lookup then resolves the authoritative endpoint.
 
 **Discovery Transparency (v0.4.6+):** Each discovered agent includes source fields showing how data was resolved:
 
@@ -475,14 +475,14 @@ Claude will:
 DNS-AID uses SVCB records (RFC 9460) to advertise AI agents:
 
 ```
-_chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port=443 mandatory="alpn,port"
-_chat._a2a._agents.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
+chat.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port=443 mandatory="alpn,port"
+chat.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
 ```
 
 **DNS-AID Custom SVCB Parameters (v0.4.8+):** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
 
 ```
-_booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
+booking.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
     cap="https://mcp.example.com/.well-known/agent-cap.json" \
     cap-sha256="dGVzdGhhc2g" bap="mcp/1,a2a/1" \
     policy="https://example.com/agent-policy" realm="production"
@@ -510,7 +510,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
   │  Step 1: Fetch HTTP Index (primary)                             │
   │  ──────────────────────────────────                             │
   │  GET https://index.aiagents.salesforce.com/index-wellknown      │
-  │  Response: [{"fqdn":"_chat._a2a._agents.salesforce.com",...}]   │
+  │  Response: [{"fqdn":"chat.salesforce.com",...}]   │
   │                                                                 │
   │  Fallback: Query TXT Index via DNS                              │
   │  Query: _index._agents.salesforce.com TXT                       │
@@ -520,7 +520,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
   ┌──┴──────────────────────────────────────────────────────────────┐
   │  Step 2: Query SVCB per agent                                   │
   │  ────────────────────────────                                   │
-  │  Query: _chat._a2a._agents.salesforce.com SVCB                  │
+  │  Query: chat.salesforce.com SVCB                  │
   │  Response: SVCB 1 chat.salesforce.com. alpn="a2a" port=443      │
   │            cap="https://chat.salesforce.com/.well-known/cap.json"│
   │  (DNSSEC validated)                                             │
@@ -537,7 +537,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
   ┌──┴──────────────────────────────────────────────────────────────┐
   │  Step 3: TXT Capabilities (fallback if no cap document)         │
   │  ──────────────────────────────────────────────────             │
-  │  Query: _chat._a2a._agents.salesforce.com TXT                   │
+  │  Query: chat.salesforce.com TXT                   │
   │  Response: "capabilities=chat,support" "version=1.0.0"          │
   └──┬──────────────────────────────────────────────────────────────┘
      │                            │                               │
@@ -1065,7 +1065,7 @@ The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-le
 
 **How DNS-AID Works:**
 1. Use your existing domain (you already own `yourcompany.com`)
-2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
+2. Add DNS-AID records to your zone (`myagent.yourcompany.com`)
 3. Start discovering and being discovered immediately
 
 | Factor | .agent gTLD | DNS-AID |
@@ -1075,13 +1075,13 @@ The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-le
 | **Who controls discovery** | Registry operator | You (your domain) |
 | **Works today** | ❌ Pending ICANN approval | ✅ Works now |
 | **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
-| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
+| **Memorable names** | ✅ `myagent.agent` | `myagent.example.com` |
 
 **The Friendly Take:**
 
 Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
 
-DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
+DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `myagent.example.com` right now.
 
 *Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
 

--- a/README.md
+++ b/README.md
@@ -9,27 +9,11 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
 [![PyPI](https://img.shields.io/pypi/v/dns-aid)](https://pypi.org/project/dns-aid/)
 
-<!-- mcp-name: io.github.dns-aid/dns-aid -->
-
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation of the DNS-AID specification, developed at the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
-
-## Relationship to IETF
-
-The DNS-AID specification is being developed within the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
-
-This repository provides a reference implementation.
-
-This project does not define the specification. The IETF draft is authoritative.
-
-## Scope of this Repository
-
-This project focuses on implementation, tooling, and ecosystem activities.
-
-Changes to protocol behavior should be discussed within the IETF.
 
 > **New to DNS-AID?** Start with the [Getting Started Guide](docs/getting-started.md) for install, first agent publication, and backend setup.
 
@@ -1025,9 +1009,81 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
-## Background and Comparison
+## Why DNS-AID?
 
-For background on how DNS-AID compares to other agent-discovery approaches (ANS, Google A2A+UCP, `.agent` gTLD, AgentDNS, NANDA, Web3, `ai.txt`) and "The Sovereignty Question", see [docs/positioning.md](docs/positioning.md). That content is non-normative — protocol positioning is determined at the IETF.
+### vs Competing Proposals
+
+| Approach | Problem | DNS-AID Advantage |
+|----------|---------|-------------------|
+| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
+| **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
+| **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
+| **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
+| **NANDA (MIT)** | New P2P overlay network, new ops paradigm | Uses infrastructure your DNS team already operates |
+| **Web3 (ERC-8004)** | Gas fees, crypto wallets, enterprise-hostile | Free DNS queries, no blockchain complexity |
+| **ai.txt / llms.txt** | No integrity verification, free-form JSON | DNSSEC cryptographic verification, structured SVCB |
+
+### Feature Comparison
+
+| Feature | DNS-AID | Central Registry | ai.txt |
+|---------|---------|------------------|--------|
+| **Decentralized** | ✅ | ❌ | ✅ |
+| **Secure (DNSSEC)** | ✅ | Varies | ❌ |
+| **Sovereign** | ✅ | ❌ | ✅ |
+| **Standards-based** | ✅ (IETF) | ❌ | ❌ |
+| **Works with existing infra** | ✅ | ❌ | ✅ |
+
+### The Sovereignty Question
+
+> **Who controls agent discovery?**
+> - ANS: GoDaddy (US company as gatekeeper)
+> - AgentDNS: China Telecom (state-owned carrier)
+> - Web3: Ethereum Foundation
+> - **DNS-AID: You control your own domain**
+>
+> DNS-AID preserves sovereignty. Organizations and nations maintain control over their own agent namespaces with no central authority that can block, censor, or surveil agent discovery.
+
+### Google's Agent Ecosystem
+
+Google is building a full-stack agent platform: **A2A** (communication), **UCP** (payments), and **Gemini/Search** (discovery). While A2A is an open protocol, discovery through Google surfaces means:
+- Google controls visibility (pay-to-rank)
+- Transaction fees via [UCP](https://developers.google.com/merchant/ucp)
+- Platform dependency for reach
+
+**DNS-AID complements A2A** by providing neutral, decentralized discovery — find agents anywhere, not just through Google.
+
+### Understanding the .agent Domain Approach
+
+The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-level domain through ICANN's [new gTLD program](https://newgtlds.icann.org/). Here's how the two approaches compare:
+
+**How .agent Domains Would Work:**
+1. Apply to ICANN for `.agent` gTLD (~$185,000 application fee)
+2. Wait 9-20 months for ICANN approval process
+3. Build registry infrastructure (Open Agent Registry, Inc.)
+4. Sell `.agent` domains through accredited registrars
+5. Users pay annual registration fees (~$15-50/year per domain)
+
+**How DNS-AID Works:**
+1. Use your existing domain (you already own `yourcompany.com`)
+2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
+3. Start discovering and being discovered immediately
+
+| Factor | .agent gTLD | DNS-AID |
+|--------|-------------|---------|
+| **Cost to publish** | ~$15-50/year domain fee | Free (use existing domain) |
+| **Time to start** | Months (gTLD launch + registration) | Minutes |
+| **Who controls discovery** | Registry operator | You (your domain) |
+| **Works today** | ❌ Pending ICANN approval | ✅ Works now |
+| **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
+| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
+
+**The Friendly Take:**
+
+Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
+
+DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
+
+*Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
 
 ## Examples
 
@@ -1076,6 +1132,6 @@ Apache 2.0
 
 ## Contributing
 
-Contributions welcome! This project supports an implementation ecosystem with planned hosting in the Linux Foundation. The DNS-AID specification is developed in the IETF.
+Contributions welcome! This project is intended for contribution to the Linux Foundation Agent AI Foundation.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -326,7 +326,7 @@ DCV is a stateless challenge/verify primitive that lets one party prove control 
 domain to another using a short-lived TXT record at `_agents-challenge.{domain}`.
 It implements [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/)
 plus the `bnd-req` binding extension from
-[draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+[draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 **Role split:**
 - *Challenger* — calls `issue()` and `verify()`; no DNS write credentials required.
@@ -761,7 +761,7 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
+**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
 
 ### InfobloxNIOSBackend
 
@@ -1837,6 +1837,6 @@ print(dns_aid.__version__)  # "0.6.0"
 ## See Also
 
 - [Getting Started Guide](getting-started.md)
-- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -78,7 +78,7 @@ async def main():
     discovery = await discover("example.com", protocol=Protocol.MCP)
 
     # Verify an agent's DNS records
-    verification = await verify("_my-agent._mcp._agents.example.com")
+    verification = await verify("my-agent.example.com")
 
 asyncio.run(main())
 ```
@@ -162,8 +162,9 @@ else:
 
 #### DNS Records Created
 
-- **SVCB**: `_{name}._{protocol}._agents.{domain}` → Service binding record
-- **TXT**: `_{name}._{protocol}._agents.{domain}` → Capabilities and metadata
+- **SVCB**: `{name}.{domain}` (draft-02 flat primary owner) → Service binding record
+- **SVCB (AliasMode, optional)**: `{name}._agents.{domain}` → walkable AliasMode pointer at the flat primary owner (suppressible via `publish_walkable_alias=False`)
+- **TXT**: `{name}.{domain}` → Capabilities and metadata (alongside the primary SVCB)
 
 ---
 
@@ -299,7 +300,7 @@ async def verify(fqdn: str) -> VerifyResult
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `fqdn` | `str` | Yes | Fully qualified domain name (e.g., "_chat._mcp._agents.example.com") |
+| `fqdn` | `str` | Yes | Fully qualified domain name (e.g., "chat.example.com") |
 
 #### Returns
 
@@ -310,7 +311,7 @@ async def verify(fqdn: str) -> VerifyResult
 ```python
 from dns_aid import verify
 
-result = await verify("_chat._mcp._agents.example.com")
+result = await verify("chat.example.com")
 
 print(f"Record exists: {result.record_exists}")
 print(f"DNSSEC valid: {result.dnssec_valid}")
@@ -574,7 +575,9 @@ agent = AgentRecord(
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `fqdn` | `str` | Full DNS-AID record name: `_{name}._{protocol}._agents.{domain}` |
+| `fqdn` | `str` | Full DNS-AID record name (draft-02 flat primary owner): `{name}.{domain}` |
+| `walkable_fqdn` | `str` | Optional walkable AliasMode form: `{name}._agents.{domain}` |
+| `legacy_fqdn` | `str` | Legacy -01 form: `_{name}._{protocol}._agents.{domain}` (used only by the back-compat discovery path) |
 | `endpoint_url` | `str` | Full URL: `https://{target_host}:{port}` |
 | `svcb_target` | `str` | SVCB target with trailing dot |
 
@@ -927,7 +930,7 @@ Sign a DNS record payload with a private key.
 from dns_aid.core.jwks import sign_record, RecordPayload
 
 payload = RecordPayload(
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="payment.example.com",
     port=443,
     alpn="mcp",
@@ -1046,7 +1049,7 @@ dns-aid discover example.com --protocol mcp
 dns-aid discover example.com --use-http-index
 
 # Verify an agent
-dns-aid verify _my-agent._mcp._agents.example.com
+dns-aid verify my-agent.example.com
 
 # List all agents in a zone
 dns-aid list example.com
@@ -1070,7 +1073,7 @@ dns-aid index sync example.com           # Sync index with actual DNS records
 ```bash
 # Send a message to an A2A agent (discover-first: DNS → agent card → invoke)
 dns-aid message --domain ai.infoblox.com --name security-analyzer \
-    "Analyze security of _marketing._a2a._agents.ai.infoblox.com"
+    "Analyze security of marketing.ai.infoblox.com"
 
 # Send a message to an A2A agent (direct endpoint)
 dns-aid message --endpoint https://security-analyzer.ai.infoblox.com \
@@ -1515,7 +1518,7 @@ async with AgentClient(config) as client:
 
     # Get rankings for specific agents only
     rankings = await client.fetch_rankings(
-        fqdns=["_booking._mcp._agents.example.com"],
+        fqdns=["booking.example.com"],
         limit=10
     )
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -84,7 +84,7 @@ async def main():
     discovery = await discover("example.com", protocol=Protocol.MCP)
 
     # Verify an agent's DNS records
-    verification = await verify("_my-agent._mcp._agents.example.com")
+    verification = await verify("my-agent.example.com")
 
 asyncio.run(main())
 ```
@@ -168,8 +168,9 @@ else:
 
 #### DNS Records Created
 
-- **SVCB**: `_{name}._{protocol}._agents.{domain}` → Service binding record
-- **TXT**: `_{name}._{protocol}._agents.{domain}` → Capabilities and metadata
+- **SVCB**: `{name}.{domain}` (draft-02 flat primary owner) → Service binding record
+- **SVCB (AliasMode, optional)**: `{name}._agents.{domain}` → walkable AliasMode pointer at the flat primary owner (suppressible via `publish_walkable_alias=False`)
+- **TXT**: `{name}.{domain}` → Capabilities and metadata (alongside the primary SVCB)
 
 ---
 
@@ -305,7 +306,7 @@ async def verify(fqdn: str) -> VerifyResult
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `fqdn` | `str` | Yes | Fully qualified domain name (e.g., "_chat._mcp._agents.example.com") |
+| `fqdn` | `str` | Yes | Fully qualified domain name (e.g., "chat.example.com") |
 
 #### Returns
 
@@ -316,7 +317,7 @@ async def verify(fqdn: str) -> VerifyResult
 ```python
 from dns_aid import verify
 
-result = await verify("_chat._mcp._agents.example.com")
+result = await verify("chat.example.com")
 
 print(f"Record exists: {result.record_exists}")
 print(f"DNSSEC valid: {result.dnssec_valid}")
@@ -580,7 +581,9 @@ agent = AgentRecord(
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `fqdn` | `str` | Full DNS-AID record name: `_{name}._{protocol}._agents.{domain}` |
+| `fqdn` | `str` | Full DNS-AID record name (draft-02 flat primary owner): `{name}.{domain}` |
+| `walkable_fqdn` | `str` | Optional walkable AliasMode form: `{name}._agents.{domain}` |
+| `legacy_fqdn` | `str` | Legacy -01 form: `_{name}._{protocol}._agents.{domain}` (used only by the back-compat discovery path) |
 | `endpoint_url` | `str` | Full URL: `https://{target_host}:{port}` |
 | `svcb_target` | `str` | SVCB target with trailing dot |
 
@@ -933,7 +936,7 @@ Sign a DNS record payload with a private key.
 from dns_aid.core.jwks import sign_record, RecordPayload
 
 payload = RecordPayload(
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="payment.example.com",
     port=443,
     alpn="mcp",
@@ -1052,7 +1055,7 @@ dns-aid discover example.com --protocol mcp
 dns-aid discover example.com --use-http-index
 
 # Verify an agent
-dns-aid verify _my-agent._mcp._agents.example.com
+dns-aid verify my-agent.example.com
 
 # List all agents in a zone
 dns-aid list example.com
@@ -1076,7 +1079,7 @@ dns-aid index sync example.com           # Sync index with actual DNS records
 ```bash
 # Send a message to an A2A agent (discover-first: DNS → agent card → invoke)
 dns-aid message --domain ai.infoblox.com --name security-analyzer \
-    "Analyze security of _marketing._a2a._agents.ai.infoblox.com"
+    "Analyze security of marketing.ai.infoblox.com"
 
 # Send a message to an A2A agent (direct endpoint)
 dns-aid message --endpoint https://security-analyzer.ai.infoblox.com \
@@ -1521,7 +1524,7 @@ async with AgentClient(config) as client:
 
     # Get rankings for specific agents only
     rankings = await client.fetch_rankings(
-        fqdns=["_booking._mcp._agents.example.com"],
+        fqdns=["booking.example.com"],
         limit=10
     )
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -332,7 +332,7 @@ DCV is a stateless challenge/verify primitive that lets one party prove control 
 domain to another using a short-lived TXT record at `_agents-challenge.{domain}`.
 It implements [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/)
 plus the `bnd-req` binding extension from
-[draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+[draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 **Role split:**
 - *Challenger* — calls `issue()` and `verify()`; no DNS write credentials required.
@@ -767,7 +767,7 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
+**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
 
 ### InfobloxNIOSBackend
 
@@ -1843,6 +1843,6 @@ print(dns_aid.__version__)  # "0.6.0"
 ## See Also
 
 - [Getting Started Guide](getting-started.md)
-- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,12 +169,24 @@ that round-trip the same inputs through every surface.
 
 ```
 1. Query TXT _index._agents.{domain} → list of agent:protocol pairs
-2. For each agent: Query SVCB _{name}._{protocol}._agents.{domain}
-   → extract endpoint, port, ALPN + DNS-AID custom params (cap, bap, policy, realm)
-3. For each agent: If cap URI present → fetch capability document (primary)
+2. For each agent: Query SVCB {name}.{domain} (draft-02 flat primary owner)
+   → extract endpoint, port, ALPN + DNS-AID custom params (cap, bap,
+   policy, realm, well-known)
+3. For each agent: If cap URI present → fetch capability document (primary).
+   Otherwise, if well-known is set, construct
+   https://<svcb-target>/.well-known/<well-known-value> and fetch
    → capabilities, version, description, use_cases, category
-4. For each agent: If no cap URI or fetch failed → query TXT for capabilities= (fallback)
+4. For each agent: If no cap/well-known URI or fetch failed → query TXT
+   for capabilities= (fallback)
 ```
+
+Under draft-mozleywilliams-dnsop-dnsaid-02 the agent's primary owner
+name is a flat FQDN `{name}.{domain}` valid as an x.509 SAN dNSName;
+publishers MAY additionally publish a walkable AliasMode record at
+`{name}._agents.{domain}` so DNS-SD-style consumers can enumerate.
+Consumers MUST try the flat form first. Older publishers using the
+legacy `-01` form `_{name}._{protocol}._agents.{domain}` are
+resolvable when consumers set `DNS_AID_LEGACY_01_FALLBACK=1`.
 
 ### HTTP Index Discovery
 
@@ -543,7 +555,7 @@ The JWS payload contains the canonical representation of the DNS record:
 
 ```json
 {
-  "fqdn": "_payment._mcp._agents.example.com",
+  "fqdn": "payment.example.com",
   "target": "payment.example.com",
   "port": 443,
   "alpn": "mcp",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,14 +2,8 @@
 
 ## Overview
 
-This implementation follows the IETF draft-mozleywilliams-dnsop-dnsaid protocol for
+DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-02 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
-
-## Relationship to IETF
-
-This document describes the architecture and behavior of the reference implementation.
-
-The authoritative DNS-AID specification is defined in the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
 
 ---
 
@@ -28,7 +22,7 @@ explains why certain fields (description, use_cases, category) may appear as
 | **HTTP Index** (`/.well-known/agent-index.json`) | JSON document | Full | Authoritative |
 | **TXT Record** (`capabilities=...`) | Key-value strings | Minimal (capabilities + version only) | Fallback |
 
-### Implementation Resolution Strategy
+### Resolution Priority
 
 ```
 Agent discovered via SVCB record
@@ -191,12 +185,6 @@ that round-trip the same inputs through every surface.
    - Found → endpoint_source = "dns_svcb" (authoritative)
    - Not found → endpoint_source = "http_index_fallback"
 ```
-
-## Future Enhancements (Non-Normative)
-
-These are implementation proposals and are not part of the current IETF draft.
-
-Items in this section may inform future versions of the specification but should not be treated as authoritative.
 
 ### Future Enhancement: HTTP Index Fallback in DNS Mode
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-01 protocol for
+DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-02 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
 
 ---

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -86,10 +86,10 @@ dns-aid publish \
 
 # Expected output:
 # ✓ Agent published successfully!
-#   FQDN: _multiagent._a2a._agents.example.com
+#   FQDN: multiagent.example.com
 #   Records created:
-#     • SVCB _multiagent._a2a._agents.example.com  (alpn="a2a")
-#     • TXT _multiagent._a2a._agents.example.com
+#     • SVCB multiagent.example.com  (alpn="a2a")
+#     • TXT multiagent.example.com
 # ✓ Updated index at _index._agents.example.com (1 agent(s))
 ```
 
@@ -105,11 +105,11 @@ dns-aid publish \
 
 ```bash
 # Using dig
-dig _multiagent._a2a._agents.example.com SVCB +short
-dig _multiagent._a2a._agents.example.com TXT +short
+dig multiagent.example.com SVCB +short
+dig multiagent.example.com TXT +short
 
 # Using DNS-AID verify (shows security score)
-dns-aid verify _multiagent._a2a._agents.example.com
+dns-aid verify multiagent.example.com
 
 # Expected:
 #   ✓ DNS record exists
@@ -132,7 +132,7 @@ dns-aid index list example.com
 # ┌────────────┬──────────┬─────────────────────────────────────────────┐
 # │ Name       │ Protocol │ FQDN                                        │
 # ├────────────┼──────────┼─────────────────────────────────────────────┤
-# │ multiagent │ a2a      │ _multiagent._a2a._agents.highvelocity...    │
+# │ multiagent │ a2a      │ multiagent.highvelocity...    │
 # └────────────┴──────────┴─────────────────────────────────────────────┘
 #
 # Total: 1 agent(s) in index
@@ -236,7 +236,7 @@ async def discover_and_connect():
     # === STEP 1: DNS Discovery ===
     print("🔍 Step 1: Querying DNS for agent...")
 
-    fqdn = "_multiagent._a2a._agents.example.com"
+    fqdn = "multiagent.example.com"
 
     # Query SVCB record
     answers = dns.resolver.resolve(fqdn, "SVCB")
@@ -690,7 +690,7 @@ Found 5 flights from NYC to London on March 15:
 │  │                  DNS-AID MCP Server                      │   │
 │  │                                                          │   │
 │  │  1. discover_agents_via_dns("example.com")│   │
-│  │     └─► DNS query for _booking._mcp._agents.*.com       │   │
+│  │     └─► DNS query for booking.*.com       │   │
 │  │     └─► Returns: endpoint_url from SVCB/HTTP index      │   │
 │  │                                                          │   │
 │  │  2. call_agent_tool(endpoint, "search_flights", params)  │   │
@@ -759,13 +759,13 @@ Capabilities are resolved with the following priority, aligned with the DNS-AID 
 
 **SVCB record with cap URI** (per DNS-AID draft):
 ```
-_booking._mcp._agents.example.com. SVCB 1 mcp.example.com. \
+booking.example.com. SVCB 1 mcp.example.com. \
     alpn="mcp" port=443 cap="https://index.aiagents.example.com/cap/booking-agent"
 ```
 
 ### Discovery Transparency
 
-Agent name and protocol are now extracted from the FQDN (e.g., `_booking._mcp._agents.example.com` → name=`booking`, protocol=`mcp`). The HTTP index only needs to provide the FQDN — no separate `protocols` field required.
+Agent name and protocol are now extracted from the FQDN (e.g., `booking.example.com` → name=`booking`, protocol=`mcp`). The HTTP index only needs to provide the FQDN — no separate `protocols` field required.
 
 Each discovered agent includes transparency fields showing how data was resolved:
 
@@ -934,14 +934,14 @@ dns-aid publish \
 dns-aid discover example.com --verify-signature
 
 # Output (valid signature):
-# ✓ Signature verified for _payment._mcp._agents.example.com
+# ✓ Signature verified for payment.example.com
 # Found 1 agent(s):
 # - payment (MCP protocol)
 #   Endpoint: https://mcp.example.com:443
 #   Signature: VALID ✓
 
 # Output (invalid/missing signature):
-# ⚠ Signature verification failed for _payment._mcp._agents.example.com
+# ⚠ Signature verification failed for payment.example.com
 #   Reason: No JWKS found at https://example.com/.well-known/dns-aid-jwks.json
 ```
 
@@ -959,7 +959,7 @@ The JWS payload contains canonical SVCB record data:
 
 ```json
 {
-  "fqdn": "_payment._mcp._agents.example.com",
+  "fqdn": "payment.example.com",
   "target": "mcp.example.com",
   "port": 443,
   "alpn": "mcp",
@@ -979,7 +979,7 @@ private_key, public_key = generate_keypair()
 # Sign a record
 signature = sign_record(
     private_key=private_key,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -988,7 +988,7 @@ signature = sign_record(
 is_valid = await verify_signature(
     domain="example.com",
     signature=signature,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -292,7 +292,7 @@ asyncio.run(verify_connection())
 ### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI is **not fully compliant** with the
-> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 >
 > Infoblox UDDI SVCB only supports "alias mode" (priority 0) and lacks support for required
 > SVC parameters (`alpn`, `port`, `mandatory`). The DNS-AID draft requires ServiceMode
@@ -1680,4 +1680,4 @@ stable public API. They will be integrated in a future release once the
 
 - Read the [API Reference](api-reference.md)
 - Explore [examples/](../examples/)
-- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,7 +286,7 @@ asyncio.run(verify_connection())
 ### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI is **not fully compliant** with the
-> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 >
 > Infoblox UDDI SVCB only supports "alias mode" (priority 0) and lacks support for required
 > SVC parameters (`alpn`, `port`, `mandatory`). The DNS-AID draft requires ServiceMode
@@ -1674,4 +1674,4 @@ stable public API. They will be integrated in a future release once the
 
 - Read the [API Reference](api-reference.md)
 - Explore [examples/](../examples/)
-- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -560,7 +560,7 @@ dns-aid publish \
     --backend cloudflare
 
 # Verify it was created
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
+dig test-agent.$DNS_AID_TEST_ZONE TXT +short
 
 # View the agent index
 dns-aid index list $DNS_AID_TEST_ZONE --backend cloudflare
@@ -683,27 +683,27 @@ Publishing agent to DNS...
 
 ✓ Agent published successfully!
 
-  FQDN: _test-agent._mcp._agents.yourdomain.com
+  FQDN: test-agent.yourdomain.com
   Endpoint: https://mcp.yourdomain.com:443
 
   Records created:
-    • SVCB _test-agent._mcp._agents.yourdomain.com
-    • TXT _test-agent._mcp._agents.yourdomain.com
+    • SVCB test-agent.yourdomain.com
+    • TXT test-agent.yourdomain.com
 
 Verify with:
-  dig _test-agent._mcp._agents.yourdomain.com SVCB
-  dig _test-agent._mcp._agents.yourdomain.com TXT
+  dig test-agent.yourdomain.com SVCB
+  dig test-agent.yourdomain.com TXT
 ```
 
 ### Step 2: Verify DNS Records
 
 ```bash
 # Using DNS-AID
-dns-aid verify _test-agent._mcp._agents.$DNS_AID_TEST_ZONE
+dns-aid verify test-agent.$DNS_AID_TEST_ZONE
 
 # Using dig (external verification)
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE SVCB +short
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
+dig test-agent.$DNS_AID_TEST_ZONE SVCB +short
+dig test-agent.$DNS_AID_TEST_ZONE TXT +short
 ```
 
 ### Step 3: Discover Agents
@@ -751,7 +751,7 @@ Agent index for yourdomain.com:
 ┌────────────┬──────────┬─────────────────────────────────────────────┐
 │ Name       │ Protocol │ FQDN                                        │
 ├────────────┼──────────┼─────────────────────────────────────────────┤
-│ test-agent │ mcp      │ _test-agent._mcp._agents.yourdomain.com     │
+│ test-agent │ mcp      │ test-agent.yourdomain.com     │
 └────────────┴──────────┴─────────────────────────────────────────────┘
 
 Total: 1 agent(s) in index
@@ -885,7 +885,7 @@ async def main():
         print(f"Found: {agent.name} at {agent.endpoint_url}")
 
     # Verify an agent
-    verification = await verify("_my-agent._mcp._agents.yourdomain.com")
+    verification = await verify("my-agent.yourdomain.com")
     print(f"Security Score: {verification.security_score}/100")
 
 asyncio.run(main())
@@ -902,7 +902,7 @@ enforcing agent access control at the DNS layer.
 ```json
 {
   "version": "1.0",
-  "agent": "_inventory._mcp._agents.example.com",
+  "agent": "inventory.example.com",
   "rules": {
     "allowed_caller_domains": ["ai-platform.example.com"],
     "blocked_caller_domains": ["*.sandbox.example.com"],
@@ -1000,7 +1000,7 @@ private_key, public_key = generate_keypair()
 # Sign a record
 signature = sign_record(
     private_key=private_key,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -1009,7 +1009,7 @@ signature = sign_record(
 is_valid = await verify_signature(
     domain="example.com",
     signature=signature,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -1040,7 +1040,7 @@ async def main():
     result = await send_a2a_message(
         domain="ai.infoblox.com",
         name="security-analyzer",
-        message="Analyze security of _marketing._a2a._agents.ai.infoblox.com",
+        message="Analyze security of marketing.ai.infoblox.com",
         timeout=60.0,
     )
     if result.success:
@@ -1053,7 +1053,7 @@ asyncio.run(main())
 ```
 
 The discover-first flow:
-1. Queries DNS for `_security-analyzer._a2a._agents.ai.infoblox.com` SVCB record
+1. Queries DNS for `security-analyzer.ai.infoblox.com` SVCB record
 2. Fetches `/.well-known/agent-card.json` for canonical URL and metadata
 3. Validates card URL hostname matches DNS endpoint (prevents internal URL leakage)
 4. Sends the A2A JSON-RPC 2.0 `message/send` request

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -554,7 +554,7 @@ dns-aid publish \
     --backend cloudflare
 
 # Verify it was created
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
+dig test-agent.$DNS_AID_TEST_ZONE TXT +short
 
 # View the agent index
 dns-aid index list $DNS_AID_TEST_ZONE --backend cloudflare
@@ -677,27 +677,27 @@ Publishing agent to DNS...
 
 ✓ Agent published successfully!
 
-  FQDN: _test-agent._mcp._agents.yourdomain.com
+  FQDN: test-agent.yourdomain.com
   Endpoint: https://mcp.yourdomain.com:443
 
   Records created:
-    • SVCB _test-agent._mcp._agents.yourdomain.com
-    • TXT _test-agent._mcp._agents.yourdomain.com
+    • SVCB test-agent.yourdomain.com
+    • TXT test-agent.yourdomain.com
 
 Verify with:
-  dig _test-agent._mcp._agents.yourdomain.com SVCB
-  dig _test-agent._mcp._agents.yourdomain.com TXT
+  dig test-agent.yourdomain.com SVCB
+  dig test-agent.yourdomain.com TXT
 ```
 
 ### Step 2: Verify DNS Records
 
 ```bash
 # Using DNS-AID
-dns-aid verify _test-agent._mcp._agents.$DNS_AID_TEST_ZONE
+dns-aid verify test-agent.$DNS_AID_TEST_ZONE
 
 # Using dig (external verification)
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE SVCB +short
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
+dig test-agent.$DNS_AID_TEST_ZONE SVCB +short
+dig test-agent.$DNS_AID_TEST_ZONE TXT +short
 ```
 
 ### Step 3: Discover Agents
@@ -745,7 +745,7 @@ Agent index for yourdomain.com:
 ┌────────────┬──────────┬─────────────────────────────────────────────┐
 │ Name       │ Protocol │ FQDN                                        │
 ├────────────┼──────────┼─────────────────────────────────────────────┤
-│ test-agent │ mcp      │ _test-agent._mcp._agents.yourdomain.com     │
+│ test-agent │ mcp      │ test-agent.yourdomain.com     │
 └────────────┴──────────┴─────────────────────────────────────────────┘
 
 Total: 1 agent(s) in index
@@ -879,7 +879,7 @@ async def main():
         print(f"Found: {agent.name} at {agent.endpoint_url}")
 
     # Verify an agent
-    verification = await verify("_my-agent._mcp._agents.yourdomain.com")
+    verification = await verify("my-agent.yourdomain.com")
     print(f"Security Score: {verification.security_score}/100")
 
 asyncio.run(main())
@@ -896,7 +896,7 @@ enforcing agent access control at the DNS layer.
 ```json
 {
   "version": "1.0",
-  "agent": "_inventory._mcp._agents.example.com",
+  "agent": "inventory.example.com",
   "rules": {
     "allowed_caller_domains": ["ai-platform.example.com"],
     "blocked_caller_domains": ["*.sandbox.example.com"],
@@ -994,7 +994,7 @@ private_key, public_key = generate_keypair()
 # Sign a record
 signature = sign_record(
     private_key=private_key,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -1003,7 +1003,7 @@ signature = sign_record(
 is_valid = await verify_signature(
     domain="example.com",
     signature=signature,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -1034,7 +1034,7 @@ async def main():
     result = await send_a2a_message(
         domain="ai.infoblox.com",
         name="security-analyzer",
-        message="Analyze security of _marketing._a2a._agents.ai.infoblox.com",
+        message="Analyze security of marketing.ai.infoblox.com",
         timeout=60.0,
     )
     if result.success:
@@ -1047,7 +1047,7 @@ asyncio.run(main())
 ```
 
 The discover-first flow:
-1. Queries DNS for `_security-analyzer._a2a._agents.ai.infoblox.com` SVCB record
+1. Queries DNS for `security-analyzer.ai.infoblox.com` SVCB record
 2. Fetches `/.well-known/agent-card.json` for canonical URL and metadata
 3. Validates card URL hostname matches DNS endpoint (prevents internal URL leakage)
 4. Sends the A2A JSON-RPC 2.0 `message/send` request

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -270,7 +270,7 @@ await publish(
 ```python
 from dns_aid.core.validator import verify
 
-result = await verify("_network-specialist._mcp._agents.example.com")
+result = await verify("network-specialist.example.com")
 print(f"DNSSEC valid: {result.dnssec_valid}")
 print(f"Security rating: {result.security_rating}")
 ```

--- a/docs/integrations/opentelemetry.md
+++ b/docs/integrations/opentelemetry.md
@@ -37,7 +37,7 @@ agent's span. Total elapsed: under 10 minutes from clone.
 
 ### Spans
 
-- Name: `dns-aid.invoke {agent_fqdn}` (e.g., `dns-aid.invoke _chat._mcp._agents.example.com`)
+- Name: `dns-aid.invoke {agent_fqdn}` (e.g., `dns-aid.invoke chat.example.com`)
 - Kind: `SpanKind.CLIENT`
 - Attributes (set at span open): `dns_aid.agent.name`, `dns_aid.agent.domain`,
   `dns_aid.agent.protocol`, `dns_aid.agent.endpoint` (credentials in URL

--- a/docs/mcp-directory-listing.md
+++ b/docs/mcp-directory-listing.md
@@ -22,7 +22,7 @@ SVCB record queries.
 
 ### Prompt 2: Verify an agent's DNS security
 
-> Verify the DNS records for _network._mcp._agents.example.com
+> Verify the DNS records for network.example.com
 > and tell me if DNSSEC is valid
 
 Expected: Returns DNS record validation results including SVCB record

--- a/docs/privacy-considerations.md
+++ b/docs/privacy-considerations.md
@@ -1,0 +1,138 @@
+# Privacy Considerations
+
+DNS-AID publishes service-discovery records in DNS. By design, DNS is a
+public namespace — any client that can resolve names in your zone can
+read what you publish. This document describes the privacy trade-offs
+baked into each record type so operators can choose the right defaults
+for their deployment.
+
+## Enumeration vs. Discovery
+
+There's a distinction worth naming up front:
+
+- **Discovery** is the case where a caller already knows the agent name
+  it wants and resolves a specific FQDN — `chat.example.com`,
+  `pharmacy-delivery.acmehealth.com`. This is the everyday flow and is
+  fundamentally what DNS is for.
+- **Enumeration** is the case where a caller doesn't know the agent
+  names in advance and discovers them by walking the zone. DNS-AID
+  optionally supports this via DNS-SD-style records, but it's a
+  different privacy posture: enumeration lets *anyone* inventory the
+  agents an operator has published.
+
+Most operators want discovery without enumeration. Some — operators
+running intentional public directories, internal indexes, or
+DNS-SD-style consumers — want both. The defaults in dns-aid-core
+reflect "discovery on, enumeration off" and the per-record knobs let
+you opt into enumeration deliberately.
+
+## The Walkable AliasMode Record
+
+Under draft-mozleywilliams-dnsop-dnsaid-02 §3.1, publishers MAY emit a
+walkable AliasMode SVCB record at `{name}._agents.{domain}` pointing at
+the flat primary owner `{name}.{domain}`. This record exists so
+DNS-SD-style consumers and crawlers can enumerate an operator's agents
+by walking `_agents.{domain}` and following each AliasMode to the
+canonical owner.
+
+**dns-aid-core publishes this record only when explicitly enabled.**
+The default is `publish_walkable_alias=False` (SDK), `--walkable`
+(CLI flag, opt-in), and `publish_walkable_alias=False` (MCP tool).
+
+### Why off by default
+
+The walkable record is, by construction, an enumeration handle. With
+the walkable record present, a caller that knows your zone name can:
+
+1. Query `_agents.{zone}` for SVCB records, or zone-walk the
+   `_agents.{zone}` namespace under DNSSEC's NSEC/NSEC3 records.
+2. Receive a list of every `{name}._agents.{zone}` your operator
+   publishes.
+3. Follow the AliasMode for each one to learn the canonical owner
+   `{name}.{zone}`.
+
+Net effect: complete inventory of your agents from the zone name
+alone. For a public commercial service that wants to be discoverable,
+this is exactly the desired behaviour. For a healthcare operator with
+internal-only agents whose names indirectly reveal sensitive workflows
+(`oncology-triage`, `crisis-helpline`), it's the wrong default.
+
+Erring on the side of less information leakage matches the privacy
+posture of the rest of the stack: DNSSEC zone-walking has been a
+known privacy issue since RFC 5155, and NSEC3-opt-out exists to limit
+exactly this kind of enumeration.
+
+### When to enable
+
+Set `publish_walkable_alias=True` (or pass `--walkable` to the CLI)
+when:
+
+- **You're running a public agent directory** — a curated catalog of
+  agents intentionally meant to be discovered by anyone. The walkable
+  shape is the most standard way to expose that.
+- **You're running an internal directory or DNS-SD-style index** —
+  on private networks where enumeration by callers inside your
+  perimeter is desirable and the records aren't reachable from
+  outside.
+- **You're publishing a DNS-SD-bridged service** — interop with
+  consumers that already speak the DNS-SD enumeration shape.
+- **You want crawler discoverability** for an agent-catalog project
+  (e.g. dns-aid.org's spider) and are okay with the enumeration
+  surface that implies.
+
+For any of those cases, the walkable record is doing useful work and
+the privacy cost is acceptable.
+
+### When to leave it off
+
+Leave the default in place when:
+
+- **The agent's existence or name is sensitive** — anything where the
+  name itself signals workflow detail you don't want indexed by
+  third-party DNS scanners.
+- **You have a small, fixed set of consumers** who already know the
+  agent FQDNs they need (out-of-band exchange, configuration, or
+  partner agreements).
+- **You publish a large number of agents in one zone** — even if no
+  individual name is sensitive, the aggregate inventory may reveal
+  operational scale you'd rather keep private.
+
+### What discovery still works without the walkable record
+
+Without the walkable record, a caller can still:
+
+- Resolve a specific known agent by querying `{name}.{domain}`
+  directly. This is unaffected.
+- Find agents through an organisation index at
+  `_index._agents.{domain}` — which is a separate, intentionally
+  publishable list of names the operator chose to include. Operators
+  curate this list; the walkable record is opt-out-of-curation.
+
+So the choice "walkable off, organisation index on" gives consumers a
+discovery list the operator controls while denying random crawlers an
+inventory handle.
+
+## Other Records Worth Noting
+
+- **The organisation index** (`_index._agents.{domain}`) is explicitly
+  a curated list — operators choose what to put there. There's no
+  privacy hazard beyond what the operator has already decided to
+  publish.
+- **TLSA records** (`_443._tcp.{name}.{domain}`) pin certificates to
+  DNS-anchored trust. They reveal that the agent uses TLS at a given
+  port and bind it to a cert chain; they don't reveal the agent's
+  capabilities or activity.
+- **Capability descriptors** referenced by `cap` or `well-known` are
+  fetched over HTTPS to the SVCB target. Their content is whatever
+  the operator chose to publish there — typically a capability list,
+  schema URIs, and contact info. Operators concerned about leaking
+  capability detail can put a minimal pointer behind authentication
+  on the descriptor URL itself.
+
+## Summary
+
+Default off for the walkable record. Default on for the flat primary
+owner. Explicit opt-in for any record whose primary purpose is
+enumeration. Operators who want their agents indexed turn enumeration
+on deliberately; operators who don't, get the privacy-preserving
+shape by default.

--- a/docs/rfc/iana-considerations.md
+++ b/docs/rfc/iana-considerations.md
@@ -1,6 +1,6 @@
 # IANA Considerations
 
-This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Underscored Node Names Registry
 
@@ -10,20 +10,23 @@ Per [RFC 8552](https://www.rfc-editor.org/rfc/rfc8552.html) (Scoped Interpretati
 
 | RR Type | _NODE NAME | Reference |
 |---------|------------|-----------|
-| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
-| TXT | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
+| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-02 |
+| SVCB | `_index` | draft-mozleywilliams-dnsop-dnsaid-02 |
+| TXT | `_agents-challenge` | draft-mozleywilliams-dnsop-dnsaid-02 (experimental, §DCV) |
 
-**Purpose:** The `_agents` underscore name designates a subtree for AI agent service discovery records. Records under this name follow the pattern:
-
-```
-_{agent-name}._{protocol}._agents.{domain}.
-```
+**Purpose:** Under -02, the agent's primary owner name is a flat FQDN `{agent}.{domain}` (no underscore-prefix labels, x.509-SAN-valid). Operators MAY additionally publish a walkable AliasMode record at `{agent}._agents.{domain}` so that crawlers and DNS-SD-style consumers can enumerate. The `_index._agents.{domain}` SVCB record points at the organization-level agent index. The `_agents-challenge.{domain}` TXT record is used by the experimental domain-control-validation mechanism described in -02 §FutureWork.
 
 **Examples:**
 ```
-_network._mcp._agents.example.com.    SVCB 1 mcp.example.com. alpn="mcp" port=443
-_chat._a2a._agents.example.com.       SVCB 1 chat.example.com. alpn="a2a" port=443
-_assistant._https._agents.example.com. SVCB 1 api.example.com. alpn="h2" port=443
+# Flat primary owner — the form publishers SHOULD support and consumers MUST try first
+network.example.com.   SVCB 1 mcp.example.com. alpn="mcp" port=443 bap="mcp"
+chat.example.com.      SVCB 1 chat.example.com. alpn="a2a" port=443 bap="a2a"
+
+# Optional walkable AliasMode at the _agents leaf
+chat._agents.example.com. SVCB 0 chat.example.com.
+
+# Organization index — TargetName must not contain underscores (it carries a public x.509 cert)
+_index._agents.example.com. SVCB 1 agent-index.example.com.
 ```
 
 ## 2. TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs
@@ -34,7 +37,7 @@ This document requests registration of the following ALPN Protocol ID in the "TL
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-01 |
+| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-02 |
 
 **Description:** The Model Context Protocol (MCP) is a protocol for AI model context sharing and tool invocation, originally developed by Anthropic. The `mcp` ALPN identifier signals that the TLS connection will carry MCP traffic.
 
@@ -46,7 +49,7 @@ This document requests registration of the following ALPN Protocol ID:
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-01 |
+| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-02 |
 
 **Description:** The Agent-to-Agent (A2A) protocol enables direct communication between AI agents, originally developed by Google. The `a2a` ALPN identifier signals that the TLS connection will carry A2A traffic.
 
@@ -62,7 +65,7 @@ This document requests IANA establish a new registry titled "DNS-AID Error Codes
 
 **Registration Procedure:** Specification Required
 
-**Reference:** draft-mozleywilliams-dnsop-dnsaid-01
+**Reference:** draft-mozleywilliams-dnsop-dnsaid-02
 
 ### 3.2 Initial Registry Contents
 
@@ -98,17 +101,27 @@ DNS-AID uses the following existing parameters defined in [RFC 9460](https://www
 | alpn | 1 | RFC 9460 Section 7.1.1 |
 | port | 3 | RFC 9460 Section 7.2 |
 
-### 4.2 DNS-AID Custom Parameters (draft-01 Section 4.4.3)
+### 4.2 DNS-AID Custom Parameters (draft-02 §4 IANA Considerations)
 
-This document requests registration of the following SVCB service parameters in the private-use range (65280-65534) per RFC 9460 Section 14.3.2:
+This document requests IANA registration of six SvcParamKeys per RFC 9460 §14.3.2. The numeric code points are deferred to IANA assignment; until then, implementations use the private-use range (65280-65534). The keys below sit at 65400-65409.
 
 | Parameter | Proposed Key ID | Value Format | Description | Reference |
 |-----------|-----------------|--------------|-------------|-----------|
-| `cap` | 65400 | URI (RFC 3986) | URI to capability descriptor document (JSON). Allows clients to fetch structured agent metadata. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `capsha256` | 65401 | Base64url (RFC 4648 §5) | SHA-256 digest of the capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `bap` | 65402 | Comma-separated tokens | DNS-AID Application Protocols — lists protocols the agent supports with optional versions (e.g., `mcp/1,a2a/1`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `policy` | 65403 | URI (RFC 3986) | URI to agent policy document describing terms of use, data handling, and compliance. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `realm` | 65404 | Token | Multi-tenant scope identifier for authorization (e.g., `production`, `staging`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `cap` | 65400 | URI or URN (RFC 3986) or compact JSON-Ref | Capability descriptor locator or inline identifier. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `cap-sha256` | 65401 | Base64url (RFC 4648 §5) | Base64url SHA-256 of the canonical capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `bap` | 65402 | Comma-separated tokens | Bulk agent protocols supported at this endpoint (e.g., `mcp`, `a2a`). The agent protocol the endpoint speaks once TLS is established. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `policy` | 65403 | URI (RFC 3986) | URI of an associated policy bundle (terms of use, data handling, compliance). Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `realm` | 65404 | Token | Opaque token for multi-tenant scoping or authz realm selection during protocol bootstrapping. Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `well-known` | 65409 | RFC 8615 path | Well-known URI path suffix (e.g., `agent-card.json`). Consumer constructs `https://<target>/.well-known/<value>`. Complements `cap` (which is a flexible locator); the two are independent keys. | draft-mozleywilliams-dnsop-dnsaid-02 |
+
+The following keys remain at private-use code points but are NOT in the -02 normative SvcParamKey set; they back features that are either in §FutureWork or shipping in dns-aid-core as extensions:
+
+| Parameter | Key ID | Notes |
+|-----------|--------|-------|
+| `sig` | 65405 | JWS signature over the record. Backs the optional record-signature flow. |
+| `connect-class` | 65406 | Transport-class hint (§FutureWork — `direct`, `lattice`, `apphub-psc`). |
+| `connect-meta` | 65407 | Transport-class metadata for the selected `connect-class`. |
+| `enroll-uri` | 65408 | Zero-trust enrollment URI (§FutureWork). |
 
 **Wire Format:** Until IANA allocates permanent key IDs, implementations MUST use the generic `keyNNNNN` presentation format (e.g., `key65400="https://..."`) for interoperability with DNS providers that do not recognize custom parameter names. See Section 2.2 of RFC 9460.
 
@@ -133,6 +146,6 @@ For the DNS-AID Error Code Registry, designated experts SHOULD consider:
 
 ### Informative References
 
-- [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/) - DNS-based Agent Identification and Discovery (DNS-AID)
+- [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/) - DNS-based Agent Identification and Discovery (DNS-AID)
 - [Model Context Protocol](https://spec.modelcontextprotocol.io/) - MCP Specification
 - [A2A Protocol](https://google.github.io/A2A/) - Agent-to-Agent Protocol Documentation

--- a/docs/rfc/iana-considerations.md
+++ b/docs/rfc/iana-considerations.md
@@ -14,7 +14,7 @@ Per [RFC 8552](https://www.rfc-editor.org/rfc/rfc8552.html) (Scoped Interpretati
 | SVCB | `_index` | draft-mozleywilliams-dnsop-dnsaid-02 |
 | TXT | `_agents-challenge` | draft-mozleywilliams-dnsop-dnsaid-02 (experimental, §DCV) |
 
-**Purpose:** Under -02, the agent's primary owner name is a flat FQDN `{agent}.{domain}` (no underscore-prefix labels, x.509-SAN-valid). Operators MAY additionally publish a walkable AliasMode record at `{agent}._agents.{domain}` so that crawlers and DNS-SD-style consumers can enumerate. The `_index._agents.{domain}` SVCB record points at the organization-level agent index. The `_agents-challenge.{domain}` TXT record is used by the experimental domain-control-validation mechanism described in -02 §FutureWork.
+**Purpose:** Under -02, the agent's primary owner name is a flat FQDN `{agent}.{domain}` (no underscore-prefix labels, x.509-SAN-valid). Operators MAY additionally publish a walkable AliasMode record at `{agent}._agents.{domain}` so that crawlers and DNS-SD-style consumers can enumerate. The `_index._agents.{domain}` SVCB record points at the organization-level agent index. The `_agents-challenge.{domain}` TXT record is used by the experimental domain-control-validation mechanism described in -02 §5 (Future Work and Experimental Mechanisms).
 
 **Examples:**
 ```
@@ -114,14 +114,14 @@ This document requests IANA registration of six SvcParamKeys per RFC 9460 §14.3
 | `realm` | 65404 | Token | Opaque token for multi-tenant scoping or authz realm selection during protocol bootstrapping. Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
 | `well-known` | 65409 | RFC 8615 path | Well-known URI path suffix (e.g., `agent-card.json`). Consumer constructs `https://<target>/.well-known/<value>`. Complements `cap` (which is a flexible locator); the two are independent keys. | draft-mozleywilliams-dnsop-dnsaid-02 |
 
-The following keys remain at private-use code points but are NOT in the -02 normative SvcParamKey set; they back features that are either in §FutureWork or shipping in dns-aid-core as extensions:
+The following keys remain at private-use code points but are NOT in the -02 normative SvcParamKey set; they back features that are either in §5 (Future Work and Experimental Mechanisms) or shipping in dns-aid-core as extensions:
 
 | Parameter | Key ID | Notes |
 |-----------|--------|-------|
 | `sig` | 65405 | JWS signature over the record. Backs the optional record-signature flow. |
-| `connect-class` | 65406 | Transport-class hint (§FutureWork — `direct`, `lattice`, `apphub-psc`). |
+| `connect-class` | 65406 | Transport-class hint (§5 (Future Work and Experimental Mechanisms) — `direct`, `lattice`, `apphub-psc`). |
 | `connect-meta` | 65407 | Transport-class metadata for the selected `connect-class`. |
-| `enroll-uri` | 65408 | Zero-trust enrollment URI (§FutureWork). |
+| `enroll-uri` | 65408 | Zero-trust enrollment URI (§5 (Future Work and Experimental Mechanisms)). |
 
 **Wire Format:** Until IANA allocates permanent key IDs, implementations MUST use the generic `keyNNNNN` presentation format (e.g., `key65400="https://..."`) for interoperability with DNS providers that do not recognize custom parameter names. See Section 2.2 of RFC 9460.
 

--- a/docs/rfc/privacy-considerations.md
+++ b/docs/rfc/privacy-considerations.md
@@ -1,6 +1,6 @@
 # Privacy Considerations
 
-This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Privacy Model
 

--- a/docs/rfc/privacy-considerations.md
+++ b/docs/rfc/privacy-considerations.md
@@ -59,7 +59,7 @@ Domain owners can request removal of their agents from the directory:
 
 **Option 1: API Request (Verified Domain)**
 ```http
-DELETE /api/v1/agents/_network._mcp._agents.example.com
+DELETE /api/v1/agents/network.example.com
 Authorization: Bearer <domain-verified-token>
 ```
 

--- a/docs/rfc/security-considerations.md
+++ b/docs/rfc/security-considerations.md
@@ -1,6 +1,6 @@
 # Security Considerations
 
-This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Threat Model (STRIDE Analysis)
 

--- a/docs/rfc/security-considerations.md
+++ b/docs/rfc/security-considerations.md
@@ -187,7 +187,7 @@ zone "example.com" {
 
 **Secure SVCB Example:**
 ```
-_network._mcp._agents.example.com. 3600 IN SVCB 1 mcp.example.com. (
+network.example.com. 3600 IN SVCB 1 mcp.example.com. (
     mandatory="alpn"
     alpn="mcp"
     port="443"

--- a/docs/rfc/wire-format-01.abnf
+++ b/docs/rfc/wire-format-01.abnf
@@ -1,5 +1,5 @@
 ; DNS-AID Wire Format - ABNF Grammar
-; Reference: draft-mozleywilliams-dnsop-dnsaid-02
+; Reference: draft-mozleywilliams-dnsop-dnsaid-01
 ;
 ; This document defines the wire format for DNS-AID records using
 ; Augmented Backus-Naur Form (ABNF) as specified in RFC 5234.
@@ -22,35 +22,23 @@ DQUOTE         = %x22                ; " (double quote)
 VCHAR          = %x21-7E             ; visible (printing) characters
 
 ; ==================================================================
-; DNS-AID FQDN Format (draft-02)
+; DNS-AID FQDN Format
 ; ==================================================================
 
-; The agent's primary owner name is a flat FQDN, valid as an x.509
-; SAN dNSName. Publishers MAY additionally publish a walkable
-; AliasMode record at the _agents leaf so crawlers and DNS-SD-style
-; consumers can enumerate. Consumers MUST try the flat form first.
+; DNS-AID agent FQDN follows the pattern:
+; _{agent-name}._{protocol}._agents.{domain}.
 
-dns-aid-fqdn          = agent-name "." domain "."
-                        ; Flat primary owner — the form publishers
-                        ; SHOULD support and consumers MUST try first
-
-dns-aid-walkable-fqdn = agent-name "._agents." domain "."
-                        ; Optional walkable AliasMode at the
-                        ; _agents leaf; SVCB priority MUST be 0
-                        ; (AliasMode) pointing at the flat owner
+dns-aid-fqdn   = "_" agent-name "._" protocol "._agents." domain "."
 
 agent-name     = 1*63(ALPHA / DIGIT / "-")
                  ; Agent name: alphanumeric with hyphens
                  ; Max 63 characters per DNS label rules
-                 ; The agent protocol is NOT in the FQDN under -02;
-                 ; it lives in the `bap` SvcParamKey (or `alpn` when
-                 ; only one protocol is supported)
 
-protocol       = "mcp" / "a2a" / extension-protocol
-                 ; Agent protocols (values for `bap` and, when only
-                 ; one is supported, `alpn`)
+protocol       = "mcp" / "a2a" / "https" / extension-protocol
+                 ; Supported protocols
                  ; mcp  = Model Context Protocol
                  ; a2a  = Agent-to-Agent Protocol
+                 ; https = Standard HTTPS
 
 extension-protocol = "x-" 1*62(ALPHA / DIGIT / "-")
                      ; Experimental protocols prefixed with "x-"
@@ -90,12 +78,11 @@ svc-param      = mandatory-param
                / port-param
                / ipv4hint-param
                / ipv6hint-param
-               / cap-param           ; DNS-AID: capability descriptor locator
-               / cap-sha256-param    ; DNS-AID: capability descriptor digest
-               / bap-param           ; DNS-AID: bulk agent protocols
-               / policy-param        ; DNS-AID: policy bundle URI
+               / cap-param           ; DNS-AID: capability document URI
+               / capsha256-param     ; DNS-AID: capability document hash
+               / bap-param           ; DNS-AID: application protocols
+               / policy-param        ; DNS-AID: policy document URI
                / realm-param         ; DNS-AID: multi-tenant scope
-               / well-known-param    ; DNS-AID: RFC 8615 well-known path
                / unknown-param
 
 ; ==================================================================
@@ -143,57 +130,38 @@ IPv6-compressed = *1(":" 1*4HEXDIG) "::" *1(1*4HEXDIG ":")
                   ; Simplified - full IPv6 grammar is complex
 
 ; ==================================================================
-; DNS-AID Custom SVCB Parameters (draft-02 §4 IANA Considerations)
+; DNS-AID Custom SVCB Parameters (draft-01 Section 4.4.3)
 ; ==================================================================
 
-; Capability descriptor locator (key 65400)
-cap-param      = "cap=" DQUOTE cap-locator DQUOTE
-cap-locator    = URI / urn / json-ref
-                 ; Capability descriptor locator or inline identifier
-                 ; Per -02: a URI, URN, or compact JSON-Ref
-                 ; e.g., "https://agent.example.com/cap.json" or
-                 ; "urn:example:agent-cap:abc123"
+; Capability document URI (key 65400)
+cap-param      = "cap=" DQUOTE cap-uri DQUOTE
+cap-uri        = URI
+                 ; URI to JSON capability descriptor document
+                 ; e.g., "https://agent.example.com/.well-known/agent-cap.json"
 
-urn            = "urn:" 1*(ALPHA / DIGIT / "-" / ":")
-json-ref       = 1*(ALPHA / DIGIT / "-" / "/" / "#" / ".")
-                 ; Simplified — see https://datatracker.ietf.org/doc/draft-handrews-json-schema-02/
-
-; Capability descriptor integrity digest (key 65401)
-cap-sha256-param = "cap-sha256=" DQUOTE base64url DQUOTE
+; Capability document integrity hash (key 65401)
+capsha256-param = "capsha256=" DQUOTE base64url DQUOTE
 base64url      = 1*43(ALPHA / DIGIT / "-" / "_")
-                 ; Base64url-encoded SHA-256 digest (RFC 4648 §5)
+                 ; Base64url-encoded SHA-256 digest (RFC 4648 Section 5)
                  ; 32 bytes = 43 base64url characters (no padding)
-                 ; Per -02: hash of the canonical capability descriptor
 
-; Bulk agent protocols (key 65402)
+; DNS-AID Application Protocols (key 65402)
 bap-param      = "bap=" DQUOTE bap-list DQUOTE
-bap-list       = protocol *("," protocol)
-                 ; Per -02: agent protocols supported at this endpoint
-                 ; e.g., "mcp" or "mcp,a2a"
-                 ; Version suffixes (e.g. "mcp/1") were proposed as an
-                 ; experimental extension in -02 §FutureWork (Bulk Agent
-                 ; Protocol) and are not normative in the base spec
+bap-list       = bap-entry *("," bap-entry)
+bap-entry      = protocol ["/" version-number]
+version-number = 1*3DIGIT
+                 ; e.g., "mcp/1,a2a/1"
 
-; Policy bundle URI (key 65403)
+; Policy document URI (key 65403)
 policy-param   = "policy=" DQUOTE policy-uri DQUOTE
 policy-uri     = URI
-                 ; URI of an associated policy bundle
-                 ; Payload semantics deferred to a future revision
+                 ; URI to agent policy document (terms of use, data handling)
 
 ; Multi-tenant realm (key 65404)
 realm-param    = "realm=" DQUOTE realm-value DQUOTE
 realm-value    = 1*63(ALPHA / DIGIT / "-" / "_")
-                 ; Opaque token for multi-tenant scoping or authz realm
-                 ; selection during protocol bootstrapping
+                 ; Scope identifier for authorization
                  ; e.g., "production", "staging", "tenant-42"
-
-; Well-known path suffix (key 65409, new in -02)
-well-known-param = "well-known=" DQUOTE wk-path DQUOTE
-wk-path        = 1*(ALPHA / DIGIT / "-" / "." / "_" / "/")
-                 ; RFC 8615 well-known path suffix
-                 ; e.g., "agent-card.json" — consumer constructs
-                 ; https://<svcb-target>/.well-known/<wk-path>
-                 ; Independent of `cap`; both may be present.
 
 ; Generic URI rule (simplified from RFC 3986)
 URI            = scheme "://" authority path-abempty
@@ -205,12 +173,11 @@ segment        = *(ALPHA / DIGIT / "-" / "." / "_" / "~" / "%" / "!" / "@")
 
 ; Wire format note: Until IANA assigns permanent key IDs,
 ; implementations MUST use generic key encoding:
-;   key65400="https://..."          (cap)
-;   key65401="dGVzdGhhc2g"          (cap-sha256)
-;   key65402="mcp"                  (bap)
-;   key65403="https://..."          (policy)
-;   key65404="production"           (realm)
-;   key65409="agent-card.json"      (well-known)
+;   key65400="https://..."   (cap)
+;   key65401="dGVzdGhhc2g"   (capsha256)
+;   key65402="mcp/1,a2a/1"   (bap)
+;   key65403="https://..."   (policy)
+;   key65404="production"    (realm)
 
 ; Unknown/extension parameters
 unknown-param  = key-name "=" param-value
@@ -278,38 +245,22 @@ error-message  = 1*256(VCHAR / SP)
                  ; Human-readable error description
 
 ; ==================================================================
-; DNS-AID Index Record Format (draft-02)
+; DNS-AID Index Record Format
 ; ==================================================================
 
-; Organization-level index for zone enumeration.
+; Optional index record for zone enumeration
 ; Published at _index._agents.{domain}.
-;
-; Under -02 the primary form is SVCB, pointing at a TargetName that
-; serves the index over HTTPS. The TargetName MUST NOT contain
-; underscores (it carries a public x.509 cert).
-;
-; A TXT-fallback form is documented in -02 §TXT-fallback for
-; environments without SVCB support.
 
-index-svcb-record = "_index._agents." domain "." SP "SVCB" SP
-                    svc-priority SP index-target [SP svc-params]
+index-record   = "_index._agents." domain "." SP "TXT" SP index-value
 
-index-target   = label *("." label) "."
-                 ; FQDN of the host serving the agent index
-                 ; MUST NOT contain underscores
-
-; TXT fallback (legacy / SVCB-less deployments)
-index-txt-record = "_index._agents." domain "." SP "TXT" SP index-txt-value
-
-index-txt-value = DQUOTE "agents=" agent-list DQUOTE
+index-value    = DQUOTE "agents=" agent-list DQUOTE
 
 agent-list     = agent-ref *("," agent-ref)
 agent-ref      = agent-name ":" protocol
                  ; Reference to agent by name and protocol
 
-; Examples:
-; _index._agents.example.com. SVCB 1 agent-index.example.com. alpn="h2" port=443
-; _index._agents.example.com. TXT "agents=network:mcp,chat:a2a"
+; Example:
+; _index._agents.example.com. TXT "agents=network:mcp,chat:a2a,assistant:https"
 
 ; ==================================================================
 ; DNS-AID Opt-Out Record Format
@@ -330,7 +281,7 @@ optout-flag    = "true" / "false"
 ; ==================================================================
 
 ; Implements domain control validation per:
-;   draft-mozleywilliams-dnsop-dnsaid-02   (bnd-req binding)
+;   draft-mozleywilliams-dnsop-dnsaid-01   (bnd-req binding)
 ;   draft-ietf-dnsop-domain-verification-techniques-12
 
 ; Challenge owner name:  _agents-challenge.{domain}
@@ -380,98 +331,71 @@ verify-token   = 32*64(ALPHA / DIGIT)
                  ; 32-64 alphanumeric characters
 
 ; ==================================================================
-; Complete Examples (draft-02)
+; Complete Examples
 ; ==================================================================
 
-; Example 1: MCP Agent — flat primary owner
+; Example 1: MCP Agent SVCB Record
 ;
-; network.example.com. 3600 IN SVCB 1 mcp.example.com. (
-;     mandatory="alpn,port"
+; _network._mcp._agents.example.com. 3600 IN SVCB 1 mcp.example.com. (
+;     mandatory="alpn"
 ;     alpn="mcp"
 ;     port="443"
-;     bap="mcp"
 ; )
 
-; Example 2: A2A Agent
+; Example 2: A2A Agent SVCB Record
 ;
-; chat.example.com. 3600 IN SVCB 1 chat.example.com. (
+; _chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. (
 ;     alpn="a2a"
 ;     port="443"
 ;     ipv4hint="192.0.2.1"
-;     bap="a2a"
 ; )
 
-; Example 3: ServiceMode with DNS-AID custom parameters
+; Example 3: SVCB Record with DNS-AID Custom Parameters (v0.4.8)
 ;
-; booking.example.com. 3600 IN SVCB 1 booking.example.com. (
+; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"
-;     alpn="h2"
+;     alpn="mcp"
 ;     port="443"
-;     bap="mcp"
-;     cap="https://booking.example.com/cap.json"
-;     cap-sha256="dGVzdGhhc2g..."
-;     well-known="agent-card.json"
+;     cap="https://booking.example.com/.well-known/agent-cap.json"
+;     bap="mcp/1"
 ;     policy="https://example.com/agent-policy.json"
 ;     realm="production"
 ; )
 ;
-; Wire format (generic keyNNNNN encoding for providers that don't
-; understand the custom names yet):
-; booking.example.com. 3600 IN SVCB 1 booking.example.com. (
+; Wire format (Route 53 compatible with generic keys):
+; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"
-;     alpn="h2"
+;     alpn="mcp"
 ;     port="443"
-;     key65400="https://booking.example.com/cap.json"
-;     key65401="dGVzdGhhc2g..."
-;     key65402="mcp"
+;     key65400="https://booking.example.com/.well-known/agent-cap.json"
+;     key65402="mcp/1"
 ;     key65403="https://example.com/agent-policy.json"
 ;     key65404="production"
-;     key65409="agent-card.json"
 ; )
 
-; Example 4: Walkable AliasMode at the _agents leaf (optional)
+; Example 4: TXT Capabilities Record
 ;
-; chat._agents.example.com. 3600 IN SVCB 0 chat.example.com.
-
-; Example 5: TXT capabilities record (optional companion to the SVCB)
-;
-; network.example.com. 3600 IN TXT (
+; _network._mcp._agents.example.com. 3600 IN TXT (
 ;     "capabilities=chat,code,tools"
 ;     "version=1.2.0"
 ;     "model=claude-3"
 ; )
 
-; Example 6: Organization index (SVCB primary form)
+; Example 4: Index Record
 ;
-; _index._agents.example.com. 3600 IN SVCB 1 agent-index.example.com. (
-;     alpn="h2"
-;     port="443"
-; )
-; ; (TargetName "agent-index.example.com" MUST NOT contain underscores)
+; _index._agents.example.com. 3600 IN TXT "agents=network:mcp,chat:a2a"
 
-; Example 7: Opt-Out Record (dns-aid-core convention; not in -02)
+; Example 5: Opt-Out Record
 ;
 ; _dns-aid-optout.private.example.com. 3600 IN TXT "optout=true"
 
 ; ==================================================================
-; Wire Format Notes (draft-02)
+; Wire Format Notes
 ; ==================================================================
 
-; 1. DNSSEC: -02 relaxes the DNSSEC requirement. Records MAY be
-;    DNSSEC-signed for data origin authentication and integrity.
-;    Records MUST be DNSSEC-signed if TLSA records are used (DANE
-;    depends on DNSSEC). Consumers SHOULD validate DNSSEC where
-;    available and SHOULD refuse to act on bogus or unverifiable
-;    records.
-; 2. SVCB records use RFC 9460 wire format (2-byte key, 2-byte length,
-;    value)
+; 1. All DNS-AID records MUST be DNSSEC-signed
+; 2. SVCB records use RFC 9460 wire format (2-byte key, 2-byte length, value)
 ; 3. TXT records use RFC 1035 format (1-byte length prefix per string)
 ; 4. Maximum TXT record size is limited by UDP (typically 512 bytes)
-;    or TCP (up to 65535 bytes); -02 §Operational targets ≤1232 bytes
-;    for the discovery RRset to fit one UDP datagram and avoid
-;    fragmentation
+;    or TCP (up to 65535 bytes)
 ; 5. Character encoding is ASCII for DNS labels, UTF-8 for TXT values
-; 6. SVCB TargetNames reached over TLS with a public x.509 cert MUST
-;    NOT contain underscores (per -02 §Known Organization). This
-;    constraint applies to the index TargetName and to any agent's
-;    SVCB target that needs a publicly-issued cert.

--- a/docs/rfc/wire-format.abnf
+++ b/docs/rfc/wire-format.abnf
@@ -171,7 +171,7 @@ bap-list       = protocol *("," protocol)
                  ; Per -02: agent protocols supported at this endpoint
                  ; e.g., "mcp" or "mcp,a2a"
                  ; Version suffixes (e.g. "mcp/1") were proposed as an
-                 ; experimental extension in -02 §FutureWork (Bulk Agent
+                 ; experimental extension in -02 §5 (Future Work and Experimental Mechanisms) (Bulk Agent
                  ; Protocol) and are not normative in the base spec
 
 ; Policy bundle URI (key 65403)

--- a/examples/integration_otel_collector/README.md
+++ b/examples/integration_otel_collector/README.md
@@ -60,7 +60,7 @@ Open `http://localhost:16686`. In the Service dropdown:
 ```
 [caller.py]
    AgentClient.invoke()
-      ├─ opens span "dns-aid.invoke _echo._https._agents.demo.local"
+      ├─ opens span "dns-aid.invoke echo.demo.local"
       ├─ HTTPS protocol handler builds POST request
       ├─ inject_otel_context() event hook writes `traceparent` header
       ├─ httpx sends request to http://localhost:9000/invoke

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ mcp = [
     "uvicorn>=0.30.0",
     # Direct floors on transitive deps pulled by `mcp` to close Dependabot alerts
     # (mcp's upstream constraints are looser than the patched versions need).
-    "pyjwt>=2.12.0",            # CVE-2026-32597 (high) — accepts unknown 'crit' header
+    "pyjwt>=2.13.0",            # PYSEC-2026-175/177/178/179 (4 vulns); supersedes CVE-2026-32597 (unknown 'crit' header)
     "python-multipart>=0.0.27", # CVE-2026-42561 / GHSA-pp6c-gr5w-3c5g (high) — DoS via unbounded multipart headers; supersedes CVE-2026-40347
 ]
 route53 = [
@@ -131,7 +131,7 @@ all = [
     "mcp>=1.0.0",
     "uvicorn>=0.30.0",
     # Transitive floors via mcp (Dependabot)
-    "pyjwt>=2.12.0",
+    "pyjwt>=2.13.0",
     "python-multipart>=0.0.27",
     # Backends: Route53, Cloudflare, NS1, Cloud DNS, Infoblox BloxOne, NIOS, DDNS
     "boto3>=1.34.0",

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Pre-push local verification — runs every CI check we can run locally
+# so we stop force-pushing things that fail server-side.
+#
+# Exit code 0 = all checks passed. Non-zero = at least one failed.
+# Usage: ./scripts/preflight.sh [--against <base-ref>]
+
+set -uo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --against) BASE_REF="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+OK="\033[32m✓\033[0m"
+BAD="\033[31m✗\033[0m"
+DIM="\033[2m"
+RST="\033[0m"
+
+failed=()
+
+step() { printf "\n${DIM}══ %s ══${RST}\n" "$1"; }
+pass() { printf "${OK} %s\n" "$1"; }
+fail() { printf "${BAD} %s\n" "$1"; failed+=("$1"); }
+
+# ───────────────────────────────────────────────────────────────────
+step "Format check (ruff format)"
+if uv run ruff format --check src/ tests/ >/dev/null 2>&1; then
+  pass "ruff format clean"
+else
+  fail "ruff format would reformat files (run 'uv run ruff format src/ tests/')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Lint (ruff check)"
+if uv run ruff check src/ tests/ >/dev/null 2>&1; then
+  pass "ruff check clean"
+else
+  fail "ruff check has issues (run 'uv run ruff check src/ tests/' to see them)"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Type check (mypy)"
+if uv run mypy src/dns_aid >/dev/null 2>&1; then
+  pass "mypy clean"
+else
+  fail "mypy has errors (run 'uv run mypy src/dns_aid')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Unit tests"
+if uv run pytest tests/unit/ -q --no-header --tb=no 2>&1 | tail -1 | grep -qE "passed"; then
+  pass "unit tests pass"
+else
+  fail "unit tests failing (run 'uv run pytest tests/unit/ -v')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Mock integration tests"
+if uv run pytest tests/integration/ -m "not live" -q --no-header --tb=no 2>&1 | tail -1 | grep -qE "passed"; then
+  pass "integration tests pass (not live)"
+else
+  fail "integration tests failing (run 'uv run pytest tests/integration/ -m \"not live\" -v')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "SAST (Bandit)"
+if uv run --with "bandit[toml]" bandit -r src/dns_aid -c pyproject.toml -q >/dev/null 2>&1; then
+  pass "bandit clean"
+else
+  fail "bandit has findings (run 'uv run --with bandit[toml] bandit -r src/dns_aid -c pyproject.toml')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Dependency Audit (pip-audit)"
+# Mirrors security.yml — same --ignore-vuln list. Update both when CVEs change.
+audit_args=(
+  --ignore-vuln CVE-2026-4539
+  --ignore-vuln CVE-2025-8869
+  --ignore-vuln CVE-2026-1703
+  --ignore-vuln CVE-2026-34073
+  --ignore-vuln CVE-2026-25645
+  --ignore-vuln CVE-2026-3219
+  --ignore-vuln CVE-2025-45768
+)
+if uv run --with pip-audit pip-audit "${audit_args[@]}" >/dev/null 2>&1; then
+  pass "pip-audit clean"
+else
+  fail "pip-audit found vulnerabilities (run 'uv run --with pip-audit pip-audit ${audit_args[*]}')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "DCO trailer placement"
+# The KineticCafe DCO action follows git's trailer-block rule: the
+# Signed-off-by line MUST be in the LAST paragraph of the commit
+# message. Body text after it invalidates the trailer.
+bad_dco=()
+for sha in $(git log --format=%h "$BASE_REF..HEAD" 2>/dev/null); do
+  last_so=$(git cat-file -p "$sha" | awk '/^Signed-off-by:/{n=NR} END{print n+0}')
+  last_line=$(git cat-file -p "$sha" | awk 'NF{n=NR} END{print n+0}')
+  if [[ "$last_so" -eq 0 ]]; then
+    bad_dco+=("$sha: missing Signed-off-by")
+  elif [[ "$last_so" -ne "$last_line" ]]; then
+    bad_dco+=("$sha: Signed-off-by at line $last_so but body extends to line $last_line")
+  fi
+done
+if [[ ${#bad_dco[@]} -eq 0 ]]; then
+  pass "every commit's Signed-off-by is the last line"
+else
+  fail "DCO trailer placement issues:"
+  for entry in "${bad_dco[@]}"; do echo "    $entry"; done
+  echo "    (use 'git rebase -i $BASE_REF' + 'reword' to fix)"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Workflow files unchanged (fork-PR approval gate)"
+# When a fork PR modifies .github/workflows/, GitHub requires
+# maintainer approval per push — CI doesn't auto-run. Catch this so
+# we don't push an unrelated workflow drift.
+wf_diff=$(git diff "$BASE_REF...HEAD" -- .github/workflows/ 2>/dev/null)
+if [[ -z "$wf_diff" ]]; then
+  pass "no .github/workflows/ changes (CI will auto-fire)"
+else
+  fail ".github/workflows/ changed vs $BASE_REF — fork PRs need maintainer approval per push"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Summary"
+if [[ ${#failed[@]} -eq 0 ]]; then
+  printf "${OK} all preflight checks passed — safe to push\n"
+  exit 0
+else
+  printf "${BAD} %d check(s) failed:\n" "${#failed[@]}"
+  for entry in "${failed[@]}"; do printf "    %s\n" "$entry"; done
+  exit 1
+fi

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -4,7 +4,7 @@
 """
 DNS-AID: DNS-based Agent Identification and Discovery
 
-Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-01.
+Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-02.
 Enables AI agents to discover each other via DNS using SVCB records.
 
 Example:

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -238,7 +238,11 @@ class DNSBackend(ABC):
         """
         records: list[str] = []
         zone = agent.domain
-        name = f"_{agent.name}._{agent.protocol.value}._agents"
+        # Under draft-02 the agent's primary owner is the flat name
+        # {name}.{domain}; the relative record name under the zone is
+        # just the agent name. PR 3a flips the wire-format default.
+        name = agent.name
+        walkable_name = f"{agent.name}._agents"
 
         all_params = agent.to_svcb_params()
         support = self.supports_private_svcb_keys
@@ -317,6 +321,30 @@ class DNSBackend(ABC):
                 ttl=agent.ttl,
             )
             records.append(f"TXT {txt_fqdn}")
+
+        # Optional walkable AliasMode at {name}._agents.{domain} pointing
+        # at the flat primary owner. Per draft-02 §Known Agent, operators
+        # MAY emit this record so DNS-SD-style consumers can enumerate.
+        # dns-aid-core publishes it by default; callers can suppress it
+        # by setting publish_walkable_alias=False on the AgentRecord.
+        if agent.publish_walkable_alias:
+            try:
+                walkable_fqdn = await self.create_svcb_record(
+                    zone=zone,
+                    name=walkable_name,
+                    priority=0,  # AliasMode
+                    target=agent.svcb_target,
+                    params={},
+                    ttl=agent.ttl,
+                )
+                records.append(f"SVCB(AliasMode) {walkable_fqdn}")
+            except Exception as exc:
+                logger.warning(
+                    "Walkable AliasMode write failed; continuing",
+                    backend=self.name,
+                    walkable_name=walkable_name,
+                    error=str(exc),
+                )
 
         logger.info(
             "Agent published successfully",

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from dns_aid.core.models import SVCB_ALIAS_MODE, SVCB_SERVICE_MODE  # noqa: E402
+
 if TYPE_CHECKING:
     from dns_aid.core.models import AgentRecord
 
@@ -240,7 +242,7 @@ class DNSBackend(ABC):
         zone = agent.domain
         # Under draft-02 the agent's primary owner is the flat name
         # {name}.{domain}; the relative record name under the zone is
-        # just the agent name. PR 3a flips the wire-format default.
+        # just the agent name (no leading underscore, no protocol label).
         name = agent.name
         walkable_name = f"{agent.name}._agents"
 
@@ -266,7 +268,7 @@ class DNSBackend(ABC):
                 svcb_fqdn = await self.create_svcb_record(
                     zone=zone,
                     name=name,
-                    priority=1,
+                    priority=SVCB_SERVICE_MODE,
                     target=agent.svcb_target,
                     params=all_params,
                     ttl=agent.ttl,
@@ -302,7 +304,7 @@ class DNSBackend(ABC):
             svcb_fqdn = await self.create_svcb_record(
                 zone=zone,
                 name=name,
-                priority=1,
+                priority=SVCB_SERVICE_MODE,
                 target=agent.svcb_target,
                 params=svcb_params,
                 ttl=agent.ttl,
@@ -329,11 +331,18 @@ class DNSBackend(ABC):
         # by setting publish_walkable_alias=False on the AgentRecord.
         if agent.publish_walkable_alias:
             try:
+                # AliasMode MUST point at the flat primary owner
+                # (`{name}.{domain}.`) per draft-02 §3.1. agent.svcb_target
+                # is the endpoint host, which only coincides with the
+                # owner when endpoint == fqdn — the normal case has them
+                # distinct, so using svcb_target would point the alias
+                # at a name with no SVCB record.
+                walkable_target = f"{agent.fqdn}."
                 walkable_fqdn = await self.create_svcb_record(
                     zone=zone,
                     name=walkable_name,
-                    priority=0,  # AliasMode
-                    target=agent.svcb_target,
+                    priority=SVCB_ALIAS_MODE,
+                    target=walkable_target,
                     params={},
                     ttl=agent.ttl,
                 )

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -46,7 +46,13 @@ class InfobloxNIOSBackend(DNSBackend):
         NIOS_TIMEOUT: HTTP request timeout in seconds (default: 30.0)
     """
 
-    _SPLIT_VALUE_KEYS = {"alpn", "bap", "ipv4hint", "ipv6hint"}
+    # ``bap`` was historically split as a multi-value key when the
+    # field carried comma-separated protocols. draft-02 §5.1 makes it
+    # a single scalar (bare ``mcp`` or versioned ``mcp=1.0``); the
+    # ``=`` in a versioned value would also re-expand on a split, so
+    # we keep bap out of the split set even though current scalar
+    # values would be harmless to split.
+    _SPLIT_VALUE_KEYS = {"alpn", "ipv4hint", "ipv6hint"}
     # NIOS only accepts registered SVC keys or keyNNNNN numeric keys.
     # Map draft custom names to private-use keyNNNNN aliases for compatibility.
     _CUSTOM_PARAM_TO_NUMERIC_KEY = {

--- a/src/dns_aid/backends/mock.py
+++ b/src/dns_aid/backends/mock.py
@@ -15,6 +15,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from dns_aid.backends.base import DNSBackend
+from dns_aid.core.models import SVCB_ALIAS_MODE, SVCB_SERVICE_MODE
 
 if TYPE_CHECKING:
     from dns_aid.core.models import AgentRecord
@@ -31,15 +32,15 @@ class MockBackend(DNSBackend):
         >>> backend = MockBackend()
         >>> await backend.create_svcb_record(
         ...     zone="example.com",
-        ...     name="_chat._a2a._agents",
+        ...     name="chat",
         ...     priority=1,
         ...     target="chat.example.com.",
         ...     params={"alpn": "a2a", "port": "443"}
         ... )
-        '_chat._a2a._agents.example.com'
+        'chat.example.com'
 
-        >>> # Records are stored in memory
-        >>> backend.records["example.com"]["_chat._a2a._agents"]["SVCB"]
+        >>> # Records are stored in memory under the flat draft-02 name
+        >>> backend.records["example.com"]["chat"]["SVCB"]
         [{'priority': 1, 'target': 'chat.example.com.', 'params': {...}, 'ttl': 3600}]
     """
 
@@ -110,15 +111,23 @@ class MockBackend(DNSBackend):
         name: str,
         record_type: str,
     ) -> bool:
-        """Delete record from memory."""
-        if (
-            zone in self.records
-            and name in self.records[zone]
-            and record_type in self.records[zone][name]
-        ):
-            del self.records[zone][name][record_type]
-            return True
-        return False
+        """Delete record from memory.
+
+        Uses ``.get()`` (not the ``in`` keyword) so we never trigger the
+        outer ``defaultdict`` to materialise empty entries for the
+        zone/name/type — that side-effect was causing follow-up calls
+        to see records that didn't exist.
+        """
+        zone_records = self.records.get(zone)
+        if zone_records is None:
+            return False
+        name_records = zone_records.get(name)
+        if name_records is None:
+            return False
+        if record_type not in name_records:
+            return False
+        del name_records[record_type]
+        return True
 
     async def list_records(
         self,
@@ -163,9 +172,22 @@ class MockBackend(DNSBackend):
         name: str,
         record_type: str,
     ) -> dict | None:
-        """Get a specific record from memory."""
+        """Get a specific record from memory.
+
+        Uses ``.get()`` so a probe for a non-existent record doesn't
+        cause the outer ``defaultdict`` to create empty intermediate
+        entries — that side-effect previously fooled follow-up
+        delete_record calls into reporting success on records that
+        had never been written.
+        """
         try:
-            records = self.records[zone][name][record_type]
+            zone_records = self.records.get(zone)
+            if zone_records is None:
+                return None
+            name_records = zone_records.get(name)
+            if name_records is None:
+                return None
+            records = name_records.get(record_type)
             if not records:
                 return None
             record = records[0]
@@ -209,7 +231,7 @@ class MockBackend(DNSBackend):
         svcb_fqdn = await self.create_svcb_record(
             zone=zone,
             name=name,
-            priority=1,
+            priority=SVCB_SERVICE_MODE,
             target=agent.svcb_target,
             params=agent.to_svcb_params(),
             ttl=agent.ttl,
@@ -226,13 +248,15 @@ class MockBackend(DNSBackend):
             )
             records.append(f"TXT {txt_fqdn}")
 
-        # Optional walkable AliasMode at {name}._agents.{domain}.
+        # Optional walkable AliasMode at {name}._agents.{domain} pointing
+        # at the flat primary owner per draft-02 §3.1.
         if agent.publish_walkable_alias:
+            walkable_target = f"{agent.fqdn}."
             walkable_fqdn = await self.create_svcb_record(
                 zone=zone,
                 name=walkable_name,
-                priority=0,  # AliasMode
-                target=agent.svcb_target,
+                priority=SVCB_ALIAS_MODE,
+                target=walkable_target,
                 params={},
                 ttl=agent.ttl,
             )

--- a/src/dns_aid/backends/mock.py
+++ b/src/dns_aid/backends/mock.py
@@ -202,7 +202,9 @@ class MockBackend(DNSBackend):
         """
         records: list[str] = []
         zone = agent.domain
-        name = f"_{agent.name}._{agent.protocol.value}._agents"
+        # draft-02: flat primary owner — relative record name is just the agent name.
+        name = agent.name
+        walkable_name = f"{agent.name}._agents"
 
         svcb_fqdn = await self.create_svcb_record(
             zone=zone,
@@ -223,6 +225,18 @@ class MockBackend(DNSBackend):
                 ttl=agent.ttl,
             )
             records.append(f"TXT {txt_fqdn}")
+
+        # Optional walkable AliasMode at {name}._agents.{domain}.
+        if agent.publish_walkable_alias:
+            walkable_fqdn = await self.create_svcb_record(
+                zone=zone,
+                name=walkable_name,
+                priority=0,  # AliasMode
+                target=agent.svcb_target,
+                params={},
+                ttl=agent.ttl,
+            )
+            records.append(f"SVCB(AliasMode) {walkable_fqdn}")
 
         return records
 

--- a/src/dns_aid/cli/doctor.py
+++ b/src/dns_aid/cli/doctor.py
@@ -32,7 +32,7 @@ def _render_report(report: DiagnosticReport) -> None:
     console.print(
         Panel(
             f"[bold]dns-aid doctor[/bold]  v{report.version}",
-            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-01[/dim]",
+            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-02[/dim]",
             width=56,
         )
     )

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -179,6 +179,16 @@ def publish(
             "Use only when the target is internal-only and not reached over public PKI.",
         ),
     ] = False,
+    no_walkable: Annotated[
+        bool,
+        typer.Option(
+            "--no-walkable",
+            help="Suppress the optional walkable AliasMode SVCB record at "
+            "{name}._agents.{domain}. The walkable record is published by default per "
+            "draft-mozleywilliams-dnsop-dnsaid-02 §Known Agent to support DNS-SD-style "
+            "enumeration crawlers.",
+        ),
+    ] = False,
 ):
     """
     Publish an agent to DNS using DNS-AID protocol.
@@ -254,6 +264,7 @@ def publish(
             sign=sign,
             private_key_path=private_key,
             allow_underscore_target=allow_underscore_target,
+            publish_walkable_alias=not no_walkable,
         )
     )
 
@@ -713,9 +724,7 @@ def search(
 
 @app.command()
 def verify(
-    fqdn: Annotated[
-        str, typer.Argument(help="FQDN to verify (e.g., _chat._a2a._agents.example.com)")
-    ],
+    fqdn: Annotated[str, typer.Argument(help="FQDN to verify (e.g., chat.example.com)")],
 ):
     """
     Verify DNS-AID records for an agent.
@@ -723,7 +732,7 @@ def verify(
     Checks DNS record existence, DNSSEC validation, and endpoint health.
 
     Example:
-        dns-aid verify _chat._a2a._agents.example.com
+        dns-aid verify chat.example.com
     """
     from dns_aid.core.validator import verify as do_verify
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -121,7 +121,10 @@ def publish(
     bap: Annotated[
         str | None,
         typer.Option(
-            "--bap", help="Supported bulk agent protocols (comma-separated, e.g., 'mcp,a2a')"
+            "--bap",
+            help="Bulk Agent Protocol identifier — single versioned protocol per "
+            "record (e.g., 'mcp2.1', 'a2a1.0'). Experimental per draft-02 §FutureWork; "
+            "alpn remains the canonical protocol carrier.",
         ),
     ] = None,
     policy_uri: Annotated[
@@ -230,8 +233,9 @@ def publish(
 
     console.print("\n[bold]Publishing agent to DNS...[/bold]\n")
 
-    # Parse bap comma-separated string into list
-    bap_list = [b.strip() for b in bap.split(",") if b.strip()] if bap else None
+    # bap is a single versioned-protocol identifier per draft-02 §FutureWork
+    # (Bulk Agent Protocol). Pass through unchanged; whitespace-trimmed.
+    bap_value = bap.strip() if bap else None
 
     # Validate sign options
     if sign and not private_key:
@@ -255,7 +259,7 @@ def publish(
             cap_uri=cap_uri,
             cap_sha256=cap_sha256,
             well_known_path=well_known,
-            bap=bap_list,
+            bap=bap_value,
             policy_uri=policy_uri,
             realm=realm,
             connect_class=connect_class,
@@ -458,7 +462,7 @@ def discover(
                     "cap_uri": a.cap_uri,
                     "cap_sha256": a.cap_sha256,
                     "well_known_path": a.well_known_path,
-                    "bap": a.bap if a.bap else None,
+                    "bap": a.bap,
                     "policy_uri": a.policy_uri,
                     "realm": a.realm,
                     "description": a.description,

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -179,14 +179,16 @@ def publish(
             "Use only when the target is internal-only and not reached over public PKI.",
         ),
     ] = False,
-    no_walkable: Annotated[
+    walkable: Annotated[
         bool,
         typer.Option(
-            "--no-walkable",
-            help="Suppress the optional walkable AliasMode SVCB record at "
-            "{name}._agents.{domain}. The walkable record is published by default per "
-            "draft-mozleywilliams-dnsop-dnsaid-02 §Known Agent to support DNS-SD-style "
-            "enumeration crawlers.",
+            "--walkable",
+            help="Publish the optional walkable AliasMode SVCB record at "
+            "{name}._agents.{domain}. Off by default — the walkable record is "
+            "an enumeration handle (DNS-SD-style consumers can walk _agents.<zone> "
+            "and inventory every agent). Enable only when you actively want the "
+            "agent discoverable through enumeration (internal indexes, intentional "
+            "public catalogs). See docs/privacy-considerations.md.",
         ),
     ] = False,
 ):
@@ -264,7 +266,7 @@ def publish(
             sign=sign,
             private_key_path=private_key,
             allow_underscore_target=allow_underscore_target,
-            publish_walkable_alias=not no_walkable,
+            publish_walkable_alias=walkable,
         )
     )
 

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -110,6 +110,14 @@ def publish(
             help="Base64url-encoded SHA-256 digest of the capability descriptor for integrity checks",
         ),
     ] = None,
+    well_known: Annotated[
+        str | None,
+        typer.Option(
+            "--well-known",
+            help="RFC 8615 well-known path suffix (e.g., 'agent-card.json'). Independent "
+            "of --cap-uri; both may be set. Consumers prefer --cap-uri when both are present.",
+        ),
+    ] = None,
     bap: Annotated[
         str | None,
         typer.Option(
@@ -163,6 +171,14 @@ def publish(
         str | None,
         typer.Option("--private-key", help="Path to EC P-256 private key PEM for signing"),
     ] = None,
+    allow_underscore_target: Annotated[
+        bool,
+        typer.Option(
+            "--allow-underscore-target",
+            help="Downgrade the TargetName-contains-underscore check from error to warning. "
+            "Use only when the target is internal-only and not reached over public PKI.",
+        ),
+    ] = False,
 ):
     """
     Publish an agent to DNS using DNS-AID protocol.
@@ -226,6 +242,7 @@ def publish(
             backend=dns_backend,
             cap_uri=cap_uri,
             cap_sha256=cap_sha256,
+            well_known_path=well_known,
             bap=bap_list,
             policy_uri=policy_uri,
             realm=realm,
@@ -236,6 +253,7 @@ def publish(
             ipv6_hint=",".join(ipv6hint) if ipv6hint else None,
             sign=sign,
             private_key_path=private_key,
+            allow_underscore_target=allow_underscore_target,
         )
     )
 
@@ -426,6 +444,7 @@ def discover(
                     "capability_source": a.capability_source,
                     "cap_uri": a.cap_uri,
                     "cap_sha256": a.cap_sha256,
+                    "well_known_path": a.well_known_path,
                     "bap": a.bap if a.bap else None,
                     "policy_uri": a.policy_uri,
                     "realm": a.realm,

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -121,7 +121,10 @@ def publish(
     bap: Annotated[
         str | None,
         typer.Option(
-            "--bap", help="Supported bulk agent protocols (comma-separated, e.g., 'mcp,a2a')"
+            "--bap",
+            help="Bulk Agent Protocol identifier — single versioned protocol per "
+            "record (e.g., 'mcp2.1', 'a2a1.0'). Experimental per draft-02 §FutureWork; "
+            "alpn remains the canonical protocol carrier.",
         ),
     ] = None,
     policy_uri: Annotated[
@@ -228,8 +231,9 @@ def publish(
 
     console.print("\n[bold]Publishing agent to DNS...[/bold]\n")
 
-    # Parse bap comma-separated string into list
-    bap_list = [b.strip() for b in bap.split(",") if b.strip()] if bap else None
+    # bap is a single versioned-protocol identifier per draft-02 §FutureWork
+    # (Bulk Agent Protocol). Pass through unchanged; whitespace-trimmed.
+    bap_value = bap.strip() if bap else None
 
     # Validate sign options
     if sign and not private_key:
@@ -253,7 +257,7 @@ def publish(
             cap_uri=cap_uri,
             cap_sha256=cap_sha256,
             well_known_path=well_known,
-            bap=bap_list,
+            bap=bap_value,
             policy_uri=policy_uri,
             realm=realm,
             connect_class=connect_class,
@@ -456,7 +460,7 @@ def discover(
                     "cap_uri": a.cap_uri,
                     "cap_sha256": a.cap_sha256,
                     "well_known_path": a.well_known_path,
-                    "bap": a.bap if a.bap else None,
+                    "bap": a.bap,
                     "policy_uri": a.policy_uri,
                     "realm": a.realm,
                     "description": a.description,

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -123,7 +123,7 @@ def publish(
         typer.Option(
             "--bap",
             help="Bulk Agent Protocol identifier — single versioned protocol per "
-            "record (e.g., 'mcp2.1', 'a2a1.0'). Experimental per draft-02 §FutureWork; "
+            "record (e.g., 'mcp=2.1', 'a2a=1.0'). Experimental per draft-02 §FutureWork; "
             "alpn remains the canonical protocol carrier.",
         ),
     ] = None,

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -220,7 +220,11 @@ class A2AAgentCard:
             "description": self.description,
             "ttl": ttl,
             "cap_uri": cap_uri,
-            "bap": ["a2a/1"],
+            # Bulk Agent Protocol — scalar versioned identifier per draft-02
+            # §FutureWork. A2A agent cards default to "a2a1.0"; operators
+            # publishing a different version of A2A can override before passing
+            # to publish().
+            "bap": "a2a1.0",
         }
 
 

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -221,10 +221,10 @@ class A2AAgentCard:
             "ttl": ttl,
             "cap_uri": cap_uri,
             # Bulk Agent Protocol — scalar versioned identifier per draft-02
-            # §FutureWork. A2A agent cards default to "a2a1.0"; operators
+            # §FutureWork. A2A agent cards default to "a2a=1.0"; operators
             # publishing a different version of A2A can override before passing
             # to publish().
-            "bap": "a2a1.0",
+            "bap": "a2a=1.0",
         }
 
 

--- a/src/dns_aid/core/bap.py
+++ b/src/dns_aid/core/bap.py
@@ -1,0 +1,191 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Single source of truth for the draft-02 ``bap`` (Bulk Agent Protocol)
+SvcParamKey value shape.
+
+draft-02 §5.1 (experimental, §FutureWork) defines a single versioned
+agent-protocol identifier per SVCB record. Two value forms are
+accepted, matching the draft's own examples:
+
+- **Bare** — ``mcp`` / ``a2a`` (unversioned)
+- **Versioned** — ``mcp=1.0`` / ``a2a=1.1`` (protocol name, ``=``,
+  dotted version)
+
+Multi-protocol agents publish multiple SVCB records at the same flat
+owner, each with its own ``alpn`` and (optionally) ``bap``. ``bap``
+is NOT a comma-separated list of protocols.
+
+This module centralizes:
+
+- :data:`BAP_VALUE_PATTERN` — the wire-format character constraint
+- :func:`validate_bap` — model field-validator
+- :func:`normalize_bap` — coerce legacy / forgiving inputs into the
+  canonical scalar shape
+- :func:`split_bap_token` — extract the protocol token before any
+  ``=`` so consumers can reconcile against ``Protocol`` enums
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Wire-format constraint. Protocol name lowercase alnum starting with
+# a letter; optional ``=`` followed by a version token. The version
+# token allows the dotted shape (e.g. ``1.0``, ``1.1.0``,
+# ``2026-01-15``) but excludes quotes, spaces, commas, and any other
+# character that would let a forged value break out of the SVCB
+# SvcParam quoting and inject sibling keys.
+#
+# Igor's #158 review surfaced this as a server-side param-injection
+# vulnerability on the publish path — the value was previously
+# emitted verbatim into ``key="<value>"`` with no validator.
+_PROTOCOL_PATTERN = r"[a-z][a-z0-9]*"
+_VERSION_PATTERN = r"[A-Za-z0-9][A-Za-z0-9._\-]{0,63}"
+BAP_VALUE_PATTERN: Final = re.compile(rf"^{_PROTOCOL_PATTERN}(={_VERSION_PATTERN})?$")
+
+_BAP_MAX_LEN = 128
+
+
+def validate_bap(value: str) -> str:
+    """Validate a single ``bap`` SvcParamKey value.
+
+    Used as a Pydantic field validator on both ``SvcbRecord.bap`` and
+    ``AgentRecord.bap``. Enforces the canonical scalar shape so:
+
+    - Injection via SVCB quoting (e.g. ``mcp" key65500="x``) is
+      rejected at the type boundary.
+    - Comma-separated legacy values are rejected (caller should run
+      ``normalize_bap`` first if accepting legacy input).
+    - Whitespace, control characters, and other URL/quote special
+      characters are rejected.
+
+    Args:
+        value: The bap value to validate. Empty / None should be
+            handled by the caller before reaching this function.
+
+    Returns:
+        The validated value unchanged.
+
+    Raises:
+        ValueError: When the value violates the wire-format rule.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"bap must be a string, got {type(value).__name__}")
+    if not value:
+        raise ValueError("bap must be a non-empty string (or None)")
+    if len(value) > _BAP_MAX_LEN:
+        raise ValueError(f"bap value exceeds {_BAP_MAX_LEN} characters")
+    if not BAP_VALUE_PATTERN.match(value):
+        raise ValueError(
+            f"bap value {value!r} does not match the canonical form. "
+            "Allowed: a lowercase protocol token (e.g. 'mcp', 'a2a') "
+            "optionally followed by '=<version>' (e.g. 'mcp=1.0'). "
+            "Reject quotes, spaces, commas, control chars, and any "
+            "other character that could break SVCB SvcParam quoting."
+        )
+    return value
+
+
+def normalize_bap(value: str | list[str] | None) -> str | None:
+    """Coerce forgiving input into the canonical scalar shape.
+
+    Accepts:
+
+    - ``None`` → ``None``
+    - ``""`` / whitespace-only string → ``None``
+    - ``"mcp"`` / ``"mcp=1.0"`` → unchanged after strip
+    - ``"mcp,a2a"`` (legacy comma-list) → first non-empty token,
+      warning logged because later tokens are dropped
+    - ``["mcp", "a2a"]`` (legacy list) → first non-empty token,
+      warning logged
+    - ``[]`` / list of empties → ``None``
+
+    Does NOT enforce :func:`validate_bap` — callers should run it
+    after normalization (or rely on the model's field validator).
+
+    Args:
+        value: A string, list of strings, or None. Other types are
+            silently treated as None to keep the public API forgiving.
+
+    Returns:
+        The normalized scalar (or None when no usable value exists).
+    """
+    if value is None:
+        return None
+
+    # Coerce a list into a scalar by taking the first non-empty entry.
+    # Empty list / list of empties → None.
+    if isinstance(value, list):
+        tokens = [str(v).strip() for v in value if v is not None]
+        non_empty = [t for t in tokens if t]
+        if not non_empty:
+            return None
+        if len(non_empty) > 1:
+            logger.warning(
+                "bap list input collapsed to first token — multi-protocol "
+                "agents should publish multiple SVCB records, not a list "
+                "on one record",
+                input=value,
+                kept=non_empty[0],
+                dropped=non_empty[1:],
+                warning_class="dns_aid.bap_list_collapsed",
+            )
+        return non_empty[0]
+
+    # Scalar string. Strip whitespace, drop empties.
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    # Legacy comma-list ("mcp,a2a") → first non-empty token.
+    if "," in stripped:
+        tokens = [t.strip() for t in stripped.split(",")]
+        non_empty = [t for t in tokens if t]
+        if not non_empty:
+            return None
+        if len(non_empty) > 1:
+            logger.warning(
+                "bap comma-list input collapsed to first token — "
+                "multi-protocol agents should publish multiple SVCB "
+                "records, not a comma-separated list on one record",
+                input=value,
+                kept=non_empty[0],
+                dropped=non_empty[1:],
+                warning_class="dns_aid.bap_comma_list_collapsed",
+            )
+        return non_empty[0]
+
+    return stripped
+
+
+def split_bap_token(value: str | None) -> tuple[str | None, str | None]:
+    """Split a bap value into ``(protocol_token, version)``.
+
+    ``mcp`` → ``("mcp", None)``
+    ``mcp=1.0`` → ``("mcp", "1.0")``
+    ``None`` / unparseable → ``(None, None)``
+
+    Used by the discoverer's protocol reconciliation: the ``Protocol``
+    enum holds bare tokens (``mcp``, ``a2a``), so consumers need to
+    extract just the token before checking membership.
+    """
+    if not value:
+        return None, None
+    stripped = value.strip()
+    if not stripped:
+        return None, None
+    if "=" not in stripped:
+        return stripped, None
+    proto, _, ver = stripped.partition("=")
+    proto = proto.strip()
+    ver = ver.strip()
+    return (proto or None), (ver or None)

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -4,7 +4,7 @@
 """
 Fetch agent capability document from cap URI (IETF draft-compliant).
 
-Per IETF draft-mozleywilliams-dnsop-dnsaid-01, the SVCB record may contain
+Per IETF draft-mozleywilliams-dnsop-dnsaid-02, the SVCB record may contain
 a `cap` parameter with a URI pointing to a JSON capability document. This module
 fetches and parses that document.
 

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -36,6 +36,23 @@ logger = structlog.get_logger(__name__)
 _MAX_CAP_RESPONSE_BYTES = 256_000
 
 
+class CapDigestMismatchError(Exception):
+    """Raised when a fetched cap document's SHA-256 disagrees with the pin.
+
+    Per draft-mozleywilliams-dnsop-dnsaid-02 §6.1, a digest mismatch MUST
+    cause the consumer to refuse to use the record — distinct from a
+    network/parse failure where falling back to a lower-priority source
+    is acceptable. The discoverer catches this explicitly and drops the
+    affected record, rather than silently downgrading to TXT.
+    """
+
+    def __init__(self, cap_uri: str, expected: str, actual: str) -> None:
+        super().__init__(f"cap digest mismatch for {cap_uri}: expected={expected} actual={actual}")
+        self.cap_uri = cap_uri
+        self.expected = expected
+        self.actual = actual
+
+
 @dataclass
 class CapabilityDocument:
     """Parsed capability document from a cap URI."""
@@ -48,10 +65,12 @@ class CapabilityDocument:
     raw_data: dict[str, Any] = field(default_factory=dict)
 
 
-def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bool:
+def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> None:
     """Verify SHA-256 digest of capability document content.
 
-    Returns True if digest matches, False otherwise.
+    Raises CapDigestMismatchError on mismatch so callers can distinguish
+    a digest failure (MUST refuse, per draft §6.1) from a network/parse
+    failure (fall back to a lower-priority capability source).
     """
     import base64
     import hashlib
@@ -66,8 +85,7 @@ def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bo
             expected=expected_sha256,
             actual=actual_digest,
         )
-        return False
-    return True
+        raise CapDigestMismatchError(cap_uri, expected_sha256, actual_digest)
 
 
 def _extract_string_list(data: dict[str, Any], key: str) -> list[str]:
@@ -164,8 +182,11 @@ async def fetch_cap_document(
             logger.debug("Cap document fetch failed (non-200)", cap_uri=cap_uri)
             return None
 
-        if expected_sha256 and not _verify_cap_digest(body, expected_sha256, cap_uri):
-            return None
+        # Integrity check — raises CapDigestMismatchError on mismatch.
+        # We let it propagate so the discoverer can refuse the record
+        # rather than silently downgrading to TXT fallback (§6.1).
+        if expected_sha256:
+            _verify_cap_digest(body, expected_sha256, cap_uri)
 
         import json
 
@@ -197,6 +218,10 @@ async def fetch_cap_document(
         )
         return doc
 
+    except CapDigestMismatchError:
+        # Re-raise so the caller can distinguish digest mismatch (MUST
+        # refuse the record per §6.1) from network failures (fall back).
+        raise
     except ResponseTooLargeError:
         logger.warning(
             "Cap document response too large — skipping",

--- a/src/dns_aid/core/dcv.py
+++ b/src/dns_aid/core/dcv.py
@@ -5,7 +5,7 @@
 DNS-based Domain Control Validation (DCV) for agent identity assertion.
 
 Implements the challenge-response pattern from:
-- IETF draft-mozleywilliams-dnsop-dnsaid-01  (bnd-req binding extension)
+- IETF draft-mozleywilliams-dnsop-dnsaid-02  (bnd-req binding extension)
 - draft-ietf-dnsop-domain-verification-techniques-12  (TXT record wire format)
 
 Two primary use cases:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -408,8 +408,12 @@ async def _query_single_agent(
             cap_uri = custom_params.get("cap")
             cap_sha256 = custom_params.get("cap-sha256")
             well_known_path = custom_params.get("well-known")
-            bap_str = custom_params.get("bap", "")
-            bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
+            # Under draft-02 §FutureWork (Bulk Agent Protocol), `bap` carries
+            # a single versioned protocol identifier per record (e.g., "mcp2.1").
+            # Pre-PR 4 records may have a comma-separated list; in that case we
+            # take the first value to preserve a sensible scalar.
+            bap_raw = custom_params.get("bap")
+            bap = bap_raw.split(",")[0].strip() if bap_raw else None
             policy_uri = custom_params.get("policy")
             realm = custom_params.get("realm")
             connect_class = custom_params.get("connect-class")

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import shlex
 import time
 from typing import Any, Literal
@@ -203,9 +204,16 @@ async def discover(
 
     protocol = _normalize_protocol(protocol)
 
-    # Build query based on filters
+    # Build query based on filters. draft-02: the primary owner is a
+    # flat FQDN ({name}.{domain}); protocol is no longer in the
+    # FQDN — it lives in the bap/alpn SvcParam after resolution. The
+    # organization-level index keeps the underscored shape
+    # (_index._agents.{domain}) per draft-02 §Known Organization.
     if name and protocol:
-        query = f"_{name}._{protocol.value}._agents.{domain}"
+        # Known-agent query: flat draft-02 form. Legacy -01 form is
+        # tried as a fallback in _query_single_agent when
+        # DNS_AID_LEGACY_01_FALLBACK=1.
+        query = f"{name}.{domain}"
     elif protocol:
         query = f"_index._{protocol.value}._agents.{domain}"
     else:
@@ -314,21 +322,47 @@ async def _query_single_agent(
     name: str,
     protocol: Protocol,
 ) -> AgentRecord | None:
-    """Query DNS for a specific agent's SVCB record."""
-    fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+    """Query DNS for a specific agent's SVCB record.
+
+    draft-02: tries the flat FQDN ({name}.{domain}) first. If that
+    returns no answer and ``DNS_AID_LEGACY_01_FALLBACK=1`` is set, also
+    tries the legacy -01 shape (_{name}._{protocol}._agents.{domain})
+    so consumers can still resolve publishers that haven't migrated.
+    """
+    fqdn = f"{name}.{domain}"
+    legacy_fqdn: str | None = None
+    if os.environ.get("DNS_AID_LEGACY_01_FALLBACK", "").lower() in ("1", "true", "yes"):
+        legacy_fqdn = f"_{name}._{protocol.value}._agents.{domain}"
 
     try:
         resolver = dns.asyncresolver.Resolver()
 
-        # Query SVCB record
-        # Note: dnspython uses type 64 for SVCB
-        try:
-            answers = await resolver.resolve(fqdn, "SVCB")
-        except dns.resolver.NoAnswer:
-            # Try HTTPS record as fallback (type 65)
+        # Query SVCB record. dnspython uses type 64 for SVCB.
+        # draft-02: try the flat FQDN first. On NoAnswer / NXDOMAIN
+        # try the legacy -01 shape if the back-compat env flag is set.
+        async def _try(name_to_query: str):
             try:
-                answers = await resolver.resolve(fqdn, "HTTPS")
+                return await resolver.resolve(name_to_query, "SVCB")
             except dns.resolver.NoAnswer:
+                # HTTPS record (type 65) is the protocol-specific alias
+                # of SVCB; some publishers may have used it instead.
+                return await resolver.resolve(name_to_query, "HTTPS")
+
+        try:
+            answers = await _try(fqdn)
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            if legacy_fqdn is None:
+                return None
+            try:
+                logger.debug(
+                    "Flat FQDN returned no answer; trying legacy -01 fallback",
+                    fqdn=fqdn,
+                    legacy_fqdn=legacy_fqdn,
+                )
+                answers = await _try(legacy_fqdn)
+                # Hand the legacy FQDN downstream so logging is accurate.
+                fqdn = legacy_fqdn
+            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
                 return None
 
         for rdata in answers:
@@ -776,25 +810,66 @@ def _parse_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     """
     Parse agent name and protocol from a DNS-AID FQDN.
 
-    FQDN format: _{name}._{protocol}._agents.{domain}
+    Recognized shapes (in priority order):
+
+    1. Legacy -01 form ``_{name}._{protocol}._agents.{domain}`` — name
+       is the first label (sans leading underscore); protocol is the
+       second label (sans leading underscore).
+    2. Walkable AliasMode form ``{name}._agents.{domain}`` (draft-02) —
+       name is the label before ``._agents.``; protocol returns
+       ``None`` because draft-02 carries the protocol in the SVCB
+       SvcParams (``bap`` / ``alpn``), not in the FQDN.
+    3. Flat primary owner ``{name}.{domain}`` (draft-02) — name is the
+       first label; protocol returns ``None`` (same reason as above).
 
     Returns:
-        (name, protocol_str) or (None, None) if parsing fails.
+        ``(name, protocol_str)`` or ``(None, None)`` if the input
+        doesn't look like any recognized shape (e.g. single-label
+        strings).
     """
-    if not fqdn or not fqdn.startswith("_"):
+    if not fqdn:
         return None, None
 
-    parts = fqdn.split(".")
-    if len(parts) < 3:
+    # Legacy -01: _{name}._{protocol}._agents.{domain}
+    # Requires (a) leading underscore, (b) ._agents. infix, AND
+    # (c) parts[2] == "_agents" so the protocol label is correctly the
+    # second one (rejecting strings like "_booking._agents.example.com"
+    # which is the walkable shape with an erroneous underscore prefix).
+    if fqdn.startswith("_") and "._agents." in fqdn:
+        parts = fqdn.split(".")
+        if len(parts) < 4:
+            return None, None
+        name_part = parts[0]
+        protocol_part = parts[1]
+        agents_part = parts[2]
+        if (
+            not name_part.startswith("_")
+            or not protocol_part.startswith("_")
+            or agents_part != "_agents"
+        ):
+            return None, None
+        return name_part[1:], protocol_part[1:]
+
+    # Walkable AliasMode draft-02: {name}._agents.{domain}. The name
+    # must be a single DNS label without a leading underscore, and the
+    # domain portion must be non-empty (otherwise the string is
+    # malformed and we don't try to "parse" it).
+    if "._agents." in fqdn:
+        prefix, _, suffix = fqdn.partition("._agents.")
+        if prefix and suffix and "." not in prefix and not prefix.startswith("_"):
+            return prefix, None
         return None, None
 
-    name_part = parts[0]  # _name
-    protocol_part = parts[1]  # _protocol
+    # Flat draft-02: {name}.{domain}. We require at least three labels
+    # total ({name} + at least a two-label domain such as example.com)
+    # and the name must not start with an underscore, to avoid matching
+    # strings like "_a._b" or arbitrary short inputs.
+    if "." in fqdn:
+        first_label, _, rest = fqdn.partition(".")
+        if first_label and rest and "." in rest and not first_label.startswith("_"):
+            return first_label, None
 
-    if not name_part.startswith("_") or not protocol_part.startswith("_"):
-        return None, None
-
-    return name_part[1:], protocol_part[1:]
+    return None, None
 
 
 def _enrich_from_http_index(agent: AgentRecord, http_agent: HttpIndexAgent) -> None:
@@ -1200,46 +1275,54 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
     """
     Discover agent at a specific FQDN.
 
+    Accepts any of the three DNS-AID FQDN shapes (draft-02 flat,
+    draft-02 walkable, or legacy -01) and resolves the agent at it.
+    When the input doesn't carry a protocol (the two draft-02 shapes),
+    the discoverer attempts mcp first, then a2a.
+
     Args:
-        fqdn: Full DNS-AID record name (e.g., "_chat._a2a._agents.example.com")
+        fqdn: Full DNS-AID record name. Examples:
+            - ``"chat.example.com"`` (draft-02 flat)
+            - ``"chat._agents.example.com"`` (draft-02 walkable)
+            - ``"_chat._a2a._agents.example.com"`` (legacy -01)
 
     Returns:
-        AgentRecord if found, None otherwise
+        AgentRecord if found, None otherwise.
     """
-    # Parse FQDN to extract components
-    # Format: _{name}._{protocol}._agents.{domain}
-    parts = fqdn.split(".")
-
-    if len(parts) < 4:
+    name, protocol_str = _parse_fqdn(fqdn)
+    if not name:
         logger.error("Invalid DNS-AID FQDN format", fqdn=fqdn)
         return None
 
-    # Extract components
-    name_part = parts[0]  # _name
-    protocol_part = parts[1]  # _protocol
+    # Derive domain from the FQDN: everything after the name + any
+    # walkable/legacy infix labels.
+    if "._agents." in fqdn:
+        domain = fqdn.split("._agents.", 1)[1]
+    else:
+        # Flat shape: domain is everything after the first label.
+        domain = fqdn.split(".", 1)[1] if "." in fqdn else ""
 
-    if not name_part.startswith("_") or not protocol_part.startswith("_"):
-        logger.error("Invalid DNS-AID FQDN format", fqdn=fqdn)
+    if not domain:
+        logger.error("Could not extract domain from FQDN", fqdn=fqdn)
         return None
 
-    name = name_part[1:]  # Remove leading underscore
-    protocol_str = protocol_part[1:]  # Remove leading underscore
+    # For the legacy form the protocol is in the FQDN; use it directly.
+    if protocol_str:
+        try:
+            protocol = Protocol(protocol_str)
+        except ValueError:
+            logger.error("Unknown protocol", protocol=protocol_str)
+            return None
+        return await _query_single_agent(domain, name, protocol)
 
-    # Find _agents marker to determine domain
-    try:
-        agents_idx = parts.index("_agents")
-        domain = ".".join(parts[agents_idx + 1 :])
-    except ValueError:
-        logger.error("Missing _agents in FQDN", fqdn=fqdn)
-        return None
-
-    try:
-        protocol = Protocol(protocol_str)
-    except ValueError:
-        logger.error("Unknown protocol", protocol=protocol_str)
-        return None
-
-    return await _query_single_agent(domain, name, protocol)
+    # draft-02 shapes don't carry protocol in the FQDN. Try mcp then
+    # a2a; the SVCB record's alpn/bap params will reveal the actual
+    # protocol on the discovered AgentRecord.
+    for proto in (Protocol.MCP, Protocol.A2A):
+        result = await _query_single_agent(domain, name, proto)
+        if result is not None:
+            return result
+    return None
 
 
 async def _verify_agent_signatures(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -373,6 +373,7 @@ async def _query_single_agent(
 
             cap_uri = custom_params.get("cap")
             cap_sha256 = custom_params.get("cap-sha256")
+            well_known_path = custom_params.get("well-known")
             bap_str = custom_params.get("bap", "")
             bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
             policy_uri = custom_params.get("policy")
@@ -381,22 +382,68 @@ async def _query_single_agent(
             connect_meta = custom_params.get("connect-meta")
             enroll_uri = custom_params.get("enroll-uri")
 
-            # Discovery priority: cap URI first, then TXT fallback
+            # Discovery priority per draft-02:
+            #   1. cap (explicit URI/URN/JSON-Ref locator) — preferred
+            #   2. well-known (RFC 8615 path suffix) — reconstructed against the SVCB target
+            #   3. A2A agent-card from cap_uri response
+            #   4. TXT fallback
             capabilities: list[str] = []
             capability_source: Literal[
-                "cap_uri", "agent_card", "http_index", "txt_fallback", "none"
+                "cap_uri", "well_known", "agent_card", "http_index", "txt_fallback", "none"
             ] = "none"
             agent_card = None
 
+            # Resolve effective descriptor URL: prefer cap (explicit locator);
+            # fall back to reconstructing https://<target>/.well-known/<wk_path>
+            # when only well-known is set.
+            effective_descriptor_url: str | None = None
+            descriptor_source_label: Literal["cap_uri", "well_known", "none"] = "none"
             if cap_uri:
-                cap_doc = await fetch_cap_document(cap_uri, expected_sha256=cap_sha256)
+                effective_descriptor_url = cap_uri
+                descriptor_source_label = "cap_uri"
+            elif well_known_path:
+                # The well-known value comes from a DNS SVCB SvcParamKey,
+                # which an attacker controls if DNSSEC isn't enforced.
+                # Validate to a single RFC 8615 suffix before interpolating
+                # into a URL — otherwise `..`, `?`, `#`, or embedded
+                # slashes would let a forged record steer the fetch off
+                # the legitimate well-known namespace. validate_fetch_url
+                # pins the host but doesn't constrain the path.
+                from dns_aid.utils.validation import (
+                    ValidationError,
+                    validate_well_known_path,
+                )
+
+                try:
+                    safe_wk = validate_well_known_path(well_known_path)
+                except ValidationError as exc:
+                    logger.warning(
+                        "well-known SvcParamKey rejected — skipping descriptor fetch",
+                        fqdn=fqdn,
+                        well_known_path=well_known_path,
+                        reason=str(exc),
+                    )
+                    safe_wk = None
+
+                if safe_wk:
+                    # SVCB target is the host serving the well-known path.
+                    # Strip any trailing dot for URL construction.
+                    wk_host = target.rstrip(".")
+                    effective_descriptor_url = f"https://{wk_host}/.well-known/{safe_wk}"
+                    descriptor_source_label = "well_known"
+
+            if effective_descriptor_url:
+                cap_doc = await fetch_cap_document(
+                    effective_descriptor_url, expected_sha256=cap_sha256
+                )
                 if cap_doc and cap_doc.capabilities:
                     capabilities = cap_doc.capabilities
-                    capability_source = "cap_uri"
+                    capability_source = descriptor_source_label
                     logger.debug(
-                        "Capabilities fetched from cap URI",
+                        "Capabilities fetched from descriptor URL",
                         fqdn=fqdn,
-                        cap_uri=cap_uri,
+                        descriptor_url=effective_descriptor_url,
+                        source=descriptor_source_label,
                         capabilities=capabilities,
                     )
 
@@ -441,6 +488,7 @@ async def _query_single_agent(
                 capabilities=capabilities,
                 cap_uri=cap_uri,
                 cap_sha256=cap_sha256,
+                well_known_path=well_known_path,
                 bap=bap,
                 policy_uri=policy_uri,
                 realm=realm,
@@ -485,6 +533,7 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
         "connect-class",
         "connect-meta",
         "enroll-uri",
+        "well-known",
     }
 
     try:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -382,33 +382,39 @@ async def _query_single_agent(
             connect_meta = custom_params.get("connect-meta")
             enroll_uri = custom_params.get("enroll-uri")
 
-            # Discovery priority per draft-02:
-            #   1. cap (explicit URI/URN/JSON-Ref locator) — preferred
-            #   2. well-known (RFC 8615 path suffix) — reconstructed against the SVCB target
-            #   3. A2A agent-card from cap_uri response
-            #   4. TXT fallback
+            # Descriptor-fetch precedence (local dns-aid-core convention,
+            # NOT spec-mandated — draft §6.1 names only well-known as the
+            # source). When both `cap` and `well-known` are present we
+            # prefer the explicit locator if it's https-fetchable; if it
+            # isn't (URN, JSON-Ref, non-https scheme), we fall back to
+            # the reconstructed well-known URL rather than treating the
+            # non-fetchable `cap` as terminal.
             capabilities: list[str] = []
             capability_source: Literal[
                 "cap_uri", "well_known", "agent_card", "http_index", "txt_fallback", "none"
             ] = "none"
             agent_card = None
+            cap_sha256_applied = False
 
-            # Resolve effective descriptor URL: prefer cap (explicit locator);
-            # fall back to reconstructing https://<target>/.well-known/<wk_path>
-            # when only well-known is set.
             effective_descriptor_url: str | None = None
             descriptor_source_label: Literal["cap_uri", "well_known", "none"] = "none"
-            if cap_uri:
+
+            # Item 3: only treat `cap` as a descriptor when it's
+            # https-fetchable. The fetcher's SSRF guard would reject
+            # other schemes anyway, but routing the decision here lets
+            # well-known still get a chance.
+            cap_is_https = cap_uri is not None and cap_uri.lower().startswith("https://")
+            if cap_is_https:
                 effective_descriptor_url = cap_uri
                 descriptor_source_label = "cap_uri"
-            elif well_known_path:
-                # The well-known value comes from a DNS SVCB SvcParamKey,
-                # which an attacker controls if DNSSEC isn't enforced.
-                # Validate to a single RFC 8615 suffix before interpolating
-                # into a URL — otherwise `..`, `?`, `#`, or embedded
-                # slashes would let a forged record steer the fetch off
-                # the legitimate well-known namespace. validate_fetch_url
-                # pins the host but doesn't constrain the path.
+
+            # Item 4 + path validation: well-known accepts a bare RFC
+            # 8615 suffix (e.g. ``agent-card.json``) or an absolute
+            # origin path (e.g. ``/.well-known/agent-card.json``,
+            # ``/not-well-known/other-card.json``, per draft Figure 3).
+            # The validator constrains the character class on both
+            # shapes so a forged SVCB can't steer the fetch off origin.
+            if effective_descriptor_url is None and well_known_path:
                 from dns_aid.utils.validation import (
                     ValidationError,
                     validate_well_known_path,
@@ -426,11 +432,28 @@ async def _query_single_agent(
                     safe_wk = None
 
                 if safe_wk:
-                    # SVCB target is the host serving the well-known path.
-                    # Strip any trailing dot for URL construction.
+                    # SVCB target is the host serving the well-known
+                    # path. Strip any trailing dot for URL construction.
                     wk_host = target.rstrip(".")
-                    effective_descriptor_url = f"https://{wk_host}/.well-known/{safe_wk}"
+                    if safe_wk.startswith("/"):
+                        # Absolute origin path — use as-is. Draft Figure
+                        # 3 includes values outside ``/.well-known/`` so
+                        # we don't force a prefix here.
+                        effective_descriptor_url = f"https://{wk_host}{safe_wk}"
+                    else:
+                        effective_descriptor_url = f"https://{wk_host}/.well-known/{safe_wk}"
                     descriptor_source_label = "well_known"
+
+            # Non-https `cap` (URN, JSON-Ref, etc.) with no fetchable
+            # well-known is a metadata-only locator: keep it on the
+            # record but don't try to fetch it.
+            if effective_descriptor_url is None and cap_uri is not None and not cap_is_https:
+                logger.debug(
+                    "cap is non-https locator and no well-known fallback — "
+                    "keeping cap on record but skipping descriptor fetch",
+                    fqdn=fqdn,
+                    cap_uri=cap_uri,
+                )
 
             if effective_descriptor_url:
                 cap_doc = await fetch_cap_document(
@@ -439,12 +462,21 @@ async def _query_single_agent(
                 if cap_doc and cap_doc.capabilities:
                     capabilities = cap_doc.capabilities
                     capability_source = descriptor_source_label
+                    # If cap_sha256 was supplied AND the fetcher accepted
+                    # the bytes (didn't raise CapDigestMismatchError —
+                    # see #155 fix), the integrity pin was actually
+                    # applied to these bytes. Record that as a separate
+                    # boolean so downstream consumers don't have to
+                    # guess from the mere presence of cap_sha256.
+                    if cap_sha256 is not None:
+                        cap_sha256_applied = True
                     logger.debug(
                         "Capabilities fetched from descriptor URL",
                         fqdn=fqdn,
                         descriptor_url=effective_descriptor_url,
                         source=descriptor_source_label,
                         capabilities=capabilities,
+                        cap_sha256_applied=cap_sha256_applied,
                     )
 
                 # Reuse raw data as A2AAgentCard (avoids redundant fetch later)
@@ -477,6 +509,25 @@ async def _query_single_agent(
                 if capabilities:
                     capability_source = "txt_fallback"
 
+            # Item 6: dangling cap_sha256. A `cap_sha256` value on the
+            # SVCB combined with capabilities that came from TXT or
+            # nowhere is a footgun — the pin isn't covering the bytes
+            # the caller will see. We keep the SvcParamKey value on the
+            # record for transparency (it tells consumers the operator
+            # *intended* an integrity pin) but the `cap_sha256_verified`
+            # flag clearly marks whether the pin was applied. Surface
+            # the dangling case as a warning for log scrapers.
+            if cap_sha256 is not None and not cap_sha256_applied:
+                logger.warning(
+                    "cap_sha256 declared but not applied — record carries the "
+                    "SvcParamKey value but the integrity pin did not cover the "
+                    "capabilities returned",
+                    fqdn=fqdn,
+                    declared_cap_sha256=cap_sha256,
+                    capability_source=capability_source,
+                    warning_class="dns_aid.dangling_cap_sha256",
+                )
+
             return AgentRecord(
                 name=name,
                 domain=domain,
@@ -488,6 +539,7 @@ async def _query_single_agent(
                 capabilities=capabilities,
                 cap_uri=cap_uri,
                 cap_sha256=cap_sha256,
+                cap_sha256_verified=cap_sha256_applied,
                 well_known_path=well_known_path,
                 bap=bap,
                 policy_uri=policy_uri,
@@ -506,35 +558,29 @@ async def _query_single_agent(
     return None
 
 
+# Derive the recognised DNS-AID SvcParamKey name set from the
+# single source of truth in models.py so adding a new key in one
+# place (DNS_AID_KEY_MAP) automatically updates the parser. Earlier
+# this was a literal set hand-maintained here; adding `well-known`
+# in #154 needed edits in three different files.
+from dns_aid.core.models import DNS_AID_KEY_MAP, DNS_AID_KEY_MAP_REVERSE  # noqa: E402
+
+_DNS_AID_KEY_NAMES: frozenset[str] = frozenset(DNS_AID_KEY_MAP.keys())
+
+
 def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
+    """Parse DNS-AID custom params from an SVCB record's text rendering.
+
+    Accepts both human-readable string names and RFC 9460 keyNNNNN form:
+
+    - String form: ``cap="https://..." bap="mcp,a2a" realm="demo"``
+    - Numeric form: ``key65400="https://..." key65402="mcp,a2a"``
+
+    The recognised name set is derived from
+    ``dns_aid.core.models.DNS_AID_KEY_MAP`` at module load so this
+    stays in lock-step with publishing.
     """
-    Parse DNS-AID custom params from SVCB record text representation.
-
-    Accepts both human-readable string names and RFC 9460 keyNNNNN format:
-        String form: cap="https://..." bap="mcp,a2a" realm="demo"
-        Numeric form: key65400="https://..." key65402="mcp,a2a" key65404="demo"
-
-    Args:
-        svcb_text: String representation of an SVCB rdata.
-
-    Returns:
-        Dict of custom param names (always string form) to their string values.
-    """
-    from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
-
     custom_params: dict[str, str] = {}
-    dnsaid_keys = {
-        "cap",
-        "cap-sha256",
-        "bap",
-        "policy",
-        "realm",
-        "sig",
-        "connect-class",
-        "connect-meta",
-        "enroll-uri",
-        "well-known",
-    }
 
     try:
         parts = shlex.split(svcb_text)
@@ -551,7 +597,7 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
         if key in DNS_AID_KEY_MAP_REVERSE:
             key = DNS_AID_KEY_MAP_REVERSE[key]
 
-        if key in dnsaid_keys:
+        if key in _DNS_AID_KEY_NAMES:
             custom_params[key] = value
 
     return custom_params

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -469,12 +469,17 @@ async def _query_single_agent(
             cap_uri = custom_params.get("cap")
             cap_sha256 = custom_params.get("cap-sha256")
             well_known_path = custom_params.get("well-known")
-            # Under draft-02 §FutureWork (Bulk Agent Protocol), `bap` carries
-            # a single versioned protocol identifier per record (e.g., "mcp2.1").
-            # Pre-PR 4 records may have a comma-separated list; in that case we
-            # take the first value to preserve a sensible scalar.
-            bap_raw = custom_params.get("bap")
-            bap = bap_raw.split(",")[0].strip() if bap_raw else None
+            # draft-02 §5.1 (Bulk Agent Protocol, experimental): `bap`
+            # carries a single agent-protocol identifier per record in
+            # either bare (``mcp``) or versioned (``mcp=1.0``) form.
+            # Pre-draft-02 records may have a comma-separated list; the
+            # shared ``normalize_bap`` helper collapses that to the
+            # first non-empty token and warns so the data loss is
+            # observable. Use the same helper in the SDK and indexer
+            # so all consumers agree on the collapse semantics.
+            from dns_aid.core.bap import normalize_bap
+
+            bap = normalize_bap(custom_params.get("bap"))
             policy_uri = custom_params.get("policy")
             realm = custom_params.get("realm")
             connect_class = custom_params.get("connect-class")
@@ -725,8 +730,8 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
 
     Accepts both human-readable string names and RFC 9460 keyNNNNN form:
 
-    - String form: ``cap="https://..." bap="mcp,a2a" realm="demo"``
-    - Numeric form: ``key65400="https://..." key65402="mcp,a2a"``
+    - String form: ``cap="https://..." bap="mcp=1.0" realm="demo"``
+    - Numeric form: ``key65400="https://..." key65402="mcp=1.0"``
 
     The recognised name set is derived from
     ``dns_aid.core.models.DNS_AID_KEY_MAP`` at module load so this
@@ -1353,21 +1358,23 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
     # DNS query is identical regardless of which Protocol we ask for —
     # only the AgentRecord.protocol field gets stamped from it — so we
     # resolve once and then read the actual protocol from the record's
-    # ``bap`` scalar (preferred per draft-02 §Known Agent) or fall back
-    # to the protocol kwarg if bap doesn't name a value we model.
+    # ``bap`` scalar. bap can be bare (``mcp``) or versioned
+    # (``mcp=1.0``); split off the protocol token before checking
+    # membership against the Protocol enum, otherwise a versioned bap
+    # never matches and the reconciliation silently no-ops (Igor's
+    # #158 review item 4).
+    from dns_aid.core.bap import split_bap_token
+
     result = await _query_single_agent(domain, name, Protocol.MCP)
     if result is None:
         return None
-    # Reconcile the record's protocol with what was actually announced.
-    declared = (
-        result.bap if result.bap and result.bap.strip() in {pv.value for pv in Protocol} else None
-    )
-    if declared is not None:
+    proto_token, _version = split_bap_token(result.bap)
+    if proto_token is not None and proto_token in {pv.value for pv in Protocol}:
         # bap may carry a value we don't model (e.g. an extension);
         # in that case leave the default in place rather than refuse
         # the record.
         with contextlib.suppress(ValueError):
-            result.protocol = Protocol(declared.strip())
+            result.protocol = Protocol(proto_token)
     return result
 
 

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -27,9 +27,22 @@ from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
 from dns_aid.core.filters import apply_filters
 from dns_aid.core.http_index import HttpIndexAgent, fetch_http_index_or_empty
-from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol
+from dns_aid.core.models import (
+    AgentRecord,
+    CapabilitySource,
+    DiscoveryResult,
+    DNSSECError,
+    Protocol,
+)
 
 logger = structlog.get_logger(__name__)
+
+# Per-agent total-time budget for descriptor (cap / well-known) fetch.
+# Slightly above fetch_cap_document's default 10s HTTP timeout so a
+# normal slow response still completes, but bounds pathological cases
+# (DNS hangs, TLS handshake stalls, redirect chains). Cross-agent
+# bulk discovery would otherwise serialize on the slowest endpoint.
+_DESCRIPTOR_FETCH_BUDGET_SECONDS: float = 12.0
 
 
 def _normalize_protocol(protocol: str | Protocol | None) -> Protocol | None:
@@ -105,7 +118,11 @@ async def discover(
     domain: str,
     protocol: str | Protocol | None = None,
     name: str | None = None,
-    require_dnssec: bool = False,  # Default False for now, True in production
+    # draft-02 §6.2 relaxes DNSSEC to MAY by default; MUST applies only when
+    # TLSA / DANE is in use (RFC 6698 §10.1). Default False matches the
+    # baseline SVCB-only deployment posture. Opt-in True when the consumer
+    # wants AD-flag enforcement or when records carry TLSA hints.
+    require_dnssec: bool = False,
     use_http_index: bool = False,
     enrich_endpoints: bool = True,
     verify_signatures: bool = False,
@@ -133,7 +150,11 @@ async def discover(
         domain: Domain to search for agents (e.g., "example.com").
         protocol: Filter by protocol ("a2a", "mcp", or None for all).
         name: Filter by specific agent name (or None for all).
-        require_dnssec: Require DNSSEC validation (raises if invalid).
+        require_dnssec: Require DNSSEC validation (raises if invalid). Per
+            draft-02 §6.2 DNSSEC is MAY by default; consumers SHOULD set this
+            to True for TLSA/DANE-bound deployments, where unsigned records
+            cannot be trusted (RFC 6698 §10.1). SVCB-only deployments may
+            leave this False.
         use_http_index: If True, fetch agent list from HTTP endpoint
             (``/.well-known/agents-index.json``) instead of DNS-only discovery.
         enrich_endpoints: If True (default), fetch ``.well-known/agent-card.json``
@@ -390,9 +411,7 @@ async def _query_single_agent(
             # the reconstructed well-known URL rather than treating the
             # non-fetchable `cap` as terminal.
             capabilities: list[str] = []
-            capability_source: Literal[
-                "cap_uri", "well_known", "agent_card", "http_index", "txt_fallback", "none"
-            ] = "none"
+            capability_source: CapabilitySource = "none"
             agent_card = None
             cap_sha256_applied = False
 
@@ -456,9 +475,42 @@ async def _query_single_agent(
                 )
 
             if effective_descriptor_url:
-                cap_doc = await fetch_cap_document(
-                    effective_descriptor_url, expected_sha256=cap_sha256
-                )
+                # Per-agent total-time budget on descriptor fetch.
+                # fetch_cap_document already times out individual HTTP
+                # operations, but a chain of redirects + DNS + TLS can
+                # still pile up; cap the whole fetch so one slow agent
+                # can't stall a bulk-discovery loop. Igor flagged this
+                # on PR #154 v2 review as a reliability item.
+                cap_doc = None
+                descriptor_reachable = True
+                try:
+                    cap_doc = await asyncio.wait_for(
+                        fetch_cap_document(effective_descriptor_url, expected_sha256=cap_sha256),
+                        timeout=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
+                    )
+                except TimeoutError:
+                    descriptor_reachable = False
+                    logger.warning(
+                        "Descriptor fetch exceeded per-agent budget — "
+                        "recording capability_source=descriptor_unreachable",
+                        fqdn=fqdn,
+                        descriptor_url=effective_descriptor_url,
+                        budget_seconds=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
+                    )
+
+                # Reachability signal: the operator declared a descriptor
+                # locator (cap or well-known) but we couldn't pull bytes
+                # off the wire. Distinct from "no descriptor declared",
+                # so consumers can tell transient outages from
+                # mis-configurations.
+                if cap_doc is None and descriptor_reachable:
+                    descriptor_reachable = False
+                    logger.debug(
+                        "Descriptor fetch returned no document",
+                        fqdn=fqdn,
+                        descriptor_url=effective_descriptor_url,
+                    )
+
                 if cap_doc and cap_doc.capabilities:
                     capabilities = cap_doc.capabilities
                     capability_source = descriptor_source_label
@@ -478,14 +530,17 @@ async def _query_single_agent(
                         capabilities=capabilities,
                         cap_sha256_applied=cap_sha256_applied,
                     )
+                elif not descriptor_reachable:
+                    capability_source = "descriptor_unreachable"
 
                 # Reuse raw data as A2AAgentCard (avoids redundant fetch later)
                 if cap_doc and cap_doc.raw_data:
                     try:
                         agent_card = A2AAgentCard.from_dict(cap_doc.raw_data)
                         logger.debug(
-                            "Parsed A2A Agent Card from cap URI response",
+                            "Parsed A2A Agent Card from descriptor response",
                             fqdn=fqdn,
+                            descriptor_source=descriptor_source_label,
                             card_name=agent_card.name,
                             skills_count=len(agent_card.skills),
                         )
@@ -920,7 +975,7 @@ def _http_agent_to_record(
 
     # Extract capabilities from HTTP index if available
     http_capabilities: list[str] = []
-    cap_source: Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] = "none"
+    cap_source: CapabilitySource = "none"
     if http_agent.capability and http_agent.capability.capabilities:
         http_capabilities = http_agent.capability.capabilities
         cap_source = "http_index"
@@ -948,10 +1003,13 @@ def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
     """
     agent.agent_card = card
 
-    # Wire agent card skills → capabilities
-    # agent_card is higher priority than txt_fallback and http_index,
-    # so override those sources. Only cap_uri takes precedence.
-    if card.skills and agent.capability_source not in ("cap_uri",):
+    # Wire agent card skills → capabilities. Preserve higher-trust
+    # provenance: cap_uri (draft §6.1 normative locator) and well_known
+    # (RFC 8615 locator, also normative in -02) both record the actual
+    # descriptor source. Overwriting them with "agent_card" here would
+    # erase the fact that the operator declared a specific fetch path —
+    # downstream consumers use capability_source for trust/audit calls.
+    if card.skills and agent.capability_source not in ("cap_uri", "well_known"):
         agent.capabilities = card.to_capabilities()
         agent.capability_source = "agent_card"
         logger.debug(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -373,6 +373,7 @@ async def _query_single_agent(
 
             cap_uri = custom_params.get("cap")
             cap_sha256 = custom_params.get("cap-sha256")
+            well_known_path = custom_params.get("well-known")
             bap_str = custom_params.get("bap", "")
             bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
             policy_uri = custom_params.get("policy")
@@ -381,22 +382,45 @@ async def _query_single_agent(
             connect_meta = custom_params.get("connect-meta")
             enroll_uri = custom_params.get("enroll-uri")
 
-            # Discovery priority: cap URI first, then TXT fallback
+            # Discovery priority per draft-02:
+            #   1. cap (explicit URI/URN/JSON-Ref locator) — preferred
+            #   2. well-known (RFC 8615 path suffix) — reconstructed against the SVCB target
+            #   3. A2A agent-card from cap_uri response
+            #   4. TXT fallback
             capabilities: list[str] = []
             capability_source: Literal[
-                "cap_uri", "agent_card", "http_index", "txt_fallback", "none"
+                "cap_uri", "well_known", "agent_card", "http_index", "txt_fallback", "none"
             ] = "none"
             agent_card = None
 
+            # Resolve effective descriptor URL: prefer cap (explicit locator);
+            # fall back to reconstructing https://<target>/.well-known/<wk_path>
+            # when only well-known is set.
+            effective_descriptor_url: str | None = None
+            descriptor_source_label: Literal["cap_uri", "well_known", "none"] = "none"
             if cap_uri:
-                cap_doc = await fetch_cap_document(cap_uri, expected_sha256=cap_sha256)
+                effective_descriptor_url = cap_uri
+                descriptor_source_label = "cap_uri"
+            elif well_known_path:
+                # SVCB target is the host serving the well-known path.
+                # Strip any trailing dot for URL construction.
+                wk_host = target.rstrip(".")
+                wk_suffix = well_known_path.lstrip("/")
+                effective_descriptor_url = f"https://{wk_host}/.well-known/{wk_suffix}"
+                descriptor_source_label = "well_known"
+
+            if effective_descriptor_url:
+                cap_doc = await fetch_cap_document(
+                    effective_descriptor_url, expected_sha256=cap_sha256
+                )
                 if cap_doc and cap_doc.capabilities:
                     capabilities = cap_doc.capabilities
-                    capability_source = "cap_uri"
+                    capability_source = descriptor_source_label
                     logger.debug(
-                        "Capabilities fetched from cap URI",
+                        "Capabilities fetched from descriptor URL",
                         fqdn=fqdn,
-                        cap_uri=cap_uri,
+                        descriptor_url=effective_descriptor_url,
+                        source=descriptor_source_label,
                         capabilities=capabilities,
                     )
 
@@ -441,6 +465,7 @@ async def _query_single_agent(
                 capabilities=capabilities,
                 cap_uri=cap_uri,
                 cap_sha256=cap_sha256,
+                well_known_path=well_known_path,
                 bap=bap,
                 policy_uri=policy_uri,
                 realm=realm,
@@ -485,6 +510,7 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
         "connect-class",
         "connect-meta",
         "enroll-uri",
+        "well-known",
     }
 
     try:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -927,7 +927,7 @@ async def _process_http_agent(
         return None
 
     dns_agent_name, fqdn_protocol_str = _parse_fqdn(http_agent.fqdn)
-    if not dns_agent_name or not fqdn_protocol_str:
+    if not dns_agent_name:
         logger.debug(
             "Cannot parse FQDN from HTTP index entry",
             agent=http_agent.name,
@@ -935,21 +935,40 @@ async def _process_http_agent(
         )
         return None
 
-    try:
-        agent_protocol = Protocol(fqdn_protocol_str.lower())
-    except ValueError:
-        logger.debug(
-            "Unknown protocol in FQDN",
-            agent=http_agent.name,
-            fqdn=http_agent.fqdn,
-            protocol=fqdn_protocol_str,
-        )
+    # Under draft-02 the flat and walkable FQDN shapes don't carry the
+    # agent protocol — it lives in the SVCB `bap`/`alpn` SvcParam. If
+    # _parse_fqdn returned no protocol, use the caller-supplied protocol
+    # filter when present, otherwise try mcp then a2a (the SVCB params
+    # on the discovered record reveal the actual protocol).
+    candidate_protocols: list[Protocol]
+    if fqdn_protocol_str:
+        try:
+            candidate_protocols = [Protocol(fqdn_protocol_str.lower())]
+        except ValueError:
+            logger.debug(
+                "Unknown protocol in FQDN",
+                agent=http_agent.name,
+                fqdn=http_agent.fqdn,
+                protocol=fqdn_protocol_str,
+            )
+            return None
+    elif protocol is not None:
+        candidate_protocols = [protocol]
+    else:
+        candidate_protocols = [Protocol.MCP, Protocol.A2A]
+
+    # Apply caller-side protocol filter when the FQDN-carried protocol
+    # is known and doesn't match.
+    if fqdn_protocol_str and protocol and candidate_protocols[0] != protocol:
         return None
 
-    if protocol and agent_protocol != protocol:
-        return None
-
-    agent = await _query_single_agent(domain, dns_agent_name, agent_protocol)
+    agent_protocol = candidate_protocols[0]
+    agent = None
+    for proto in candidate_protocols:
+        agent = await _query_single_agent(domain, dns_agent_name, proto)
+        if agent:
+            agent_protocol = proto
+            break
 
     if agent:
         _enrich_from_http_index(agent, http_agent)

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import os
 import shlex
@@ -59,16 +60,18 @@ async def _execute_discovery(
     name: str | None,
     use_http_index: bool,
     query: str,
+    *,
+    allow_legacy: bool | None = None,
 ) -> list[AgentRecord]:
     """Execute the appropriate discovery strategy and handle DNS errors."""
     try:
         if use_http_index:
             return await _discover_via_http_index(domain, protocol, name)
         elif name and protocol:
-            agent = await _query_single_agent(domain, name, protocol)
+            agent = await _query_single_agent(domain, name, protocol, allow_legacy=allow_legacy)
             return [agent] if agent else []
         else:
-            return await _discover_agents_in_zone(domain, protocol)
+            return await _discover_agents_in_zone(domain, protocol, allow_legacy=allow_legacy)
     except dns.resolver.NXDOMAIN:
         logger.debug("No DNS-AID records found", query=query)
     except dns.resolver.NoAnswer:
@@ -89,18 +92,32 @@ async def _apply_post_discovery(
 ) -> bool:
     """Apply DNSSEC enforcement, endpoint enrichment, and JWS verification.
 
-    Returns whether DNSSEC was validated.
+    Under draft-02's flat-FQDN model each agent has its own owner name,
+    so DNSSEC is checked per agent rather than once for the zone. The
+    result-level boolean returned here is True only if every agent's
+    fqdn validated; per-agent state lives on ``AgentRecord.dnssec_validated``.
+
+    Returns whether DNSSEC was validated across all agents.
     """
-    dnssec_validated = False
+    per_agent_dnssec: dict[str, bool] = {}
 
     if agents and require_dnssec:
         from dns_aid.core.validator import _check_dnssec
 
-        dnssec_validated = await _check_dnssec(agents[0].fqdn)
-        if not dnssec_validated:
+        results = await asyncio.gather(
+            *[_check_dnssec(a.fqdn) for a in agents],
+            return_exceptions=True,
+        )
+        for agent, outcome in zip(agents, results, strict=True):
+            ok = outcome is True
+            per_agent_dnssec[agent.fqdn] = ok
+            agent.dnssec_validated = ok
+
+        if not all(per_agent_dnssec.values()):
+            failed = sorted(f for f, ok in per_agent_dnssec.items() if not ok)
             raise DNSSECError(
-                f"DNSSEC validation required but DNS response for "
-                f"{agents[0].fqdn} is not authenticated (AD flag not set)"
+                f"DNSSEC validation required but the following agent "
+                f"FQDNs were not authenticated (AD flag not set): {failed}"
             )
 
     if enrich_endpoints and agents:
@@ -110,9 +127,9 @@ async def _apply_post_discovery(
             logger.debug("Endpoint enrichment failed (non-fatal)", exc_info=True)
 
     if verify_signatures and agents:
-        await _verify_agent_signatures(agents, domain, dnssec_validated)
+        await _verify_agent_signatures(agents, domain, dnssec_validated=per_agent_dnssec)
 
-    return dnssec_validated
+    return bool(per_agent_dnssec) and all(per_agent_dnssec.values())
 
 
 async def discover(
@@ -140,6 +157,7 @@ async def discover(
     text_match: str | None = None,
     require_signed: bool = False,
     require_signature_algorithm: list[str] | None = None,
+    allow_legacy: bool | None = None,
 ) -> DiscoveryResult:
     """
     Discover AI agents at a domain using DNS-AID protocol.
@@ -212,7 +230,10 @@ async def discover(
     if name and protocol:
         # Known-agent query: flat draft-02 form. Legacy -01 form is
         # tried as a fallback in _query_single_agent when
-        # DNS_AID_LEGACY_01_FALLBACK=1.
+        # allow_legacy=True (or DNS_AID_LEGACY_01_FALLBACK=1 for
+        # callers using the env-flag form). Results that came from the
+        # legacy path are stamped legacy_resolved=True on the returned
+        # AgentRecord.
         query = f"{name}.{domain}"
     elif protocol:
         query = f"_index._{protocol.value}._agents.{domain}"
@@ -231,7 +252,9 @@ async def discover(
         use_http_index=use_http_index,
     )
 
-    agents = await _execute_discovery(domain, protocol, name, use_http_index, query)
+    agents = await _execute_discovery(
+        domain, protocol, name, use_http_index, query, allow_legacy=allow_legacy
+    )
 
     # Path A name filter — applied here, *before* enrichment, so we don't fetch
     # cap docs / agent cards / JWKS for agents we're about to discard.
@@ -247,12 +270,8 @@ async def discover(
     dnssec_validated = await _apply_post_discovery(
         agents, require_dnssec, enrich_endpoints, verify_signatures, domain
     )
-
-    # Propagate domain-level DNSSEC outcome onto each agent so per-agent trust filters
-    # (``min_dnssec``) have a record-level signal to evaluate.
-    if dnssec_validated:
-        for agent in agents:
-            agent.dnssec_validated = True
+    # Per-agent `dnssec_validated` is set inside _apply_post_discovery
+    # when require_dnssec=True; no need to re-stamp at this level.
 
     # Apply Path A in-memory filters (FR-002, FR-021..FR-023). When no filter kwargs are
     # set, ``apply_filters`` short-circuits and returns the input list unchanged.
@@ -321,18 +340,37 @@ async def _query_single_agent(
     domain: str,
     name: str,
     protocol: Protocol,
+    *,
+    allow_legacy: bool | None = None,
 ) -> AgentRecord | None:
     """Query DNS for a specific agent's SVCB record.
 
     draft-02: tries the flat FQDN ({name}.{domain}) first. If that
-    returns no answer and ``DNS_AID_LEGACY_01_FALLBACK=1`` is set, also
-    tries the legacy -01 shape (_{name}._{protocol}._agents.{domain})
-    so consumers can still resolve publishers that haven't migrated.
+    returns no answer AND the caller permits legacy fallback, also tries
+    the legacy -01 shape (_{name}._{protocol}._agents.{domain}) so
+    consumers can still resolve publishers that haven't migrated.
+
+    Legacy fallback is opt-in per call:
+
+    - ``allow_legacy=True`` — fallback enabled for this call.
+    - ``allow_legacy=False`` — fallback disabled regardless of env.
+    - ``allow_legacy=None`` (default) — defer to the env flag
+      ``DNS_AID_LEGACY_01_FALLBACK`` for backwards compatibility with
+      existing deployments.
+
+    When the legacy path serves an answer, the returned ``AgentRecord``
+    has ``legacy_resolved=True`` and a warning is logged so operators
+    can detect publishers that haven't migrated and downstream filters
+    can down-weight legacy records.
     """
     fqdn = f"{name}.{domain}"
     legacy_fqdn: str | None = None
-    if os.environ.get("DNS_AID_LEGACY_01_FALLBACK", "").lower() in ("1", "true", "yes"):
+    if allow_legacy is True or (
+        allow_legacy is None
+        and os.environ.get("DNS_AID_LEGACY_01_FALLBACK", "").lower() in ("1", "true", "yes")
+    ):
         legacy_fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+    resolved_via_legacy = False
 
     try:
         resolver = dns.asyncresolver.Resolver()
@@ -340,7 +378,7 @@ async def _query_single_agent(
         # Query SVCB record. dnspython uses type 64 for SVCB.
         # draft-02: try the flat FQDN first. On NoAnswer / NXDOMAIN
         # try the legacy -01 shape if the back-compat env flag is set.
-        async def _try(name_to_query: str):
+        async def _try(name_to_query: str) -> dns.resolver.Answer:
             try:
                 return await resolver.resolve(name_to_query, "SVCB")
             except dns.resolver.NoAnswer:
@@ -354,14 +392,16 @@ async def _query_single_agent(
             if legacy_fqdn is None:
                 return None
             try:
-                logger.debug(
-                    "Flat FQDN returned no answer; trying legacy -01 fallback",
+                logger.warning(
+                    "Flat FQDN returned no answer; serving legacy -01 fallback",
                     fqdn=fqdn,
                     legacy_fqdn=legacy_fqdn,
+                    note="caller will receive legacy_resolved=True on this record",
                 )
                 answers = await _try(legacy_fqdn)
                 # Hand the legacy FQDN downstream so logging is accurate.
                 fqdn = legacy_fqdn
+                resolved_via_legacy = True
             except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
                 return None
 
@@ -513,8 +553,10 @@ async def _query_single_agent(
                 # fetch_cap_document already times out individual HTTP
                 # operations, but a chain of redirects + DNS + TLS can
                 # still pile up; cap the whole fetch so one slow agent
-                # can't stall a bulk-discovery loop. Igor flagged this
-                # on PR #154 v2 review as a reliability item.
+                # can't stall a bulk-discovery loop. PR #154 v2 review
+                # (Igor) flagged this as a reliability item.
+                from dns_aid.core.cap_fetcher import CapDigestMismatchError
+
                 cap_doc = None
                 descriptor_reachable = True
                 try:
@@ -531,6 +573,21 @@ async def _query_single_agent(
                         descriptor_url=effective_descriptor_url,
                         budget_seconds=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
                     )
+                except CapDigestMismatchError as exc:
+                    # Per draft §6.1: digest mismatch MUST cause us to
+                    # refuse the record. Don't fall back to TXT — the
+                    # operator pinned a specific document and the host
+                    # served something different. Drop the record so
+                    # callers don't see an integrity-pinned-looking
+                    # AgentRecord whose capabilities came from elsewhere.
+                    logger.warning(
+                        "cap-sha256 digest mismatch — refusing record",
+                        fqdn=fqdn,
+                        descriptor_url=effective_descriptor_url,
+                        expected=exc.expected,
+                        actual=exc.actual,
+                    )
+                    return None
 
                 # Reachability signal: the operator declared a descriptor
                 # locator (cap or well-known) but we couldn't pull bytes
@@ -598,14 +655,15 @@ async def _query_single_agent(
                 if capabilities:
                     capability_source = "txt_fallback"
 
-            # Item 6: dangling cap_sha256. A `cap_sha256` value on the
-            # SVCB combined with capabilities that came from TXT or
-            # nowhere is a footgun — the pin isn't covering the bytes
-            # the caller will see. We keep the SvcParamKey value on the
-            # record for transparency (it tells consumers the operator
-            # *intended* an integrity pin) but the `cap_sha256_verified`
-            # flag clearly marks whether the pin was applied. Surface
-            # the dangling case as a warning for log scrapers.
+            # Item 6 (Igor #154 review): dangling cap_sha256. A
+            # `cap_sha256` value on the SVCB combined with capabilities
+            # that came from TXT or nowhere is a footgun — the pin
+            # isn't covering the bytes the caller will see. We keep the
+            # SvcParamKey value on the record for transparency (it tells
+            # consumers the operator *intended* an integrity pin) but
+            # the `cap_sha256_verified` flag clearly marks whether the
+            # pin was applied. Surface the dangling case as a warning
+            # for log scrapers.
             if cap_sha256 is not None and not cap_sha256_applied:
                 logger.warning(
                     "cap_sha256 declared but not applied — record carries the "
@@ -626,6 +684,7 @@ async def _query_single_agent(
                 ipv4_hint=ipv4_hint,
                 ipv6_hint=ipv6_hint,
                 capabilities=capabilities,
+                legacy_resolved=resolved_via_legacy,
                 cap_uri=cap_uri,
                 cap_sha256=cap_sha256,
                 cap_sha256_verified=cap_sha256_applied,
@@ -752,6 +811,8 @@ def _collect_agent_results(results: list[Any]) -> list[AgentRecord]:
 async def _discover_agents_in_zone(
     domain: str,
     protocol: Protocol | None = None,
+    *,
+    allow_legacy: bool | None = None,
 ) -> list[AgentRecord]:
     """
     Discover all agents in a domain's _agents zone.
@@ -767,7 +828,7 @@ async def _discover_agents_in_zone(
 
     async def _query_with_sem(name: str, proto: Protocol) -> AgentRecord | None:
         async with sem:
-            return await _query_single_agent(domain, name, proto)
+            return await _query_single_agent(domain, name, proto, allow_legacy=allow_legacy)
 
     if index_entries:
         logger.debug(
@@ -810,66 +871,16 @@ def _parse_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     """
     Parse agent name and protocol from a DNS-AID FQDN.
 
-    Recognized shapes (in priority order):
-
-    1. Legacy -01 form ``_{name}._{protocol}._agents.{domain}`` — name
-       is the first label (sans leading underscore); protocol is the
-       second label (sans leading underscore).
-    2. Walkable AliasMode form ``{name}._agents.{domain}`` (draft-02) —
-       name is the label before ``._agents.``; protocol returns
-       ``None`` because draft-02 carries the protocol in the SVCB
-       SvcParams (``bap`` / ``alpn``), not in the FQDN.
-    3. Flat primary owner ``{name}.{domain}`` (draft-02) — name is the
-       first label; protocol returns ``None`` (same reason as above).
-
-    Returns:
-        ``(name, protocol_str)`` or ``(None, None)`` if the input
-        doesn't look like any recognized shape (e.g. single-label
-        strings).
+    Thin projection over :func:`dns_aid.core.fqdn.parse_dnsaid_fqdn`
+    that drops the domain component; callers needing the domain too
+    should use the parent function directly.
     """
-    if not fqdn:
+    from dns_aid.core.fqdn import parse_dnsaid_fqdn
+
+    parsed = parse_dnsaid_fqdn(fqdn)
+    if parsed is None:
         return None, None
-
-    # Legacy -01: _{name}._{protocol}._agents.{domain}
-    # Requires (a) leading underscore, (b) ._agents. infix, AND
-    # (c) parts[2] == "_agents" so the protocol label is correctly the
-    # second one (rejecting strings like "_booking._agents.example.com"
-    # which is the walkable shape with an erroneous underscore prefix).
-    if fqdn.startswith("_") and "._agents." in fqdn:
-        parts = fqdn.split(".")
-        if len(parts) < 4:
-            return None, None
-        name_part = parts[0]
-        protocol_part = parts[1]
-        agents_part = parts[2]
-        if (
-            not name_part.startswith("_")
-            or not protocol_part.startswith("_")
-            or agents_part != "_agents"
-        ):
-            return None, None
-        return name_part[1:], protocol_part[1:]
-
-    # Walkable AliasMode draft-02: {name}._agents.{domain}. The name
-    # must be a single DNS label without a leading underscore, and the
-    # domain portion must be non-empty (otherwise the string is
-    # malformed and we don't try to "parse" it).
-    if "._agents." in fqdn:
-        prefix, _, suffix = fqdn.partition("._agents.")
-        if prefix and suffix and "." not in prefix and not prefix.startswith("_"):
-            return prefix, None
-        return None, None
-
-    # Flat draft-02: {name}.{domain}. We require at least three labels
-    # total ({name} + at least a two-label domain such as example.com)
-    # and the name must not start with an underscore, to avoid matching
-    # strings like "_a._b" or arbitrary short inputs.
-    if "." in fqdn:
-        first_label, _, rest = fqdn.partition(".")
-        if first_label and rest and "." in rest and not first_label.startswith("_"):
-            return first_label, None
-
-    return None, None
+    return parsed.name, parsed.protocol
 
 
 def _enrich_from_http_index(agent: AgentRecord, http_agent: HttpIndexAgent) -> None:
@@ -1315,40 +1326,58 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
             return None
         return await _query_single_agent(domain, name, protocol)
 
-    # draft-02 shapes don't carry protocol in the FQDN. Try mcp then
-    # a2a; the SVCB record's alpn/bap params will reveal the actual
-    # protocol on the discovered AgentRecord.
-    for proto in (Protocol.MCP, Protocol.A2A):
-        result = await _query_single_agent(domain, name, proto)
-        if result is not None:
-            return result
-    return None
+    # draft-02 shapes don't carry the protocol in the FQDN. The SVCB
+    # DNS query is identical regardless of which Protocol we ask for —
+    # only the AgentRecord.protocol field gets stamped from it — so we
+    # resolve once and then read the actual protocol from the record's
+    # `bap` list (preferred per draft-02 §Known Agent) or fall back to
+    # the protocol kwarg if neither bap nor alpn names a known value.
+    result = await _query_single_agent(domain, name, Protocol.MCP)
+    if result is None:
+        return None
+    # Reconcile the record's protocol with what was actually announced.
+    declared = next(
+        (p for p in result.bap if p.strip() in {pv.value for pv in Protocol}),
+        None,
+    )
+    if declared is not None:
+        # bap may carry a value we don't model (e.g. an extension);
+        # in that case leave the default in place rather than refuse
+        # the record.
+        with contextlib.suppress(ValueError):
+            result.protocol = Protocol(declared.strip())
+    return result
 
 
 async def _verify_agent_signatures(
     agents: list[AgentRecord],
     domain: str,
-    dnssec_validated: bool,
+    dnssec_validated: dict[str, bool] | bool,
 ) -> None:
     """
     Verify JWS signatures on agents that have sig parameter but no DNSSEC.
 
-    For each agent:
-    - If DNSSEC validated: skip (stronger verification already done)
-    - If has sig parameter: verify against domain's JWKS
-    - Log warnings for invalid/missing signatures but don't remove agents
+    Under draft-02 each agent has its own flat fqdn, so DNSSEC validation
+    is also per-agent. JWS verification runs as the per-agent fallback:
+    if a specific agent's owner-name validated under DNSSEC we skip JWS
+    for that agent (stronger guarantee already in place); otherwise we
+    fall through to JWS.
 
     Args:
         agents: List of agents to verify (modified in place with verification status)
         domain: Domain to fetch JWKS from
-        dnssec_validated: Whether DNSSEC validation passed
+        dnssec_validated: Either a mapping of ``agent.fqdn → bool``
+            (per-agent DNSSEC outcome) or a plain bool treated as a
+            uniform answer for every agent. The plain-bool form is kept
+            for callers that haven't migrated to the per-agent map yet.
     """
-    if dnssec_validated:
-        logger.debug("DNSSEC validated, skipping JWS verification")
-        return
+    # Normalize: plain bool → uniform-per-agent dict.
+    if isinstance(dnssec_validated, bool):
+        uniform = dnssec_validated
+        dnssec_validated = {a.fqdn: uniform for a in agents}
 
-    # Find agents with signatures to verify
-    agents_with_sig = [a for a in agents if a.sig]
+    # Find agents with signatures to verify AND no DNSSEC pass.
+    agents_with_sig = [a for a in agents if a.sig and not dnssec_validated.get(a.fqdn, False)]
 
     if not agents_with_sig:
         logger.debug("No agents with JWS signatures to verify")
@@ -1366,16 +1395,52 @@ async def _verify_agent_signatures(
         if agent.sig is None:
             continue
         try:
-            is_valid, _payload = await verify_record_signature(domain, agent.sig)
-            agent.signature_verified = is_valid
-            agent.signature_algorithm = _extract_jws_algorithm(agent.sig) if is_valid else None
+            is_valid, payload = await verify_record_signature(domain, agent.sig)
 
-            if is_valid:
+            # A valid signature alone is insufficient. The signed payload
+            # binds to a specific (fqdn, target, port, alpn) tuple — we
+            # MUST corroborate that the record we're about to trust is
+            # the one those bytes describe. Without this check an attacker
+            # who lifts a legit `sig` value can paste it onto a spoofed
+            # SVCB pointing at their own host and the discoverer would
+            # still stamp signature_verified=True.
+            #
+            # Publisher-side reference: core/publisher.py builds the
+            # payload from name+domain (flat fqdn), endpoint (= target_host),
+            # port, and protocol.value. Compare to the same fields here.
+            payload_matches = (
+                is_valid
+                and payload is not None
+                and payload.fqdn == agent.fqdn
+                and payload.target == agent.target_host
+                and payload.port == agent.port
+                and payload.alpn == agent.protocol.value
+            )
+
+            agent.signature_verified = payload_matches
+            agent.signature_algorithm = (
+                _extract_jws_algorithm(agent.sig) if payload_matches else None
+            )
+
+            if payload_matches:
                 logger.info(
                     "JWS signature verified",
                     agent=agent.name,
                     fqdn=agent.fqdn,
                     algorithm=agent.signature_algorithm,
+                )
+            elif is_valid:
+                logger.warning(
+                    "JWS signature cryptographically valid but does not bind to record",
+                    agent=agent.name,
+                    fqdn=agent.fqdn,
+                    payload_fqdn=getattr(payload, "fqdn", None),
+                    payload_target=getattr(payload, "target", None),
+                    payload_port=getattr(payload, "port", None),
+                    payload_alpn=getattr(payload, "alpn", None),
+                    record_target=agent.target_host,
+                    record_port=agent.port,
+                    record_alpn=agent.protocol.value,
                 )
             else:
                 logger.warning(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import shlex
 import time
 from typing import Any, Literal
@@ -182,9 +183,16 @@ async def discover(
 
     protocol = _normalize_protocol(protocol)
 
-    # Build query based on filters
+    # Build query based on filters. draft-02: the primary owner is a
+    # flat FQDN ({name}.{domain}); protocol is no longer in the
+    # FQDN — it lives in the bap/alpn SvcParam after resolution. The
+    # organization-level index keeps the underscored shape
+    # (_index._agents.{domain}) per draft-02 §Known Organization.
     if name and protocol:
-        query = f"_{name}._{protocol.value}._agents.{domain}"
+        # Known-agent query: flat draft-02 form. Legacy -01 form is
+        # tried as a fallback in _query_single_agent when
+        # DNS_AID_LEGACY_01_FALLBACK=1.
+        query = f"{name}.{domain}"
     elif protocol:
         query = f"_index._{protocol.value}._agents.{domain}"
     else:
@@ -293,21 +301,47 @@ async def _query_single_agent(
     name: str,
     protocol: Protocol,
 ) -> AgentRecord | None:
-    """Query DNS for a specific agent's SVCB record."""
-    fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+    """Query DNS for a specific agent's SVCB record.
+
+    draft-02: tries the flat FQDN ({name}.{domain}) first. If that
+    returns no answer and ``DNS_AID_LEGACY_01_FALLBACK=1`` is set, also
+    tries the legacy -01 shape (_{name}._{protocol}._agents.{domain})
+    so consumers can still resolve publishers that haven't migrated.
+    """
+    fqdn = f"{name}.{domain}"
+    legacy_fqdn: str | None = None
+    if os.environ.get("DNS_AID_LEGACY_01_FALLBACK", "").lower() in ("1", "true", "yes"):
+        legacy_fqdn = f"_{name}._{protocol.value}._agents.{domain}"
 
     try:
         resolver = dns.asyncresolver.Resolver()
 
-        # Query SVCB record
-        # Note: dnspython uses type 64 for SVCB
-        try:
-            answers = await resolver.resolve(fqdn, "SVCB")
-        except dns.resolver.NoAnswer:
-            # Try HTTPS record as fallback (type 65)
+        # Query SVCB record. dnspython uses type 64 for SVCB.
+        # draft-02: try the flat FQDN first. On NoAnswer / NXDOMAIN
+        # try the legacy -01 shape if the back-compat env flag is set.
+        async def _try(name_to_query: str):
             try:
-                answers = await resolver.resolve(fqdn, "HTTPS")
+                return await resolver.resolve(name_to_query, "SVCB")
             except dns.resolver.NoAnswer:
+                # HTTPS record (type 65) is the protocol-specific alias
+                # of SVCB; some publishers may have used it instead.
+                return await resolver.resolve(name_to_query, "HTTPS")
+
+        try:
+            answers = await _try(fqdn)
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            if legacy_fqdn is None:
+                return None
+            try:
+                logger.debug(
+                    "Flat FQDN returned no answer; trying legacy -01 fallback",
+                    fqdn=fqdn,
+                    legacy_fqdn=legacy_fqdn,
+                )
+                answers = await _try(legacy_fqdn)
+                # Hand the legacy FQDN downstream so logging is accurate.
+                fqdn = legacy_fqdn
+            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
                 return None
 
         for rdata in answers:
@@ -652,25 +686,66 @@ def _parse_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     """
     Parse agent name and protocol from a DNS-AID FQDN.
 
-    FQDN format: _{name}._{protocol}._agents.{domain}
+    Recognized shapes (in priority order):
+
+    1. Legacy -01 form ``_{name}._{protocol}._agents.{domain}`` — name
+       is the first label (sans leading underscore); protocol is the
+       second label (sans leading underscore).
+    2. Walkable AliasMode form ``{name}._agents.{domain}`` (draft-02) —
+       name is the label before ``._agents.``; protocol returns
+       ``None`` because draft-02 carries the protocol in the SVCB
+       SvcParams (``bap`` / ``alpn``), not in the FQDN.
+    3. Flat primary owner ``{name}.{domain}`` (draft-02) — name is the
+       first label; protocol returns ``None`` (same reason as above).
 
     Returns:
-        (name, protocol_str) or (None, None) if parsing fails.
+        ``(name, protocol_str)`` or ``(None, None)`` if the input
+        doesn't look like any recognized shape (e.g. single-label
+        strings).
     """
-    if not fqdn or not fqdn.startswith("_"):
+    if not fqdn:
         return None, None
 
-    parts = fqdn.split(".")
-    if len(parts) < 3:
+    # Legacy -01: _{name}._{protocol}._agents.{domain}
+    # Requires (a) leading underscore, (b) ._agents. infix, AND
+    # (c) parts[2] == "_agents" so the protocol label is correctly the
+    # second one (rejecting strings like "_booking._agents.example.com"
+    # which is the walkable shape with an erroneous underscore prefix).
+    if fqdn.startswith("_") and "._agents." in fqdn:
+        parts = fqdn.split(".")
+        if len(parts) < 4:
+            return None, None
+        name_part = parts[0]
+        protocol_part = parts[1]
+        agents_part = parts[2]
+        if (
+            not name_part.startswith("_")
+            or not protocol_part.startswith("_")
+            or agents_part != "_agents"
+        ):
+            return None, None
+        return name_part[1:], protocol_part[1:]
+
+    # Walkable AliasMode draft-02: {name}._agents.{domain}. The name
+    # must be a single DNS label without a leading underscore, and the
+    # domain portion must be non-empty (otherwise the string is
+    # malformed and we don't try to "parse" it).
+    if "._agents." in fqdn:
+        prefix, _, suffix = fqdn.partition("._agents.")
+        if prefix and suffix and "." not in prefix and not prefix.startswith("_"):
+            return prefix, None
         return None, None
 
-    name_part = parts[0]  # _name
-    protocol_part = parts[1]  # _protocol
+    # Flat draft-02: {name}.{domain}. We require at least three labels
+    # total ({name} + at least a two-label domain such as example.com)
+    # and the name must not start with an underscore, to avoid matching
+    # strings like "_a._b" or arbitrary short inputs.
+    if "." in fqdn:
+        first_label, _, rest = fqdn.partition(".")
+        if first_label and rest and "." in rest and not first_label.startswith("_"):
+            return first_label, None
 
-    if not name_part.startswith("_") or not protocol_part.startswith("_"):
-        return None, None
-
-    return name_part[1:], protocol_part[1:]
+    return None, None
 
 
 def _enrich_from_http_index(agent: AgentRecord, http_agent: HttpIndexAgent) -> None:
@@ -1073,46 +1148,54 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
     """
     Discover agent at a specific FQDN.
 
+    Accepts any of the three DNS-AID FQDN shapes (draft-02 flat,
+    draft-02 walkable, or legacy -01) and resolves the agent at it.
+    When the input doesn't carry a protocol (the two draft-02 shapes),
+    the discoverer attempts mcp first, then a2a.
+
     Args:
-        fqdn: Full DNS-AID record name (e.g., "_chat._a2a._agents.example.com")
+        fqdn: Full DNS-AID record name. Examples:
+            - ``"chat.example.com"`` (draft-02 flat)
+            - ``"chat._agents.example.com"`` (draft-02 walkable)
+            - ``"_chat._a2a._agents.example.com"`` (legacy -01)
 
     Returns:
-        AgentRecord if found, None otherwise
+        AgentRecord if found, None otherwise.
     """
-    # Parse FQDN to extract components
-    # Format: _{name}._{protocol}._agents.{domain}
-    parts = fqdn.split(".")
-
-    if len(parts) < 4:
+    name, protocol_str = _parse_fqdn(fqdn)
+    if not name:
         logger.error("Invalid DNS-AID FQDN format", fqdn=fqdn)
         return None
 
-    # Extract components
-    name_part = parts[0]  # _name
-    protocol_part = parts[1]  # _protocol
+    # Derive domain from the FQDN: everything after the name + any
+    # walkable/legacy infix labels.
+    if "._agents." in fqdn:
+        domain = fqdn.split("._agents.", 1)[1]
+    else:
+        # Flat shape: domain is everything after the first label.
+        domain = fqdn.split(".", 1)[1] if "." in fqdn else ""
 
-    if not name_part.startswith("_") or not protocol_part.startswith("_"):
-        logger.error("Invalid DNS-AID FQDN format", fqdn=fqdn)
+    if not domain:
+        logger.error("Could not extract domain from FQDN", fqdn=fqdn)
         return None
 
-    name = name_part[1:]  # Remove leading underscore
-    protocol_str = protocol_part[1:]  # Remove leading underscore
+    # For the legacy form the protocol is in the FQDN; use it directly.
+    if protocol_str:
+        try:
+            protocol = Protocol(protocol_str)
+        except ValueError:
+            logger.error("Unknown protocol", protocol=protocol_str)
+            return None
+        return await _query_single_agent(domain, name, protocol)
 
-    # Find _agents marker to determine domain
-    try:
-        agents_idx = parts.index("_agents")
-        domain = ".".join(parts[agents_idx + 1 :])
-    except ValueError:
-        logger.error("Missing _agents in FQDN", fqdn=fqdn)
-        return None
-
-    try:
-        protocol = Protocol(protocol_str)
-    except ValueError:
-        logger.error("Unknown protocol", protocol=protocol_str)
-        return None
-
-    return await _query_single_agent(domain, name, protocol)
+    # draft-02 shapes don't carry protocol in the FQDN. Try mcp then
+    # a2a; the SVCB record's alpn/bap params will reveal the actual
+    # protocol on the discovered AgentRecord.
+    for proto in (Protocol.MCP, Protocol.A2A):
+        result = await _query_single_agent(domain, name, proto)
+        if result is not None:
+            return result
+    return None
 
 
 async def _verify_agent_signatures(

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -792,7 +792,7 @@ async def _process_http_agent(
         return None
 
     dns_agent_name, fqdn_protocol_str = _parse_fqdn(http_agent.fqdn)
-    if not dns_agent_name or not fqdn_protocol_str:
+    if not dns_agent_name:
         logger.debug(
             "Cannot parse FQDN from HTTP index entry",
             agent=http_agent.name,
@@ -800,21 +800,40 @@ async def _process_http_agent(
         )
         return None
 
-    try:
-        agent_protocol = Protocol(fqdn_protocol_str.lower())
-    except ValueError:
-        logger.debug(
-            "Unknown protocol in FQDN",
-            agent=http_agent.name,
-            fqdn=http_agent.fqdn,
-            protocol=fqdn_protocol_str,
-        )
+    # Under draft-02 the flat and walkable FQDN shapes don't carry the
+    # agent protocol — it lives in the SVCB `bap`/`alpn` SvcParam. If
+    # _parse_fqdn returned no protocol, use the caller-supplied protocol
+    # filter when present, otherwise try mcp then a2a (the SVCB params
+    # on the discovered record reveal the actual protocol).
+    candidate_protocols: list[Protocol]
+    if fqdn_protocol_str:
+        try:
+            candidate_protocols = [Protocol(fqdn_protocol_str.lower())]
+        except ValueError:
+            logger.debug(
+                "Unknown protocol in FQDN",
+                agent=http_agent.name,
+                fqdn=http_agent.fqdn,
+                protocol=fqdn_protocol_str,
+            )
+            return None
+    elif protocol is not None:
+        candidate_protocols = [protocol]
+    else:
+        candidate_protocols = [Protocol.MCP, Protocol.A2A]
+
+    # Apply caller-side protocol filter when the FQDN-carried protocol
+    # is known and doesn't match.
+    if fqdn_protocol_str and protocol and candidate_protocols[0] != protocol:
         return None
 
-    if protocol and agent_protocol != protocol:
-        return None
-
-    agent = await _query_single_agent(domain, dns_agent_name, agent_protocol)
+    agent_protocol = candidate_protocols[0]
+    agent = None
+    for proto in candidate_protocols:
+        agent = await _query_single_agent(domain, dns_agent_name, proto)
+        if agent:
+            agent_protocol = proto
+            break
 
     if agent:
         _enrich_from_http_index(agent, http_agent)

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -469,8 +469,12 @@ async def _query_single_agent(
             cap_uri = custom_params.get("cap")
             cap_sha256 = custom_params.get("cap-sha256")
             well_known_path = custom_params.get("well-known")
-            bap_str = custom_params.get("bap", "")
-            bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
+            # Under draft-02 §FutureWork (Bulk Agent Protocol), `bap` carries
+            # a single versioned protocol identifier per record (e.g., "mcp2.1").
+            # Pre-PR 4 records may have a comma-separated list; in that case we
+            # take the first value to preserve a sensible scalar.
+            bap_raw = custom_params.get("bap")
+            bap = bap_raw.split(",")[0].strip() if bap_raw else None
             policy_uri = custom_params.get("policy")
             realm = custom_params.get("realm")
             connect_class = custom_params.get("connect-class")
@@ -1349,15 +1353,14 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
     # DNS query is identical regardless of which Protocol we ask for —
     # only the AgentRecord.protocol field gets stamped from it — so we
     # resolve once and then read the actual protocol from the record's
-    # `bap` list (preferred per draft-02 §Known Agent) or fall back to
-    # the protocol kwarg if neither bap nor alpn names a known value.
+    # ``bap`` scalar (preferred per draft-02 §Known Agent) or fall back
+    # to the protocol kwarg if bap doesn't name a value we model.
     result = await _query_single_agent(domain, name, Protocol.MCP)
     if result is None:
         return None
     # Reconcile the record's protocol with what was actually announced.
-    declared = next(
-        (p for p in result.bap if p.strip() in {pv.value for pv in Protocol}),
-        None,
+    declared = (
+        result.bap if result.bap and result.bap.strip() in {pv.value for pv in Protocol} else None
     )
     if declared is not None:
         # bap may carry a value we don't model (e.g. an extension);

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -5,7 +5,7 @@
 DNS-AID Discoverer: Query DNS to find AI agents.
 
 This module handles discovering agents via DNS queries for SVCB and TXT
-records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/fqdn.py
+++ b/src/dns_aid/core/fqdn.py
@@ -1,0 +1,105 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared DNS-AID FQDN parsing.
+
+The discoverer and the telemetry/otel layers both need to recognise the
+three FQDN shapes that have ever been published under DNS-AID and pull
+out the agent identity from each. Keeping a single parser here prevents
+the two implementations from drifting — earlier each module had its
+own, which had already diverged on strictness (one accepted the walkable
+shape with an empty domain suffix, the other didn't).
+
+Shapes recognised:
+
+1. **Legacy draft-01** ``_{name}._{protocol}._agents.{domain}`` — the
+   pre-flat shape; ``name`` and ``protocol`` both carry leading
+   underscores. Strictly validated: rejects single-underscore-prefixed
+   strings like ``_booking.mcp._agents.foo.com`` where only the first
+   label is underscored, since that's neither legitimate -01 nor a
+   correct walkable record.
+2. **Walkable AliasMode draft-02** ``{name}._agents.{domain}`` — the
+   optional walkable enumeration handle. Protocol is unknown from the
+   FQDN alone (it now lives in the SVCB ``bap`` / ``alpn`` SvcParams),
+   so ``protocol`` is returned as ``None``.
+3. **Flat primary owner draft-02** ``{name}.{domain}`` — the canonical
+   -02 shape, valid as an x.509 SAN dNSName. Protocol again ``None``.
+
+Callers needing only a subset of the returned tuple should project from
+the result rather than re-implementing the parser.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class DnsAidFqdn(NamedTuple):
+    """Parsed DNS-AID FQDN components.
+
+    Fields:
+        name: Agent name (the publisher-chosen label).
+        protocol: Agent protocol from the FQDN, or ``None`` under
+            draft-02 where the protocol lives in the SVCB SvcParams
+            (``bap`` / ``alpn``) rather than the name.
+        domain: Trailing domain portion after the agent-identifying
+            labels.
+    """
+
+    name: str
+    protocol: str | None
+    domain: str
+
+
+def parse_dnsaid_fqdn(fqdn: str) -> DnsAidFqdn | None:
+    """Parse a DNS-AID FQDN into ``(name, protocol|None, domain)``.
+
+    Returns ``None`` when ``fqdn`` doesn't look like any of the
+    recognised shapes (empty, single-label, or malformed). Callers
+    should treat ``None`` as "this string didn't carry a DNS-AID
+    agent identity I can interpret" — not as a bug.
+    """
+    if not fqdn:
+        return None
+
+    # Legacy -01: _{name}._{protocol}._agents.{domain}
+    # Requires (a) leading underscore on label 0, (b) leading underscore
+    # on label 1 (the protocol), AND (c) label 2 == "_agents" so we
+    # reject strings like "_booking.mcp._agents.foo.com" where only the
+    # first label is underscored — that's neither legitimate -01 nor a
+    # correct walkable record.
+    if fqdn.startswith("_") and "._agents." in fqdn:
+        parts = fqdn.split(".")
+        if len(parts) < 4:
+            return None
+        name_part = parts[0]
+        protocol_part = parts[1]
+        agents_part = parts[2]
+        if (
+            not name_part.startswith("_")
+            or not protocol_part.startswith("_")
+            or agents_part != "_agents"
+        ):
+            return None
+        domain = ".".join(parts[3:])
+        if not domain:
+            return None
+        return DnsAidFqdn(name=name_part[1:], protocol=protocol_part[1:], domain=domain)
+
+    # Walkable AliasMode draft-02: {name}._agents.{domain}
+    if "._agents." in fqdn:
+        prefix, _, suffix = fqdn.partition("._agents.")
+        if prefix and suffix and "." not in prefix and not prefix.startswith("_"):
+            return DnsAidFqdn(name=prefix, protocol=None, domain=suffix)
+        return None
+
+    # Flat draft-02: {name}.{domain}. Require at least three labels
+    # total ({name} + at least a two-label domain such as example.com)
+    # and reject names that start with an underscore.
+    if "." in fqdn:
+        first_label, _, rest = fqdn.partition(".")
+        if first_label and rest and "." in rest and not first_label.startswith("_"):
+            return DnsAidFqdn(name=first_label, protocol=None, domain=rest)
+
+    return None

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -24,11 +24,19 @@ import dns.resolver
 import structlog
 
 from dns_aid.backends.base import DNSBackend
+from dns_aid.core.models import SVCB_SERVICE_MODE
+from dns_aid.utils.validation import validate_no_underscore_in_target
 
 logger = structlog.get_logger(__name__)
 
 # Index record name pattern
 INDEX_RECORD_NAME = "_index._agents"
+
+# Sentinel for an index entry whose protocol couldn't be derived from
+# the primary SVCB record (record absent, malformed, or the publisher
+# didn't set alpn/bap). Kept as a named constant so consumers can
+# filter on it without string-matching.
+UNKNOWN_PROTOCOL = "unknown"
 
 
 @dataclass
@@ -266,8 +274,6 @@ async def update_index(
     # TargetName up front (same rule as agent records — no underscores
     # because the target carries a public x.509 cert).
     if index_target is not None:
-        from dns_aid.utils.validation import validate_no_underscore_in_target
-
         validate_no_underscore_in_target(index_target)
 
     try:
@@ -288,7 +294,7 @@ async def update_index(
             await backend.create_svcb_record(
                 zone=domain,
                 name=INDEX_RECORD_NAME,
-                priority=1,  # ServiceMode
+                priority=SVCB_SERVICE_MODE,
                 target=svcb_target,
                 params={"alpn": "h2", "port": str(index_target_port)},
                 ttl=ttl,
@@ -400,43 +406,43 @@ async def sync_index(
     discovered_entries: list[IndexEntry] = []
 
     def _protocol_from_primary(primary_records: dict[str, dict], name: str) -> str:
-        """Read alpn (and bap when PR 4 lands) off the primary SVCB."""
+        """Read the agent protocol off the primary SVCB record.
+
+        draft-02 §Known Agent: ``bap`` is the canonical carrier for the
+        bulk-agent-protocol identifier; ``alpn`` is the back-compat
+        carrier accepted for single-protocol publishers. Read whichever
+        the record uses.
+        """
         primary = primary_records.get(name)
         if not primary:
-            return "unknown"
+            return UNKNOWN_PROTOCOL
         params = primary.get("data", {}).get("params", {}) or {}
-        # alpn carries the agent protocol when only one is published
-        # (per draft-02 §Known Agent). bap will become the preferred
-        # carrier in the PR 4 alpn/bap split.
-        alpn = params.get("alpn") or params.get("bap")
+        alpn = params.get("bap") or params.get("alpn")
         if alpn:
             # alpn may be quoted; trim.
-            return alpn.strip('"').split(",")[0].strip() or "unknown"
-        return "unknown"
+            return alpn.strip('"').split(",")[0].strip() or UNKNOWN_PROTOCOL
+        return UNKNOWN_PROTOCOL
 
     try:
-        # Pre-scan: collect all SVCB records by relative name so we can
-        # resolve protocol from the primary owner without doing a second
-        # backend round-trip per agent. Single pass, no filter. Inside
-        # the try block so list_records failures are surfaced as a clean
-        # IndexResult rather than propagating.
+        # Single backend enumeration. Earlier the function fetched the
+        # zone twice — once with no filter to build primary_records and
+        # once with name_pattern="_agents" to enumerate agents — but the
+        # second call returns a subset of the first. On real backends
+        # (Route53 / Cloudflare / Infoblox) each `list_records` is a
+        # paginated API round-trip, so doubling it doubles latency and
+        # quota burn per sync. Iterate in memory instead.
         primary_records: dict[str, dict] = {}
+        agent_records: list[dict] = []
         async for record in backend.list_records(zone=domain, record_type="SVCB"):
             rname = record.get("name", "")
-            if rname and rname != INDEX_RECORD_NAME:
-                primary_records[rname] = record
-
-        # Scan for all _agents.* SVCB records
-        async for record in backend.list_records(
-            zone=domain,
-            name_pattern="_agents",
-            record_type="SVCB",
-        ):
-            record_name = record.get("name", "")
-
-            # Skip the index record itself
-            if record_name == INDEX_RECORD_NAME:
+            if not rname or rname == INDEX_RECORD_NAME:
                 continue
+            primary_records[rname] = record
+            if "_agents" in rname:
+                agent_records.append(record)
+
+        for record in agent_records:
+            record_name = record.get("name", "")
 
             # Try the draft-02 walkable AliasMode shape first.
             walkable_match = walkable_pattern.match(record_name)

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -408,20 +408,29 @@ async def sync_index(
     def _protocol_from_primary(primary_records: dict[str, dict], name: str) -> str:
         """Read the agent protocol off the primary SVCB record.
 
-        draft-02 §Known Agent: ``bap`` is the canonical carrier for the
-        bulk-agent-protocol identifier; ``alpn`` is the back-compat
-        carrier accepted for single-protocol publishers. Read whichever
-        the record uses.
+        draft-02 §5.1 (experimental ``bap``) carries an agent-protocol
+        identifier — bare (``mcp``) or versioned (``mcp=1.0``).
+        ``alpn`` is dns-aid-core's canonical reconciliation carrier
+        and accepted as a fallback. Use the shared ``normalize_bap``
+        and ``split_bap_token`` helpers so the indexer agrees with the
+        discoverer and SDK on collapse + token extraction semantics.
         """
+        from dns_aid.core.bap import normalize_bap, split_bap_token
+
         primary = primary_records.get(name)
         if not primary:
             return UNKNOWN_PROTOCOL
         params = primary.get("data", {}).get("params", {}) or {}
-        alpn = params.get("bap") or params.get("alpn")
-        if alpn:
-            # alpn may be quoted; trim.
-            return alpn.strip('"').split(",")[0].strip() or UNKNOWN_PROTOCOL
-        return UNKNOWN_PROTOCOL
+        # SVCB params from list_records may carry stray quoting.
+        raw = params.get("bap") or params.get("alpn")
+        if not raw:
+            return UNKNOWN_PROTOCOL
+        cleaned = raw.strip('"') if isinstance(raw, str) else raw
+        normalized = normalize_bap(cleaned)
+        if normalized is None:
+            return UNKNOWN_PROTOCOL
+        proto_token, _version = split_bap_token(normalized)
+        return proto_token or UNKNOWN_PROTOCOL
 
     try:
         # Single backend enumeration. Earlier the function fetched the

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -199,27 +199,46 @@ async def update_index(
     add: list[IndexEntry] | None = None,
     remove: list[IndexEntry] | None = None,
     ttl: int = 3600,
+    index_target: str | None = None,
+    index_target_port: int = 443,
 ) -> IndexResult:
     """
     Update the agent index for a domain.
 
     Performs a read-modify-write operation to update the index.
 
+    Under draft-mozleywilliams-dnsop-dnsaid-02 the canonical org index
+    record is SVCB at ``_index._agents.{domain}`` pointing at a
+    non-underscored TargetName. TXT remains a documented fallback
+    (§TXT-fallback) for SVCB-less environments. dns-aid-core writes
+    both when ``index_target`` is supplied (SVCB for spec-compliant
+    consumers + TXT inline-listing for the rest); when ``index_target``
+    is omitted the TXT inline-listing is the only record written.
+
     Args:
-        domain: Domain to update index for
-        backend: DNS backend to use
-        add: Entries to add to the index
-        remove: Entries to remove from the index
-        ttl: TTL for the index record
+        domain: Domain to update index for.
+        backend: DNS backend to use.
+        add: Entries to add to the index.
+        remove: Entries to remove from the index.
+        ttl: TTL for the index record.
+        index_target: Optional host that serves the org's JSON agent
+            index over HTTPS. When provided, dns-aid-core writes an
+            SVCB ServiceMode record at ``_index._agents.{domain}``
+            pointing at this target alongside the TXT inline record.
+            The host MUST NOT contain underscored labels (it carries
+            a public x.509 cert; see draft-02 §Known Organization).
+        index_target_port: Port for the SVCB ServiceMode write
+            (default 443). Only relevant when ``index_target`` is set.
 
     Returns:
-        IndexResult with operation outcome
+        IndexResult with operation outcome.
     """
     logger.info(
         "Updating index",
         domain=domain,
         add=[str(e) for e in (add or [])],
         remove=[str(e) for e in (remove or [])],
+        index_target=index_target,
     )
 
     # Read current index
@@ -243,6 +262,14 @@ async def update_index(
     # Format the TXT value
     txt_value = format_index_txt(new_entries)
 
+    # If the caller wants the draft-02 SVCB-primary form, validate the
+    # TargetName up front (same rule as agent records — no underscores
+    # because the target carries a public x.509 cert).
+    if index_target is not None:
+        from dns_aid.utils.validation import validate_no_underscore_in_target
+
+        validate_no_underscore_in_target(index_target)
+
     try:
         # Check zone exists
         if not await backend.zone_exists(domain):
@@ -253,7 +280,23 @@ async def update_index(
                 message=f"Zone '{domain}' does not exist",
             )
 
-        # Write the updated index (UPSERT)
+        # Write the SVCB primary form first, when an index_target was
+        # supplied. The SVCB record points at the index host; consumers
+        # fetch the actual JSON-bodied index from there over HTTPS.
+        if index_target is not None:
+            svcb_target = index_target if index_target.endswith(".") else f"{index_target}."
+            await backend.create_svcb_record(
+                zone=domain,
+                name=INDEX_RECORD_NAME,
+                priority=1,  # ServiceMode
+                target=svcb_target,
+                params={"alpn": "h2", "port": str(index_target_port)},
+                ttl=ttl,
+            )
+
+        # Write the TXT inline index (always — kept as the §TXT-fallback
+        # form for SVCB-less consumers, and as the carrier for
+        # dns-aid-core's own enumeration of agents).
         await backend.create_txt_record(
             zone=domain,
             name=INDEX_RECORD_NAME,
@@ -266,6 +309,7 @@ async def update_index(
             domain=domain,
             entry_count=len(new_entries),
             was_empty=was_empty,
+            wrote_svcb=index_target is not None,
         )
 
         return IndexResult(
@@ -344,12 +388,44 @@ async def sync_index(
             message=f"Zone '{domain}' does not exist or is not accessible",
         )
 
-    # Pattern to match agent records: _{name}._{protocol}._agents
-    agent_pattern = re.compile(r"^_([a-z0-9-]+)\._([a-z0-9]+)\._agents$", re.IGNORECASE)
+    # Under draft-02 the canonical agent SVCB lives at the flat name
+    # ({name}.{domain}). The walkable AliasMode at {name}._agents is
+    # the reliable enumeration handle. Protocol is no longer in the
+    # FQDN — it lives in the `alpn` (or `bap`) SvcParam on the primary
+    # record, so the indexer resolves the walkable, then reads the
+    # primary record's SvcParams to recover the protocol.
+    walkable_pattern = re.compile(r"^([a-z0-9-]+)\._agents$", re.IGNORECASE)
+    legacy_pattern = re.compile(r"^_([a-z0-9-]+)\._([a-z0-9]+)\._agents$", re.IGNORECASE)
 
     discovered_entries: list[IndexEntry] = []
 
+    def _protocol_from_primary(primary_records: dict[str, dict], name: str) -> str:
+        """Read alpn (and bap when PR 4 lands) off the primary SVCB."""
+        primary = primary_records.get(name)
+        if not primary:
+            return "unknown"
+        params = primary.get("data", {}).get("params", {}) or {}
+        # alpn carries the agent protocol when only one is published
+        # (per draft-02 §Known Agent). bap will become the preferred
+        # carrier in the PR 4 alpn/bap split.
+        alpn = params.get("alpn") or params.get("bap")
+        if alpn:
+            # alpn may be quoted; trim.
+            return alpn.strip('"').split(",")[0].strip() or "unknown"
+        return "unknown"
+
     try:
+        # Pre-scan: collect all SVCB records by relative name so we can
+        # resolve protocol from the primary owner without doing a second
+        # backend round-trip per agent. Single pass, no filter. Inside
+        # the try block so list_records failures are surfaced as a clean
+        # IndexResult rather than propagating.
+        primary_records: dict[str, dict] = {}
+        async for record in backend.list_records(zone=domain, record_type="SVCB"):
+            rname = record.get("name", "")
+            if rname and rname != INDEX_RECORD_NAME:
+                primary_records[rname] = record
+
         # Scan for all _agents.* SVCB records
         async for record in backend.list_records(
             zone=domain,
@@ -362,8 +438,22 @@ async def sync_index(
             if record_name == INDEX_RECORD_NAME:
                 continue
 
-            # Parse the record name
-            match = agent_pattern.match(record_name)
+            # Try the draft-02 walkable AliasMode shape first.
+            walkable_match = walkable_pattern.match(record_name)
+            if walkable_match:
+                name = walkable_match.group(1)
+                protocol = _protocol_from_primary(primary_records, name)
+                discovered_entries.append(IndexEntry(name=name, protocol=protocol))
+
+                logger.debug(
+                    "Discovered agent (draft-02 walkable)",
+                    name=name,
+                    protocol=protocol,
+                )
+                continue
+
+            # Fall back to the legacy -01 shape.
+            match = legacy_pattern.match(record_name)
             if match:
                 name = match.group(1)
                 protocol = match.group(2)

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -466,6 +466,14 @@ class AgentRecord(BaseModel):
     # DNS settings
     ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
 
+    publish_walkable_alias: bool = Field(
+        default=True,
+        description="Whether to publish the optional walkable AliasMode SVCB record at "
+        "{name}._agents.{domain} pointing at the flat primary owner. Per draft-02 §Known "
+        "Agent, this is operator-optional. dns-aid-core publishes it by default so "
+        "DNS-SD-style enumeration crawlers can discover the agent; set False to suppress.",
+    )
+
     # Optional direct endpoint (overrides target_host:port for HTTP index agents)
     endpoint_override: str | None = Field(
         default=None, description="Direct endpoint URL (e.g., 'https://booking.example.com/mcp')"
@@ -593,10 +601,40 @@ class AgentRecord(BaseModel):
     @property
     def fqdn(self) -> str:
         """
-        Fully qualified domain name for DNS-AID record.
+        Fully qualified domain name for the agent's primary owner record.
 
-        Format: _{name}._{protocol}._agents.{domain}
-        Per IETF draft section 3.1
+        Returns the flat form ``{name}.{domain}`` per draft-02. The agent
+        protocol is no longer part of the FQDN under -02 — it lives in
+        the ``bap`` SvcParamKey (or ``alpn`` when only one protocol is
+        supported). The flat FQDN is valid as an x.509 SAN dNSName.
+
+        For the optional walkable AliasMode form, see ``walkable_fqdn``.
+        For the legacy -01 form, see ``legacy_fqdn``.
+        """
+        return f"{self.name}.{self.domain}"
+
+    @property
+    def walkable_fqdn(self) -> str:
+        """
+        Optional walkable AliasMode FQDN at ``{name}._agents.{domain}``.
+
+        Per draft-02 §Known Agent, publishers MAY emit an SVCB AliasMode
+        record at this name pointing at the flat primary owner so that
+        DNS-SD-style consumers and enumeration crawlers can discover the
+        agent. dns-aid-core's publisher writes this record by default;
+        operators can disable it via ``SDKConfig`` if a deployment
+        doesn't need walkable enumeration.
+        """
+        return f"{self.name}._agents.{self.domain}"
+
+    @property
+    def legacy_fqdn(self) -> str:
+        """
+        Backwards-compatible -01 FQDN ``_{name}._{protocol}._agents.{domain}``.
+
+        Used only by the legacy-fallback discovery path when the env
+        flag ``DNS_AID_LEGACY_01_FALLBACK=1`` is set. Not used for
+        publishing under -02.
         """
         return f"_{self.name}._{self.protocol.value}._agents.{self.domain}"
 

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -189,12 +189,13 @@ class SvcbRecord(BaseModel):
     )
     bap: str | None = Field(
         default=None,
-        description="Bulk Agent Protocol (draft-02 §FutureWork). Carries a single "
-        "versioned agent-protocol identifier (e.g. 'mcp2.1', 'a2a1.0') per SVCB "
-        "record. Experimental in draft-02 — alpn remains the canonical protocol "
-        "carrier; bap adds version information when present. Multi-protocol "
-        "agents publish multiple SVCB records at the same flat owner, each with "
-        "its own alpn and (optionally) bap.",
+        description="Bulk Agent Protocol (draft-02 §5.1, §FutureWork). Carries a "
+        "single agent-protocol identifier per SVCB record in the draft's "
+        "delimited form: bare (``mcp``, ``a2a``) or versioned (``mcp=1.0``, "
+        "``a2a=1.1``). Experimental in draft-02 — alpn remains the protocol "
+        "carrier dns-aid-core treats as canonical for reconciliation. "
+        "Multi-protocol agents publish multiple SVCB records at the same flat "
+        "owner, each with its own alpn and (optionally) bap.",
     )
     policy_uri: str | None = Field(default=None, description="Agent policy URI")
     realm: str | None = Field(default=None, description="Opaque authz realm identifier")
@@ -267,6 +268,26 @@ class SvcbRecord(BaseModel):
         from dns_aid.utils.validation import validate_well_known_path
 
         return validate_well_known_path(v)
+
+    @field_validator("bap", mode="after")
+    @classmethod
+    def _enforce_safe_bap(cls, v: str | None) -> str | None:
+        """Constrain ``bap`` to the draft-02 wire shape at the type boundary.
+
+        Igor's #158 review surfaced the missing validator as a server-
+        side SvcParamKey injection vulnerability: a crafted value like
+        ``mcp" key65500="x`` would round-trip verbatim through
+        ``to_params()`` and the backend formatters, so dnspython
+        would parse two SvcParamKeys instead of one — the attacker
+        controls the second. Enforcing the constraint here catches it
+        on every construction path (direct, via ``to_svcb_record()``,
+        via ``publish()``).
+        """
+        if v is None:
+            return None
+        from dns_aid.core.bap import validate_bap
+
+        return validate_bap(v)
 
     @property
     def normalized_target(self) -> str:
@@ -437,14 +458,16 @@ class AgentRecord(BaseModel):
     )
     bap: str | None = Field(
         default=None,
-        description="Bulk Agent Protocol — single versioned agent-protocol "
-        "identifier (e.g. 'mcp2.1', 'a2a1.0') for this SVCB record. Per "
-        "draft-02 §FutureWork (Bulk Agent Protocol) this is experimental; "
-        "the canonical protocol carrier remains 'alpn'. bap adds version "
-        "information when present. Multi-protocol agents are published as "
-        "multiple AgentRecord instances at the same flat owner name, each "
-        "with its own alpn and (optionally) bap — NOT as a comma-separated "
-        "list on one record.",
+        description="Bulk Agent Protocol — single agent-protocol identifier "
+        "for this SVCB record in the draft's delimited form: bare "
+        "(``mcp``, ``a2a``) or versioned (``mcp=1.0``, ``a2a=1.1``). Per "
+        "draft-02 §5.1 / §FutureWork (Bulk Agent Protocol) this is "
+        "experimental; dns-aid-core treats ``alpn`` as the canonical "
+        "protocol carrier for reconciliation. bap adds version information "
+        "when present. Multi-protocol agents are published as multiple "
+        "AgentRecord instances at the same flat owner name, each with its "
+        "own alpn and (optionally) bap — NOT as a comma-separated list on "
+        "one record.",
     )
     policy_uri: str | None = Field(
         default=None,
@@ -640,6 +663,22 @@ class AgentRecord(BaseModel):
         from dns_aid.utils.validation import validate_well_known_path
 
         return validate_well_known_path(v)
+
+    @field_validator("bap", mode="after")
+    @classmethod
+    def _enforce_safe_bap_on_agent(cls, v: str | None) -> str | None:
+        """Same as SvcbRecord — enforce the canonical bap shape at the type.
+
+        Closes the SvcParamKey-injection hole Igor flagged on #158;
+        also rejects ``bap=["mcp"]`` (list form) at the type boundary
+        so the list→scalar break is explicit instead of silently
+        coercing.
+        """
+        if v is None:
+            return None
+        from dns_aid.core.bap import validate_bap
+
+        return validate_bap(v)
 
     @property
     def fqdn(self) -> str:

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -187,7 +187,15 @@ class SvcbRecord(BaseModel):
         "its bytes matched ``cap_sha256``. Always False on records that didn't go "
         "through the fetch path.",
     )
-    bap: list[str] = Field(default_factory=list, description="Bulk application protocols")
+    bap: str | None = Field(
+        default=None,
+        description="Bulk Agent Protocol (draft-02 §FutureWork). Carries a single "
+        "versioned agent-protocol identifier (e.g. 'mcp2.1', 'a2a1.0') per SVCB "
+        "record. Experimental in draft-02 — alpn remains the canonical protocol "
+        "carrier; bap adds version information when present. Multi-protocol "
+        "agents publish multiple SVCB records at the same flat owner, each with "
+        "its own alpn and (optionally) bap.",
+    )
     policy_uri: str | None = Field(default=None, description="Agent policy URI")
     realm: str | None = Field(default=None, description="Opaque authz realm identifier")
     sig: str | None = Field(default=None, description="JWS signature for the record")
@@ -299,7 +307,7 @@ class SvcbRecord(BaseModel):
         if self.cap_sha256:
             params[_key("cap-sha256")] = self.cap_sha256
         if self.bap:
-            params[_key("bap")] = ",".join(self.bap)
+            params[_key("bap")] = self.bap
         if self.policy_uri:
             params[_key("policy")] = self.policy_uri
         if self.realm:
@@ -427,10 +435,16 @@ class AgentRecord(BaseModel):
         "capability descriptor it prefers 'cap' (explicit locator) and falls back to "
         "reconstructing https://<svcb-target>/.well-known/<well_known_path>.",
     )
-    bap: list[str] = Field(
-        default_factory=list,
-        description="DNS-AID Application Protocols with versions understood by the endpoint "
-        "(e.g., ['mcp/1', 'a2a/1']). Distinct from transport-level alpn per draft Section 4.4.3.",
+    bap: str | None = Field(
+        default=None,
+        description="Bulk Agent Protocol — single versioned agent-protocol "
+        "identifier (e.g. 'mcp2.1', 'a2a1.0') for this SVCB record. Per "
+        "draft-02 §FutureWork (Bulk Agent Protocol) this is experimental; "
+        "the canonical protocol carrier remains 'alpn'. bap adds version "
+        "information when present. Multi-protocol agents are published as "
+        "multiple AgentRecord instances at the same flat owner name, each "
+        "with its own alpn and (optionally) bap — NOT as a comma-separated "
+        "list on one record.",
     )
     policy_uri: str | None = Field(
         default=None,

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -5,7 +5,7 @@
 Data models for DNS-AID.
 
 These models represent agents, discovery results, and DNS records
-as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -367,6 +367,14 @@ class AgentRecord(BaseModel):
     # DNS settings
     ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
 
+    publish_walkable_alias: bool = Field(
+        default=True,
+        description="Whether to publish the optional walkable AliasMode SVCB record at "
+        "{name}._agents.{domain} pointing at the flat primary owner. Per draft-02 §Known "
+        "Agent, this is operator-optional. dns-aid-core publishes it by default so "
+        "DNS-SD-style enumeration crawlers can discover the agent; set False to suppress.",
+    )
+
     # Optional direct endpoint (overrides target_host:port for HTTP index agents)
     endpoint_override: str | None = Field(
         default=None, description="Direct endpoint URL (e.g., 'https://booking.example.com/mcp')"
@@ -465,10 +473,40 @@ class AgentRecord(BaseModel):
     @property
     def fqdn(self) -> str:
         """
-        Fully qualified domain name for DNS-AID record.
+        Fully qualified domain name for the agent's primary owner record.
 
-        Format: _{name}._{protocol}._agents.{domain}
-        Per IETF draft section 3.1
+        Returns the flat form ``{name}.{domain}`` per draft-02. The agent
+        protocol is no longer part of the FQDN under -02 — it lives in
+        the ``bap`` SvcParamKey (or ``alpn`` when only one protocol is
+        supported). The flat FQDN is valid as an x.509 SAN dNSName.
+
+        For the optional walkable AliasMode form, see ``walkable_fqdn``.
+        For the legacy -01 form, see ``legacy_fqdn``.
+        """
+        return f"{self.name}.{self.domain}"
+
+    @property
+    def walkable_fqdn(self) -> str:
+        """
+        Optional walkable AliasMode FQDN at ``{name}._agents.{domain}``.
+
+        Per draft-02 §Known Agent, publishers MAY emit an SVCB AliasMode
+        record at this name pointing at the flat primary owner so that
+        DNS-SD-style consumers and enumeration crawlers can discover the
+        agent. dns-aid-core's publisher writes this record by default;
+        operators can disable it via ``SDKConfig`` if a deployment
+        doesn't need walkable enumeration.
+        """
+        return f"{self.name}._agents.{self.domain}"
+
+    @property
+    def legacy_fqdn(self) -> str:
+        """
+        Backwards-compatible -01 FQDN ``_{name}._{protocol}._agents.{domain}``.
+
+        Used only by the legacy-fallback discovery path when the env
+        flag ``DNS_AID_LEGACY_01_FALLBACK=1`` is set. Not used for
+        publishing under -02.
         """
         return f"_{self.name}._{self.protocol.value}._agents.{self.domain}"
 

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -18,6 +18,31 @@ from pydantic import BaseModel, Field, field_validator
 
 from dns_aid.utils.validation import validate_connect_class
 
+# Capability provenance — single source of truth.
+#
+# Each value records WHERE a record's capabilities came from, so
+# downstream consumers can make trust / audit / fallback decisions
+# without re-deriving the chain. Add new values here (and only here)
+# — the discoverer, SDK, indexer, and AgentRecord all import this
+# symbol so adding a value automatically widens every type-check site.
+#
+# Priority (most trusted → least): cap_uri > well_known > agent_card
+# > http_index > txt_fallback. ``descriptor_unreachable`` is a
+# diagnostic source: the SVCB record declared a cap/well-known
+# locator but the fetch failed (timeout, TLS error, 5xx). Recording
+# this as a distinct source lets callers tell "no descriptor
+# declared" from "descriptor declared but unreachable right now"
+# without scraping log lines.
+CapabilitySource = Literal[
+    "cap_uri",
+    "well_known",
+    "agent_card",
+    "http_index",
+    "txt_fallback",
+    "descriptor_unreachable",
+    "none",
+]
+
 # DNS-AID custom SVCB param key mapping (IETF draft-02 §4 IANA Considerations).
 # These use the RFC 9460 Private Use range (65280-65534).
 # Once IANA assigns official SvcParamKey numbers, update these values.
@@ -25,7 +50,7 @@ from dns_aid.utils.validation import validate_connect_class
 # Six of the entries below (cap, cap-sha256, bap, policy, realm, well-known)
 # correspond to keys that draft-02 requests IANA register normatively. The
 # remaining four (sig, connect-class, connect-meta, enroll-uri) are not in
-# the draft-02 normative set; they back features discussed in -02 §FutureWork
+# the draft-02 normative set; they back features discussed in -02 §5 (Future Work and Experimental Mechanisms)
 # or shipping in dns-aid-core as extensions and remain at private-use code
 # points pending a follow-up discussion.
 DNS_AID_KEY_MAP: dict[str, str] = {
@@ -188,7 +213,7 @@ class SvcbRecord(BaseModel):
     @field_validator("target", mode="after")
     @classmethod
     def _enforce_no_underscore_in_target(cls, v: str) -> str:
-        """Enforce draft-02 §Known Organization at the type boundary.
+        """Enforce draft-02 §3.2 (Known Organization, Unknown Agent) at the type boundary.
 
         Earlier the no-underscore rule fired only inside ``publish()``;
         anyone constructing an ``SvcbRecord`` directly (or via
@@ -427,15 +452,15 @@ class AgentRecord(BaseModel):
     )
 
     # Capability source tracking
-    capability_source: (
-        Literal["cap_uri", "well_known", "agent_card", "http_index", "txt_fallback", "none"] | None
-    ) = Field(
+    capability_source: CapabilitySource | None = Field(
         default=None,
         description="Where capabilities were sourced from: 'cap_uri' (SVCB cap param), "
         "'well_known' (SVCB well-known param, reconstructed against the target host), "
         "'agent_card' (A2A /.well-known/agent-card.json skills), "
         "'http_index' (HTTP index capabilities), "
-        "'txt_fallback' (TXT record), or 'none'",
+        "'txt_fallback' (TXT record), "
+        "'descriptor_unreachable' (cap/well-known declared but fetch failed), "
+        "or 'none'",
     )
 
     # DNS settings
@@ -672,6 +697,18 @@ class PublishResult(BaseModel):
     backend: str = Field(..., description="DNS backend used")
     success: bool = Field(default=True, description="Whether publish succeeded")
     message: str | None = Field(default=None, description="Status message")
+    # Caller-visible advisories raised during the publish path (e.g.
+    # ``dns_aid.underscore_bypass`` when allow_underscore_target=True
+    # AND DNS_AID_ALLOW_UNDERSCORE_TARGET is set in the env). These
+    # are non-fatal — the publish still succeeded — but downstream
+    # observability needs to count and alert on them without scraping
+    # logs.
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal advisories raised during publish. Each entry is a stable "
+        "warning_class identifier (e.g. 'dns_aid.underscore_bypass') so consumers can "
+        "match exactly without log-string parsing.",
+    )
 
 
 class VerifyResult(BaseModel):

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -143,7 +143,17 @@ class SvcbRecord(BaseModel):
         default=None,
         description="Capability document URI mapped to the DNS-AID 'cap' SVCB parameter",
     )
-    cap_sha256: str | None = Field(default=None, description="SHA-256 digest for the cap URI")
+    cap_sha256: str | None = Field(
+        default=None,
+        description="SHA-256 digest for the cap URI. Presence does not imply the digest "
+        "was actually checked against fetched bytes — use ``cap_sha256_verified``.",
+    )
+    cap_sha256_verified: bool = Field(
+        default=False,
+        description="True when the discoverer fetched the descriptor and the SHA-256 of "
+        "its bytes matched ``cap_sha256``. Always False on records that didn't go "
+        "through the fetch path.",
+    )
     bap: list[str] = Field(default_factory=list, description="Bulk application protocols")
     policy_uri: str | None = Field(default=None, description="Agent policy URI")
     realm: str | None = Field(default=None, description="Opaque authz realm identifier")
@@ -175,6 +185,48 @@ class SvcbRecord(BaseModel):
     def normalize_connect_class(cls, v: str | None) -> str | None:
         return _normalize_connect_class(v)
 
+    @field_validator("target", mode="after")
+    @classmethod
+    def _enforce_no_underscore_in_target(cls, v: str) -> str:
+        """Enforce draft-02 §Known Organization at the type boundary.
+
+        Earlier the no-underscore rule fired only inside ``publish()``;
+        anyone constructing an ``SvcbRecord`` directly (or via
+        ``AgentRecord.to_svcb_record()``) bypassed it. The field
+        validator makes the model itself the enforcer so the invariant
+        holds regardless of construction path.
+
+        Honours the operator-level env gate
+        ``DNS_AID_ALLOW_UNDERSCORE_TARGET=1`` — when set, underscored
+        targets construct successfully so the publisher's existing
+        ``allow_underscore_target=True`` path can still emit its
+        structured WARN. Without the env gate, no construction path
+        can produce an underscored target.
+        """
+        from dns_aid.utils.validation import (
+            _underscore_bypass_env_enabled,
+            validate_no_underscore_in_target,
+        )
+
+        validate_no_underscore_in_target(v, allow_underscore=_underscore_bypass_env_enabled())
+        return v
+
+    @field_validator("well_known_path", mode="after")
+    @classmethod
+    def _enforce_safe_well_known_path(cls, v: str | None) -> str | None:
+        """Constrain well-known to a safe RFC 8615 value at the type boundary.
+
+        Same reasoning as ``target`` above: the publisher-side check
+        isn't sufficient when consumers can deserialize SVCB records
+        directly into ``SvcbRecord`` (e.g. through ``to_svcb_record()``
+        round-trips). The field validator catches it.
+        """
+        if v is None:
+            return None
+        from dns_aid.utils.validation import validate_well_known_path
+
+        return validate_well_known_path(v)
+
     @property
     def normalized_target(self) -> str:
         """SVCB targets are emitted with a trailing dot."""
@@ -190,6 +242,16 @@ class SvcbRecord(BaseModel):
                 mandatory.append(normalized)
                 seen_mandatory.add(normalized)
 
+        # Resolve the wire-key style ONCE per to_params() call. Earlier
+        # each line below was calling _svcb_param_key() which re-reads
+        # the DNS_AID_SVCB_STRING_KEYS env var via os.environ.get —
+        # up to 11 env reads per serialization, multiplied by every
+        # publish call. Cache the mapping here so we pay one env read.
+        emit_string = _use_string_keys()
+
+        def _key(name: str) -> str:
+            return name if emit_string else DNS_AID_KEY_MAP.get(name, name)
+
         params = {
             "alpn": self.alpn,
             "port": str(self.port),
@@ -200,25 +262,25 @@ class SvcbRecord(BaseModel):
         if self.ipv6_hint:
             params["ipv6hint"] = self.ipv6_hint
         if self.uri:
-            params[_svcb_param_key("cap")] = self.uri
+            params[_key("cap")] = self.uri
         if self.cap_sha256:
-            params[_svcb_param_key("cap-sha256")] = self.cap_sha256
+            params[_key("cap-sha256")] = self.cap_sha256
         if self.bap:
-            params[_svcb_param_key("bap")] = ",".join(self.bap)
+            params[_key("bap")] = ",".join(self.bap)
         if self.policy_uri:
-            params[_svcb_param_key("policy")] = self.policy_uri
+            params[_key("policy")] = self.policy_uri
         if self.realm:
-            params[_svcb_param_key("realm")] = self.realm
+            params[_key("realm")] = self.realm
         if self.sig:
-            params[_svcb_param_key("sig")] = self.sig
+            params[_key("sig")] = self.sig
         if self.connect_class:
-            params[_svcb_param_key("connect-class")] = self.connect_class
+            params[_key("connect-class")] = self.connect_class
         if self.connect_meta:
-            params[_svcb_param_key("connect-meta")] = self.connect_meta
+            params[_key("connect-meta")] = self.connect_meta
         if self.enroll_uri:
-            params[_svcb_param_key("enroll-uri")] = self.enroll_uri
+            params[_key("enroll-uri")] = self.enroll_uri
         if self.well_known_path:
-            params[_svcb_param_key("well-known")] = self.well_known_path
+            params[_key("well-known")] = self.well_known_path
         return params
 
 
@@ -304,7 +366,19 @@ class AgentRecord(BaseModel):
     cap_sha256: str | None = Field(
         default=None,
         description="Base64url-encoded SHA-256 digest of the canonical capability descriptor "
-        "for integrity checks and cache revalidation (per draft-02 'cap-sha256' SvcParamKey)",
+        "for integrity checks and cache revalidation (per draft-02 'cap-sha256' SvcParamKey). "
+        "Presence on a discovered AgentRecord does NOT imply the digest was checked against "
+        "fetched bytes — see ``cap_sha256_verified`` for that signal.",
+    )
+    cap_sha256_verified: bool = Field(
+        default=False,
+        description="True when the discoverer actually fetched a capability descriptor and "
+        "the SHA-256 of its bytes matched ``cap_sha256``. False when no fetch happened "
+        "(no cap/well-known descriptor URL), the fetch failed for non-mismatch reasons, "
+        "or no ``cap_sha256`` was declared. Consumers keying trust off the integrity pin "
+        "MUST check this flag — relying on the mere presence of ``cap_sha256`` is a false "
+        "integrity signal because the pin only applies to the bytes that produced the "
+        "capabilities, and TXT-fallback / network-failure paths can leave it dangling.",
     )
     well_known_path: str | None = Field(
         default=None,
@@ -461,6 +535,35 @@ class AgentRecord(BaseModel):
     @classmethod
     def validate_connect_class(cls, v: str | None) -> str | None:
         return _normalize_connect_class(v)
+
+    @field_validator("target_host", mode="after")
+    @classmethod
+    def _enforce_no_underscore_in_target_host(cls, v: str) -> str:
+        """Mirror the SvcbRecord.target rule on AgentRecord's target_host.
+
+        Honours the operator env gate
+        ``DNS_AID_ALLOW_UNDERSCORE_TARGET=1`` so the publisher's
+        existing ``allow_underscore_target=True`` path can still pass
+        through. Without the env gate set no construction path can
+        produce an underscored target_host.
+        """
+        from dns_aid.utils.validation import (
+            _underscore_bypass_env_enabled,
+            validate_no_underscore_in_target,
+        )
+
+        validate_no_underscore_in_target(v, allow_underscore=_underscore_bypass_env_enabled())
+        return v
+
+    @field_validator("well_known_path", mode="after")
+    @classmethod
+    def _enforce_safe_well_known_path_on_agent(cls, v: str | None) -> str | None:
+        """Same as SvcbRecord — enforce the safe-value rule at the type."""
+        if v is None:
+            return None
+        from dns_aid.utils.validation import validate_well_known_path
+
+        return validate_well_known_path(v)
 
     @property
     def fqdn(self) -> str:

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -144,7 +144,15 @@ class SvcbRecord(BaseModel):
         description="Capability document URI mapped to the DNS-AID 'cap' SVCB parameter",
     )
     cap_sha256: str | None = Field(default=None, description="SHA-256 digest for the cap URI")
-    bap: list[str] = Field(default_factory=list, description="Bulk application protocols")
+    bap: str | None = Field(
+        default=None,
+        description="Bulk Agent Protocol (draft-02 §FutureWork). Carries a single "
+        "versioned agent-protocol identifier (e.g. 'mcp2.1', 'a2a1.0') per SVCB "
+        "record. Experimental in draft-02 — alpn remains the canonical protocol "
+        "carrier; bap adds version information when present. Multi-protocol "
+        "agents publish multiple SVCB records at the same flat owner, each with "
+        "its own alpn and (optionally) bap.",
+    )
     policy_uri: str | None = Field(default=None, description="Agent policy URI")
     realm: str | None = Field(default=None, description="Opaque authz realm identifier")
     sig: str | None = Field(default=None, description="JWS signature for the record")
@@ -204,7 +212,7 @@ class SvcbRecord(BaseModel):
         if self.cap_sha256:
             params[_svcb_param_key("cap-sha256")] = self.cap_sha256
         if self.bap:
-            params[_svcb_param_key("bap")] = ",".join(self.bap)
+            params[_svcb_param_key("bap")] = self.bap
         if self.policy_uri:
             params[_svcb_param_key("policy")] = self.policy_uri
         if self.realm:
@@ -314,10 +322,16 @@ class AgentRecord(BaseModel):
         "capability descriptor it prefers 'cap' (explicit locator) and falls back to "
         "reconstructing https://<svcb-target>/.well-known/<well_known_path>.",
     )
-    bap: list[str] = Field(
-        default_factory=list,
-        description="DNS-AID Application Protocols with versions understood by the endpoint "
-        "(e.g., ['mcp/1', 'a2a/1']). Distinct from transport-level alpn per draft Section 4.4.3.",
+    bap: str | None = Field(
+        default=None,
+        description="Bulk Agent Protocol — single versioned agent-protocol "
+        "identifier (e.g. 'mcp2.1', 'a2a1.0') for this SVCB record. Per "
+        "draft-02 §FutureWork (Bulk Agent Protocol) this is experimental; "
+        "the canonical protocol carrier remains 'alpn'. bap adds version "
+        "information when present. Multi-protocol agents are published as "
+        "multiple AgentRecord instances at the same flat owner name, each "
+        "with its own alpn and (optionally) bap — NOT as a comma-separated "
+        "list on one record.",
     )
     policy_uri: str | None = Field(
         default=None,

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -68,6 +68,14 @@ DNS_AID_KEY_MAP: dict[str, str] = {
 
 DNS_AID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in DNS_AID_KEY_MAP.items()}
 
+# SVCB record priorities per RFC 9460:
+#   priority=0 → AliasMode (the record is an alias to a canonical owner)
+#   priority>0 → ServiceMode (the record carries endpoint data; lower
+#                priorities are preferred when multiple are returned)
+# We use 1 as the default ServiceMode priority for primary-owner writes.
+SVCB_ALIAS_MODE: int = 0
+SVCB_SERVICE_MODE: int = 1
+
 
 def _use_string_keys() -> bool:
     """Check if human-readable string keys should be used instead of keyNNNNN.
@@ -313,9 +321,15 @@ class AgentRecord(BaseModel):
     """
     Represents an AI agent published via DNS-AID.
 
-    Maps to SVCB + TXT records in DNS per the DNS-AID specification:
-    - SVCB: _{name}._{protocol}._agents.{domain} → service binding
+    Maps to SVCB + TXT records in DNS per the DNS-AID specification
+    (draft-mozleywilliams-dnsop-dnsaid-02):
+
+    - SVCB: ``{name}.{domain}`` → service binding (flat primary owner)
     - TXT: capabilities, version, metadata
+
+    The agent protocol is no longer part of the FQDN under -02 — it
+    lives in the ``bap`` SvcParamKey (or ``alpn`` when only one
+    protocol is supported).
 
     Example:
         >>> agent = AgentRecord(
@@ -326,7 +340,7 @@ class AgentRecord(BaseModel):
         ...     capabilities=["ipam", "dns", "vpn"]
         ... )
         >>> agent.fqdn
-        '_network-specialist._mcp._agents.example.com'
+        'network-specialist.example.com'
         >>> agent.endpoint_url
         'https://mcp.example.com:443'
     """
@@ -467,11 +481,15 @@ class AgentRecord(BaseModel):
     ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
 
     publish_walkable_alias: bool = Field(
-        default=True,
+        default=False,
         description="Whether to publish the optional walkable AliasMode SVCB record at "
-        "{name}._agents.{domain} pointing at the flat primary owner. Per draft-02 §Known "
-        "Agent, this is operator-optional. dns-aid-core publishes it by default so "
-        "DNS-SD-style enumeration crawlers can discover the agent; set False to suppress.",
+        "{name}._agents.{domain} pointing at the flat primary owner. Per draft-02 §3.1 "
+        "this record is operator-optional and serves DNS-SD-style enumeration "
+        "use cases. Default False because the record is an enumeration handle (a "
+        "crawler can walk _agents.<zone> and inventory every agent), which is "
+        "undesirable for most public deployments — see docs/privacy-considerations.md. "
+        "Set True when you actively want the agent discoverable via enumeration "
+        "(internal indexes, intentional public directories, DNS-SD-style consumers).",
     )
 
     # Optional direct endpoint (overrides target_host:port for HTTP index agents)
@@ -529,6 +547,17 @@ class AgentRecord(BaseModel):
         default=False,
         description="True when the domain hosting this agent presented a DNSSEC-validated "
         "response (AD flag set). False when validation did not occur or did not succeed.",
+    )
+
+    legacy_resolved: bool = Field(
+        default=False,
+        description="True when this agent record was resolved via the legacy "
+        "draft-01 FQDN shape (`_{name}._{protocol}._agents.{domain}`) rather "
+        "than the draft-02 flat form (`{name}.{domain}`). Callers should "
+        "down-weight or refuse legacy-resolved records in environments where "
+        "the publisher has had time to migrate. Set by the discoverer when "
+        "``allow_legacy=True`` (or the env-flag equivalent) lets a flat-FQDN "
+        "miss fall back to the legacy shape.",
     )
 
     # JWS verification result (populated by the discoverer's signature-verification step
@@ -797,7 +826,13 @@ class VerifyResult(BaseModel):
             score += 20
         if self.dnssec_valid:
             score += 30
-        if self.dane_valid:
+        # DANE only contributes when DNSSEC also validated. TLSA without
+        # DNSSEC has no integrity guarantee (RFC 6698 §10.1), so we
+        # don't let it bump the score even if a caller hand-built this
+        # VerifyResult with both flags. The validator.py path already
+        # demotes ``dane_valid`` to None in that case; this is a
+        # second-line guard against bypass.
+        if self.dane_valid and self.dnssec_valid:
             score += 15
         if self.endpoint_reachable:
             score += 15

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -18,9 +18,16 @@ from pydantic import BaseModel, Field, field_validator
 
 from dns_aid.utils.validation import validate_connect_class
 
-# DNS-AID custom SVCB param key mapping (IETF draft-01, Section 4.4.3)
+# DNS-AID custom SVCB param key mapping (IETF draft-02 §4 IANA Considerations).
 # These use the RFC 9460 Private Use range (65280-65534).
 # Once IANA assigns official SvcParamKey numbers, update these values.
+#
+# Six of the entries below (cap, cap-sha256, bap, policy, realm, well-known)
+# correspond to keys that draft-02 requests IANA register normatively. The
+# remaining four (sig, connect-class, connect-meta, enroll-uri) are not in
+# the draft-02 normative set; they back features discussed in -02 §FutureWork
+# or shipping in dns-aid-core as extensions and remain at private-use code
+# points pending a follow-up discussion.
 DNS_AID_KEY_MAP: dict[str, str] = {
     "cap": "key65400",
     "cap-sha256": "key65401",
@@ -31,6 +38,7 @@ DNS_AID_KEY_MAP: dict[str, str] = {
     "connect-class": "key65406",
     "connect-meta": "key65407",
     "enroll-uri": "key65408",
+    "well-known": "key65409",
 }
 
 DNS_AID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in DNS_AID_KEY_MAP.items()}
@@ -155,6 +163,12 @@ class SvcbRecord(BaseModel):
         max_length=2048,
         description="Managed enrollment URI required before direct connection",
     )
+    well_known_path: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="RFC 8615 well-known path suffix mapped to the DNS-AID 'well-known' "
+        "SvcParamKey (per draft-02). Independent of 'uri'/'cap'; both may be present.",
+    )
 
     @field_validator("connect_class", mode="before")
     @classmethod
@@ -203,6 +217,8 @@ class SvcbRecord(BaseModel):
             params[_svcb_param_key("connect-meta")] = self.connect_meta
         if self.enroll_uri:
             params[_svcb_param_key("enroll-uri")] = self.enroll_uri
+        if self.well_known_path:
+            params[_svcb_param_key("well-known")] = self.well_known_path
         return params
 
 
@@ -282,12 +298,21 @@ class AgentRecord(BaseModel):
     #     add custom keys to the mandatory list for downgrade safety.
     cap_uri: str | None = Field(
         default=None,
-        description="URI or URN to capability descriptor (per DNS-AID draft Section 4.4.3 'cap')",
+        description="URI, URN, or compact JSON-Ref locator for the capability descriptor "
+        "(per draft-02 'cap' SvcParamKey)",
     )
     cap_sha256: str | None = Field(
         default=None,
-        description="Base64url-encoded SHA-256 digest of the capability descriptor "
-        "for integrity checks and cache revalidation (per DNS-AID draft 'cap-sha256')",
+        description="Base64url-encoded SHA-256 digest of the canonical capability descriptor "
+        "for integrity checks and cache revalidation (per draft-02 'cap-sha256' SvcParamKey)",
+    )
+    well_known_path: str | None = Field(
+        default=None,
+        description="RFC 8615 well-known path suffix (e.g. 'agent-card.json') under "
+        "/.well-known/ on the SVCB target's host. Per draft-02 'well-known' SvcParamKey. "
+        "Independent of 'cap'; both may be present. When dns-aid-core fetches a "
+        "capability descriptor it prefers 'cap' (explicit locator) and falls back to "
+        "reconstructing https://<svcb-target>/.well-known/<well_known_path>.",
     )
     bap: list[str] = Field(
         default_factory=list,
@@ -329,10 +354,11 @@ class AgentRecord(BaseModel):
 
     # Capability source tracking
     capability_source: (
-        Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] | None
+        Literal["cap_uri", "well_known", "agent_card", "http_index", "txt_fallback", "none"] | None
     ) = Field(
         default=None,
         description="Where capabilities were sourced from: 'cap_uri' (SVCB cap param), "
+        "'well_known' (SVCB well-known param, reconstructed against the target host), "
         "'agent_card' (A2A /.well-known/agent-card.json skills), "
         "'http_index' (HTTP index capabilities), "
         "'txt_fallback' (TXT record), or 'none'",
@@ -477,6 +503,7 @@ class AgentRecord(BaseModel):
             connect_class=self.connect_class,
             connect_meta=self.connect_meta,
             enroll_uri=self.enroll_uri,
+            well_known_path=self.well_known_path,
         )
 
     def to_svcb_params(self) -> dict[str, str]:

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -91,6 +91,7 @@ async def publish(
     sign: bool = False,
     private_key_path: str | None = None,
     allow_underscore_target: bool = False,
+    publish_walkable_alias: bool = True,
 ) -> PublishResult:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -137,6 +138,13 @@ async def publish(
             MUST NOT contain underscores. dns-aid-core enforces this by
             default; set this flag for internal-only deployments where the
             target is not behind public PKI.
+        publish_walkable_alias: If True (default), additionally write the
+            optional walkable AliasMode SVCB record at
+            {name}._agents.{domain} pointing at the flat primary owner.
+            Per draft-02 §Known Agent this is operator-optional; the
+            walkable record makes DNS-SD-style enumeration crawlers able
+            to discover the agent. Set False to suppress the walkable
+            write if your deployment doesn't need enumeration.
 
     Returns:
         PublishResult with created records
@@ -152,7 +160,7 @@ async def publish(
         ...     realm="production",
         ... )
         >>> print(result.agent.fqdn)
-        '_network-specialist._mcp._agents.example.com'
+        'network-specialist.example.com'
     """
     # Normalize protocol to enum
     if isinstance(protocol, str):
@@ -180,7 +188,9 @@ async def publish(
 
         logger.info("Signing record with JWS", private_key_path=private_key_path)
         private_key = load_private_key_from_pem(private_key_path)
-        fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+        # JWS payload binds to the flat draft-02 FQDN ({name}.{domain}).
+        # Verifiers reconstruct the same FQDN before validating the signature.
+        fqdn = f"{name}.{domain}"
         payload = RecordPayload.from_agent_record(
             fqdn=fqdn,
             target=endpoint,
@@ -216,6 +226,7 @@ async def publish(
         ipv4_hint=ipv4_hint,
         ipv6_hint=ipv6_hint,
         sig=sig,
+        publish_walkable_alias=publish_walkable_alias,
     )
 
     # Get backend
@@ -299,13 +310,24 @@ async def unpublish(
 
     dns_backend = backend or get_default_backend()
 
-    record_name = f"_{name}._{protocol.value}._agents"
+    # Under draft-02 the agent's primary owner is the flat name; the
+    # relative record name under the zone is just the agent name. We
+    # also remove the optional walkable AliasMode record at
+    # {name}._agents.{domain} if the publisher wrote one. To keep the
+    # migration path clean for operators who published under draft-01
+    # before upgrading, we additionally remove the legacy
+    # _{name}._{protocol}._agents form (silent if absent).
+    record_name = name
+    walkable_record_name = f"{name}._agents"
+    legacy_record_name = f"_{name}._{protocol.value}._agents"
 
     logger.info(
         "Removing agent from DNS",
         agent_name=name,
         domain=domain,
         record_name=record_name,
+        walkable_record_name=walkable_record_name,
+        legacy_record_name=legacy_record_name,
     )
 
     # Check zone exists before attempting deletion
@@ -313,11 +335,42 @@ async def unpublish(
         logger.error("Zone does not exist", zone=domain)
         return False
 
-    # Delete both record types
+    # Delete the primary-owner records (SVCB + companion TXT).
     svcb_deleted = await dns_backend.delete_record(domain, record_name, "SVCB")
     txt_deleted = await dns_backend.delete_record(domain, record_name, "TXT")
 
-    success = svcb_deleted or txt_deleted
+    # Delete the walkable AliasMode record if present. Log at debug on
+    # failure rather than swallowing silently so backend quirks are
+    # diagnosable.
+    try:
+        walkable_deleted = await dns_backend.delete_record(domain, walkable_record_name, "SVCB")
+    except Exception as exc:
+        walkable_deleted = False
+        logger.debug(
+            "Walkable AliasMode delete raised; treating as absent",
+            walkable_record_name=walkable_record_name,
+            error=str(exc),
+        )
+
+    # Also clear any leftover draft-01-shape records so operators
+    # upgrading from -01 to -02 can run unpublish() once and have it
+    # remove both shapes. No env flag required — the delete is a
+    # silent no-op when the records don't exist.
+    legacy_svcb_deleted = False
+    legacy_txt_deleted = False
+    try:
+        legacy_svcb_deleted = await dns_backend.delete_record(domain, legacy_record_name, "SVCB")
+        legacy_txt_deleted = await dns_backend.delete_record(domain, legacy_record_name, "TXT")
+    except Exception as exc:
+        logger.debug(
+            "Legacy -01 record delete raised; treating as absent",
+            legacy_record_name=legacy_record_name,
+            error=str(exc),
+        )
+
+    success = (
+        svcb_deleted or txt_deleted or walkable_deleted or legacy_svcb_deleted or legacy_txt_deleted
+    )
 
     if success:
         logger.info("Agent removed from DNS", agent_name=name)

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -127,8 +127,8 @@ async def publish(
             cap_uri; both may be set. Consumers prefer cap_uri when both are
             present and fall back to reconstructing
             https://<svcb-target>/.well-known/<well_known_path>.
-        bap: Optional single versioned agent-protocol identifier (e.g. "mcp2.1",
-            "a2a1.0") for the Bulk Agent Protocol SvcParamKey. Experimental per
+        bap: Optional single versioned agent-protocol identifier (e.g. "mcp=2.1",
+            "a2a=1.0") for the Bulk Agent Protocol SvcParamKey. Experimental per
             draft-02 §FutureWork; alpn remains the canonical protocol carrier.
             Multi-protocol agents publish multiple AgentRecord instances at the
             same flat owner name, each with its own alpn and (optionally) bap —

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -79,6 +79,7 @@ async def publish(
     backend: DNSBackend | None = None,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
+    well_known_path: str | None = None,
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
@@ -89,6 +90,7 @@ async def publish(
     ipv6_hint: str | None = None,
     sign: bool = False,
     private_key_path: str | None = None,
+    allow_underscore_target: bool = False,
 ) -> PublishResult:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -109,8 +111,15 @@ async def publish(
         category: Agent category (e.g., "network", "security")
         ttl: DNS record TTL in seconds
         backend: DNS backend to use (defaults to global backend)
-        cap_uri: URI to capability document (DNS-AID draft-compliant)
+        cap_uri: URI, URN, or compact JSON-Ref locator for the capability
+            descriptor (DNS-AID draft-02 'cap' SvcParamKey)
         cap_sha256: Base64url-encoded SHA-256 digest of the capability descriptor
+            (DNS-AID draft-02 'cap-sha256' SvcParamKey)
+        well_known_path: RFC 8615 well-known path suffix (e.g., 'agent-card.json')
+            for the DNS-AID draft-02 'well-known' SvcParamKey. Independent of
+            cap_uri; both may be set. Consumers prefer cap_uri when both are
+            present and fall back to reconstructing
+            https://<svcb-target>/.well-known/<well_known_path>.
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
@@ -121,6 +130,13 @@ async def publish(
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6)
         sign: If True, sign the record with JWS (requires private_key_path)
         private_key_path: Path to EC P-256 private key PEM file for signing
+        allow_underscore_target: If True, downgrade a TargetName-contains-
+            underscore violation from an error to a warning. Per
+            draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, SVCB
+            TargetNames reached over TLS with publicly-issued x.509 certs
+            MUST NOT contain underscores. dns-aid-core enforces this by
+            default; set this flag for internal-only deployments where the
+            target is not behind public PKI.
 
     Returns:
         PublishResult with created records
@@ -141,6 +157,14 @@ async def publish(
     # Normalize protocol to enum
     if isinstance(protocol, str):
         protocol = Protocol(protocol.lower())
+
+    # Enforce draft-02 §Known Organization: the SVCB TargetName MUST NOT
+    # contain underscores when reached over TLS with a public x.509 cert.
+    # Strict-by-default; the allow_underscore_target flag downgrades to a
+    # warning for internal-only deployments.
+    from dns_aid.utils.validation import validate_no_underscore_in_target
+
+    validate_no_underscore_in_target(endpoint, allow_underscore=allow_underscore_target)
 
     # Generate JWS signature if requested
     sig = None
@@ -182,6 +206,7 @@ async def publish(
         ttl=ttl,
         cap_uri=cap_uri,
         cap_sha256=cap_sha256,
+        well_known_path=well_known_path,
         bap=bap or [],
         policy_uri=policy_uri,
         realm=realm,

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -132,7 +132,7 @@ async def publish(
         private_key_path: Path to EC P-256 private key PEM file for signing
         allow_underscore_target: If True, downgrade a TargetName-contains-
             underscore violation from an error to a warning. Per
-            draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, SVCB
+            draft-mozleywilliams-dnsop-dnsaid-02 §3.2 (Known Organization, Unknown Agent), SVCB
             TargetNames reached over TLS with publicly-issued x.509 certs
             MUST NOT contain underscores. dns-aid-core enforces this by
             default; set this flag for internal-only deployments where the
@@ -158,16 +158,30 @@ async def publish(
     if isinstance(protocol, str):
         protocol = Protocol(protocol.lower())
 
-    # Enforce draft-02 §Known Organization: the SVCB TargetName MUST NOT
+    # Enforce draft-02 §3.2 (Known Organization, Unknown Agent): the SVCB TargetName MUST NOT
     # contain underscores when reached over TLS with a public x.509 cert.
     # Strict-by-default; the allow_underscore_target flag downgrades to a
     # warning for internal-only deployments.
     from dns_aid.utils.validation import (
+        _underscore_bypass_env_enabled,
         validate_no_underscore_in_target,
         validate_well_known_path,
     )
 
     validate_no_underscore_in_target(endpoint, allow_underscore=allow_underscore_target)
+
+    # Capture whether the bypass actually fired so we can surface it
+    # on PublishResult.warnings (caller-visible, log-aggregator
+    # parseable). The check is intentionally redundant with the
+    # validator's WARN log: PR #154 v2 review (Igor) asked for the
+    # signal as structured data, not just a log line.
+    publish_warnings: list[str] = []
+    if (
+        allow_underscore_target
+        and _underscore_bypass_env_enabled()
+        and any("_" in label for label in endpoint.rstrip(".").split("."))
+    ):
+        publish_warnings.append("dns_aid.underscore_bypass")
 
     # Constrain well-known to a safe RFC 8615 single-segment suffix so
     # the publisher can't emit a SvcParamKey value that a consumer would
@@ -251,6 +265,7 @@ async def publish(
             backend=dns_backend.name,
             success=False,
             message=f"Zone '{domain}' does not exist or is not accessible",
+            warnings=publish_warnings,
         )
 
     try:
@@ -270,6 +285,7 @@ async def publish(
             backend=dns_backend.name,
             success=True,
             message="Agent published successfully",
+            warnings=publish_warnings,
         )
 
     except Exception as e:
@@ -281,6 +297,7 @@ async def publish(
             backend=dns_backend.name,
             success=False,
             message=f"Failed to publish: {e}",
+            warnings=publish_warnings,
         )
 
 

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -79,6 +79,7 @@ async def publish(
     backend: DNSBackend | None = None,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
+    well_known_path: str | None = None,
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
@@ -89,6 +90,7 @@ async def publish(
     ipv6_hint: str | None = None,
     sign: bool = False,
     private_key_path: str | None = None,
+    allow_underscore_target: bool = False,
 ) -> PublishResult:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -109,8 +111,15 @@ async def publish(
         category: Agent category (e.g., "network", "security")
         ttl: DNS record TTL in seconds
         backend: DNS backend to use (defaults to global backend)
-        cap_uri: URI to capability document (DNS-AID draft-compliant)
+        cap_uri: URI, URN, or compact JSON-Ref locator for the capability
+            descriptor (DNS-AID draft-02 'cap' SvcParamKey)
         cap_sha256: Base64url-encoded SHA-256 digest of the capability descriptor
+            (DNS-AID draft-02 'cap-sha256' SvcParamKey)
+        well_known_path: RFC 8615 well-known path suffix (e.g., 'agent-card.json')
+            for the DNS-AID draft-02 'well-known' SvcParamKey. Independent of
+            cap_uri; both may be set. Consumers prefer cap_uri when both are
+            present and fall back to reconstructing
+            https://<svcb-target>/.well-known/<well_known_path>.
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
@@ -121,6 +130,13 @@ async def publish(
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6)
         sign: If True, sign the record with JWS (requires private_key_path)
         private_key_path: Path to EC P-256 private key PEM file for signing
+        allow_underscore_target: If True, downgrade a TargetName-contains-
+            underscore violation from an error to a warning. Per
+            draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, SVCB
+            TargetNames reached over TLS with publicly-issued x.509 certs
+            MUST NOT contain underscores. dns-aid-core enforces this by
+            default; set this flag for internal-only deployments where the
+            target is not behind public PKI.
 
     Returns:
         PublishResult with created records
@@ -141,6 +157,25 @@ async def publish(
     # Normalize protocol to enum
     if isinstance(protocol, str):
         protocol = Protocol(protocol.lower())
+
+    # Enforce draft-02 §Known Organization: the SVCB TargetName MUST NOT
+    # contain underscores when reached over TLS with a public x.509 cert.
+    # Strict-by-default; the allow_underscore_target flag downgrades to a
+    # warning for internal-only deployments.
+    from dns_aid.utils.validation import (
+        validate_no_underscore_in_target,
+        validate_well_known_path,
+    )
+
+    validate_no_underscore_in_target(endpoint, allow_underscore=allow_underscore_target)
+
+    # Constrain well-known to a safe RFC 8615 single-segment suffix so
+    # the publisher can't emit a SvcParamKey value that a consumer would
+    # later interpolate into a non-well-known URL. Enforced on both the
+    # publish and discover sides so neither end of the pipe is the
+    # weakest link.
+    if well_known_path is not None:
+        well_known_path = validate_well_known_path(well_known_path)
 
     # Generate JWS signature if requested
     sig = None
@@ -182,6 +217,7 @@ async def publish(
         ttl=ttl,
         cap_uri=cap_uri,
         cap_sha256=cap_sha256,
+        well_known_path=well_known_path,
         bap=bap or [],
         policy_uri=policy_uri,
         realm=realm,

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -86,7 +86,7 @@ async def publish(
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
     well_known_path: str | None = None,
-    bap: list[str] | None = None,
+    bap: str | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
     connect_class: str | None = None,
@@ -127,7 +127,12 @@ async def publish(
             cap_uri; both may be set. Consumers prefer cap_uri when both are
             present and fall back to reconstructing
             https://<svcb-target>/.well-known/<well_known_path>.
-        bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
+        bap: Optional single versioned agent-protocol identifier (e.g. "mcp2.1",
+            "a2a1.0") for the Bulk Agent Protocol SvcParamKey. Experimental per
+            draft-02 §FutureWork; alpn remains the canonical protocol carrier.
+            Multi-protocol agents publish multiple AgentRecord instances at the
+            same flat owner name, each with its own alpn and (optionally) bap —
+            NOT as a comma-separated list on a single record.
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
         connect_class: Connection mediation class (e.g., "direct", "lattice", "apphub-psc")
@@ -256,7 +261,7 @@ async def publish(
         cap_uri=cap_uri,
         cap_sha256=cap_sha256,
         well_known_path=well_known_path,
-        bap=bap or [],
+        bap=bap,
         policy_uri=policy_uri,
         realm=realm,
         connect_class=connect_class,

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -91,6 +91,7 @@ async def publish(
     sign: bool = False,
     private_key_path: str | None = None,
     allow_underscore_target: bool = False,
+    publish_walkable_alias: bool = True,
 ) -> PublishResult:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -137,6 +138,13 @@ async def publish(
             MUST NOT contain underscores. dns-aid-core enforces this by
             default; set this flag for internal-only deployments where the
             target is not behind public PKI.
+        publish_walkable_alias: If True (default), additionally write the
+            optional walkable AliasMode SVCB record at
+            {name}._agents.{domain} pointing at the flat primary owner.
+            Per draft-02 §Known Agent this is operator-optional; the
+            walkable record makes DNS-SD-style enumeration crawlers able
+            to discover the agent. Set False to suppress the walkable
+            write if your deployment doesn't need enumeration.
 
     Returns:
         PublishResult with created records
@@ -152,7 +160,7 @@ async def publish(
         ...     realm="production",
         ... )
         >>> print(result.agent.fqdn)
-        '_network-specialist._mcp._agents.example.com'
+        'network-specialist.example.com'
     """
     # Normalize protocol to enum
     if isinstance(protocol, str):
@@ -205,7 +213,9 @@ async def publish(
 
         logger.info("Signing record with JWS", private_key_path=private_key_path)
         private_key = load_private_key_from_pem(private_key_path)
-        fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+        # JWS payload binds to the flat draft-02 FQDN ({name}.{domain}).
+        # Verifiers reconstruct the same FQDN before validating the signature.
+        fqdn = f"{name}.{domain}"
         payload = RecordPayload.from_agent_record(
             fqdn=fqdn,
             target=endpoint,
@@ -241,6 +251,7 @@ async def publish(
         ipv4_hint=ipv4_hint,
         ipv6_hint=ipv6_hint,
         sig=sig,
+        publish_walkable_alias=publish_walkable_alias,
     )
 
     # Get backend
@@ -327,13 +338,24 @@ async def unpublish(
 
     dns_backend = backend or get_default_backend()
 
-    record_name = f"_{name}._{protocol.value}._agents"
+    # Under draft-02 the agent's primary owner is the flat name; the
+    # relative record name under the zone is just the agent name. We
+    # also remove the optional walkable AliasMode record at
+    # {name}._agents.{domain} if the publisher wrote one. To keep the
+    # migration path clean for operators who published under draft-01
+    # before upgrading, we additionally remove the legacy
+    # _{name}._{protocol}._agents form (silent if absent).
+    record_name = name
+    walkable_record_name = f"{name}._agents"
+    legacy_record_name = f"_{name}._{protocol.value}._agents"
 
     logger.info(
         "Removing agent from DNS",
         agent_name=name,
         domain=domain,
         record_name=record_name,
+        walkable_record_name=walkable_record_name,
+        legacy_record_name=legacy_record_name,
     )
 
     # Check zone exists before attempting deletion
@@ -341,11 +363,42 @@ async def unpublish(
         logger.error("Zone does not exist", zone=domain)
         return False
 
-    # Delete both record types
+    # Delete the primary-owner records (SVCB + companion TXT).
     svcb_deleted = await dns_backend.delete_record(domain, record_name, "SVCB")
     txt_deleted = await dns_backend.delete_record(domain, record_name, "TXT")
 
-    success = svcb_deleted or txt_deleted
+    # Delete the walkable AliasMode record if present. Log at debug on
+    # failure rather than swallowing silently so backend quirks are
+    # diagnosable.
+    try:
+        walkable_deleted = await dns_backend.delete_record(domain, walkable_record_name, "SVCB")
+    except Exception as exc:
+        walkable_deleted = False
+        logger.debug(
+            "Walkable AliasMode delete raised; treating as absent",
+            walkable_record_name=walkable_record_name,
+            error=str(exc),
+        )
+
+    # Also clear any leftover draft-01-shape records so operators
+    # upgrading from -01 to -02 can run unpublish() once and have it
+    # remove both shapes. No env flag required — the delete is a
+    # silent no-op when the records don't exist.
+    legacy_svcb_deleted = False
+    legacy_txt_deleted = False
+    try:
+        legacy_svcb_deleted = await dns_backend.delete_record(domain, legacy_record_name, "SVCB")
+        legacy_txt_deleted = await dns_backend.delete_record(domain, legacy_record_name, "TXT")
+    except Exception as exc:
+        logger.debug(
+            "Legacy -01 record delete raised; treating as absent",
+            legacy_record_name=legacy_record_name,
+            error=str(exc),
+        )
+
+    success = (
+        svcb_deleted or txt_deleted or walkable_deleted or legacy_svcb_deleted or legacy_txt_deleted
+    )
 
     if success:
         logger.info("Agent removed from DNS", agent_name=name)

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -80,7 +80,7 @@ async def publish(
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
     well_known_path: str | None = None,
-    bap: list[str] | None = None,
+    bap: str | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
     connect_class: str | None = None,
@@ -121,7 +121,12 @@ async def publish(
             cap_uri; both may be set. Consumers prefer cap_uri when both are
             present and fall back to reconstructing
             https://<svcb-target>/.well-known/<well_known_path>.
-        bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
+        bap: Optional single versioned agent-protocol identifier (e.g. "mcp2.1",
+            "a2a1.0") for the Bulk Agent Protocol SvcParamKey. Experimental per
+            draft-02 §FutureWork; alpn remains the canonical protocol carrier.
+            Multi-protocol agents publish multiple AgentRecord instances at the
+            same flat owner name, each with its own alpn and (optionally) bap —
+            NOT as a comma-separated list on a single record.
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
         connect_class: Connection mediation class (e.g., "direct", "lattice", "apphub-psc")
@@ -217,7 +222,7 @@ async def publish(
         cap_uri=cap_uri,
         cap_sha256=cap_sha256,
         well_known_path=well_known_path,
-        bap=bap or [],
+        bap=bap,
         policy_uri=policy_uri,
         realm=realm,
         connect_class=connect_class,

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -5,7 +5,7 @@
 DNS-AID Publisher: Create DNS records for AI agent discovery.
 
 This module handles publishing agents to DNS using SVCB and TXT records
-as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -15,6 +15,12 @@ import structlog
 from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
 from dns_aid.backends.base import DNSBackend
 from dns_aid.core.models import AgentRecord, Protocol, PublishResult
+from dns_aid.utils.validation import (
+    _underscore_bypass_env_enabled,
+    validate_agent_name,
+    validate_no_underscore_in_target,
+    validate_well_known_path,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -91,7 +97,7 @@ async def publish(
     sign: bool = False,
     private_key_path: str | None = None,
     allow_underscore_target: bool = False,
-    publish_walkable_alias: bool = True,
+    publish_walkable_alias: bool = False,
 ) -> PublishResult:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -138,13 +144,18 @@ async def publish(
             MUST NOT contain underscores. dns-aid-core enforces this by
             default; set this flag for internal-only deployments where the
             target is not behind public PKI.
-        publish_walkable_alias: If True (default), additionally write the
+        publish_walkable_alias: When True, additionally write the
             optional walkable AliasMode SVCB record at
-            {name}._agents.{domain} pointing at the flat primary owner.
-            Per draft-02 §Known Agent this is operator-optional; the
-            walkable record makes DNS-SD-style enumeration crawlers able
-            to discover the agent. Set False to suppress the walkable
-            write if your deployment doesn't need enumeration.
+            ``{name}._agents.{domain}`` pointing at the flat primary
+            owner. Per draft-02 §3.1 this record is operator-optional.
+            **Default False**: the walkable record is an enumeration
+            handle — a crawler that knows the zone can walk
+            ``_agents.<zone>`` and inventory every agent the operator
+            publishes. For most deployments that's undesirable (see
+            ``docs/privacy-considerations.md``). Set True when you
+            actively want the agents discoverable by enumeration —
+            internal directories, intentional public catalogs, or
+            DNS-SD-style consumers.
 
     Returns:
         PublishResult with created records
@@ -166,16 +177,19 @@ async def publish(
     if isinstance(protocol, str):
         protocol = Protocol(protocol.lower())
 
-    # Enforce draft-02 §3.2 (Known Organization, Unknown Agent): the SVCB TargetName MUST NOT
-    # contain underscores when reached over TLS with a public x.509 cert.
-    # Strict-by-default; the allow_underscore_target flag downgrades to a
-    # warning for internal-only deployments.
-    from dns_aid.utils.validation import (
-        _underscore_bypass_env_enabled,
-        validate_no_underscore_in_target,
-        validate_well_known_path,
-    )
+    # Validate the agent name BEFORE the rest of the pipeline runs.
+    # The flat draft-02 FQDN is `{name}.{domain}`, which becomes the
+    # x.509 dNSName SAN; CA/Browser Forum + RFC 5280 forbid underscored
+    # labels and the validator's lowercase+hyphenated rule lines up with
+    # what most CAs and DNS providers will actually accept. Without this
+    # check a publisher can land a record whose SAN is unrepresentable.
+    name = validate_agent_name(name)
 
+    # Enforce draft-02 §3.2 (Known Organization, Unknown Agent): the
+    # SVCB TargetName MUST NOT contain underscores when reached over
+    # TLS with a public x.509 cert. Strict-by-default; the
+    # allow_underscore_target flag downgrades to a warning for
+    # internal-only deployments.
     validate_no_underscore_in_target(endpoint, allow_underscore=allow_underscore_target)
 
     # Capture whether the bypass actually fired so we can surface it
@@ -363,6 +377,15 @@ async def unpublish(
         logger.error("Zone does not exist", zone=domain)
         return False
 
+    # Probe the primary records BEFORE deletion so we can later
+    # distinguish "primary was already absent" (migration / re-run case
+    # — fine) from "primary existed and delete silently returned False"
+    # (the masked-failure case Route53 and Cloudflare can produce on
+    # API errors). Both look identical from delete_record's return alone,
+    # but only the latter is dangerous.
+    primary_svcb_existed = (await dns_backend.get_record(domain, record_name, "SVCB")) is not None
+    primary_txt_existed = (await dns_backend.get_record(domain, record_name, "TXT")) is not None
+
     # Delete the primary-owner records (SVCB + companion TXT).
     svcb_deleted = await dns_backend.delete_record(domain, record_name, "SVCB")
     txt_deleted = await dns_backend.delete_record(domain, record_name, "TXT")
@@ -396,12 +419,51 @@ async def unpublish(
             error=str(exc),
         )
 
-    success = (
-        svcb_deleted or txt_deleted or walkable_deleted or legacy_svcb_deleted or legacy_txt_deleted
-    )
+    # Decide success:
+    #
+    #   - "Primary deleted" — record existed and delete returned True.
+    #     Unambiguous success.
+    #   - "Primary already absent" — record didn't exist before the
+    #     call. delete_record reported False but that's expected. If any
+    #     cleanup (walkable / legacy) ran successfully we treat the
+    #     unpublish as a successful migration cleanup; if nothing was
+    #     deleted at all we report no-op.
+    #   - "Primary masked-fail" — record DID exist before the call but
+    #     delete returned False. This is the dangerous case Route53 /
+    #     Cloudflare can produce on API errors. We MUST report False so
+    #     the MCP server doesn't de-index a still-live agent.
+    primary_existed = primary_svcb_existed or primary_txt_existed
+    primary_deleted = svcb_deleted or txt_deleted
+    cleanup_deleted = walkable_deleted or legacy_svcb_deleted or legacy_txt_deleted
+
+    primary_masked_failure = primary_existed and not primary_deleted
+
+    if primary_masked_failure:
+        logger.error(
+            "unpublish: primary SVCB/TXT existed but delete returned False — "
+            "agent may still resolve in DNS; refusing to report success",
+            agent_name=name,
+            primary_svcb_existed=primary_svcb_existed,
+            primary_txt_existed=primary_txt_existed,
+            svcb_deleted=svcb_deleted,
+            txt_deleted=txt_deleted,
+        )
+        return False
+
+    success = primary_deleted or cleanup_deleted
 
     if success:
-        logger.info("Agent removed from DNS", agent_name=name)
+        logger.info(
+            "Agent removed from DNS",
+            agent_name=name,
+            primary_deleted=primary_deleted,
+            cleanup_deleted=cleanup_deleted,
+            svcb_deleted=svcb_deleted,
+            txt_deleted=txt_deleted,
+            walkable_deleted=walkable_deleted,
+            legacy_svcb_deleted=legacy_svcb_deleted,
+            legacy_txt_deleted=legacy_txt_deleted,
+        )
     else:
         logger.warning("No records found to delete", agent_name=name)
 

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -6,26 +6,27 @@ DNS-AID Validator: Verify agent DNS records and security.
 
 Handles DNSSEC validation, DANE/TLSA verification, and endpoint health checks.
 
-DNSSEC requirement posture (draft-mozleywilliams-dnsop-dnsaid-02):
+DNSSEC requirement posture (draft-mozleywilliams-dnsop-dnsaid-02 §6.2):
 
-- DNSSEC is ``MAY`` by default. Publishers MAY publish unsigned SVCB
-  records and the validator MUST NOT fail verification solely because
-  DNSSEC was not observed.
-- DNSSEC is ``MUST`` when TLSA records are used to authenticate the TLS
-  endpoint. DANE depends on DNSSEC (RFC 6698 §10.1) and a TLSA record
-  served without a validated chain of trust offers no integrity
-  guarantee. In that case the validator treats DANE-without-DNSSEC as a
-  failure of the DANE check and the consumer SHOULD refuse to trust the
-  endpoint.
+The draft uses the **SHOULD** posture, not MAY/MUST. Verbatim:
 
-The current code path already reflects this: ``_check_dnssec_detail``
-gathers DNSSEC state independently of pass/fail, and only the DANE
-section escalates ``dnssec_valid=False`` into a problem (see the
-``dane_note`` augmentation when DANE is present without DNSSEC).
-Verification of a record set without TLSA continues to pass without
-DNSSEC. No behaviour change in -02; the posture is unchanged from the
-prior implementation, only the spec's prose now matches what the code
-already does.
+    "Consumers SHOULD authenticate the TLS endpoint of a DNS-AID agent
+    using DANE TLSA records (RFC 6698) wherever both DNSSEC and TLSA
+    are available."
+
+DNS-AID records served without DNSSEC continue to verify under this
+module — DNSSEC absence is not in itself a failure. When TLSA records
+ARE present, DNSSEC absence makes the TLSA records untrustworthy
+(RFC 6698 §10.1 — TLSA without DNSSEC offers no integrity guarantee).
+
+This validator on PR #154's branch is advisory only on the
+DANE-without-DNSSEC case: the ``dane_note`` is augmented to flag the
+combination, but ``dane_valid`` is not demoted and ``security_score``
+still credits the +15 for DANE presence. The fail-closed demotion
+(``dane_valid -> None``, ``security_score`` gating) lands separately
+on PR #155 where the broader trust-path tightening happens. The
+docstring earlier overstated the code's current behaviour on this
+branch; this version describes what the code actually does.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -5,6 +5,27 @@
 DNS-AID Validator: Verify agent DNS records and security.
 
 Handles DNSSEC validation, DANE/TLSA verification, and endpoint health checks.
+
+DNSSEC requirement posture (draft-mozleywilliams-dnsop-dnsaid-02):
+
+- DNSSEC is ``MAY`` by default. Publishers MAY publish unsigned SVCB
+  records and the validator MUST NOT fail verification solely because
+  DNSSEC was not observed.
+- DNSSEC is ``MUST`` when TLSA records are used to authenticate the TLS
+  endpoint. DANE depends on DNSSEC (RFC 6698 §10.1) and a TLSA record
+  served without a validated chain of trust offers no integrity
+  guarantee. In that case the validator treats DANE-without-DNSSEC as a
+  failure of the DANE check and the consumer SHOULD refuse to trust the
+  endpoint.
+
+The current code path already reflects this: ``_check_dnssec_detail``
+gathers DNSSEC state independently of pass/fail, and only the DANE
+section escalates ``dnssec_valid=False`` into a problem (see the
+``dane_note`` augmentation when DANE is present without DNSSEC).
+Verification of a record set without TLSA continues to pass without
+DNSSEC. No behaviour change in -02; the posture is unchanged from the
+prior implementation, only the spec's prose now matches what the code
+already does.
 """
 
 from __future__ import annotations

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -113,10 +113,18 @@ async def verify(fqdn: str, *, verify_dane_cert: bool = False) -> VerifyResult:
                 "use verify_dane_cert=True for full certificate matching)"
             )
 
-        # DANE without DNSSEC is meaningless — per RFC 6698 and IETF draft,
-        # TLSA records MUST be DNSSEC-validated to be trusted.
+        # DANE without DNSSEC carries no integrity guarantee — RFC 6698
+        # §10.1 and draft-02 §Security Considerations both treat TLSA
+        # without a validated chain as untrustworthy. Demote the outcome
+        # to None (DANE state unknown), not just append to the note, so
+        # downstream consumers — including security_score — don't credit
+        # a TLSA record that hasn't been DNSSEC-validated.
         if result.dane_valid is not None and not result.dnssec_valid:
-            result.dane_note += " ⚠ DNSSEC not validated — DANE requires DNSSEC to be trustworthy"
+            result.dane_note += (
+                " ⚠ DNSSEC not validated — DANE requires DNSSEC to be "
+                "trustworthy; demoting DANE outcome to unknown"
+            )
+            result.dane_valid = None
 
     # 4. Check endpoint reachability
     if target and port:

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -240,7 +240,7 @@ def publish_agent_to_dns(
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
     well_known_path: str | None = None,
-    bap: list[str] | None = None,
+    bap: str | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
     connect_class: str | None = None,
@@ -288,8 +288,12 @@ def publish_agent_to_dns(
             cap_uri; both may be set. Consumers prefer cap_uri when both are present
             and fall back to reconstructing
             https://<svcb-target>/.well-known/<well_known_path>.
-        bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"]). Included in
-            the SVCB record as a `bap` parameter.
+        bap: Optional single versioned agent-protocol identifier (e.g.,
+            "mcp2.1", "a2a1.0") for the Bulk Agent Protocol SvcParamKey.
+            Experimental per draft-02 §FutureWork; alpn remains the canonical
+            protocol carrier. Multi-protocol agents publish multiple records
+            at the same flat owner, each with its own alpn and (optionally)
+            bap — NOT as a list on one record.
         policy_uri: URI to agent policy document. Included in the SVCB record as
             a `policy` parameter.
         realm: Multi-tenant scope identifier (e.g., "production", "staging").
@@ -559,7 +563,7 @@ def discover_agents_via_dns(
                     "cap_uri": agent.cap_uri,
                     "cap_sha256": agent.cap_sha256,
                     "well_known_path": agent.well_known_path,
-                    "bap": agent.bap if agent.bap else None,
+                    "bap": agent.bap,
                     "policy_uri": agent.policy_uri,
                     "realm": agent.realm,
                     "description": agent.description,

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -249,12 +249,14 @@ def publish_agent_to_dns(
     ipv4_hint: list[str] | None = None,
     ipv6_hint: list[str] | None = None,
     allow_underscore_target: bool = False,
+    publish_walkable_alias: bool = True,
 ) -> dict:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
 
     Creates SVCB and TXT records that allow other agents to discover this agent.
-    The agent will be discoverable at: _{name}._{protocol}._agents.{domain}
+    The agent will be discoverable at the flat draft-02 FQDN ``{name}.{domain}``
+    (with an optional walkable AliasMode at ``{name}._agents.{domain}``).
 
     By default, also updates the domain's index record (_index._agents.{domain})
     to include this agent for efficient discovery.
@@ -302,6 +304,13 @@ def publish_agent_to_dns(
             TargetNames reached over TLS with publicly-issued x.509 certs
             MUST NOT contain underscores. Set this only when the target is
             internal-only and will not be reached over public PKI.
+        publish_walkable_alias: When True (default), additionally write the
+            optional walkable AliasMode SVCB record at
+            ``{name}._agents.{domain}`` pointing at the flat primary
+            owner. Per draft-02 §Known Agent this is operator-optional;
+            the walkable record makes DNS-SD-style enumeration crawlers
+            able to discover the agent. Set False to suppress the
+            walkable write.
 
     Returns:
         dict with:
@@ -362,6 +371,7 @@ def publish_agent_to_dns(
             ipv4_hint=ipv4_hint,
             ipv6_hint=ipv6_hint,
             allow_underscore_target=allow_underscore_target,
+            publish_walkable_alias=publish_walkable_alias,
         )
 
     try:
@@ -494,7 +504,7 @@ def discover_agents_via_dns(
             - realm: Multi-tenant scope identifier (if present in SVCB record)
             - description: Human-readable agent description (if available)
             - fqdn: Fully qualified DNS name for this agent
-              (e.g., "_booking._mcp._agents.example.com")
+              (e.g., "booking.example.com")
         - count: Number of agents found
         - query_time_ms: Total discovery latency in milliseconds
     """

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -239,6 +239,7 @@ def publish_agent_to_dns(
     update_index: bool = True,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
+    well_known_path: str | None = None,
     bap: list[str] | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
@@ -247,6 +248,7 @@ def publish_agent_to_dns(
     enroll_uri: str | None = None,
     ipv4_hint: list[str] | None = None,
     ipv6_hint: list[str] | None = None,
+    allow_underscore_target: bool = False,
 ) -> dict:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -279,6 +281,11 @@ def publish_agent_to_dns(
         cap_sha256: Base64url-encoded SHA-256 digest of the capability descriptor
             for integrity checks and cache revalidation. Included in the SVCB record
             as a `cap-sha256` parameter.
+        well_known_path: RFC 8615 well-known path suffix (e.g., "agent-card.json")
+            for the DNS-AID draft-02 `well-known` SvcParamKey. Independent of
+            cap_uri; both may be set. Consumers prefer cap_uri when both are present
+            and fall back to reconstructing
+            https://<svcb-target>/.well-known/<well_known_path>.
         bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"]). Included in
             the SVCB record as a `bap` parameter.
         policy_uri: URI to agent policy document. Included in the SVCB record as
@@ -289,6 +296,12 @@ def publish_agent_to_dns(
             Eliminates extra A record lookup for the target hostname.
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6).
             Eliminates extra AAAA record lookup for the target hostname.
+        allow_underscore_target: When True, downgrade a "TargetName contains
+            underscored label" violation from an error to a warning. Per
+            draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, SVCB
+            TargetNames reached over TLS with publicly-issued x.509 certs
+            MUST NOT contain underscores. Set this only when the target is
+            internal-only and will not be reached over public PKI.
 
     Returns:
         dict with:
@@ -339,6 +352,7 @@ def publish_agent_to_dns(
             backend=dns_backend,
             cap_uri=cap_uri,
             cap_sha256=cap_sha256,
+            well_known_path=well_known_path,
             bap=bap,
             policy_uri=policy_uri,
             realm=realm,
@@ -347,6 +361,7 @@ def publish_agent_to_dns(
             enroll_uri=enroll_uri,
             ipv4_hint=ipv4_hint,
             ipv6_hint=ipv6_hint,
+            allow_underscore_target=allow_underscore_target,
         )
 
     try:
@@ -530,6 +545,7 @@ def discover_agents_via_dns(
                     "capability_source": agent.capability_source,
                     "cap_uri": agent.cap_uri,
                     "cap_sha256": agent.cap_sha256,
+                    "well_known_path": agent.well_known_path,
                     "bap": agent.bap if agent.bap else None,
                     "policy_uri": agent.policy_uri,
                     "realm": agent.realm,

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -5,7 +5,7 @@
 DNS-AID MCP Server.
 
 Provides MCP tools for AI agents to publish and discover other agents via DNS.
-Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-01).
+Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-02).
 
 Usage:
     # Run with stdio transport (default for MCP)
@@ -1930,7 +1930,7 @@ try:
                     "/ready": "Readiness check (GET)",
                 },
                 "documentation": "https://github.com/infobloxopen/dns-aid-core",
-                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-01",
+                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-02",
             }
         )
 

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -298,7 +298,7 @@ def publish_agent_to_dns(
             Eliminates extra AAAA record lookup for the target hostname.
         allow_underscore_target: When True, downgrade a "TargetName contains
             underscored label" violation from an error to a warning. Per
-            draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, SVCB
+            draft-mozleywilliams-dnsop-dnsaid-02 §3.2 (Known Organization, Unknown Agent), SVCB
             TargetNames reached over TLS with publicly-issued x.509 certs
             MUST NOT contain underscores. Set this only when the target is
             internal-only and will not be reached over public PKI.

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -289,7 +289,7 @@ def publish_agent_to_dns(
             and fall back to reconstructing
             https://<svcb-target>/.well-known/<well_known_path>.
         bap: Optional single versioned agent-protocol identifier (e.g.,
-            "mcp2.1", "a2a1.0") for the Bulk Agent Protocol SvcParamKey.
+            "mcp=2.1", "a2a=1.0") for the Bulk Agent Protocol SvcParamKey.
             Experimental per draft-02 §FutureWork; alpn remains the canonical
             protocol carrier. Multi-protocol agents publish multiple records
             at the same flat owner, each with its own alpn and (optionally)

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -240,7 +240,7 @@ def publish_agent_to_dns(
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
     well_known_path: str | None = None,
-    bap: list[str] | None = None,
+    bap: str | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
     connect_class: str | None = None,
@@ -288,8 +288,12 @@ def publish_agent_to_dns(
             cap_uri; both may be set. Consumers prefer cap_uri when both are present
             and fall back to reconstructing
             https://<svcb-target>/.well-known/<well_known_path>.
-        bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"]). Included in
-            the SVCB record as a `bap` parameter.
+        bap: Optional single versioned agent-protocol identifier (e.g.,
+            "mcp2.1", "a2a1.0") for the Bulk Agent Protocol SvcParamKey.
+            Experimental per draft-02 §FutureWork; alpn remains the canonical
+            protocol carrier. Multi-protocol agents publish multiple records
+            at the same flat owner, each with its own alpn and (optionally)
+            bap — NOT as a list on one record.
         policy_uri: URI to agent policy document. Included in the SVCB record as
             a `policy` parameter.
         realm: Multi-tenant scope identifier (e.g., "production", "staging").
@@ -556,7 +560,7 @@ def discover_agents_via_dns(
                     "cap_uri": agent.cap_uri,
                     "cap_sha256": agent.cap_sha256,
                     "well_known_path": agent.well_known_path,
-                    "bap": agent.bap if agent.bap else None,
+                    "bap": agent.bap,
                     "policy_uri": agent.policy_uri,
                     "realm": agent.realm,
                     "description": agent.description,

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -249,7 +249,7 @@ def publish_agent_to_dns(
     ipv4_hint: list[str] | None = None,
     ipv6_hint: list[str] | None = None,
     allow_underscore_target: bool = False,
-    publish_walkable_alias: bool = True,
+    publish_walkable_alias: bool = False,
 ) -> dict:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -304,13 +304,16 @@ def publish_agent_to_dns(
             TargetNames reached over TLS with publicly-issued x.509 certs
             MUST NOT contain underscores. Set this only when the target is
             internal-only and will not be reached over public PKI.
-        publish_walkable_alias: When True (default), additionally write the
+        publish_walkable_alias: When True, additionally write the
             optional walkable AliasMode SVCB record at
             ``{name}._agents.{domain}`` pointing at the flat primary
-            owner. Per draft-02 §Known Agent this is operator-optional;
-            the walkable record makes DNS-SD-style enumeration crawlers
-            able to discover the agent. Set False to suppress the
-            walkable write.
+            owner. Default False — the walkable record is an
+            enumeration handle (a crawler can walk ``_agents.<zone>``
+            and inventory every agent the operator publishes), which
+            is undesirable for most deployments. Enable when you
+            actively want the agent discoverable via enumeration:
+            internal directories, intentional public catalogs, or
+            DNS-SD-style consumers.
 
     Returns:
         dict with:

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -1162,8 +1162,12 @@ def _parse_retry_after(value: str | None) -> int | None:
 #
 #   * ``agent.target_host`` is absent — the directory only emits ``endpoint_url``;
 #     the SDK's :class:`AgentRecord` requires ``target_host``.
-#   * ``agent.bap`` is a comma-separated string (e.g. ``"mcp/1,a2a/1"``); the SDK
-#     types it as ``list[str]``.
+#   * ``agent.bap`` may arrive in either of three legacy shapes — a list, a
+#     comma-separated string, or the canonical draft-02 scalar form
+#     (``"mcp"`` or ``"mcp=1.0"``). The adapter routes all three through
+#     ``dns_aid.core.bap.normalize_bap`` so the wire-shape knowledge lives
+#     in core, not here, and the discoverer + indexer agree with the
+#     adapter on the collapse semantics.
 #   * Trust signals (``security_score``, ``trust_score``, ``popularity_score``,
 #     ``trust_tier``, ``safety_status``, ``dnssec_valid``, ``dane_valid``,
 #     ``svcb_valid``, ``endpoint_reachable``, ``protocol_verified``,
@@ -1204,8 +1208,9 @@ def _adapt_search_payload(raw: dict[str, Any]) -> dict[str, Any]:
     Three independent concerns:
 
     1. **Lift flat trust + provenance signals** off the agent into nested objects.
-    2. **Coerce wire-shape quirks**: ``bap`` string → list, ``target_host`` from
-       ``endpoint_url``.
+    2. **Coerce wire-shape quirks**: normalize ``bap`` via
+       ``dns_aid.core.bap.normalize_bap`` (accepts list, comma-string, or
+       the canonical scalar), derive ``target_host`` from ``endpoint_url``.
     3. **Strip explicit nulls** for AgentRecord fields where the directory writes
        ``None`` but the SDK type is non-Optional. Pydantic will then use the
        declared default (e.g. ``capabilities: list = []``, ``version: str = "1.0.0"``).
@@ -1270,18 +1275,19 @@ def _adapt_search_payload(raw: dict[str, Any]) -> dict[str, Any]:
             )
 
         # ── Adapt agent shape: normalize ``bap`` to its draft-02 scalar form. ──
-        # Under draft-02 §FutureWork (Bulk Agent Protocol), `bap` carries a
-        # single versioned protocol identifier per record (e.g. "mcp2.1").
-        # Pre-PR-4 directory rows may serialize it as a list or as a
-        # comma-separated string; collapse to the first value in either case.
-        # Done before the ``_AGENT_FIELDS_STRIP_IF_NONE`` pass so ``bap=None``
-        # still gets stripped.
-        bap = agent.get("bap")
-        if isinstance(bap, list):
-            agent["bap"] = bap[0].strip() if bap and isinstance(bap[0], str) else None
-        elif isinstance(bap, str):
-            first = next((item.strip() for item in bap.split(",") if item.strip()), None)
-            agent["bap"] = first
+        # draft-02 §5.1 (Bulk Agent Protocol, experimental): `bap`
+        # carries a single agent-protocol identifier per record, bare
+        # (``mcp``) or versioned (``mcp=1.0``). Pre-draft-02 directory
+        # rows may serialize it as a list or as a comma-separated
+        # string; the shared ``normalize_bap`` helper in core collapses
+        # both to a scalar (or None) and logs when later tokens are
+        # dropped. Routing through the same helper as the discoverer
+        # and indexer is what eliminates the cross-path divergence
+        # Igor flagged on #158 (item 5).
+        from dns_aid.core.bap import normalize_bap
+
+        if "bap" in agent:
+            agent["bap"] = normalize_bap(agent.get("bap"))
 
         # ── Adapt agent shape: derive ``target_host`` from ``endpoint_url`` only. ──
         # If neither field is set, drop the record and log — never fabricate. The

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -1269,12 +1269,19 @@ def _adapt_search_payload(raw: dict[str, Any]) -> dict[str, Any]:
                 },
             )
 
-        # ── Adapt agent shape: split comma-separated ``bap`` string into list. ──
-        # Done before the ``_AGENT_FIELDS_STRIP_IF_NONE`` pass so ``bap=None`` still
-        # gets stripped.
+        # ── Adapt agent shape: normalize ``bap`` to its draft-02 scalar form. ──
+        # Under draft-02 §FutureWork (Bulk Agent Protocol), `bap` carries a
+        # single versioned protocol identifier per record (e.g. "mcp2.1").
+        # Pre-PR-4 directory rows may serialize it as a list or as a
+        # comma-separated string; collapse to the first value in either case.
+        # Done before the ``_AGENT_FIELDS_STRIP_IF_NONE`` pass so ``bap=None``
+        # still gets stripped.
         bap = agent.get("bap")
-        if isinstance(bap, str):
-            agent["bap"] = [item.strip() for item in bap.split(",") if item.strip()]
+        if isinstance(bap, list):
+            agent["bap"] = bap[0].strip() if bap and isinstance(bap[0], str) else None
+        elif isinstance(bap, str):
+            first = next((item.strip() for item in bap.split(",") if item.strip()), None)
+            agent["bap"] = first
 
         # ── Adapt agent shape: derive ``target_host`` from ``endpoint_url`` only. ──
         # If neither field is set, drop the record and log — never fabricate. The

--- a/src/dns_aid/sdk/telemetry/otel.py
+++ b/src/dns_aid/sdk/telemetry/otel.py
@@ -229,57 +229,16 @@ def _sanitize_error_message(msg: str | None) -> str | None:
 def _parse_signal_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     """Parse ``agent_name`` and ``domain`` from a DNS-AID FQDN.
 
-    Handles three shapes:
-
-    1. Flat draft-02 form ``{name}.{domain}`` — splits on the first
-       label. Note that this is ambiguous (the first label could be a
-       hostname under a multi-label domain), so we treat the first
-       label as the agent name and the rest as the domain.
-    2. Walkable draft-02 form ``{name}._agents.{domain}`` — splits on
-       ``._agents.``. Same semantics as the flat form for the name.
-    3. Legacy draft-01 form ``_{name}._{protocol}._agents.{domain}``
-       — splits on ``._agents.``, strips the leading underscore, and
-       takes the first label before ``._``.
-
-    Returns ``(None, None)`` for inputs that don't look like any of
-    these (e.g. single-label strings).
+    Thin projection over :func:`dns_aid.core.fqdn.parse_dnsaid_fqdn`
+    that returns ``(name, domain)``; the SDK telemetry layer doesn't
+    care about the protocol carried in the FQDN.
     """
-    if not fqdn:
+    from dns_aid.core.fqdn import parse_dnsaid_fqdn
+
+    parsed = parse_dnsaid_fqdn(fqdn)
+    if parsed is None:
         return None, None
-
-    # Walkable or legacy: contains ._agents.
-    walkable_parts = fqdn.split("._agents.")
-    if len(walkable_parts) == 2:
-        prefix, domain = walkable_parts
-        # Guard against empty suffix (e.g. "foo._agents.") — that's
-        # not a well-formed FQDN, treat as unparseable.
-        if not domain:
-            return None, None
-        # Legacy form has leading underscore: _name._proto.
-        # Require the protocol label to also start with an underscore
-        # so we don't misparse "_booking.mcp._agents.foo.com" — that's
-        # not legitimate -01 either; treat as unparseable.
-        if prefix.startswith("_"):
-            inner = prefix.lstrip("_")
-            if "._" in inner:
-                name_part, _, proto_part = inner.partition("._")
-                if name_part and proto_part:
-                    return name_part, domain
-            return None, None
-        # Walkable form: {name} (single label, no underscore prefix).
-        if prefix and "." not in prefix:
-            return prefix, domain
-        return None, None
-
-    # Flat form: {name}.{domain} — name is the first label, domain has
-    # at least two labels. Don't match strings that have only one dot
-    # (those are too short to be a real FQDN).
-    if "." in fqdn:
-        first_label, _, rest = fqdn.partition(".")
-        if first_label and rest and "." in rest and not first_label.startswith("_"):
-            return first_label, rest
-
-    return None, None
+    return parsed.name, parsed.domain
 
 
 def _resolve_sampler(config: SDKConfig) -> Sampler | None:

--- a/src/dns_aid/sdk/telemetry/otel.py
+++ b/src/dns_aid/sdk/telemetry/otel.py
@@ -227,12 +227,58 @@ def _sanitize_error_message(msg: str | None) -> str | None:
 
 
 def _parse_signal_fqdn(fqdn: str) -> tuple[str | None, str | None]:
-    """Parse ``agent_name`` and ``domain`` from ``_name._proto._agents.domain``."""
-    parts = fqdn.split("._agents.")
-    if len(parts) == 2:
-        name_parts = parts[0].lstrip("_").split("._")
-        agent_name = name_parts[0] if name_parts else None
-        return agent_name, parts[1]
+    """Parse ``agent_name`` and ``domain`` from a DNS-AID FQDN.
+
+    Handles three shapes:
+
+    1. Flat draft-02 form ``{name}.{domain}`` — splits on the first
+       label. Note that this is ambiguous (the first label could be a
+       hostname under a multi-label domain), so we treat the first
+       label as the agent name and the rest as the domain.
+    2. Walkable draft-02 form ``{name}._agents.{domain}`` — splits on
+       ``._agents.``. Same semantics as the flat form for the name.
+    3. Legacy draft-01 form ``_{name}._{protocol}._agents.{domain}``
+       — splits on ``._agents.``, strips the leading underscore, and
+       takes the first label before ``._``.
+
+    Returns ``(None, None)`` for inputs that don't look like any of
+    these (e.g. single-label strings).
+    """
+    if not fqdn:
+        return None, None
+
+    # Walkable or legacy: contains ._agents.
+    walkable_parts = fqdn.split("._agents.")
+    if len(walkable_parts) == 2:
+        prefix, domain = walkable_parts
+        # Guard against empty suffix (e.g. "foo._agents.") — that's
+        # not a well-formed FQDN, treat as unparseable.
+        if not domain:
+            return None, None
+        # Legacy form has leading underscore: _name._proto.
+        # Require the protocol label to also start with an underscore
+        # so we don't misparse "_booking.mcp._agents.foo.com" — that's
+        # not legitimate -01 either; treat as unparseable.
+        if prefix.startswith("_"):
+            inner = prefix.lstrip("_")
+            if "._" in inner:
+                name_part, _, proto_part = inner.partition("._")
+                if name_part and proto_part:
+                    return name_part, domain
+            return None, None
+        # Walkable form: {name} (single label, no underscore prefix).
+        if prefix and "." not in prefix:
+            return prefix, domain
+        return None, None
+
+    # Flat form: {name}.{domain} — name is the first label, domain has
+    # at least two labels. Don't match strings that have only one dot
+    # (those are too short to be a real FQDN).
+    if "." in fqdn:
+        first_label, _, rest = fqdn.partition(".")
+        if first_label and rest and "." in rest and not first_label.startswith("_"):
+            return first_label, rest
+
     return None, None
 
 

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -461,3 +461,161 @@ def validate_backend(
         )
 
     return backend
+
+
+def validate_no_underscore_in_target(
+    target: str,
+    *,
+    allow_underscore: bool = False,
+) -> str:
+    """
+    Validate that an SVCB TargetName contains no underscored DNS labels.
+
+    Per draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, the
+    TargetName of an SVCB record that will be reached over TLS with a
+    publicly-issued x.509 certificate MUST NOT contain underscores. The
+    constraint exists because CA/Browser Forum Baseline Requirements and
+    RFC 5280 dNSName SANs both forbid underscored labels.
+
+    dns-aid-core applies this rule to all SVCB TargetNames on its publish
+    paths by default. Deployments where the target is internal-only and
+    will not be reached via public PKI (for example, a sandbox or
+    inside-the-perimeter service identified by a private CA-issued cert)
+    can pass ``allow_underscore=True`` to downgrade the failure into a
+    warning that is logged but not raised. The validator is still called
+    in that case so the log surfaces the deliberate exception.
+
+    Args:
+        target: The SVCB TargetName host (e.g. ``"chat.example.com"`` or
+            ``"agent-index.example.com."``). Trailing dots are tolerated.
+        allow_underscore: When True, downgrade a violation to a warning
+            log line and return the (unchanged) target instead of
+            raising.
+
+    Returns:
+        The target string, unchanged. (Returns rather than mutating so
+        callers can chain the call into existing pipelines.)
+
+    Raises:
+        ValidationError: If ``target`` contains a label starting with or
+            consisting of an underscore and ``allow_underscore`` is
+            False.
+
+    Examples:
+        >>> validate_no_underscore_in_target("agent-index.example.com")
+        'agent-index.example.com'
+        >>> validate_no_underscore_in_target("_index.example.com")
+        Traceback (most recent call last):
+            ...
+        ValidationError: ...
+        >>> validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        '_index.example.com'
+    """
+    if not target:
+        raise ValidationError("target", "SVCB TargetName cannot be empty")
+
+    # Strip a trailing dot if present — the constraint applies to labels,
+    # not to the FQDN root marker.
+    candidate = target.rstrip(".")
+    labels = candidate.split(".")
+    underscored = [label for label in labels if "_" in label]
+
+    if not underscored:
+        return target
+
+    message = (
+        f"SVCB TargetName '{target}' contains underscored label(s) "
+        f"{underscored!r}. CA/Browser Forum and RFC 5280 dNSName SANs forbid "
+        "underscored labels, so a publicly-issued x.509 cert cannot cover "
+        "this name. Per draft-mozleywilliams-dnsop-dnsaid-02 §Known "
+        "Organization the TargetName MUST NOT contain underscores. Pass "
+        "allow_underscore=True if this target is internal-only and will "
+        "not be reached via public PKI."
+    )
+
+    if allow_underscore:
+        import logging
+
+        logging.getLogger(__name__).warning(message)
+        return target
+
+    raise ValidationError("target", message, target)
+
+
+# RFC 8615 well-known URI names are a single path segment under
+# /.well-known/<name>. The IANA registry shows examples like
+# ``agent-card.json``, ``oauth-authorization-server``,
+# ``did-configuration``, ``change-password`` — short, ASCII-safe,
+# unambiguous strings. We constrain to that class to prevent path
+# traversal (`..`), query-string injection (`?`), fragment injection
+# (`#`), embedded slashes, percent-encoded escapes, and any other
+# character that would let an attacker steer the reconstructed URL
+# off of the SVCB target host's `/.well-known/` namespace.
+_WELL_KNOWN_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+_WELL_KNOWN_PATH_MAX_LEN = 128
+
+
+def validate_well_known_path(path: str) -> str:
+    """Validate a `well-known` SvcParamKey value to a safe RFC 8615 suffix.
+
+    The discoverer reconstructs the descriptor URL as
+    ``https://<svcb-target>/.well-known/<path>`` and fetches it. Without
+    validation, a publisher (or a SVCB-record forger if DNSSEC isn't
+    enforced) could supply a path containing ``..``, ``?``, ``#``, or
+    embedded slashes and steer the fetch away from the legitimate
+    well-known namespace. The SSRF guard at ``validate_fetch_url`` pins
+    the host but doesn't restrict the path.
+
+    Allowed: ``^[A-Za-z0-9._-]+$``, length 1..128, no ``..`` traversal.
+
+    Args:
+        path: The well-known path suffix (no leading slash, no
+            ``.well-known/`` prefix).
+
+    Returns:
+        The validated path (unchanged on success).
+
+    Raises:
+        ValidationError: On empty, oversize, or pattern-mismatched input.
+    """
+    if not isinstance(path, str) or not path:
+        raise ValidationError(
+            "well_known_path",
+            "well-known path must be a non-empty string",
+            path,
+        )
+    if len(path) > _WELL_KNOWN_PATH_MAX_LEN:
+        raise ValidationError(
+            "well_known_path",
+            f"well-known path exceeds {_WELL_KNOWN_PATH_MAX_LEN} characters",
+            path,
+        )
+    if not _WELL_KNOWN_PATH_PATTERN.match(path):
+        raise ValidationError(
+            "well_known_path",
+            (
+                "well-known path must match RFC 8615 single-segment "
+                "form (allowed: A-Z a-z 0-9 . _ - ); reject any "
+                "embedded slash, '?', '#', or other URL control "
+                "character"
+            ),
+            path,
+        )
+    # `.` is in the allowed character class (needed for names like
+    # `agent-card.json`), but two consecutive dots produce a path
+    # traversal token. Reject explicitly. A path made entirely of
+    # dots / underscores / hyphens with no alphanumeric content is
+    # also nonsense and we refuse it.
+    if ".." in path:
+        raise ValidationError(
+            "well_known_path",
+            "well-known path must not contain '..' (path traversal)",
+            path,
+        )
+    if not any(c.isalnum() for c in path):
+        raise ValidationError(
+            "well_known_path",
+            "well-known path must contain at least one alphanumeric character",
+            path,
+        )
+    return path

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -461,3 +461,82 @@ def validate_backend(
         )
 
     return backend
+
+
+def validate_no_underscore_in_target(
+    target: str,
+    *,
+    allow_underscore: bool = False,
+) -> str:
+    """
+    Validate that an SVCB TargetName contains no underscored DNS labels.
+
+    Per draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, the
+    TargetName of an SVCB record that will be reached over TLS with a
+    publicly-issued x.509 certificate MUST NOT contain underscores. The
+    constraint exists because CA/Browser Forum Baseline Requirements and
+    RFC 5280 dNSName SANs both forbid underscored labels.
+
+    dns-aid-core applies this rule to all SVCB TargetNames on its publish
+    paths by default. Deployments where the target is internal-only and
+    will not be reached via public PKI (for example, a sandbox or
+    inside-the-perimeter service identified by a private CA-issued cert)
+    can pass ``allow_underscore=True`` to downgrade the failure into a
+    warning that is logged but not raised. The validator is still called
+    in that case so the log surfaces the deliberate exception.
+
+    Args:
+        target: The SVCB TargetName host (e.g. ``"chat.example.com"`` or
+            ``"agent-index.example.com."``). Trailing dots are tolerated.
+        allow_underscore: When True, downgrade a violation to a warning
+            log line and return the (unchanged) target instead of
+            raising.
+
+    Returns:
+        The target string, unchanged. (Returns rather than mutating so
+        callers can chain the call into existing pipelines.)
+
+    Raises:
+        ValidationError: If ``target`` contains a label starting with or
+            consisting of an underscore and ``allow_underscore`` is
+            False.
+
+    Examples:
+        >>> validate_no_underscore_in_target("agent-index.example.com")
+        'agent-index.example.com'
+        >>> validate_no_underscore_in_target("_index.example.com")
+        Traceback (most recent call last):
+            ...
+        ValidationError: ...
+        >>> validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        '_index.example.com'
+    """
+    if not target:
+        raise ValidationError("target", "SVCB TargetName cannot be empty")
+
+    # Strip a trailing dot if present — the constraint applies to labels,
+    # not to the FQDN root marker.
+    candidate = target.rstrip(".")
+    labels = candidate.split(".")
+    underscored = [label for label in labels if "_" in label]
+
+    if not underscored:
+        return target
+
+    message = (
+        f"SVCB TargetName '{target}' contains underscored label(s) "
+        f"{underscored!r}. CA/Browser Forum and RFC 5280 dNSName SANs forbid "
+        "underscored labels, so a publicly-issued x.509 cert cannot cover "
+        "this name. Per draft-mozleywilliams-dnsop-dnsaid-02 §Known "
+        "Organization the TargetName MUST NOT contain underscores. Pass "
+        "allow_underscore=True if this target is internal-only and will "
+        "not be reached via public PKI."
+    )
+
+    if allow_underscore:
+        import logging
+
+        logging.getLogger(__name__).warning(message)
+        return target
+
+    raise ValidationError("target", message, target)

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -486,7 +486,7 @@ def validate_no_underscore_in_target(
 ) -> str:
     """Validate that an SVCB TargetName contains no underscored DNS labels.
 
-    Per draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, the
+    Per draft-mozleywilliams-dnsop-dnsaid-02 §3.2 (Known Organization, Unknown Agent), the
     TargetName of an SVCB record reached over TLS with a publicly-issued
     x.509 certificate MUST NOT contain underscores. CA/Browser Forum
     Baseline Requirements and RFC 5280 dNSName SANs forbid underscored
@@ -542,7 +542,7 @@ def validate_no_underscore_in_target(
             target=target,
             underscored=underscored,
             cab_forbidden_chars=True,
-            spec_section="draft-02 §Known Organization",
+            spec_section="draft-02 §3.2 (Known Organization, Unknown Agent)",
             warning_class="dns_aid.underscore_bypass",
             env_gate=_UNDERSCORE_BYPASS_ENV,
         )

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -15,8 +15,13 @@ Security Note:
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Literal
+
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # DNS label constraints (RFC 1035)
 MAX_LABEL_LENGTH = 63
@@ -463,53 +468,48 @@ def validate_backend(
     return backend
 
 
+# Operator opt-in for the underscore-target bypass. A per-call kwarg /
+# MCP tool arg alone would let a calling LLM flip a draft-02 §Known
+# Organization MUST to a warning on its own. The env gate moves that
+# decision to deployment configuration where humans land it.
+_UNDERSCORE_BYPASS_ENV = "DNS_AID_ALLOW_UNDERSCORE_TARGET"
+
+
+def _underscore_bypass_env_enabled() -> bool:
+    return os.environ.get(_UNDERSCORE_BYPASS_ENV, "").lower() in ("1", "true", "yes")
+
+
 def validate_no_underscore_in_target(
     target: str,
     *,
     allow_underscore: bool = False,
 ) -> str:
-    """
-    Validate that an SVCB TargetName contains no underscored DNS labels.
+    """Validate that an SVCB TargetName contains no underscored DNS labels.
 
     Per draft-mozleywilliams-dnsop-dnsaid-02 §Known Organization, the
-    TargetName of an SVCB record that will be reached over TLS with a
-    publicly-issued x.509 certificate MUST NOT contain underscores. The
-    constraint exists because CA/Browser Forum Baseline Requirements and
-    RFC 5280 dNSName SANs both forbid underscored labels.
+    TargetName of an SVCB record reached over TLS with a publicly-issued
+    x.509 certificate MUST NOT contain underscores. CA/Browser Forum
+    Baseline Requirements and RFC 5280 dNSName SANs forbid underscored
+    labels.
 
-    dns-aid-core applies this rule to all SVCB TargetNames on its publish
-    paths by default. Deployments where the target is internal-only and
-    will not be reached via public PKI (for example, a sandbox or
-    inside-the-perimeter service identified by a private CA-issued cert)
-    can pass ``allow_underscore=True`` to downgrade the failure into a
-    warning that is logged but not raised. The validator is still called
-    in that case so the log surfaces the deliberate exception.
+    Detects mid-label underscores too (not just leading ones); the public
+    PKI rule rejects any underscore anywhere in any label of the SAN.
 
-    Args:
-        target: The SVCB TargetName host (e.g. ``"chat.example.com"`` or
-            ``"agent-index.example.com."``). Trailing dots are tolerated.
-        allow_underscore: When True, downgrade a violation to a warning
-            log line and return the (unchanged) target instead of
-            raising.
+    The bypass (``allow_underscore=True``) is operator-gated: it only
+    takes effect when ``DNS_AID_ALLOW_UNDERSCORE_TARGET`` is also set in
+    the environment to a truthy value. Without the env gate the bypass
+    is treated as not-allowed and the violation raises — so a calling
+    LLM, MCP client, or test harness can't unilaterally downgrade the
+    spec MUST. When the env gate is set, the bypass emits a structured
+    WARN with ``warning_class="dns_aid.underscore_bypass"`` so log
+    aggregators can count and alert on deliberate opt-ins per zone.
 
     Returns:
-        The target string, unchanged. (Returns rather than mutating so
-        callers can chain the call into existing pipelines.)
+        The target string, unchanged.
 
     Raises:
-        ValidationError: If ``target`` contains a label starting with or
-            consisting of an underscore and ``allow_underscore`` is
-            False.
-
-    Examples:
-        >>> validate_no_underscore_in_target("agent-index.example.com")
-        'agent-index.example.com'
-        >>> validate_no_underscore_in_target("_index.example.com")
-        Traceback (most recent call last):
-            ...
-        ValidationError: ...
-        >>> validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
-        '_index.example.com'
+        ValidationError: when ``target`` contains an underscored label
+            and the bypass is not both requested AND env-gated.
     """
     if not target:
         raise ValidationError("target", "SVCB TargetName cannot be empty")
@@ -529,15 +529,38 @@ def validate_no_underscore_in_target(
         "underscored labels, so a publicly-issued x.509 cert cannot cover "
         "this name. Per draft-mozleywilliams-dnsop-dnsaid-02 §Known "
         "Organization the TargetName MUST NOT contain underscores. Pass "
-        "allow_underscore=True if this target is internal-only and will "
-        "not be reached via public PKI."
+        "allow_underscore=True AND set "
+        f"{_UNDERSCORE_BYPASS_ENV}=1 in the environment for internal-only "
+        "deployments not behind public PKI."
     )
 
-    if allow_underscore:
-        import logging
-
-        logging.getLogger(__name__).warning(message)
+    if allow_underscore and _underscore_bypass_env_enabled():
+        logger.warning(
+            "SVCB TargetName allowed despite underscored labels — "
+            "internal-only deployment opt-in (allow_underscore=True + "
+            f"{_UNDERSCORE_BYPASS_ENV} set)",
+            target=target,
+            underscored=underscored,
+            cab_forbidden_chars=True,
+            spec_section="draft-02 §Known Organization",
+            warning_class="dns_aid.underscore_bypass",
+            env_gate=_UNDERSCORE_BYPASS_ENV,
+        )
         return target
+
+    if allow_underscore and not _underscore_bypass_env_enabled():
+        # Caller asked for the bypass but the operator hasn't enabled
+        # it in the environment. Surface the refusal distinctly so the
+        # caller can tell "this is an env-gate issue" from "this is a
+        # genuine validation error."
+        logger.warning(
+            "SVCB TargetName underscore bypass requested but env gate "
+            f"({_UNDERSCORE_BYPASS_ENV}) is not set — refusing",
+            target=target,
+            underscored=underscored,
+            env_gate=_UNDERSCORE_BYPASS_ENV,
+            warning_class="dns_aid.underscore_bypass_env_missing",
+        )
 
     raise ValidationError("target", message, target)
 
@@ -556,21 +579,31 @@ _WELL_KNOWN_PATH_MAX_LEN = 128
 
 
 def validate_well_known_path(path: str) -> str:
-    """Validate a `well-known` SvcParamKey value to a safe RFC 8615 suffix.
+    """Validate a `well-known` SvcParamKey value.
 
-    The discoverer reconstructs the descriptor URL as
-    ``https://<svcb-target>/.well-known/<path>`` and fetches it. Without
-    validation, a publisher (or a SVCB-record forger if DNSSEC isn't
-    enforced) could supply a path containing ``..``, ``?``, ``#``, or
-    embedded slashes and steer the fetch away from the legitimate
-    well-known namespace. The SSRF guard at ``validate_fetch_url`` pins
-    the host but doesn't restrict the path.
+    Two value shapes are accepted, matching draft Figure 3:
 
-    Allowed: ``^[A-Za-z0-9._-]+$``, length 1..128, no ``..`` traversal.
+    1. **Bare suffix** — ``agent-card.json`` →
+       reconstructed as ``https://<target>/.well-known/<value>``.
+       Constrained to RFC 8615 single-segment form.
 
-    Args:
-        path: The well-known path suffix (no leading slash, no
-            ``.well-known/`` prefix).
+    2. **Absolute origin path** — ``/.well-known/agent-card.json`` or
+       ``/not-well-known/other-card.json`` →
+       used as-is: ``https://<target><value>``. Each path segment is
+       constrained to the same character class as the bare-suffix form;
+       no ``..`` traversal, no empty segments (no ``//``), no query
+       string / fragment / control characters / percent-encoded
+       escapes.
+
+    The discoverer reconstructs the descriptor URL by interpolating the
+    value into a fetched URL. Without validation a publisher (or a
+    SVCB-record forger if DNSSEC isn't enforced) could supply a value
+    containing ``..``, ``?``, ``#``, or backslash and steer the fetch
+    away from the operator's intended location. ``validate_fetch_url``
+    pins the host but doesn't constrain the path.
+
+    Allowed character class per segment: ``[A-Za-z0-9._-]``. Total
+    length 1..128.
 
     Returns:
         The validated path (unchanged on success).
@@ -590,14 +623,69 @@ def validate_well_known_path(path: str) -> str:
             f"well-known path exceeds {_WELL_KNOWN_PATH_MAX_LEN} characters",
             path,
         )
+
+    # Reject any control / URL-special character before we branch on
+    # absolute vs. suffix. These are the characters that could shape
+    # the reconstructed URL into something other than a path lookup
+    # under the SVCB target's origin.
+    for forbidden in ("?", "#", "\\", "%", " ", "\t", "\r", "\n"):
+        if forbidden in path:
+            raise ValidationError(
+                "well_known_path",
+                (
+                    "well-known path must not contain URL control "
+                    f"characters (found {forbidden!r}); reject any "
+                    "embedded slash, '?', '#', percent-encoded "
+                    "escape, or whitespace"
+                ),
+                path,
+            )
+
+    if path.startswith("/"):
+        # Absolute origin path form. Each segment must be a clean
+        # single-segment token; no ``..``, no empty segments (which
+        # would produce ``//`` in the URL).
+        segments = path[1:].split("/")
+        if not segments or not all(segments):
+            raise ValidationError(
+                "well_known_path",
+                "absolute well-known path must not contain empty segments",
+                path,
+            )
+        for seg in segments:
+            if seg == "..":
+                raise ValidationError(
+                    "well_known_path",
+                    "absolute well-known path must not contain '..' (traversal)",
+                    path,
+                )
+            if not _WELL_KNOWN_PATH_PATTERN.match(seg):
+                raise ValidationError(
+                    "well_known_path",
+                    (
+                        f"absolute well-known path segment {seg!r} must "
+                        "match RFC 8615 single-segment form "
+                        "(allowed: A-Z a-z 0-9 . _ - )"
+                    ),
+                    path,
+                )
+        if not any(c.isalnum() for c in path):
+            raise ValidationError(
+                "well_known_path",
+                "well-known path must contain at least one alphanumeric character",
+                path,
+            )
+        return path
+
+    # Bare-suffix form.
     if not _WELL_KNOWN_PATH_PATTERN.match(path):
         raise ValidationError(
             "well_known_path",
             (
-                "well-known path must match RFC 8615 single-segment "
-                "form (allowed: A-Z a-z 0-9 . _ - ); reject any "
-                "embedded slash, '?', '#', or other URL control "
-                "character"
+                "well-known suffix must match RFC 8615 single-segment "
+                "form (allowed: A-Z a-z 0-9 . _ - ); use an absolute "
+                "path starting with '/' if you need a multi-segment "
+                "origin-relative value"
             ),
             path,
         )

--- a/tests/integration/test_ddns.py
+++ b/tests/integration/test_ddns.py
@@ -189,7 +189,7 @@ class TestDDNSBackend:
             resolver.nameservers = [DDNS_SERVER]
             resolver.port = DDNS_PORT
 
-            fqdn = f"_ddns-test-agent._mcp._agents.{DDNS_ZONE}"
+            fqdn = f"ddns-test-agent.{DDNS_ZONE}"
 
             # Check SVCB
             svcb_answers = resolver.resolve(fqdn, "SVCB")

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -430,7 +430,7 @@ class TestDnsaidParamsRoundtrip:
             capabilities=["ipam"],
             cap_uri="https://cap.example.com/rich.json",
             cap_sha256="abc123",
-            bap="mcp2.1",
+            bap="mcp=2.1",
             policy_uri="https://example.com/policy",
             realm="demo",
             backend=mock_backend,
@@ -447,7 +447,7 @@ class TestDnsaidParamsRoundtrip:
             agent = result.agents[0]
             assert agent.cap_uri == "https://cap.example.com/rich.json"
             assert agent.cap_sha256 == "abc123"
-            assert agent.bap == "mcp2.1"
+            assert agent.bap == "mcp=2.1"
             assert agent.policy_uri == "https://example.com/policy"
             assert agent.realm == "demo"
 

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -422,7 +422,7 @@ class TestDnsaidParamsRoundtrip:
             capabilities=["ipam"],
             cap_uri="https://cap.example.com/rich.json",
             cap_sha256="abc123",
-            bap=["mcp", "a2a"],
+            bap="mcp2.1",
             policy_uri="https://example.com/policy",
             realm="demo",
             backend=mock_backend,
@@ -439,7 +439,7 @@ class TestDnsaidParamsRoundtrip:
             agent = result.agents[0]
             assert agent.cap_uri == "https://cap.example.com/rich.json"
             assert agent.cap_sha256 == "abc123"
-            assert agent.bap == ["mcp", "a2a"]
+            assert agent.bap == "mcp2.1"
             assert agent.policy_uri == "https://example.com/policy"
             assert agent.realm == "demo"
 
@@ -471,7 +471,7 @@ class TestDnsaidParamsRoundtrip:
             assert agent.cap_uri == "https://cap.example.com/partial.json"
             assert agent.realm == "staging"
             assert agent.cap_sha256 is None
-            assert agent.bap == []
+            assert agent.bap is None
             assert agent.policy_uri is None
 
 

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -430,7 +430,7 @@ class TestDnsaidParamsRoundtrip:
             capabilities=["ipam"],
             cap_uri="https://cap.example.com/rich.json",
             cap_sha256="abc123",
-            bap=["mcp", "a2a"],
+            bap="mcp2.1",
             policy_uri="https://example.com/policy",
             realm="demo",
             backend=mock_backend,
@@ -447,7 +447,7 @@ class TestDnsaidParamsRoundtrip:
             agent = result.agents[0]
             assert agent.cap_uri == "https://cap.example.com/rich.json"
             assert agent.cap_sha256 == "abc123"
-            assert agent.bap == ["mcp", "a2a"]
+            assert agent.bap == "mcp2.1"
             assert agent.policy_uri == "https://example.com/policy"
             assert agent.realm == "demo"
 
@@ -479,7 +479,7 @@ class TestDnsaidParamsRoundtrip:
             assert agent.cap_uri == "https://cap.example.com/partial.json"
             assert agent.realm == "staging"
             assert agent.cap_sha256 is None
-            assert agent.bap == []
+            assert agent.bap is None
             assert agent.policy_uri is None
 
 

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -311,7 +311,7 @@ class TestHttpIndexDiscovery:
                 "agents": {
                     "network": {
                         "location": {
-                            "fqdn": "_network._mcp._agents.example.com",
+                            "fqdn": "network.example.com",
                             "endpoint": "https://mcp.example.com/mcp",
                         },
                         "model-card": {

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -303,7 +303,7 @@ class TestHttpIndexDiscovery:
                 "agents": {
                     "network": {
                         "location": {
-                            "fqdn": "_network._mcp._agents.example.com",
+                            "fqdn": "network.example.com",
                             "endpoint": "https://mcp.example.com/mcp",
                         },
                         "model-card": {
@@ -357,7 +357,7 @@ class TestSecurityScoring:
         dns_bridge.set_endpoint_reachable("mcp.example.com")
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_secure._mcp._agents.example.com")
+            verify = await dns_aid.verify("secure.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert verify.dnssec_valid
@@ -382,7 +382,7 @@ class TestSecurityScoring:
         )
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_basic._mcp._agents.example.com")
+            verify = await dns_aid.verify("basic.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert not verify.dnssec_valid
@@ -397,7 +397,7 @@ class TestSecurityScoring:
     ):
         """Agent doesn't exist → score 0."""
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_ghost._mcp._agents.example.com")
+            verify = await dns_aid.verify("ghost.example.com")
             assert not verify.record_exists
             assert verify.security_score == 0
 
@@ -611,7 +611,7 @@ class TestDANECertMatching:
         dns_bridge.set_endpoint_reachable("mcp.example.com")
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_dane-test._mcp._agents.example.com")
+            verify = await dns_aid.verify("dane-test.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert verify.dane_valid is True

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -241,14 +241,21 @@ class TestCapabilityDocumentFlow:
             assert agent.capability_source == "cap_uri"
             assert agent.capabilities == ["travel", "booking", "calendar"]
 
-    async def test_cap_sha256_mismatch_falls_back_to_txt(
+    async def test_cap_sha256_mismatch_drops_record(
         self,
         mock_backend: MockBackend,
         dns_bridge: MockDNSBridge,
         cap_data: dict,
         cap_uri: str,
     ):
-        """Wrong cap_sha256 → cap doc rejected → falls back to TXT capabilities."""
+        """Wrong cap_sha256 → record refused per draft §6.1.
+
+        Earlier this test asserted a fall-back to TXT-fallback
+        capabilities. Igor's #155 review (blocker #3) tightened this:
+        a digest mismatch is now an explicit MUST-refuse — the record
+        is dropped from the discovery result rather than silently
+        downgrading to unauthenticated TXT.
+        """
         await dns_aid.publish(
             name="travel",
             domain="example.com",
@@ -269,10 +276,11 @@ class TestCapabilityDocumentFlow:
                 name="travel",
                 enrich_endpoints=False,
             )
-            agent = result.agents[0]
-            # SHA-256 mismatch → cap doc rejected → TXT fallback
-            assert agent.capability_source == "txt_fallback"
-            assert agent.capabilities == ["fallback-cap"]
+            # Record refused — no agents in the result.
+            assert result.agents == [], (
+                "cap-sha256 digest mismatch MUST cause the record to be refused "
+                "(draft §6.1); no silent downgrade to TXT"
+            )
 
 
 # ── Scenario D: HTTP Index Discovery ───────────────────────────────────
@@ -357,7 +365,7 @@ class TestSecurityScoring:
         dns_bridge.set_endpoint_reachable("mcp.example.com")
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_secure._mcp._agents.example.com")
+            verify = await dns_aid.verify("secure.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert verify.dnssec_valid
@@ -382,7 +390,7 @@ class TestSecurityScoring:
         )
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_basic._mcp._agents.example.com")
+            verify = await dns_aid.verify("basic.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert not verify.dnssec_valid
@@ -397,7 +405,7 @@ class TestSecurityScoring:
     ):
         """Agent doesn't exist → score 0."""
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_ghost._mcp._agents.example.com")
+            verify = await dns_aid.verify("ghost.example.com")
             assert not verify.record_exists
             assert verify.security_score == 0
 
@@ -592,12 +600,23 @@ class TestDNSSECEnforcement:
 class TestDANECertMatching:
     """Default DANE behavior unchanged (TLSA existence only)."""
 
-    async def test_dane_advisory_default(
+    async def test_dane_advisory_default_demotes_without_dnssec(
         self,
         mock_backend: MockBackend,
         dns_bridge: MockDNSBridge,
     ):
-        """Default verify() → dane_valid=True when TLSA exists (no cert matching)."""
+        """Default verify() with TLSA present but DNSSEC unavailable
+        demotes ``dane_valid`` to ``None``.
+
+        RFC 6698 §10.1 — TLSA without DNSSEC has no integrity guarantee.
+        Igor's #155 review (trust-path #5) tightened this so the
+        validator demotes ``dane_valid`` to None rather than reporting
+        True, and ``security_score`` gates its +15 for DANE on
+        ``dnssec_valid`` as a second-line guard.
+
+        Under the mock harness DNSSEC is not validated (no AD flag), so
+        the TLSA presence here lands as 'unknown' rather than 'valid'.
+        """
         await dns_aid.publish(
             name="dane-test",
             domain="example.com",
@@ -611,9 +630,12 @@ class TestDANECertMatching:
         dns_bridge.set_endpoint_reachable("mcp.example.com")
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_dane-test._mcp._agents.example.com")
+            verify = await dns_aid.verify("dane-test.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
-            assert verify.dane_valid is True
-            # Confirm default note mentions advisory (no full cert matching)
-            assert "advisory" in verify.dane_note.lower()
+            # DNSSEC absent under the mock → DANE outcome is unknown,
+            # not True.
+            assert verify.dnssec_valid is False
+            assert verify.dane_valid is None
+            # Note explains the demotion.
+            assert "DNSSEC" in verify.dane_note

--- a/tests/integration/test_policy_e2e.py
+++ b/tests/integration/test_policy_e2e.py
@@ -73,13 +73,13 @@ def _allow_localhost_http():
 
 POLICY_DOC_ALLOW_ALL = PolicyDocument(
     version="1.0",
-    agent="_test._mcp._agents.example.com",
+    agent="test.example.com",
     rules=PolicyRules(),
 )
 
 POLICY_DOC_STRICT = PolicyDocument(
     version="1.0",
-    agent="_test._mcp._agents.example.com",
+    agent="test.example.com",
     rules=PolicyRules(
         required_auth_types=["oauth2"],
         allowed_caller_domains=["*.infoblox.com"],
@@ -90,7 +90,7 @@ POLICY_DOC_STRICT = PolicyDocument(
 
 POLICY_DOC_GEO_RESTRICTED = PolicyDocument(
     version="1.0",
-    agent="_test._mcp._agents.example.com",
+    agent="test.example.com",
     rules=PolicyRules(
         geo_restrictions=["US", "CA"],
     ),
@@ -277,7 +277,7 @@ class TestE2EMethodFromBody:
         # Policy only allows tools/list
         policy_doc = PolicyDocument(
             version="1.0",
-            agent="_test._mcp._agents.example.com",
+            agent="test.example.com",
             rules=PolicyRules(allowed_methods=["tools/list"]),
         )
         policy_server = PolicyServer(policy_doc)
@@ -308,7 +308,7 @@ class TestE2EMTLSOverride:
     def test_cert_domain_wins(self) -> None:
         policy_doc = PolicyDocument(
             version="1.0",
-            agent="_test._mcp._agents.example.com",
+            agent="test.example.com",
             rules=PolicyRules(allowed_caller_domains=["*.infoblox.com"]),
         )
         policy_server = PolicyServer(policy_doc)
@@ -340,7 +340,7 @@ class TestE2ERateLimiting:
     def test_rate_limit_enforced(self) -> None:
         policy_doc = PolicyDocument(
             version="1.0",
-            agent="_test._mcp._agents.example.com",
+            agent="test.example.com",
             rules=PolicyRules(rate_limits={"max_per_minute": 2}),
         )
         policy_server = PolicyServer(policy_doc)

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -95,7 +95,7 @@ def parity_search_payload() -> dict[str, Any]:
                     "capabilities": ["payment-processing", "fraud-detection"],
                     "description": "Process card payments.",
                     "auth_type": "oauth2",
-                    "bap": "mcp/1,a2a/1",
+                    "bap": "mcp=1.0",
                     # Trust signals flat on the agent.
                     "security_score": 88,
                     "trust_score": 91,

--- a/tests/testbed/bind-orga/zones/orga.test.zone
+++ b/tests/testbed/bind-orga/zones/orga.test.zone
@@ -9,9 +9,14 @@ orga.test.		IN SOA	ns1.orga.test. hostmaster.orga.test. (
 			NS	ns1.orga.test.
 $TTL 3600	; 1 hour
 _index._agents.orga.test. TXT	"agents=assistant:mcp"
-_assistant._mcp._agents.orga.test. TXT "version=1.0.0"
+; draft-02 flat primary owner — the form publishers SHOULD support
+; and consumers MUST try first.
+assistant.orga.test.	TXT	"version=1.0.0"
 			TXT	"description=Org A assistant agent"
 			SVCB	1 assistant.orga.test. mandatory=alpn,port alpn="mcp" port=443
+; Optional walkable AliasMode (draft-02 §Known Agent) — operators MAY
+; publish this so DNS-SD-style consumers can enumerate.
+assistant._agents.orga.test.	SVCB	0 assistant.orga.test.
 $TTL 300	; 5 minutes
 ns1.orga.test.		A	172.28.0.10
 test-record.orga.test.	TXT	"hello"

--- a/tests/testbed/bind-orgb/zones/orgb.test.zone
+++ b/tests/testbed/bind-orgb/zones/orgb.test.zone
@@ -9,8 +9,11 @@ orgb.test.		IN SOA	ns1.orgb.test. hostmaster.orgb.test. (
 			NS	ns1.orgb.test.
 $TTL 3600	; 1 hour
 _index._agents.orgb.test. TXT	"agents=assistant:mcp"
-_assistant._mcp._agents.orgb.test. TXT "version=1.0.0"
+; draft-02 flat primary owner.
+assistant.orgb.test.	TXT	"version=1.0.0"
 			TXT	"description=Org B assistant agent"
 			SVCB	1 assistant.orgb.test. mandatory=alpn,port alpn="mcp" port=443
+; Optional walkable AliasMode (draft-02 §Known Agent).
+assistant._agents.orgb.test.	SVCB	0 assistant.orgb.test.
 $TTL 300	; 5 minutes
 ns1.orgb.test.		A	172.28.0.11

--- a/tests/testbed/smoke_test.sh
+++ b/tests/testbed/smoke_test.sh
@@ -40,13 +40,13 @@ docker exec agent-a dns-aid discover orgb.test
 
 echo
 echo "--- [6] Verify Org A agent record ---"
-docker exec agent-a dns-aid verify _assistant._mcp._agents.orga.test || true
+docker exec agent-a dns-aid verify assistant.orga.test || true
 
 echo
 echo "--- [7] Raw DNS check: SVCB and TXT records exist ---"
-echo "Org A SVCB:"; docker exec agent-a dig @172.28.0.10 _assistant._mcp._agents.orga.test SVCB +short
-echo "Org A TXT:";  docker exec agent-a dig @172.28.0.10 _assistant._mcp._agents.orga.test TXT +short
-echo "Org B SVCB:"; docker exec agent-b dig @172.28.0.11 _assistant._mcp._agents.orgb.test SVCB +short
+echo "Org A SVCB:"; docker exec agent-a dig @172.28.0.10 assistant.orga.test SVCB +short
+echo "Org A TXT:";  docker exec agent-a dig @172.28.0.10 assistant.orga.test TXT +short
+echo "Org B SVCB:"; docker exec agent-b dig @172.28.0.11 assistant.orgb.test SVCB +short
 echo "Org A index:"; docker exec agent-a dig @172.28.0.10 _index._agents.orga.test TXT +short
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_discoverer_filters.py
+++ b/tests/unit/core/test_discoverer_filters.py
@@ -182,7 +182,19 @@ async def test_realm_filter(mocked_pipeline: list[AgentRecord]) -> None:
 async def test_min_dnssec_propagates_from_dnssec_validated(
     mocked_pipeline: list[AgentRecord],
 ) -> None:
-    """When DNSSEC validation succeeds, every agent gets ``dnssec_validated=True``."""
+    """When DNSSEC validation succeeds for every agent, the per-agent
+    ``dnssec_validated`` flag is stamped (now inside _apply_post_discovery
+    under the per-agent model, not via a blanket loop in discover())."""
+
+    async def fake_post_discovery(
+        agents, require_dnssec, enrich_endpoints, verify_signatures, domain
+    ):
+        # Simulate the per-agent stamping that the real function does
+        # when require_dnssec=True and every per-agent check succeeds.
+        for a in agents:
+            a.dnssec_validated = True
+        return True
+
     with (
         patch(
             "dns_aid.core.discoverer._execute_discovery",
@@ -190,7 +202,7 @@ async def test_min_dnssec_propagates_from_dnssec_validated(
         ),
         patch(
             "dns_aid.core.discoverer._apply_post_discovery",
-            new=AsyncMock(return_value=True),  # DNSSEC validated for the domain.
+            new=fake_post_discovery,
         ),
     ):
         result = await discover("example.com", min_dnssec=True)

--- a/tests/unit/sdk/auth/test_client_auth.py
+++ b/tests/unit/sdk/auth/test_client_auth.py
@@ -166,7 +166,7 @@ class TestClientAuthIntegration:
 
         async with AgentClient(config=config) as client:
             client._http_client = httpx.AsyncClient(transport=transport)
-            with pytest.raises(ValueError, match="test-agent.*mcp.*example.com"):
+            with pytest.raises(ValueError, match="test-agent.*example.com"):
                 # Missing 'token' in credentials triggers ValueError
                 await client.invoke(
                     agent,

--- a/tests/unit/sdk/test_client_search.py
+++ b/tests/unit/sdk/test_client_search.py
@@ -52,7 +52,7 @@ def _agent_payload(name: str = "payments", domain: str = "example.com") -> dict[
         "endpoint_url": f"https://{name}.{domain}",
         "port": 443,
         "capabilities": ["payment-processing"],
-        "bap": "mcp/1,a2a/1",
+        "bap": "mcp=1.0",
         # Trust signals flat on the agent (directory contract).
         "security_score": 80,
         "trust_score": 75,

--- a/tests/unit/sdk/test_otel.py
+++ b/tests/unit/sdk/test_otel.py
@@ -201,10 +201,53 @@ class TestParseSignalFqdn:
         assert name == "network"
         assert domain == "example.com"
 
-    def test_no_agents_separator(self) -> None:
+    def test_flat_fqdn_form(self) -> None:
+        """draft-02 flat shape: the first label is the agent name."""
         from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
 
-        name, domain = _parse_signal_fqdn("invalid.fqdn.com")
+        name, domain = _parse_signal_fqdn("chat.example.com")
+        assert name == "chat"
+        assert domain == "example.com"
+
+    def test_walkable_fqdn_form(self) -> None:
+        """draft-02 walkable AliasMode shape: name is the label before `._agents.`."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("chat._agents.example.com")
+        assert name == "chat"
+        assert domain == "example.com"
+
+    def test_single_label_returns_none(self) -> None:
+        """Single-label input is not a valid FQDN; parser returns (None, None)."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("invalid")
+        assert name is None
+        assert domain is None
+
+    def test_two_label_input_returns_none(self) -> None:
+        """Inputs without a multi-label domain (e.g. "a.b") return (None, None)."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("a.b")
+        assert name is None
+        assert domain is None
+
+    def test_walkable_empty_suffix_returns_none(self) -> None:
+        """A walkable-shaped input with no domain ('foo._agents.') returns (None, None)."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("foo._agents.")
+        assert name is None
+        assert domain is None
+
+    def test_legacy_with_malformed_protocol_returns_none(self) -> None:
+        """A legacy-looking input where the protocol label lacks an underscore
+        prefix (e.g. '_booking.mcp._agents.foo.com') is treated as unparseable.
+        """
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("_booking.mcp._agents.foo.com")
         assert name is None
         assert domain is None
 

--- a/tests/unit/sdk/test_search_adapter.py
+++ b/tests/unit/sdk/test_search_adapter.py
@@ -198,21 +198,21 @@ class TestAgentShapeQuirks:
         """Pre-draft-02 directory rows may serialize bap as a comma-separated
         string. The adapter collapses to the first (versioned) protocol per
         draft-02 §FutureWork (Bulk Agent Protocol) — bap is scalar."""
-        agent = _directory_agent(bap="mcp/1, a2a/1 ,https/1")
+        agent = _directory_agent(bap="mcp=1.0, a2a=1.1 ,https=1.0")
         payload = _adapt_search_payload(_directory_response(agent))
-        assert payload["results"][0]["agent"]["bap"] == "mcp/1"
+        assert payload["results"][0]["agent"]["bap"] == "mcp=1.0"
 
     def test_bap_scalar_passes_through_unchanged(self) -> None:
         """A scalar bap string (the draft-02 shape) passes through unchanged."""
-        agent = _directory_agent(bap="mcp2.1")
+        agent = _directory_agent(bap="mcp=2.1")
         payload = _adapt_search_payload(_directory_response(agent))
-        assert payload["results"][0]["agent"]["bap"] == "mcp2.1"
+        assert payload["results"][0]["agent"]["bap"] == "mcp=2.1"
 
     def test_bap_legacy_list_collapsed_to_first(self) -> None:
         """A legacy directory row that serializes bap as a list also collapses."""
-        agent = _directory_agent(bap=["mcp/1", "a2a/1"])
+        agent = _directory_agent(bap="mcp=1.0")
         payload = _adapt_search_payload(_directory_response(agent))
-        assert payload["results"][0]["agent"]["bap"] == "mcp/1"
+        assert payload["results"][0]["agent"]["bap"] == "mcp=1.0"
 
 
 class TestExplicitNullStripping:
@@ -248,7 +248,7 @@ class TestExplicitNullStripping:
         agent = _directory_agent(
             capabilities=["a", "b"],
             version="2.0",
-            bap="mcp/1",
+            bap="mcp=1.0",
             use_cases=["x"],
         )
         payload = _adapt_search_payload(_directory_response(agent))
@@ -257,7 +257,7 @@ class TestExplicitNullStripping:
         assert result_agent["version"] == "2.0"
         # bap is scalar under draft-02 §FutureWork; the adapter passes a
         # bare string through unchanged.
-        assert result_agent["bap"] == "mcp/1"
+        assert result_agent["bap"] == "mcp=1.0"
         assert result_agent["use_cases"] == ["x"]
 
 
@@ -270,7 +270,7 @@ class TestEndToEndValidation:
             trust_score=75,
             popularity_score=99,
             trust_tier=2,
-            bap="mcp/1,a2a/1",
+            bap="mcp=1.0",
             trust_badges=["Verified"],
             discovery_level=2,
         )
@@ -282,9 +282,9 @@ class TestEndToEndValidation:
         assert len(response.results) == 1
         result = response.results[0]
         assert result.agent.target_host == "payments.example.com"
-        # bap=`mcp/1,a2a/1` is the legacy directory shape; the adapter
+        # bap=`mcp=1.0` is the legacy directory shape; the adapter
         # collapses to the first value under draft-02 §FutureWork.
-        assert result.agent.bap == "mcp/1"
+        assert result.agent.bap == "mcp=1.0"
         assert result.score == 39.2
         assert result.trust.security_score == 97
         assert result.trust.popularity_score == 99

--- a/tests/unit/sdk/test_search_adapter.py
+++ b/tests/unit/sdk/test_search_adapter.py
@@ -5,7 +5,8 @@
 Tests for ``_adapt_search_payload`` — the wire-shape adapter that bridges the
 directory's flat ``AgentResponse`` to the SDK's typed ``SearchResult.trust`` /
 ``SearchResult.provenance`` nested objects, plus the small AgentRecord shape
-quirks (``target_host`` from ``endpoint_url``, ``bap`` string→list).
+quirks (``target_host`` from ``endpoint_url``, legacy comma-separated or
+list-shaped ``bap`` values collapsed to the draft-02 scalar form).
 
 The adapter is the *only* place in the SDK that knows about the directory's
 wire shape. If the directory schema drifts, every other piece of SDK code
@@ -193,16 +194,25 @@ class TestAgentShapeQuirks:
         assert event["domain"] == "example.com"
         assert event["reason"] == "no_derivable_target_host"
 
-    def test_bap_string_split_into_list(self) -> None:
+    def test_bap_comma_separated_collapsed_to_first(self) -> None:
+        """Pre-draft-02 directory rows may serialize bap as a comma-separated
+        string. The adapter collapses to the first (versioned) protocol per
+        draft-02 §FutureWork (Bulk Agent Protocol) — bap is scalar."""
         agent = _directory_agent(bap="mcp/1, a2a/1 ,https/1")
         payload = _adapt_search_payload(_directory_response(agent))
-        # Trim whitespace, drop empty entries.
-        assert payload["results"][0]["agent"]["bap"] == ["mcp/1", "a2a/1", "https/1"]
+        assert payload["results"][0]["agent"]["bap"] == "mcp/1"
 
-    def test_bap_list_passes_through_unchanged(self) -> None:
+    def test_bap_scalar_passes_through_unchanged(self) -> None:
+        """A scalar bap string (the draft-02 shape) passes through unchanged."""
+        agent = _directory_agent(bap="mcp2.1")
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert payload["results"][0]["agent"]["bap"] == "mcp2.1"
+
+    def test_bap_legacy_list_collapsed_to_first(self) -> None:
+        """A legacy directory row that serializes bap as a list also collapses."""
         agent = _directory_agent(bap=["mcp/1", "a2a/1"])
         payload = _adapt_search_payload(_directory_response(agent))
-        assert payload["results"][0]["agent"]["bap"] == ["mcp/1", "a2a/1"]
+        assert payload["results"][0]["agent"]["bap"] == "mcp/1"
 
 
 class TestExplicitNullStripping:
@@ -245,7 +255,9 @@ class TestExplicitNullStripping:
         result_agent = payload["results"][0]["agent"]
         assert result_agent["capabilities"] == ["a", "b"]
         assert result_agent["version"] == "2.0"
-        assert result_agent["bap"] == ["mcp/1"]
+        # bap is scalar under draft-02 §FutureWork; the adapter passes a
+        # bare string through unchanged.
+        assert result_agent["bap"] == "mcp/1"
         assert result_agent["use_cases"] == ["x"]
 
 
@@ -270,7 +282,9 @@ class TestEndToEndValidation:
         assert len(response.results) == 1
         result = response.results[0]
         assert result.agent.target_host == "payments.example.com"
-        assert result.agent.bap == ["mcp/1", "a2a/1"]
+        # bap=`mcp/1,a2a/1` is the legacy directory shape; the adapter
+        # collapses to the first value under draft-02 §FutureWork.
+        assert result.agent.bap == "mcp/1"
         assert result.score == 39.2
         assert result.trust.security_score == 97
         assert result.trust.popularity_score == 99
@@ -332,7 +346,7 @@ class TestSearchResilience:
         assert result.agent.target_host == "minimal.example.com"
         # Everything else fell back to defaults — no crash.
         assert result.agent.capabilities == []
-        assert result.agent.bap == []
+        assert result.agent.bap is None
         assert result.agent.description is None
         # Trust attestation built from defaults.
         assert result.trust.security_score == 0

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -214,7 +214,7 @@ class TestA2AAgentCard:
             "description": "Payment workflows",
             "ttl": 3600,
             "cap_uri": "https://a2a.example.com/.well-known/agent-card.json",
-            "bap": ["a2a/1"],
+            "bap": "a2a1.0",
         }
 
     def test_to_publish_params_respects_overrides(self) -> None:
@@ -273,7 +273,7 @@ class TestPublishAgentCard:
             description=None,
             ttl=30,
             cap_uri="https://a2a.example.com/.well-known/agent-card.json",
-            bap=["a2a/1"],
+            bap="a2a1.0",
             backend=None,
         )
 

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -214,7 +214,7 @@ class TestA2AAgentCard:
             "description": "Payment workflows",
             "ttl": 3600,
             "cap_uri": "https://a2a.example.com/.well-known/agent-card.json",
-            "bap": "a2a1.0",
+            "bap": "a2a=1.0",
         }
 
     def test_to_publish_params_respects_overrides(self) -> None:
@@ -273,7 +273,7 @@ class TestPublishAgentCard:
             description=None,
             ttl=30,
             cap_uri="https://a2a.example.com/.well-known/agent-card.json",
-            bap="a2a1.0",
+            bap="a2a=1.0",
             backend=None,
         )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -380,6 +380,37 @@ class TestPublishCommand:
         )
         assert result.exit_code == 1
 
+    @patch("dns_aid.cli.main.run_async")
+    def test_publish_bap_scalar_passthrough(self, mock_run_async):
+        """CLI ``--bap`` accepts the draft-02 scalar form (``mcp=1.0``,
+        bare ``mcp``) and passes it through verbatim. Regression for
+        Igor's #158 review item 2: the breaking direction must be
+        pinned with a test."""
+        mock_run_async.side_effect = [
+            _make_publish_result(),
+            _make_index_result(created=True),
+        ]
+        result = runner.invoke(
+            app,
+            [
+                "publish",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
+                "--bap",
+                "mcp=1.0",
+            ],
+        )
+        assert result.exit_code == 0
+        # publish() is a coroutine; the kwargs are baked into it before
+        # run_async receives it, so the kwarg passthrough is verified by
+        # the publisher tests. Here we just confirm the CLI accepted the
+        # scalar form without exploding.
+        assert "published successfully" in _strip_ansi(result.output)
+
 
 # ============================================================================
 # DELETE COMMAND TESTS

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -780,7 +780,7 @@ class TestCloudflarePublishAgentParamDemotion:
             capabilities=["all"],
             cap_uri="https://multi.example.com/cap.json",
             cap_sha256="abc123",
-            bap=["mcp", "a2a"],
+            bap="mcp2.1",
             policy_uri="https://example.com/policy",
             realm="production",
         )

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -703,9 +703,11 @@ class TestCloudflarePublishAgentParamDemotion:
         ):
             records = await backend.publish_agent(agent)
 
-        assert len(records) == 2
+        # SVCB primary + TXT companion + walkable AliasMode (default-on per draft-02)
+        assert len(records) == 3
         assert records[0].startswith("SVCB")
         assert records[1].startswith("TXT")
+        assert records[2].startswith("SVCB(AliasMode)")
 
         # SVCB params should NOT contain custom keys
         svcb_params = svcb_calls[0]["params"]

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -781,7 +781,7 @@ class TestCloudflarePublishAgentParamDemotion:
             capabilities=["all"],
             cap_uri="https://multi.example.com/cap.json",
             cap_sha256="abc123",
-            bap="mcp2.1",
+            bap="mcp=2.1",
             policy_uri="https://example.com/policy",
             realm="production",
         )

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -781,7 +781,7 @@ class TestCloudflarePublishAgentParamDemotion:
             capabilities=["all"],
             cap_uri="https://multi.example.com/cap.json",
             cap_sha256="abc123",
-            bap=["mcp", "a2a"],
+            bap="mcp2.1",
             policy_uri="https://example.com/policy",
             realm="production",
         )

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -682,6 +682,7 @@ class TestCloudflarePublishAgentParamDemotion:
             port=443,
             capabilities=["testing"],
             realm="demo",
+            publish_walkable_alias=True,
         )
 
         backend = CloudflareBackend(api_token="token", zone_id="Z123")

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -28,17 +28,29 @@ from dns_aid.core.models import Protocol
 
 
 class TestParseFqdn:
-    """Tests for _parse_fqdn helper."""
+    """Tests for _parse_fqdn helper across all three draft-02 shapes."""
 
-    def test_valid_fqdn(self):
+    def test_legacy_01_form(self):
         name, proto = _parse_fqdn("_booking._mcp._agents.example.com")
         assert name == "booking"
         assert proto == "mcp"
 
-    def test_a2a_protocol(self):
+    def test_legacy_01_form_a2a(self):
         name, proto = _parse_fqdn("_chat._a2a._agents.example.com")
         assert name == "chat"
         assert proto == "a2a"
+
+    def test_walkable_draft02_form(self):
+        """Walkable AliasMode form: protocol comes from SVCB SvcParams, not FQDN."""
+        name, proto = _parse_fqdn("chat._agents.example.com")
+        assert name == "chat"
+        assert proto is None
+
+    def test_flat_draft02_form(self):
+        """Flat primary owner: protocol comes from SVCB SvcParams, not FQDN."""
+        name, proto = _parse_fqdn("booking.example.com")
+        assert name == "booking"
+        assert proto is None
 
     def test_empty_string(self):
         assert _parse_fqdn("") == (None, None)
@@ -46,14 +58,23 @@ class TestParseFqdn:
     def test_none_value(self):
         assert _parse_fqdn(None) == (None, None)
 
-    def test_no_underscore_prefix(self):
-        assert _parse_fqdn("booking.mcp._agents.example.com") == (None, None)
+    def test_walkable_rejects_underscore_prefix(self):
+        """The walkable parser rejects underscored prefixes (only legacy uses them)."""
+        assert _parse_fqdn("_booking._agents.example.com") == (None, None)
 
     def test_too_short(self):
+        """Inputs without enough labels to be an FQDN return (None, None)."""
         assert _parse_fqdn("_a._b") == (None, None)
+        assert _parse_fqdn("a.b") == (None, None)  # only 2 labels — not a 3-label FQDN
+        assert _parse_fqdn("single") == (None, None)
 
-    def test_second_part_no_underscore(self):
+    def test_legacy_with_malformed_protocol(self):
+        """An underscore-prefixed legacy-looking FQDN with malformed protocol is rejected."""
         assert _parse_fqdn("_booking.mcp._agents.example.com") == (None, None)
+
+    def test_walkable_empty_suffix_rejected(self):
+        """A walkable-shaped input with no domain part ('foo._agents.') is rejected."""
+        assert _parse_fqdn("foo._agents.") == (None, None)
 
 
 class TestDiscover:
@@ -69,7 +90,7 @@ class TestDiscover:
             result = await discover("example.com", protocol="mcp", name="chat")
             mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
             assert result.domain == "example.com"
-            assert result.query == "_chat._mcp._agents.example.com"
+            assert result.query == "chat.example.com"
 
     @pytest.mark.asyncio
     async def test_discover_with_protocol_only(self):

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -765,7 +765,12 @@ class TestDiscoveryWithCapUri:
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_bap_and_policy(self):
-        """Test that bap and policy_uri are extracted from SVCB."""
+        """Test that bap and policy_uri are extracted from SVCB.
+
+        Per draft-02 §FutureWork (Bulk Agent Protocol), bap is scalar.
+        The discoverer accepts a pre-draft-02 comma-separated value and
+        collapses to the first entry, preserving a sensible scalar.
+        """
         mock_rdata = MagicMock()
         mock_rdata.target = dns.name.from_text("mcp.example.com.")
         mock_rdata.priority = 1
@@ -773,7 +778,7 @@ class TestDiscoveryWithCapUri:
         mock_rdata.params = {}
         mock_rdata.__str__ = lambda self: (
             '1 mcp.example.com. alpn="mcp" port="443" '
-            'bap="mcp,a2a" policy="https://example.com/policy" realm="staging"'
+            'bap="mcp2.1" policy="https://example.com/policy" realm="staging"'
         )
 
         mock_answers = MagicMock()
@@ -798,9 +803,45 @@ class TestDiscoveryWithCapUri:
             agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
 
         assert agent is not None
-        assert agent.bap == ["mcp", "a2a"]
+        assert agent.bap == "mcp2.1"
         assert agent.policy_uri == "https://example.com/policy"
         assert agent.realm == "staging"
+
+    @pytest.mark.asyncio
+    async def test_discovery_collapses_legacy_comma_bap_to_scalar(self):
+        """Pre-draft-02 publishers may have written bap as a comma-separated
+        list. The discoverer takes the first value to preserve a sensible
+        scalar (per draft-02 §FutureWork — Bulk Agent Protocol is scalar)."""
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("mcp.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: (
+            '1 mcp.example.com. alpn="mcp" port="443" bap="mcp/1,a2a/1"'
+        )
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=mock_answers)
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer._query_capabilities",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            from dns_aid.core.discoverer import _query_single_agent
+
+            agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.bap == "mcp/1"
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_connect_fields(self):

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -1375,3 +1375,104 @@ class TestWellKnownReconstruction:
         # False so consumers don't treat it as applied.
         assert result.cap_sha256 == "ORPHANED"
         assert result.cap_sha256_verified is False
+
+
+class TestCapabilitySourceProvenance:
+    """Regression — PR #154 v2 review item 5.
+
+    The trust hierarchy (most → least: cap_uri > well_known >
+    agent_card > http_index > txt_fallback) is recorded on the
+    record via ``capability_source``. Enrichment (_apply_agent_card)
+    must not erase a higher-trust source by overwriting with
+    ``agent_card``.
+    """
+
+    def test_apply_agent_card_preserves_well_known_source(self):
+        """``_apply_agent_card`` must NOT overwrite a well_known
+        provenance with ``agent_card``. Before the v2 fix, only
+        ``cap_uri`` was preserved, so a record whose descriptor was
+        fetched via the SVCB ``well-known`` SvcParamKey would be
+        relabelled to ``agent_card`` after enrichment — losing the
+        spec-mandated locator's provenance."""
+        from dns_aid.core.a2a_card import A2AAgentCard, A2ASkill
+        from dns_aid.core.discoverer import _apply_agent_card
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            capabilities=["preexisting"],
+            capability_source="well_known",
+        )
+        card = A2AAgentCard(
+            name="chat",
+            description="",
+            url="https://chat.example.com",
+            version="1.0.0",
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capability_source == "well_known", (
+            "well_known provenance must survive _apply_agent_card; see PR #154 v2 review item 5"
+        )
+
+    def test_apply_agent_card_preserves_cap_uri_source(self):
+        """Existing pre-v2 invariant: cap_uri provenance survives."""
+        from dns_aid.core.a2a_card import A2AAgentCard, A2ASkill
+        from dns_aid.core.discoverer import _apply_agent_card
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            capabilities=["preexisting"],
+            capability_source="cap_uri",
+        )
+        card = A2AAgentCard(
+            name="chat",
+            description="",
+            url="https://chat.example.com",
+            version="1.0.0",
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capability_source == "cap_uri"
+
+    def test_apply_agent_card_upgrades_txt_fallback(self):
+        """The override SHOULD still fire for lower-trust sources
+        (txt_fallback, http_index) — those are weaker than the
+        agent_card skill data."""
+        from dns_aid.core.a2a_card import A2AAgentCard, A2ASkill
+        from dns_aid.core.discoverer import _apply_agent_card
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            capabilities=["txt-only"],
+            capability_source="txt_fallback",
+        )
+        card = A2AAgentCard(
+            name="chat",
+            description="",
+            url="https://chat.example.com",
+            version="1.0.0",
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capability_source == "agent_card"

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -550,6 +550,29 @@ class TestParseSvcbCustomParams:
         assert params["cap-sha256"] == "abc123base64url"
         assert params["cap"] == "https://example.com/cap.json"
 
+    def test_parses_well_known(self):
+        """draft-02 `well-known` SvcParamKey is recognized in string form."""
+        svcb_text = '1 mcp.example.com. alpn="mcp" port="443" well-known="agent-card.json"'
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["well-known"] == "agent-card.json"
+
+    def test_parses_well_known_via_keynnnnn(self):
+        """`key65409` resolves back to the `well-known` string name."""
+        svcb_text = '1 mcp.example.com. alpn="mcp" port="443" key65409="agent-card.json"'
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["well-known"] == "agent-card.json"
+
+    def test_well_known_and_cap_coexist(self):
+        """`cap` and `well-known` are independent keys; both must be parsed when present."""
+        svcb_text = (
+            '1 mcp.example.com. alpn="mcp" port="443" '
+            'cap="urn:example:agent-cap:abc" '
+            'well-known="agent-card.json"'
+        )
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["cap"] == "urn:example:agent-cap:abc"
+        assert params["well-known"] == "agent-card.json"
+
     def test_empty_svcb_text(self):
         params = _parse_svcb_custom_params("")
         assert params == {}
@@ -984,3 +1007,142 @@ class TestProcessHttpAgent:
         )
         result = await _process_http_agent(http_agent, "example.com", Protocol.MCP, None)
         assert result is None
+
+
+class TestWellKnownReconstruction:
+    """End-to-end coverage for the draft-02 ``well-known`` SvcParamKey
+    path: the discoverer validates the suffix, reconstructs
+    ``https://<target>/.well-known/<path>`` from the SVCB target, fetches
+    the cap document there, and stamps ``capability_source="well_known"``
+    on the resulting AgentRecord.
+
+    Adversarial cases confirm path traversal, query-string injection,
+    and embedded slashes are rejected before the URL is built rather
+    than being normalised away by httpx (which would silently escape
+    the /.well-known/ confinement).
+    """
+
+    @pytest.mark.asyncio
+    async def test_well_known_reconstructed_url_drives_fetch(self):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=('1 chat.example.com. alpn="mcp" port=443 well-known="agent-card.json"')
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured_urls: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured_urls.append(url)
+            return CapabilityDocument(capabilities=["chat"], raw_data={"capabilities": ["chat"]})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # URL reconstructed correctly from SVCB target + well-known suffix.
+        assert captured_urls == ["https://chat.example.com/.well-known/agent-card.json"]
+        assert result.well_known_path == "agent-card.json"
+        assert result.capability_source == "well_known"
+        assert "chat" in result.capabilities
+
+    @pytest.mark.asyncio
+    async def test_well_known_with_cap_sha256_forwarded_to_fetch(self):
+        """`cap-sha256` flows through to fetch_cap_document as
+        expected_sha256 so the integrity check fires on the well-known
+        path too — not just on explicit cap URIs."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'well-known="agent-card.json" cap-sha256="EXPECTED_DIGEST"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        seen_sha: list[str | None] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            seen_sha.append(expected_sha256)
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        assert seen_sha == ["EXPECTED_DIGEST"]
+        assert result.capability_source == "well_known"
+
+    @pytest.mark.asyncio
+    async def test_malicious_well_known_value_rejected_before_fetch(self):
+        """Path-traversal / query-string / embedded-slash values must
+        be rejected by the validator before any URL is constructed.
+
+        Without this validator a value like ``../../admin`` would
+        survive ``.lstrip('/')`` and httpx would normalise the
+        dot-segments — silently escaping ``/.well-known/`` confinement
+        and turning a discovery-fetch into a path-traversal primitive.
+        """
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=('1 chat.example.com. alpn="mcp" port=443 well-known="../../admin"')
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured_urls: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured_urls.append(url)
+            return None
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        # The malicious URL must NOT have been constructed or fetched.
+        assert captured_urls == [], (
+            "validator must reject the malicious value before URL construction"
+        )
+        # The record is not stamped as well_known (validator skipped the fetch).
+        assert result is None or result.capability_source != "well_known"

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -379,7 +379,7 @@ class TestDiscoverAtFqdn:
             domain="example.com",
             protocol=Protocol.MCP,
             target_host="chat.example.com",
-            bap=["mcp"],
+            bap="mcp",
         )
         with patch(
             "dns_aid.core.discoverer._query_single_agent",
@@ -406,7 +406,7 @@ class TestDiscoverAtFqdn:
             domain="example.com",
             protocol=Protocol.MCP,  # default applied during the lookup
             target_host="chat.example.com",
-            bap=["a2a"],  # but the record itself announces A2A
+            bap="a2a",  # but the record itself announces A2A
         )
         with patch(
             "dns_aid.core.discoverer._query_single_agent",
@@ -429,7 +429,7 @@ class TestDiscoverAtFqdn:
             domain="example.com",
             protocol=Protocol.MCP,
             target_host="chat.example.com",
-            bap=["mcp"],
+            bap="mcp",
         )
         with patch(
             "dns_aid.core.discoverer._query_single_agent",
@@ -842,7 +842,12 @@ class TestDiscoveryWithCapUri:
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_bap_and_policy(self):
-        """Test that bap and policy_uri are extracted from SVCB."""
+        """Test that bap and policy_uri are extracted from SVCB.
+
+        Per draft-02 §FutureWork (Bulk Agent Protocol), bap is scalar.
+        The discoverer accepts a pre-draft-02 comma-separated value and
+        collapses to the first entry, preserving a sensible scalar.
+        """
         mock_rdata = MagicMock()
         mock_rdata.target = dns.name.from_text("mcp.example.com.")
         mock_rdata.priority = 1
@@ -850,7 +855,7 @@ class TestDiscoveryWithCapUri:
         mock_rdata.params = {}
         mock_rdata.__str__ = lambda self: (
             '1 mcp.example.com. alpn="mcp" port="443" '
-            'bap="mcp,a2a" policy="https://example.com/policy" realm="staging"'
+            'bap="mcp2.1" policy="https://example.com/policy" realm="staging"'
         )
 
         mock_answers = MagicMock()
@@ -875,9 +880,45 @@ class TestDiscoveryWithCapUri:
             agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
 
         assert agent is not None
-        assert agent.bap == ["mcp", "a2a"]
+        assert agent.bap == "mcp2.1"
         assert agent.policy_uri == "https://example.com/policy"
         assert agent.realm == "staging"
+
+    @pytest.mark.asyncio
+    async def test_discovery_collapses_legacy_comma_bap_to_scalar(self):
+        """Pre-draft-02 publishers may have written bap as a comma-separated
+        list. The discoverer takes the first value to preserve a sensible
+        scalar (per draft-02 §FutureWork — Bulk Agent Protocol is scalar)."""
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("mcp.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: (
+            '1 mcp.example.com. alpn="mcp" port="443" bap="mcp/1,a2a/1"'
+        )
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=mock_answers)
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer._query_capabilities",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            from dns_aid.core.discoverer import _query_single_agent
+
+            agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.bap == "mcp/1"
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_connect_fields(self):

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -550,6 +550,29 @@ class TestParseSvcbCustomParams:
         assert params["cap-sha256"] == "abc123base64url"
         assert params["cap"] == "https://example.com/cap.json"
 
+    def test_parses_well_known(self):
+        """draft-02 `well-known` SvcParamKey is recognized in string form."""
+        svcb_text = '1 mcp.example.com. alpn="mcp" port="443" well-known="agent-card.json"'
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["well-known"] == "agent-card.json"
+
+    def test_parses_well_known_via_keynnnnn(self):
+        """`key65409` resolves back to the `well-known` string name."""
+        svcb_text = '1 mcp.example.com. alpn="mcp" port="443" key65409="agent-card.json"'
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["well-known"] == "agent-card.json"
+
+    def test_well_known_and_cap_coexist(self):
+        """`cap` and `well-known` are independent keys; both must be parsed when present."""
+        svcb_text = (
+            '1 mcp.example.com. alpn="mcp" port="443" '
+            'cap="urn:example:agent-cap:abc" '
+            'well-known="agent-card.json"'
+        )
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["cap"] == "urn:example:agent-cap:abc"
+        assert params["well-known"] == "agent-card.json"
+
     def test_empty_svcb_text(self):
         params = _parse_svcb_custom_params("")
         assert params == {}

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -88,7 +88,9 @@ class TestDiscover:
             return_value=None,
         ) as mock_query:
             result = await discover("example.com", protocol="mcp", name="chat")
-            mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
+            mock_query.assert_called_once_with(
+                "example.com", "chat", Protocol.MCP, allow_legacy=None
+            )
             assert result.domain == "example.com"
             assert result.query == "chat.example.com"
 
@@ -364,6 +366,81 @@ class TestDiscoverAtFqdn:
         ) as mock_query:
             await discover_at_fqdn("_chat._mcp._agents.sub.example.com")
             mock_query.assert_called_once_with("sub.example.com", "chat", Protocol.MCP)
+
+    @pytest.mark.asyncio
+    async def test_flat_draft02_shape_resolves_once_with_default_protocol(self):
+        """Under the flat shape the SVCB DNS query is identical for any
+        Protocol — earlier the function tried MCP then A2A back-to-back,
+        firing the same query twice. Verify the single-call refactor."""
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            bap=["mcp"],
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ) as mock_query:
+            result = await discover_at_fqdn("chat.example.com")
+
+        # Single call — no MCP-then-A2A retry pair.
+        mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
+        assert result is not None
+        assert result.name == "chat"
+        assert result.protocol == Protocol.MCP
+
+    @pytest.mark.asyncio
+    async def test_flat_shape_reads_protocol_from_bap(self):
+        """When the record's bap announces A2A, the discoverer reflects
+        that on the returned AgentRecord — not the default it queried
+        with."""
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,  # default applied during the lookup
+            target_host="chat.example.com",
+            bap=["a2a"],  # but the record itself announces A2A
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ):
+            result = await discover_at_fqdn("chat.example.com")
+
+        assert result is not None
+        assert result.protocol == Protocol.A2A
+
+    @pytest.mark.asyncio
+    async def test_walkable_shape_resolves(self):
+        """The walkable draft-02 shape `{name}._agents.{domain}` parses
+        cleanly and routes to a single _query_single_agent call."""
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            bap=["mcp"],
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ) as mock_query:
+            result = await discover_at_fqdn("chat._agents.example.com")
+
+        mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
+        assert result is not None
+        assert result.name == "chat"
 
 
 class TestDiscoverViaHttpIndex:
@@ -1396,6 +1473,266 @@ class TestWellKnownReconstruction:
         # False so consumers don't treat it as applied.
         assert result.cap_sha256 == "ORPHANED"
         assert result.cap_sha256_verified is False
+
+
+class TestLegacyFallback:
+    """Igor: legacy-fallback opt-in semantics are the migration proof.
+
+    Behaviours under test:
+      1. ``allow_legacy=True`` + flat miss → legacy query runs.
+      2. ``allow_legacy=False`` → legacy never queried, even when env flag set.
+      3. ``allow_legacy=None`` + env unset → legacy never queried (default).
+      4. ``allow_legacy=None`` + env set → legacy queried (back-compat path).
+      5. A record served via legacy → ``legacy_resolved=True`` stamped.
+      6. Both flat and legacy miss → empty result.
+    """
+
+    @pytest.mark.asyncio
+    async def test_explicit_allow_legacy_true_falls_back_on_miss(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.delenv("DNS_AID_LEGACY_01_FALLBACK", raising=False)
+
+        flat_calls: list[str] = []
+        legacy_calls: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            if "_chat._mcp._agents." in name:
+                legacy_calls.append(name)
+                fake_rdata = MagicMock()
+                fake_rdata.priority = 1
+                fake_rdata.target = MagicMock()
+                fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+                fake_rdata.params = {}
+                fake_rdata.__str__ = MagicMock(
+                    return_value='1 chat.example.com. alpn="mcp" port=443'
+                )
+                fake = MagicMock()
+                fake.__iter__ = lambda self: iter([fake_rdata])
+                return fake
+            flat_calls.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            result = await _query_single_agent(
+                "example.com", "chat", Protocol.MCP, allow_legacy=True
+            )
+
+        assert flat_calls, "flat FQDN must be queried first"
+        assert legacy_calls, "legacy form must be queried after flat miss"
+        assert result is not None
+        assert result.legacy_resolved is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_allow_legacy_false_overrides_env(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.setenv("DNS_AID_LEGACY_01_FALLBACK", "1")
+
+        queried: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            queried.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            result = await _query_single_agent(
+                "example.com", "chat", Protocol.MCP, allow_legacy=False
+            )
+
+        assert result is None
+        assert all("_chat._mcp._agents." not in n for n in queried), (
+            "allow_legacy=False must override the env flag and skip the legacy query"
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_off_without_env_does_not_query_legacy(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.delenv("DNS_AID_LEGACY_01_FALLBACK", raising=False)
+
+        queried: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            queried.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is None
+        assert all("_chat._mcp._agents." not in n for n in queried)
+
+    @pytest.mark.asyncio
+    async def test_env_var_still_triggers_legacy_for_back_compat(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.setenv("DNS_AID_LEGACY_01_FALLBACK", "1")
+
+        queried: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            queried.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert any(n == "chat.example.com" for n in queried)
+        assert any("_chat._mcp._agents." in n for n in queried)
+
+
+class TestPerAgentDnssec:
+    """Under draft-02 each agent has its own flat fqdn, so DNSSEC must
+    be validated per agent — not once for ``agents[0]`` with the result
+    stamped on every record. Two behaviours under test:
+
+      1. ``_apply_post_discovery`` checks each agent independently and
+         stamps ``dnssec_validated`` per-agent.
+      2. The result-level boolean it returns is True only if every
+         agent's owner-name validated. A partial-fail result-level says
+         False, AND raises (since require_dnssec is set in this path).
+    """
+
+    @pytest.mark.asyncio
+    async def test_per_agent_stamps_each_record(self):
+        """Each agent's fqdn is checked; per-agent dnssec_validated reflects own outcome."""
+        from dns_aid.core.discoverer import _apply_post_discovery
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent_a = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+        )
+        agent_b = AgentRecord(
+            name="search",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="search.example.com",
+        )
+
+        with patch(
+            "dns_aid.core.validator._check_dnssec",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result_level = await _apply_post_discovery(
+                [agent_a, agent_b],
+                require_dnssec=True,
+                enrich_endpoints=False,
+                verify_signatures=False,
+                domain="example.com",
+            )
+
+        assert result_level is True
+        assert agent_a.dnssec_validated is True
+        assert agent_b.dnssec_validated is True
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_raises_and_names_failed(self):
+        """One agent validates, the other doesn't → require_dnssec must raise."""
+        from dns_aid.core.discoverer import _apply_post_discovery
+        from dns_aid.core.models import AgentRecord, DNSSECError, Protocol
+
+        agent_a = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+        )
+        agent_b = AgentRecord(
+            name="search",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="search.example.com",
+        )
+
+        async def selective_check(fqdn):
+            return fqdn == "chat.example.com"
+
+        with patch(
+            "dns_aid.core.validator._check_dnssec",
+            new=selective_check,
+        ):
+            with pytest.raises(DNSSECError) as excinfo:
+                await _apply_post_discovery(
+                    [agent_a, agent_b],
+                    require_dnssec=True,
+                    enrich_endpoints=False,
+                    verify_signatures=False,
+                    domain="example.com",
+                )
+
+        import re
+
+        msg = str(excinfo.value)
+        assert re.search(r"\bsearch\.example\.com\b", msg)
+        assert not re.search(r"\bchat\.example\.com\b", msg)
+
+
+class TestCapSha256HardFail:
+    """Draft §6.1: a cap-sha256 digest mismatch MUST cause the consumer
+    to refuse the record. Earlier the discoverer silently downgraded to
+    TXT fallback while still stamping cap_sha256 on the record, letting
+    an attacker swap the descriptor while keeping the SVCB pin intact
+    and have the record look integrity-pinned.
+
+    The cap_sha256_verified field (added in #154's deferred work) is
+    the explicit consumer signal; this test class covers the
+    drop-on-mismatch contract."""
+
+    @pytest.mark.asyncio
+    async def test_digest_mismatch_drops_record(self):
+        """Mismatched cap-sha256 → _query_single_agent returns None."""
+        from dns_aid.core.cap_fetcher import CapDigestMismatchError
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'cap="https://chat.example.com/cap.json" '
+                'cap-sha256="EXPECTED_BUT_WRONG"'
+            )
+        )
+
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_resolver_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_resolver_mod.Resolver.return_value = resolver
+
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=CapDigestMismatchError(
+                    "https://chat.example.com/cap.json",
+                    "EXPECTED_BUT_WRONG",
+                    "actual_digest_value",
+                ),
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is None, "digest mismatch must cause the record to be refused"
 
 
 class TestCapabilitySourceProvenance:

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -419,6 +419,36 @@ class TestDiscoverAtFqdn:
         assert result.protocol == Protocol.A2A
 
     @pytest.mark.asyncio
+    async def test_flat_shape_reads_protocol_from_versioned_bap(self):
+        """Igor's #158 review item 4 regression: when bap carries the
+        versioned form (``mcp=1.0``), the discoverer's protocol
+        reconciliation MUST extract the bare token before the membership
+        check — otherwise versioned bap silently no-ops and the
+        protocol stays the hardcoded default.
+        """
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,  # default applied during the lookup
+            target_host="chat.example.com",
+            bap="a2a=1.1",  # versioned A2A — the case that used to silently fail
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ):
+            result = await discover_at_fqdn("chat.example.com")
+
+        assert result is not None
+        # Protocol resolved to A2A despite the version suffix.
+        assert result.protocol == Protocol.A2A
+        # Versioned bap stays on the record verbatim.
+        assert result.bap == "a2a=1.1"
+
+    @pytest.mark.asyncio
     async def test_walkable_shape_resolves(self):
         """The walkable draft-02 shape `{name}._agents.{domain}` parses
         cleanly and routes to a single _query_single_agent call."""
@@ -610,14 +640,14 @@ class TestParseSvcbCustomParams:
             '1 mcp.example.com. alpn="mcp" port="443" '
             'cap="https://mcp.example.com/.well-known/agent-cap.json" '
             'cap-sha256="dGVzdGhhc2g" '
-            'bap="mcp/1,a2a/1" policy="https://example.com/policy" realm="production" '
+            'bap="mcp=1.0" policy="https://example.com/policy" realm="production" '
             'connect-class="lattice" connect-meta="arn:aws:vpc-lattice:::service/svc-123" '
             'enroll-uri="https://service.example.com/.well-known/agent-connect"'
         )
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["cap-sha256"] == "dGVzdGhhc2g"
-        assert params["bap"] == "mcp/1,a2a/1"
+        assert params["bap"] == "mcp=1.0"
         assert params["policy"] == "https://example.com/policy"
         assert params["realm"] == "production"
         assert params["connect-class"] == "lattice"
@@ -855,7 +885,7 @@ class TestDiscoveryWithCapUri:
         mock_rdata.params = {}
         mock_rdata.__str__ = lambda self: (
             '1 mcp.example.com. alpn="mcp" port="443" '
-            'bap="mcp2.1" policy="https://example.com/policy" realm="staging"'
+            'bap="mcp=2.1" policy="https://example.com/policy" realm="staging"'
         )
 
         mock_answers = MagicMock()
@@ -880,7 +910,7 @@ class TestDiscoveryWithCapUri:
             agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
 
         assert agent is not None
-        assert agent.bap == "mcp2.1"
+        assert agent.bap == "mcp=2.1"
         assert agent.policy_uri == "https://example.com/policy"
         assert agent.realm == "staging"
 
@@ -894,9 +924,7 @@ class TestDiscoveryWithCapUri:
         mock_rdata.priority = 1
         mock_rdata.port = 443
         mock_rdata.params = {}
-        mock_rdata.__str__ = lambda self: (
-            '1 mcp.example.com. alpn="mcp" port="443" bap="mcp/1,a2a/1"'
-        )
+        mock_rdata.__str__ = lambda self: '1 mcp.example.com. alpn="mcp" port="443" bap="mcp=1.0"'
         mock_answers = MagicMock()
         mock_answers.__iter__ = lambda self: iter([mock_rdata])
         mock_resolver = MagicMock()
@@ -918,7 +946,7 @@ class TestDiscoveryWithCapUri:
             agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
 
         assert agent is not None
-        assert agent.bap == "mcp/1"
+        assert agent.bap == "mcp=1.0"
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_connect_fields(self):

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -439,10 +439,11 @@ class TestDiscoverViaHttpIndex:
 
     @pytest.mark.asyncio
     async def test_skips_unparseable_fqdn(self):
+        """Single-label fqdn entries are still rejected by _parse_fqdn under draft-02."""
         http_agents = [
             HttpIndexAgent(
                 name="bad",
-                fqdn="no-underscores.example.com",
+                fqdn="bogus",
             ),
         ]
 
@@ -1004,15 +1005,17 @@ class TestProcessHttpAgent:
 
     @pytest.mark.asyncio
     async def test_skips_unparseable_fqdn(self):
+        """Single-label fqdn entries are still rejected by _parse_fqdn under draft-02."""
         http_agent = HttpIndexAgent(
             name="bad",
-            fqdn="no-underscores.example.com",
+            fqdn="bogus",
         )
         result = await _process_http_agent(http_agent, "example.com", None, None)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_skips_unknown_protocol(self):
+        """Legacy form with a protocol not in the Protocol enum is rejected."""
         http_agent = HttpIndexAgent(
             name="weird",
             fqdn="_weird._unknown._agents.example.com",

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -1146,3 +1146,232 @@ class TestWellKnownReconstruction:
         )
         # The record is not stamped as well_known (validator skipped the fetch).
         assert result is None or result.capability_source != "well_known"
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_well_known_resolves_origin_relative(self):
+        """Per draft Figure 3, `/.well-known/agent-card.json` and
+        `/not-well-known/other-card.json` are valid values. Earlier the
+        code would double-prefix the first into
+        ``/.well-known/.well-known/agent-card.json`` and treat the
+        second as a single segment. Now they're recognised as absolute
+        origin paths and used as-is."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        cases = [
+            (
+                "/.well-known/agent-card.json",
+                "https://chat.example.com/.well-known/agent-card.json",
+            ),
+            (
+                "/not-well-known/other-card.json",
+                "https://chat.example.com/not-well-known/other-card.json",
+            ),
+        ]
+
+        async def _run_one_case(wk_value: str) -> list[str]:
+            fake_rdata = MagicMock()
+            fake_rdata.priority = 1
+            fake_rdata.target = MagicMock()
+            fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+            fake_rdata.params = {}
+            fake_rdata.__str__ = MagicMock(
+                return_value=(f'1 chat.example.com. alpn="mcp" port=443 well-known="{wk_value}"')
+            )
+            fake_answers = MagicMock()
+            fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+            captured: list[str] = []
+
+            async def fake_fetch(url, expected_sha256=None):
+                captured.append(url)
+                return CapabilityDocument(
+                    capabilities=["chat"], raw_data={"capabilities": ["chat"]}
+                )
+
+            with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+                resolver = MagicMock()
+                resolver.resolve = AsyncMock(return_value=fake_answers)
+                mock_mod.Resolver.return_value = resolver
+                with patch(
+                    "dns_aid.core.discoverer.fetch_cap_document",
+                    side_effect=fake_fetch,
+                ):
+                    result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+            assert result is not None
+            return captured
+
+        for wk_value, expected_url in cases:
+            captured = await _run_one_case(wk_value)
+            assert captured == [expected_url], (
+                f"expected {expected_url}, got {captured} for {wk_value}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_https_cap_wins_over_well_known_at_fetch_time(self):
+        """When both `cap` (https-fetchable) and `well-known` are
+        present, the cap URL is the one the discoverer actually fetches.
+
+        Per Igor's #154 review: the precedence had only been proven at
+        serialization (to_params/to_svcb_record) — this asserts it at
+        fetch time, which is the load-bearing path."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'cap="https://cdn.example.com/cap.json" '
+                'well-known="agent-card.json"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured.append(url)
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # cap URL fetched, not the reconstructed well-known URL.
+        assert captured == ["https://cdn.example.com/cap.json"]
+        assert result.capability_source == "cap_uri"
+
+    @pytest.mark.asyncio
+    async def test_non_https_cap_falls_back_to_well_known(self):
+        """When `cap` is a URN or JSON-Ref (non-https), treating it as
+        terminal would silently disable a perfectly good `well-known`
+        and downgrade discovery to unauthenticated TXT. Per Igor's #154
+        review: fall through to well-known on non-https cap, keep the
+        URN cap on the record as a metadata locator."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'cap="urn:dns-aid:cap:chat:v1" '
+                'well-known="agent-card.json"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured.append(url)
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # The well-known URL was used, not the URN cap.
+        assert captured == ["https://chat.example.com/.well-known/agent-card.json"]
+        assert result.capability_source == "well_known"
+        # The cap URN stays on the record as a metadata locator.
+        assert result.cap_uri == "urn:dns-aid:cap:chat:v1"
+
+    @pytest.mark.asyncio
+    async def test_cap_sha256_verified_true_only_when_fetch_succeeds(self):
+        """The `cap_sha256_verified` flag is True only when the digest
+        was actually checked against fetched bytes — distinguishes
+        'integrity pin honoured' from 'pin declared but never applied'."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'well-known="agent-card.json" cap-sha256="DIGEST_HERE"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        async def fake_fetch(url, expected_sha256=None):
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        assert result.cap_sha256 == "DIGEST_HERE"
+        assert result.cap_sha256_verified is True
+
+    @pytest.mark.asyncio
+    async def test_cap_sha256_verified_false_when_dangling(self):
+        """When `cap_sha256` is declared but no descriptor URL is
+        constructible (no cap, no well-known), cap_sha256_verified
+        stays False so consumers don't treat the declared pin as
+        integrity-applied."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=('1 chat.example.com. alpn="mcp" port=443 cap-sha256="ORPHANED"')
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                AsyncMock(return_value=None),
+            ):
+                with patch(
+                    "dns_aid.core.discoverer._query_capabilities",
+                    AsyncMock(return_value=[]),
+                ):
+                    result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # Pin value present for transparency, but the verified flag is
+        # False so consumers don't treat it as applied.
+        assert result.cap_sha256 == "ORPHANED"
+        assert result.cap_sha256_verified is False

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -516,10 +516,11 @@ class TestDiscoverViaHttpIndex:
 
     @pytest.mark.asyncio
     async def test_skips_unparseable_fqdn(self):
+        """Single-label fqdn entries are still rejected by _parse_fqdn under draft-02."""
         http_agents = [
             HttpIndexAgent(
                 name="bad",
-                fqdn="no-underscores.example.com",
+                fqdn="bogus",
             ),
         ]
 
@@ -1081,15 +1082,17 @@ class TestProcessHttpAgent:
 
     @pytest.mark.asyncio
     async def test_skips_unparseable_fqdn(self):
+        """Single-label fqdn entries are still rejected by _parse_fqdn under draft-02."""
         http_agent = HttpIndexAgent(
             name="bad",
-            fqdn="no-underscores.example.com",
+            fqdn="bogus",
         )
         result = await _process_http_agent(http_agent, "example.com", None, None)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_skips_unknown_protocol(self):
+        """Legacy form with a protocol not in the Protocol enum is rejected."""
         http_agent = HttpIndexAgent(
             name="weird",
             fqdn="_weird._unknown._agents.example.com",

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -437,7 +437,14 @@ class TestSyncIndex:
 
     @pytest.mark.asyncio
     async def test_sync_discovers_agents(self, mock_backend: MockBackend):
-        """Test that sync discovers published agents."""
+        """Test that sync discovers published agents.
+
+        sync_index discovers agents via the walkable AliasMode record at
+        {name}._agents.{domain} — which is opt-in under -02. Opt walkable
+        in here to exercise the discovery path. The follow-up Igor
+        cleanup item (iterate flat owners off the SVCB enumeration
+        directly) will let sync work without the walkable record at all.
+        """
         # Publish some agents
         await publish(
             name="chat",
@@ -445,6 +452,7 @@ class TestSyncIndex:
             protocol="mcp",
             endpoint="mcp.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
         await publish(
             name="billing",
@@ -452,6 +460,7 @@ class TestSyncIndex:
             protocol="a2a",
             endpoint="a2a.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         result = await sync_index("example.com", mock_backend)
@@ -464,13 +473,15 @@ class TestSyncIndex:
     @pytest.mark.asyncio
     async def test_sync_creates_index(self, mock_backend: MockBackend):
         """Test that sync creates index if it doesn't exist."""
-        # Publish an agent (without updating index)
+        # Publish an agent (without updating index). Walkable opt-in so
+        # sync_index can discover it via the AliasMode shape.
         await publish(
             name="chat",
             domain="example.com",
             protocol="mcp",
             endpoint="mcp.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         result = await sync_index("example.com", mock_backend)
@@ -490,13 +501,14 @@ class TestSyncIndex:
             ttl=3600,
         )
 
-        # Publish new agent
+        # Publish new agent (walkable opt-in for sync_index discovery).
         await publish(
             name="chat",
             domain="example.com",
             protocol="mcp",
             endpoint="mcp.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         result = await sync_index("example.com", mock_backend)

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -340,6 +340,60 @@ class TestUpdateIndex:
         assert txt is not None
 
 
+class TestUpdateIndexSvcbPrimary:
+    """Tests for draft-02 SVCB-primary org index (opt-in via index_target)."""
+
+    @pytest.mark.asyncio
+    async def test_index_target_writes_svcb_and_txt(self, mock_backend: MockBackend):
+        """When index_target is provided, both SVCB and TXT records are written."""
+        result = await update_index(
+            domain="example.com",
+            backend=mock_backend,
+            add=[IndexEntry(name="chat", protocol="mcp")],
+            index_target="agent-index.example.com",
+        )
+
+        assert result.success is True
+
+        # SVCB primary at _index._agents pointing at the (non-underscored) target
+        svcb = mock_backend.get_svcb_record("example.com", INDEX_RECORD_NAME)
+        assert svcb is not None
+        assert svcb["priority"] == 1  # ServiceMode
+        assert svcb["target"] == "agent-index.example.com."
+
+        # TXT inline-listing still written as the §TXT-fallback form
+        txt = mock_backend.get_txt_record("example.com", INDEX_RECORD_NAME)
+        assert txt is not None
+        assert any("chat:mcp" in v for v in txt)
+
+    @pytest.mark.asyncio
+    async def test_index_target_underscored_rejected(self, mock_backend: MockBackend):
+        """Underscored TargetName fails the validator (no public x.509 cert)."""
+        from dns_aid.utils.validation import ValidationError
+
+        with pytest.raises(ValidationError) as exc:
+            await update_index(
+                domain="example.com",
+                backend=mock_backend,
+                add=[IndexEntry(name="chat", protocol="mcp")],
+                index_target="_internal.example.com",
+            )
+        assert exc.value.field == "target"
+
+    @pytest.mark.asyncio
+    async def test_no_index_target_keeps_txt_only(self, mock_backend: MockBackend):
+        """Without index_target the behavior matches pre-draft-02 (TXT only)."""
+        result = await update_index(
+            domain="example.com",
+            backend=mock_backend,
+            add=[IndexEntry(name="chat", protocol="mcp")],
+        )
+
+        assert result.success is True
+        assert mock_backend.get_svcb_record("example.com", INDEX_RECORD_NAME) is None
+        assert mock_backend.get_txt_record("example.com", INDEX_RECORD_NAME) is not None
+
+
 class TestDeleteIndex:
     """Tests for delete_index function."""
 

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -157,7 +157,7 @@ class TestInfobloxNIOSSvcParameters:
             "mandatory": "alpn,port,cap,connect-class",
             "alpn": "h2,h3",
             "port": "443",
-            "bap": "mcp/1,a2a/1",
+            "bap": "mcp=1.0",
             "cap": "https://example.com/.well-known/agent-cap.json",
             "sig": "abc123",
             "connect-class": "lattice",
@@ -168,7 +168,10 @@ class TestInfobloxNIOSSvcParameters:
         as_map = {item["svc_key"]: item for item in converted}
         assert as_map["alpn"]["svc_value"] == ["h2", "h3"]
         assert as_map["alpn"]["mandatory"] is True
-        assert as_map["key65402"]["svc_value"] == ["mcp/1", "a2a/1"]
+        # bap is no longer in _SPLIT_VALUE_KEYS (draft-02 §5.1 makes it
+        # a single scalar) — NIOS wraps non-split values in a 1-element
+        # list for the API shape regardless.
+        assert as_map["key65402"]["svc_value"] == ["mcp=1.0"]
         assert as_map["port"]["svc_value"] == ["443"]
         assert as_map["key65400"]["mandatory"] is True
         assert as_map["key65405"]["svc_value"] == ["abc123"]
@@ -177,12 +180,12 @@ class TestInfobloxNIOSSvcParameters:
 
     def test_svc_parameters_preserves_numeric_keys(self) -> None:
         converted = InfobloxNIOSBackend._svc_parameters_from_params(
-            {"mandatory": "key65402,port", "key65402": "mcp/1,a2a/1", "port": "443"}
+            {"mandatory": "key65402,port", "key65402": "mcp=1.0", "port": "443"}
         )
         as_map = {item["svc_key"]: item for item in converted}
 
         assert as_map["key65402"]["mandatory"] is True
-        assert as_map["key65402"]["svc_value"] == ["mcp/1", "a2a/1"]
+        assert as_map["key65402"]["svc_value"] == ["mcp=1.0"]
         assert as_map["port"]["mandatory"] is True
 
     def test_format_svc_parameters_for_value(self) -> None:

--- a/tests/unit/test_jws.py
+++ b/tests/unit/test_jws.py
@@ -499,3 +499,185 @@ class TestModelIntegration:
 
         params = agent.to_svcb_params()
         assert "sig" not in params
+
+
+class TestSignatureBindsToRecord:
+    """Regression tests: a valid signature MUST bind to the record it travels with.
+
+    Before this binding was enforced, an attacker could lift a legitimately
+    signed `sig` value from one agent's SVCB record and paste it onto a
+    spoofed SVCB pointing at their own host. The signature would still
+    verify (it's cryptographically valid) and the discoverer would stamp
+    ``signature_verified=True`` — turning the JWS into a forgeable
+    rubber-stamp instead of a record-binding proof.
+
+    Publisher-side: ``core/publisher.py`` signs a ``RecordPayload`` whose
+    fields are ``(fqdn, target, port, alpn)``. Verifier-side: the
+    discoverer must re-derive the same tuple from the AgentRecord it's
+    about to trust and refuse if any field disagrees.
+    """
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_with_mismatched_target_is_rejected(self):
+        """Sig is cryptographically valid but signed payload.target != agent.target_host."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        # Sign a payload that says target=legit.example.com.
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="legit.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        legit_sig = sign_record(payload, private_key)
+
+        # Attacker pastes the legit sig onto a spoofed record pointing
+        # at attacker.example.com.
+        spoofed = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="attacker.example.com",
+            port=443,
+            sig=legit_sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([spoofed], "example.com", dnssec_validated=False)
+
+        assert spoofed.signature_verified is False
+        assert spoofed.signature_algorithm is None
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_with_mismatched_port_is_rejected(self):
+        """Sig is valid; port disagrees; binding must reject."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        sig = sign_record(payload, private_key)
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=8443,  # disagrees with signed payload.port
+            sig=sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([agent], "example.com", dnssec_validated=False)
+
+        assert agent.signature_verified is False
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_with_mismatched_alpn_is_rejected(self):
+        """Sig is valid for protocol=mcp; record claims a2a; binding must reject."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        sig = sign_record(payload, private_key)
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.A2A,  # disagrees with signed payload.alpn
+            target_host="chat.example.com",
+            port=443,
+            sig=sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([agent], "example.com", dnssec_validated=False)
+
+        assert agent.signature_verified is False
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_matching_record_is_accepted(self):
+        """Happy path: every field of the signed payload binds to the record."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        sig = sign_record(payload, private_key)
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            sig=sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([agent], "example.com", dnssec_validated=False)
+
+        assert agent.signature_verified is True
+        assert agent.signature_algorithm is not None

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -309,3 +309,37 @@ class TestSDKAvailabilityFlag:
 
         tools = list(mcp._tool_manager._tools.keys())
         assert "list_agent_tools" in tools
+
+
+class TestPublishBapScalar:
+    """Regression for Igor's #158 review: the MCP tool input schema
+    changed from list[str] to str when bap moved to scalar. Pin both
+    the accept-scalar path and the reject-list path so the API break
+    is explicit."""
+
+    def test_publish_with_bap_scalar(self):
+        """Scalar passthrough — bap survives onto the AgentRecord."""
+        from dns_aid.mcp.server import publish_agent_to_dns
+
+        result = publish_agent_to_dns(
+            name="chat",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="chat.example.com",
+            bap="mcp=1.0",
+            backend="mock",
+        )
+        assert result["success"] is True
+
+    def test_publish_with_bap_absent(self):
+        """bap=None (default) publishes cleanly without a bap param."""
+        from dns_aid.mcp.server import publish_agent_to_dns
+
+        result = publish_agent_to_dns(
+            name="chat",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="chat.example.com",
+            backend="mock",
+        )
+        assert result["success"] is True

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -54,9 +54,10 @@ class TestPublishAgentTool:
         )
 
         assert result["success"] is True
-        assert result["fqdn"] == "_test-agent._mcp._agents.example.com"
+        assert result["fqdn"] == "test-agent.example.com"
         assert result["endpoint_url"] == "https://mcp.example.com:443"
-        assert len(result["records_created"]) == 2
+        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default-on)
+        assert len(result["records_created"]) == 3
 
     def test_publish_default_endpoint(self):
         """Test publishing with default endpoint."""

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -56,8 +56,9 @@ class TestPublishAgentTool:
         assert result["success"] is True
         assert result["fqdn"] == "test-agent.example.com"
         assert result["endpoint_url"] == "https://mcp.example.com:443"
-        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default-on)
-        assert len(result["records_created"]) == 3
+        # SVCB primary + TXT companion. Walkable AliasMode is opt-in
+        # (default off under -02 to avoid an enumeration handle).
+        assert len(result["records_created"]) == 2
 
     def test_publish_default_endpoint(self):
         """Test publishing with default endpoint."""

--- a/tests/unit/test_mock_backend.py
+++ b/tests/unit/test_mock_backend.py
@@ -201,15 +201,15 @@ class TestMockBackend:
 
     @pytest.mark.asyncio
     async def test_publish_agent_helper(self, mock_backend: MockBackend, sample_agent):
-        """Test publish_agent convenience method."""
+        """Test publish_agent convenience method (draft-02 default writes walkable too)."""
         records = await mock_backend.publish_agent(sample_agent)
 
-        assert len(records) == 2
+        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default-on)
+        assert len(records) == 3
         assert any("SVCB" in r for r in records)
         assert any("TXT" in r for r in records)
+        assert any("AliasMode" in r for r in records)
 
-        # Verify records created
-        svcb = mock_backend.get_svcb_record(
-            sample_agent.domain, f"_{sample_agent.name}._{sample_agent.protocol.value}._agents"
-        )
+        # Verify records created — flat primary owner under draft-02
+        svcb = mock_backend.get_svcb_record(sample_agent.domain, sample_agent.name)
         assert svcb is not None

--- a/tests/unit/test_mock_backend.py
+++ b/tests/unit/test_mock_backend.py
@@ -201,10 +201,15 @@ class TestMockBackend:
 
     @pytest.mark.asyncio
     async def test_publish_agent_helper(self, mock_backend: MockBackend, sample_agent):
-        """Test publish_agent convenience method (draft-02 default writes walkable too)."""
+        """Test publish_agent convenience method.
+
+        Default walkable=False under -02 (avoids enumeration handle).
+        Opt into walkable explicitly to verify the AliasMode write.
+        """
+        sample_agent.publish_walkable_alias = True
         records = await mock_backend.publish_agent(sample_agent)
 
-        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default-on)
+        # SVCB primary + TXT companion + walkable AliasMode (opted in).
         assert len(records) == 3
         assert any("SVCB" in r for r in records)
         assert any("TXT" in r for r in records)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -220,6 +220,39 @@ class TestAgentRecord:
         assert params["key65401"] == "dGVzdGhhc2g"
         assert "key65400" not in params
 
+    def test_svcb_params_with_well_known_path(self):
+        """Test draft-02 `well-known` SvcParamKey is emitted at key65409."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            well_known_path="agent-card.json",
+        )
+
+        params = agent.to_svcb_params()
+
+        assert params["key65409"] == "agent-card.json"
+
+    def test_svcb_params_well_known_independent_of_cap(self):
+        """`well-known` and `cap` are independent keys; both may be present."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            cap_uri="urn:example:agent-cap:abc",
+            cap_sha256="dGVzdGhhc2g",
+            well_known_path="agent-card.json",
+        )
+
+        params = agent.to_svcb_params()
+
+        # All three SvcParamKeys present, none collapsing into another.
+        assert params["key65400"] == "urn:example:agent-cap:abc"
+        assert params["key65401"] == "dGVzdGhhc2g"
+        assert params["key65409"] == "agent-card.json"
+
     def test_svcb_params_with_connect_fields(self):
         """Test provider-managed connection params are serialized as SVCB custom keys."""
         agent = AgentRecord(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -141,7 +141,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -151,7 +151,7 @@ class TestAgentRecord:
         # Default: keyNNNNN format per RFC 9460
         assert params["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["key65401"] == "abc123base64url"
-        assert params["key65402"] == "mcp/1,a2a/1"
+        assert params["key65402"] == "mcp2.1"  # scalar bap per draft-02 §FutureWork
         assert params["key65403"] == "https://example.com/agent-policy"
         assert params["key65404"] == "production"
         # Standard params still present
@@ -170,7 +170,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -180,7 +180,7 @@ class TestAgentRecord:
 
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["cap-sha256"] == "abc123base64url"
-        assert params["bap"] == "mcp/1,a2a/1"
+        assert params["bap"] == "mcp2.1"
         assert params["policy"] == "https://example.com/agent-policy"
         assert params["realm"] == "production"
 
@@ -239,6 +239,32 @@ class TestAgentRecord:
 
         assert params["key65401"] == "dGVzdGhhc2g"
         assert "key65400" not in params
+
+    def test_svcb_params_bap_emits_as_scalar(self):
+        """draft-02 §FutureWork: bap is a single versioned protocol per record."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            bap="mcp2.1",
+        )
+        params = agent.to_svcb_params()
+        # No comma, no list — emitted exactly as the scalar string.
+        assert params["key65402"] == "mcp2.1"
+        assert "," not in params["key65402"]
+
+    def test_svcb_params_bap_absent_when_none(self):
+        """When bap is unset (None) the key65402 param is not emitted."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        params = agent.to_svcb_params()
+        assert "key65402" not in params
+        assert "bap" not in params
 
     def test_svcb_params_with_well_known_path(self):
         """Test draft-02 `well-known` SvcParamKey is emitted at key65409."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -504,3 +504,25 @@ class TestVerifyResult:
 
         assert result.security_score == 20
         assert result.security_rating == "Poor"
+
+    def test_dane_without_dnssec_does_not_score(self):
+        """DANE +15 must be gated on DNSSEC.
+
+        A spoofer with no DNSSEC chain can still serve a TLSA record;
+        TLSA without DNSSEC has no integrity guarantee (RFC 6698 §10.1).
+        If a hand-built VerifyResult carries dane_valid=True but
+        dnssec_valid=False, security_score MUST NOT credit the DANE
+        bonus — otherwise a non-DNSSEC spoofer can reach ``Good``.
+        """
+        result = VerifyResult(
+            fqdn="chat.example.com",
+            record_exists=True,
+            svcb_valid=True,
+            dnssec_valid=False,  # NOT validated
+            dane_valid=True,  # claims TLSA present
+            endpoint_reachable=True,
+        )
+
+        # 20 (record) + 20 (svcb) + 0 (dnssec) + 0 (dane gated) + 15 (endpoint)
+        assert result.security_score == 55
+        assert result.security_rating == "Fair"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -141,7 +141,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -151,7 +151,7 @@ class TestAgentRecord:
         # Default: keyNNNNN format per RFC 9460
         assert params["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["key65401"] == "abc123base64url"
-        assert params["key65402"] == "mcp/1,a2a/1"
+        assert params["key65402"] == "mcp2.1"  # scalar bap per draft-02 §FutureWork
         assert params["key65403"] == "https://example.com/agent-policy"
         assert params["key65404"] == "production"
         # Standard params still present
@@ -170,7 +170,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -180,7 +180,7 @@ class TestAgentRecord:
 
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["cap-sha256"] == "abc123base64url"
-        assert params["bap"] == "mcp/1,a2a/1"
+        assert params["bap"] == "mcp2.1"
         assert params["policy"] == "https://example.com/agent-policy"
         assert params["realm"] == "production"
 
@@ -239,6 +239,32 @@ class TestAgentRecord:
 
         assert params["key65401"] == "dGVzdGhhc2g"
         assert "key65400" not in params
+
+    def test_svcb_params_bap_emits_as_scalar(self):
+        """draft-02 §FutureWork: bap is a single versioned protocol per record."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            bap="mcp2.1",
+        )
+        params = agent.to_svcb_params()
+        # No comma, no list — emitted exactly as the scalar string.
+        assert params["key65402"] == "mcp2.1"
+        assert "," not in params["key65402"]
+
+    def test_svcb_params_bap_absent_when_none(self):
+        """When bap is unset (None) the key65402 param is not emitted."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        params = agent.to_svcb_params()
+        assert "key65402" not in params
+        assert "bap" not in params
 
     def test_svcb_params_with_well_known_path(self):
         """Test draft-02 ``well-known`` SvcParamKey is emitted at the

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -221,7 +221,12 @@ class TestAgentRecord:
         assert "key65400" not in params
 
     def test_svcb_params_with_well_known_path(self):
-        """Test draft-02 `well-known` SvcParamKey is emitted at key65409."""
+        """Test draft-02 ``well-known`` SvcParamKey is emitted at the
+        project's interim private-use code point ``key65409``.
+
+        Per draft section 7.1 the actual SvcParamKey numbers are
+        deferred to IANA (Standards Action); 65409 is dns-aid-core's
+        private-use placeholder, not draft-assigned."""
         agent = AgentRecord(
             name="booking",
             domain="example.com",

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -141,7 +141,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap="mcp2.1",
+            bap="mcp=2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -151,7 +151,7 @@ class TestAgentRecord:
         # Default: keyNNNNN format per RFC 9460
         assert params["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["key65401"] == "abc123base64url"
-        assert params["key65402"] == "mcp2.1"  # scalar bap per draft-02 §FutureWork
+        assert params["key65402"] == "mcp=2.1"  # scalar bap per draft-02 §FutureWork
         assert params["key65403"] == "https://example.com/agent-policy"
         assert params["key65404"] == "production"
         # Standard params still present
@@ -170,7 +170,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap="mcp2.1",
+            bap="mcp=2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -180,7 +180,7 @@ class TestAgentRecord:
 
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["cap-sha256"] == "abc123base64url"
-        assert params["bap"] == "mcp2.1"
+        assert params["bap"] == "mcp=2.1"
         assert params["policy"] == "https://example.com/agent-policy"
         assert params["realm"] == "production"
 
@@ -247,11 +247,11 @@ class TestAgentRecord:
             domain="example.com",
             protocol=Protocol.MCP,
             target_host="mcp.example.com",
-            bap="mcp2.1",
+            bap="mcp=2.1",
         )
         params = agent.to_svcb_params()
         # No comma, no list — emitted exactly as the scalar string.
-        assert params["key65402"] == "mcp2.1"
+        assert params["key65402"] == "mcp=2.1"
         assert "," not in params["key65402"]
 
     def test_svcb_params_bap_absent_when_none(self):
@@ -552,3 +552,209 @@ class TestVerifyResult:
         # 20 (record) + 20 (svcb) + 0 (dnssec) + 0 (dane gated) + 15 (endpoint)
         assert result.security_score == 55
         assert result.security_rating == "Fair"
+
+
+class TestBapValidator:
+    """Regression tests for Igor's #158 review.
+
+    The ``bap`` SvcParamKey value goes straight onto the wire as
+    ``key65402="<value>"`` via the publisher and every backend formatter.
+    Without a field-validator a crafted value can inject sibling
+    SvcParamKeys (e.g. ``mcp" key65500="x``) — a multi-tenant publish
+    path turns into server-side param injection. The validator now
+    constrains bap to the canonical draft-02 form at the type boundary
+    so every construction path (direct, ``to_svcb_record()``, MCP,
+    CLI) inherits the rule.
+    """
+
+    def test_bare_protocol_accepted(self):
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            bap="mcp",
+        )
+        assert agent.bap == "mcp"
+
+    def test_versioned_form_accepted(self):
+        for value in ("mcp=1.0", "a2a=1.1", "https=2"):
+            agent = AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap=value,
+            )
+            assert agent.bap == value
+
+    def test_svcparam_injection_rejected(self):
+        """The original vulnerability: a crafted value with a quote
+        escape can be parsed by dnspython as two SvcParamKeys, the
+        second one attacker-controlled."""
+        for evil in (
+            'mcp" key65500="x',
+            'mcp\\"',
+            'mcp" key65500="x',
+        ):
+            with pytest.raises(ValidationError):
+                AgentRecord(
+                    name="chat",
+                    domain="example.com",
+                    protocol=Protocol.MCP,
+                    target_host="chat.example.com",
+                    bap=evil,
+                )
+
+    def test_legacy_comma_list_rejected(self):
+        """Pre-draft-02 comma-list (``mcp,a2a``) is rejected at the
+        type — callers passing legacy input should run
+        ``normalize_bap`` first."""
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="mcp,a2a",
+            )
+
+    def test_list_form_rejected_on_agent_record(self):
+        """Pin the breaking change direction: ``bap=["mcp"]`` raises."""
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap=["mcp"],  # type: ignore[arg-type]
+            )
+
+    def test_list_form_rejected_on_svcb_record(self):
+        from dns_aid.core.models import SvcbRecord
+
+        with pytest.raises(ValidationError):
+            SvcbRecord(
+                target="chat.example.com.",
+                alpn="mcp",
+                port=443,
+                bap=["mcp"],  # type: ignore[arg-type]
+            )
+
+    def test_uppercase_protocol_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="MCP",
+            )
+
+    def test_whitespace_in_value_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="mcp 1.0",
+            )
+
+    def test_empty_string_passed_as_bap_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="",
+            )
+
+
+class TestNormalizeBap:
+    """Tests for the shared ``normalize_bap`` collapse helper.
+
+    The discoverer, SDK adapter, and indexer all route through this
+    one function so they agree on edge inputs (empty string vs None
+    vs whitespace-only vs leading-comma legacy etc.).
+    """
+
+    def test_none_passthrough(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap(None) is None
+
+    def test_empty_string_to_none(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap("") is None
+        assert normalize_bap("   ") is None
+        assert normalize_bap("\t\n") is None
+
+    def test_scalar_passthrough(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap("mcp") == "mcp"
+        assert normalize_bap("mcp=1.0") == "mcp=1.0"
+        assert normalize_bap("  mcp=1.0  ") == "mcp=1.0"
+
+    def test_comma_list_collapsed_to_first_non_empty(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap("mcp,a2a") == "mcp"
+        assert normalize_bap("mcp=1.0,a2a=1.1") == "mcp=1.0"
+        # Leading comma — Igor's #158 item 5 regression.
+        assert normalize_bap(",mcp=1.0") == "mcp=1.0"
+        # Trailing comma.
+        assert normalize_bap("mcp=1.0,") == "mcp=1.0"
+        # Comma-only / all empties.
+        assert normalize_bap(",,,") is None
+        assert normalize_bap(", ,") is None
+
+    def test_list_form_collapsed_to_first(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap(["mcp"]) == "mcp"
+        assert normalize_bap(["mcp", "a2a"]) == "mcp"
+        # Empty list, list of empties.
+        assert normalize_bap([]) is None
+        assert normalize_bap(["", " ", None]) is None  # type: ignore[list-item]
+        # Defensive: non-string elements survive via str().
+        assert normalize_bap([" mcp "]) == "mcp"
+
+    def test_non_string_non_list_input(self):
+        from dns_aid.core.bap import normalize_bap
+
+        # Forgiving public API: anything not a str/list/None returns None.
+        assert normalize_bap(42) is None  # type: ignore[arg-type]
+        assert normalize_bap({"mcp": True}) is None  # type: ignore[arg-type]
+
+
+class TestSplitBapToken:
+    """Tests for protocol/version token extraction."""
+
+    def test_bare_form(self):
+        from dns_aid.core.bap import split_bap_token
+
+        assert split_bap_token("mcp") == ("mcp", None)
+        assert split_bap_token("a2a") == ("a2a", None)
+
+    def test_versioned_form(self):
+        from dns_aid.core.bap import split_bap_token
+
+        assert split_bap_token("mcp=1.0") == ("mcp", "1.0")
+        assert split_bap_token("a2a=1.1") == ("a2a", "1.1")
+
+    def test_none_and_empty(self):
+        from dns_aid.core.bap import split_bap_token
+
+        assert split_bap_token(None) == (None, None)
+        assert split_bap_token("") == (None, None)
+        assert split_bap_token("   ") == (None, None)
+
+    def test_dangling_equals_returns_only_proto(self):
+        from dns_aid.core.bap import split_bap_token
+
+        # ``mcp=`` is unusual but defensive — keep the proto, no version.
+        assert split_bap_token("mcp=") == ("mcp", None)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -59,7 +59,7 @@ class TestAgentRecord:
             assert agent.endpoint_source == source
 
     def test_fqdn_generation(self):
-        """Test FQDN is generated correctly per DNS-AID spec."""
+        """Test FQDN is generated as the flat draft-02 form."""
         agent = AgentRecord(
             name="network-specialist",
             domain="example.com",
@@ -67,8 +67,28 @@ class TestAgentRecord:
             target_host="mcp.example.com",
         )
 
-        # Format: _{name}._{protocol}._agents.{domain}
-        assert agent.fqdn == "_network-specialist._mcp._agents.example.com"
+        # Flat draft-02 form: {name}.{domain}
+        assert agent.fqdn == "network-specialist.example.com"
+
+    def test_walkable_fqdn_generation(self):
+        """The walkable AliasMode form uses the _agents leaf."""
+        agent = AgentRecord(
+            name="network-specialist",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        assert agent.walkable_fqdn == "network-specialist._agents.example.com"
+
+    def test_legacy_fqdn_generation(self):
+        """The legacy -01 form is retained for the legacy-fallback discovery path."""
+        agent = AgentRecord(
+            name="network-specialist",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        assert agent.legacy_fqdn == "_network-specialist._mcp._agents.example.com"
 
     def test_endpoint_url(self):
         """Test endpoint URL generation."""

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -130,7 +130,7 @@ class TestPublish:
             capabilities=["travel", "booking"],
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="dGVzdGhhc2g",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
             backend=mock_backend,
@@ -139,7 +139,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri == "https://mcp.example.com/.well-known/agent-cap.json"
         assert result.agent.cap_sha256 == "dGVzdGhhc2g"
-        assert result.agent.bap == ["mcp/1", "a2a/1"]
+        assert result.agent.bap == "mcp2.1"
         assert result.agent.policy_uri == "https://example.com/agent-policy"
         assert result.agent.realm == "production"
 
@@ -149,7 +149,7 @@ class TestPublish:
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
-        assert svcb["params"]["key65402"] == "mcp/1,a2a/1"
+        assert svcb["params"]["key65402"] == "mcp2.1"
         assert svcb["params"]["key65403"] == "https://example.com/agent-policy"
         assert svcb["params"]["key65404"] == "production"
 
@@ -167,7 +167,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri is None
         assert result.agent.cap_sha256 is None
-        assert result.agent.bap == []
+        assert result.agent.bap is None
         assert result.agent.policy_uri is None
         assert result.agent.realm is None
 

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -28,8 +28,9 @@ class TestPublish:
         assert result.success is True
         assert result.agent.name == "chat"
         assert result.agent.fqdn == "chat.example.com"
-        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default)
-        assert len(result.records_created) == 3
+        # SVCB primary + TXT companion. Walkable AliasMode is opt-in
+        # (default off under -02 to avoid an enumeration handle).
+        assert len(result.records_created) == 2
 
     @pytest.mark.asyncio
     async def test_publish_with_capabilities(self, mock_backend: MockBackend):
@@ -597,14 +598,31 @@ class TestPublishWalkableAlias:
     """Tests for the draft-02 walkable AliasMode write."""
 
     @pytest.mark.asyncio
-    async def test_walkable_alias_written_by_default(self, mock_backend: MockBackend):
-        """publish() emits the walkable record at {name}._agents by default."""
+    async def test_walkable_alias_off_by_default(self, mock_backend: MockBackend):
+        """The walkable record is opt-in under -02 to avoid an
+        enumeration handle (crawlers walking _agents.<zone>).
+        Operators who want DNS-SD-style enumeration explicitly enable it."""
         await publish(
             name="chat",
             domain="example.com",
             protocol="a2a",
             endpoint="chat.example.com",
             backend=mock_backend,
+        )
+
+        walkable = mock_backend.get_svcb_record("example.com", "chat._agents")
+        assert walkable is None, "default must be off to avoid enumeration handle"
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_written_when_opted_in(self, mock_backend: MockBackend):
+        """publish_walkable_alias=True emits the walkable record."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         walkable = mock_backend.get_svcb_record("example.com", "chat._agents")
@@ -640,6 +658,7 @@ class TestPublishWalkableAlias:
             protocol="a2a",
             endpoint="chat.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
         assert mock_backend.get_svcb_record("example.com", "chat") is not None
         assert mock_backend.get_svcb_record("example.com", "chat._agents") is not None

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -131,7 +131,7 @@ class TestPublish:
             capabilities=["travel", "booking"],
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="dGVzdGhhc2g",
-            bap="mcp2.1",
+            bap="mcp=2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
             backend=mock_backend,
@@ -140,7 +140,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri == "https://mcp.example.com/.well-known/agent-cap.json"
         assert result.agent.cap_sha256 == "dGVzdGhhc2g"
-        assert result.agent.bap == "mcp2.1"
+        assert result.agent.bap == "mcp=2.1"
         assert result.agent.policy_uri == "https://example.com/agent-policy"
         assert result.agent.realm == "production"
 
@@ -150,7 +150,7 @@ class TestPublish:
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
-        assert svcb["params"]["key65402"] == "mcp2.1"
+        assert svcb["params"]["key65402"] == "mcp=2.1"
         assert svcb["params"]["key65403"] == "https://example.com/agent-policy"
         assert svcb["params"]["key65404"] == "production"
 

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -293,11 +293,18 @@ class TestPublishTargetUnderscoreValidation:
         assert exc.value.field == "target"
 
     @pytest.mark.asyncio
-    async def test_underscored_endpoint_allowed_with_flag(self, mock_backend: MockBackend, caplog):
-        """allow_underscore_target=True downgrades to a warning and proceeds."""
-        import logging
+    async def test_underscored_endpoint_allowed_with_flag_and_env(
+        self, mock_backend: MockBackend, monkeypatch
+    ):
+        """allow_underscore_target=True now requires the operator to
+        ALSO opt in via the env var. Both together let the publish
+        proceed with a structured WARN; one without the other raises."""
+        from unittest.mock import patch
 
-        with caplog.at_level(logging.WARNING):
+        from dns_aid.utils import validation as validation_module
+
+        monkeypatch.setenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", "1")
+        with patch.object(validation_module, "logger") as mock_logger:
             result = await publish(
                 name="chat",
                 domain="example.com",
@@ -307,7 +314,30 @@ class TestPublishTargetUnderscoreValidation:
                 allow_underscore_target=True,
             )
         assert result.success is True
-        assert any("_chat" in record.message for record in caplog.records)
+        # The warn fires from each enforcement site (publisher entrypoint
+        # + AgentRecord field_validator + SvcbRecord field_validator) —
+        # all carrying the same warning_class, all keyed on the same
+        # target. That's noisy but coherent: every gate sees the bypass.
+        warn_calls = mock_logger.warning.call_args_list
+        assert len(warn_calls) >= 1
+        assert all(c.kwargs.get("warning_class") == "dns_aid.underscore_bypass" for c in warn_calls)
+        assert all("_chat" in c.kwargs.get("target", "") for c in warn_calls)
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_flag_without_env_raises(
+        self, mock_backend: MockBackend, monkeypatch
+    ):
+        """Without the env gate, the per-call flag alone is insufficient."""
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+        with pytest.raises(ValidationError):
+            await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="_chat.internal.example",
+                backend=mock_backend,
+                allow_underscore_target=True,
+            )
 
     @pytest.mark.asyncio
     async def test_clean_endpoint_passes(self, mock_backend: MockBackend):

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -322,6 +322,48 @@ class TestPublishTargetUnderscoreValidation:
         assert len(warn_calls) >= 1
         assert all(c.kwargs.get("warning_class") == "dns_aid.underscore_bypass" for c in warn_calls)
         assert all("_chat" in c.kwargs.get("target", "") for c in warn_calls)
+        # PR #154 v2 review (Igor): the bypass must also surface on
+        # PublishResult.warnings as a stable warning_class identifier
+        # — log lines alone aren't a usable signal for log aggregators
+        # or downstream observability.
+        assert "dns_aid.underscore_bypass" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_strict_default_is_bc_break(
+        self, mock_backend: MockBackend, monkeypatch
+    ):
+        """BC-pin — PR #154 strict-by-default tightening.
+
+        Even without explicitly passing ``allow_underscore_target``, a
+        plain `publish()` with an underscored endpoint MUST raise. This
+        is the BREAKING behaviour called out in CHANGELOG [Unreleased]
+        — a deliberate, versioned change per draft-02 §3.2. If a future
+        commit accidentally relaxes the default, this test holds the
+        line.
+        """
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+        with pytest.raises(ValidationError):
+            await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="my_service.internal.example",
+                backend=mock_backend,
+            )
+
+    @pytest.mark.asyncio
+    async def test_clean_endpoint_no_warnings_emitted(self, mock_backend: MockBackend):
+        """A normal endpoint must not populate warnings — the field is
+        for advisories, not always-on noise."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+        assert result.success is True
+        assert result.warnings == []
 
     @pytest.mark.asyncio
     async def test_underscored_endpoint_flag_without_env_raises(

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -131,7 +131,7 @@ class TestPublish:
             capabilities=["travel", "booking"],
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="dGVzdGhhc2g",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
             backend=mock_backend,
@@ -140,7 +140,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri == "https://mcp.example.com/.well-known/agent-cap.json"
         assert result.agent.cap_sha256 == "dGVzdGhhc2g"
-        assert result.agent.bap == ["mcp/1", "a2a/1"]
+        assert result.agent.bap == "mcp2.1"
         assert result.agent.policy_uri == "https://example.com/agent-policy"
         assert result.agent.realm == "production"
 
@@ -150,7 +150,7 @@ class TestPublish:
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
-        assert svcb["params"]["key65402"] == "mcp/1,a2a/1"
+        assert svcb["params"]["key65402"] == "mcp2.1"
         assert svcb["params"]["key65403"] == "https://example.com/agent-policy"
         assert svcb["params"]["key65404"] == "production"
 
@@ -168,7 +168,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri is None
         assert result.agent.cap_sha256 is None
-        assert result.agent.bap == []
+        assert result.agent.bap is None
         assert result.agent.policy_uri is None
         assert result.agent.realm is None
 

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -27,8 +27,9 @@ class TestPublish:
 
         assert result.success is True
         assert result.agent.name == "chat"
-        assert result.agent.fqdn == "_chat._a2a._agents.example.com"
-        assert len(result.records_created) == 2  # SVCB + TXT
+        assert result.agent.fqdn == "chat.example.com"
+        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default)
+        assert len(result.records_created) == 3
 
     @pytest.mark.asyncio
     async def test_publish_with_capabilities(self, mock_backend: MockBackend):
@@ -46,7 +47,7 @@ class TestPublish:
         assert result.agent.capabilities == ["ipam", "dns", "vpn"]
 
         # Check TXT record was created with capabilities
-        txt_values = mock_backend.get_txt_record("example.com", "_network._mcp._agents")
+        txt_values = mock_backend.get_txt_record("example.com", "network")
         assert txt_values is not None
         assert "capabilities=ipam,dns,vpn" in txt_values
 
@@ -62,7 +63,7 @@ class TestPublish:
             backend=mock_backend,
         )
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
 
         assert svcb is not None
         assert svcb["target"] == "chat.example.com."
@@ -115,7 +116,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.ttl == 300
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
         assert svcb["ttl"] == 300
 
     @pytest.mark.asyncio
@@ -143,7 +144,7 @@ class TestPublish:
         assert result.agent.realm == "production"
 
         # SVCB params should include custom DNS-AID params
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
@@ -170,7 +171,7 @@ class TestPublish:
         assert result.agent.policy_uri is None
         assert result.agent.realm is None
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
         assert svcb is not None
         assert "cap" not in svcb["params"]
         assert "cap-sha256" not in svcb["params"]
@@ -192,7 +193,7 @@ class TestPublish:
         )
 
         assert result.success is True
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65404"] == "demo"
@@ -221,7 +222,7 @@ class TestPublish:
         )
         assert result.agent.enroll_uri == "https://overlay.example.com/.well-known/agent-connect"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_overlay._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "overlay")
         assert svcb is not None
         assert svcb["params"]["key65406"] == "lattice"
         assert (
@@ -248,7 +249,7 @@ class TestPublishWellKnown:
         assert result.success is True
         assert result.agent.well_known_path == "agent-card.json"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65409"] == "agent-card.json"
 
@@ -269,7 +270,7 @@ class TestPublishWellKnown:
         assert result.agent.cap_uri == "urn:example:agent-cap:abc"
         assert result.agent.well_known_path == "agent-card.json"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65400"] == "urn:example:agent-cap:abc"
         assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
@@ -338,7 +339,7 @@ class TestUnpublish:
         )
 
         # Verify records exist
-        assert mock_backend.get_svcb_record("example.com", "_chat._a2a._agents") is not None
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
 
         # Unpublish
         result = await unpublish(
@@ -349,7 +350,7 @@ class TestUnpublish:
         )
 
         assert result is True
-        assert mock_backend.get_svcb_record("example.com", "_chat._a2a._agents") is None
+        assert mock_backend.get_svcb_record("example.com", "chat") is None
 
     @pytest.mark.asyncio
     async def test_unpublish_nonexistent(self, mock_backend: MockBackend):
@@ -518,3 +519,103 @@ class TestPublishEdgeCases:
             )
             assert result.success is False
             assert "boom" in result.message
+
+
+class TestPublishWalkableAlias:
+    """Tests for the draft-02 walkable AliasMode write."""
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_written_by_default(self, mock_backend: MockBackend):
+        """publish() emits the walkable record at {name}._agents by default."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+
+        walkable = mock_backend.get_svcb_record("example.com", "chat._agents")
+        assert walkable is not None
+        assert walkable["priority"] == 0  # AliasMode
+        assert walkable["target"] == "chat.example.com."
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_can_be_suppressed(self, mock_backend: MockBackend):
+        """Setting publish_walkable_alias=False on the AgentRecord skips the walkable write."""
+        from dns_aid.core.models import AgentRecord
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.A2A,
+            target_host="chat.example.com",
+            publish_walkable_alias=False,
+        )
+        records = await mock_backend.publish_agent(agent)
+
+        # Only SVCB primary + TXT (no walkable).
+        assert len(records) == 2
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is None
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
+
+    @pytest.mark.asyncio
+    async def test_unpublish_removes_walkable(self, mock_backend: MockBackend):
+        """unpublish() removes both the flat owner and the walkable alias."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is not None
+
+        result = await unpublish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            backend=mock_backend,
+        )
+        assert result is True
+        assert mock_backend.get_svcb_record("example.com", "chat") is None
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_unpublish_also_clears_legacy_01_shape(self, mock_backend: MockBackend):
+        """Migration path: unpublish() cleans up draft-01 records too.
+
+        Operators who published under -01 and then upgraded to a -02
+        dns-aid-core should be able to call unpublish() once and have
+        the SVCB + TXT records at `_{name}._{protocol}._agents.{domain}`
+        deleted alongside the new flat / walkable forms.
+        """
+        # Simulate a pre-existing draft-01 publication by writing records
+        # directly at the legacy name.
+        await mock_backend.create_svcb_record(
+            zone="example.com",
+            name="_legacy._mcp._agents",
+            priority=1,
+            target="legacy.example.com.",
+            params={"alpn": "mcp", "port": "443"},
+            ttl=3600,
+        )
+        await mock_backend.create_txt_record(
+            zone="example.com",
+            name="_legacy._mcp._agents",
+            values=["capabilities=test"],
+            ttl=3600,
+        )
+        assert mock_backend.get_svcb_record("example.com", "_legacy._mcp._agents") is not None
+
+        # unpublish() finds and deletes the legacy records even though
+        # nothing was published at the flat/walkable names.
+        result = await unpublish(
+            name="legacy",
+            domain="example.com",
+            protocol="mcp",
+            backend=mock_backend,
+        )
+        assert result is True
+        assert mock_backend.get_svcb_record("example.com", "_legacy._mcp._agents") is None

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -8,6 +8,7 @@ import pytest
 from dns_aid.backends.mock import MockBackend
 from dns_aid.core.models import Protocol
 from dns_aid.core.publisher import publish, unpublish
+from dns_aid.utils.validation import ValidationError
 
 
 class TestPublish:
@@ -228,6 +229,97 @@ class TestPublish:
             == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
         )
         assert svcb["params"]["key65408"] == "https://overlay.example.com/.well-known/agent-connect"
+
+
+class TestPublishWellKnown:
+    """Tests for the draft-02 `well-known` SvcParamKey on the publish path."""
+
+    @pytest.mark.asyncio
+    async def test_publish_with_well_known_path(self, mock_backend: MockBackend):
+        """Setting well_known_path emits key65409 on the SVCB record."""
+        result = await publish(
+            name="booking",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="booking.example.com",
+            well_known_path="agent-card.json",
+            backend=mock_backend,
+        )
+        assert result.success is True
+        assert result.agent.well_known_path == "agent-card.json"
+
+        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        assert svcb is not None
+        assert svcb["params"]["key65409"] == "agent-card.json"
+
+    @pytest.mark.asyncio
+    async def test_publish_cap_and_well_known_coexist(self, mock_backend: MockBackend):
+        """`cap` and `well-known` are independent — both may be set on one record."""
+        result = await publish(
+            name="booking",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="booking.example.com",
+            cap_uri="urn:example:agent-cap:abc",
+            cap_sha256="dGVzdGhhc2g",
+            well_known_path="agent-card.json",
+            backend=mock_backend,
+        )
+        assert result.success is True
+        assert result.agent.cap_uri == "urn:example:agent-cap:abc"
+        assert result.agent.well_known_path == "agent-card.json"
+
+        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        assert svcb is not None
+        assert svcb["params"]["key65400"] == "urn:example:agent-cap:abc"
+        assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
+        assert svcb["params"]["key65409"] == "agent-card.json"
+
+
+class TestPublishTargetUnderscoreValidation:
+    """Tests for the draft-02 §Known-Organization no-underscore-in-target rule."""
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_rejected_by_default(self, mock_backend: MockBackend):
+        """Underscored TargetName fails publish unless explicitly allowed."""
+        with pytest.raises(ValidationError) as exc:
+            await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="_chat.example.com",
+                backend=mock_backend,
+            )
+        assert exc.value.field == "target"
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_allowed_with_flag(self, mock_backend: MockBackend, caplog):
+        """allow_underscore_target=True downgrades to a warning and proceeds."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="_chat.internal.example",
+                backend=mock_backend,
+                allow_underscore_target=True,
+            )
+        assert result.success is True
+        assert any("_chat" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_clean_endpoint_passes(self, mock_backend: MockBackend):
+        """A normal hostname publishes without warnings or errors."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+        assert result.success is True
 
 
 class TestUnpublish:

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -27,8 +27,9 @@ class TestPublish:
 
         assert result.success is True
         assert result.agent.name == "chat"
-        assert result.agent.fqdn == "_chat._a2a._agents.example.com"
-        assert len(result.records_created) == 2  # SVCB + TXT
+        assert result.agent.fqdn == "chat.example.com"
+        # SVCB primary + TXT companion + walkable AliasMode (draft-02 default)
+        assert len(result.records_created) == 3
 
     @pytest.mark.asyncio
     async def test_publish_with_capabilities(self, mock_backend: MockBackend):
@@ -46,7 +47,7 @@ class TestPublish:
         assert result.agent.capabilities == ["ipam", "dns", "vpn"]
 
         # Check TXT record was created with capabilities
-        txt_values = mock_backend.get_txt_record("example.com", "_network._mcp._agents")
+        txt_values = mock_backend.get_txt_record("example.com", "network")
         assert txt_values is not None
         assert "capabilities=ipam,dns,vpn" in txt_values
 
@@ -62,7 +63,7 @@ class TestPublish:
             backend=mock_backend,
         )
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
 
         assert svcb is not None
         assert svcb["target"] == "chat.example.com."
@@ -115,7 +116,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.ttl == 300
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
         assert svcb["ttl"] == 300
 
     @pytest.mark.asyncio
@@ -143,7 +144,7 @@ class TestPublish:
         assert result.agent.realm == "production"
 
         # SVCB params should include custom DNS-AID params
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
@@ -170,7 +171,7 @@ class TestPublish:
         assert result.agent.policy_uri is None
         assert result.agent.realm is None
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
         assert svcb is not None
         assert "cap" not in svcb["params"]
         assert "cap-sha256" not in svcb["params"]
@@ -192,7 +193,7 @@ class TestPublish:
         )
 
         assert result.success is True
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65404"] == "demo"
@@ -221,7 +222,7 @@ class TestPublish:
         )
         assert result.agent.enroll_uri == "https://overlay.example.com/.well-known/agent-connect"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_overlay._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "overlay")
         assert svcb is not None
         assert svcb["params"]["key65406"] == "lattice"
         assert (
@@ -248,7 +249,7 @@ class TestPublishWellKnown:
         assert result.success is True
         assert result.agent.well_known_path == "agent-card.json"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65409"] == "agent-card.json"
 
@@ -269,7 +270,7 @@ class TestPublishWellKnown:
         assert result.agent.cap_uri == "urn:example:agent-cap:abc"
         assert result.agent.well_known_path == "agent-card.json"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65400"] == "urn:example:agent-cap:abc"
         assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
@@ -410,7 +411,7 @@ class TestUnpublish:
         )
 
         # Verify records exist
-        assert mock_backend.get_svcb_record("example.com", "_chat._a2a._agents") is not None
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
 
         # Unpublish
         result = await unpublish(
@@ -421,7 +422,7 @@ class TestUnpublish:
         )
 
         assert result is True
-        assert mock_backend.get_svcb_record("example.com", "_chat._a2a._agents") is None
+        assert mock_backend.get_svcb_record("example.com", "chat") is None
 
     @pytest.mark.asyncio
     async def test_unpublish_nonexistent(self, mock_backend: MockBackend):
@@ -590,3 +591,103 @@ class TestPublishEdgeCases:
             )
             assert result.success is False
             assert "boom" in result.message
+
+
+class TestPublishWalkableAlias:
+    """Tests for the draft-02 walkable AliasMode write."""
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_written_by_default(self, mock_backend: MockBackend):
+        """publish() emits the walkable record at {name}._agents by default."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+
+        walkable = mock_backend.get_svcb_record("example.com", "chat._agents")
+        assert walkable is not None
+        assert walkable["priority"] == 0  # AliasMode
+        assert walkable["target"] == "chat.example.com."
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_can_be_suppressed(self, mock_backend: MockBackend):
+        """Setting publish_walkable_alias=False on the AgentRecord skips the walkable write."""
+        from dns_aid.core.models import AgentRecord
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.A2A,
+            target_host="chat.example.com",
+            publish_walkable_alias=False,
+        )
+        records = await mock_backend.publish_agent(agent)
+
+        # Only SVCB primary + TXT (no walkable).
+        assert len(records) == 2
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is None
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
+
+    @pytest.mark.asyncio
+    async def test_unpublish_removes_walkable(self, mock_backend: MockBackend):
+        """unpublish() removes both the flat owner and the walkable alias."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is not None
+
+        result = await unpublish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            backend=mock_backend,
+        )
+        assert result is True
+        assert mock_backend.get_svcb_record("example.com", "chat") is None
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_unpublish_also_clears_legacy_01_shape(self, mock_backend: MockBackend):
+        """Migration path: unpublish() cleans up draft-01 records too.
+
+        Operators who published under -01 and then upgraded to a -02
+        dns-aid-core should be able to call unpublish() once and have
+        the SVCB + TXT records at `_{name}._{protocol}._agents.{domain}`
+        deleted alongside the new flat / walkable forms.
+        """
+        # Simulate a pre-existing draft-01 publication by writing records
+        # directly at the legacy name.
+        await mock_backend.create_svcb_record(
+            zone="example.com",
+            name="_legacy._mcp._agents",
+            priority=1,
+            target="legacy.example.com.",
+            params={"alpn": "mcp", "port": "443"},
+            ttl=3600,
+        )
+        await mock_backend.create_txt_record(
+            zone="example.com",
+            name="_legacy._mcp._agents",
+            values=["capabilities=test"],
+            ttl=3600,
+        )
+        assert mock_backend.get_svcb_record("example.com", "_legacy._mcp._agents") is not None
+
+        # unpublish() finds and deletes the legacy records even though
+        # nothing was published at the flat/walkable names.
+        result = await unpublish(
+            name="legacy",
+            domain="example.com",
+            protocol="mcp",
+            backend=mock_backend,
+        )
+        assert result is True
+        assert mock_backend.get_svcb_record("example.com", "_legacy._mcp._agents") is None

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -608,6 +608,7 @@ class TestRoute53PublishAgentParamDemotion:
             port=443,
             capabilities=["testing"],
             realm="demo",
+            publish_walkable_alias=True,
         )
 
         backend = Route53Backend(zone_id="Z123")
@@ -653,6 +654,7 @@ class TestRoute53PublishAgentParamDemotion:
             target_host="simple.example.com",
             port=443,
             capabilities=["chat"],
+            publish_walkable_alias=True,
         )
 
         backend = Route53Backend(zone_id="Z123")

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -688,7 +688,7 @@ class TestRoute53PublishAgentParamDemotion:
             capabilities=["dns"],
             realm="production",
             policy_uri="urn:policy:strict",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
         )
 
         backend = Route53Backend(zone_id="Z123")

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -617,10 +617,12 @@ class TestRoute53PublishAgentParamDemotion:
         with patch.object(backend, "_get_client", return_value=mock_client):
             records = await backend.publish_agent(agent)
 
-        # Should create both SVCB and TXT
-        assert len(records) == 2
+        # Should create SVCB primary, TXT companion, and the walkable
+        # AliasMode (default-on per draft-02).
+        assert len(records) == 3
         assert records[0].startswith("SVCB")
         assert records[1].startswith("TXT")
+        assert records[2].startswith("SVCB(AliasMode)")
 
         # Inspect the SVCB call — must NOT contain key65404
         svcb_call = mock_client.change_resource_record_sets.call_args_list[0]
@@ -660,7 +662,8 @@ class TestRoute53PublishAgentParamDemotion:
         with patch.object(backend, "_get_client", return_value=mock_client):
             records = await backend.publish_agent(agent)
 
-        assert len(records) == 2
+        # SVCB + TXT + walkable AliasMode (default-on per draft-02)
+        assert len(records) == 3
         # No dnsaid_ entries in TXT
         txt_call = mock_client.change_resource_record_sets.call_args_list[1]
         txt_values = txt_call[1]["ChangeBatch"]["Changes"][0]["ResourceRecordSet"][

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -686,7 +686,7 @@ class TestRoute53PublishAgentParamDemotion:
             capabilities=["dns"],
             realm="production",
             policy_uri="urn:policy:strict",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp2.1",
         )
 
         backend = Route53Backend(zone_id="Z123")

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -688,7 +688,7 @@ class TestRoute53PublishAgentParamDemotion:
             capabilities=["dns"],
             realm="production",
             policy_uri="urn:policy:strict",
-            bap="mcp2.1",
+            bap="mcp=2.1",
         )
 
         backend = Route53Backend(zone_id="Z123")

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -185,9 +185,11 @@ class TestCapSha256Verification:
                 assert doc.capabilities == ["test"]
 
     @pytest.mark.asyncio
-    async def test_hash_mismatch_returns_none(self):
-        """Wrong hash should cause fetch to return None."""
-        from dns_aid.core.cap_fetcher import fetch_cap_document
+    async def test_hash_mismatch_raises_digest_error(self):
+        """Wrong hash MUST raise CapDigestMismatchError so the discoverer
+        can distinguish digest mismatch (refuse the record) from network
+        failures (fall back to a lower-priority capability source)."""
+        from dns_aid.core.cap_fetcher import CapDigestMismatchError, fetch_cap_document
 
         content = b'{"capabilities": ["test"]}'
 
@@ -196,11 +198,13 @@ class TestCapSha256Verification:
 
         with patch("dns_aid.utils.url_safety.validate_fetch_url", return_value="https://ok.com"):
             with patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch):
-                doc = await fetch_cap_document(
-                    "https://ok.com/cap.json",
-                    expected_sha256="WRONG_HASH",
-                )
-                assert doc is None
+                with pytest.raises(CapDigestMismatchError) as excinfo:
+                    await fetch_cap_document(
+                        "https://ok.com/cap.json",
+                        expected_sha256="WRONG_HASH",
+                    )
+                assert excinfo.value.expected == "WRONG_HASH"
+                assert excinfo.value.cap_uri == "https://ok.com/cap.json"
 
     @pytest.mark.asyncio
     async def test_no_hash_skips_verification(self):

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -14,10 +14,12 @@ from dns_aid.utils.validation import (
     validate_domain,
     validate_endpoint,
     validate_fqdn,
+    validate_no_underscore_in_target,
     validate_port,
     validate_protocol,
     validate_ttl,
     validate_version,
+    validate_well_known_path,
 )
 
 
@@ -336,3 +338,134 @@ class TestValidateBackend:
         with pytest.raises(ValidationError) as exc:
             validate_backend("")
         assert exc.value.field == "backend"
+
+
+class TestValidateNoUnderscoreInTarget:
+    """Tests for the SVCB TargetName no-underscore rule (draft-02 §Known Organization)."""
+
+    def test_clean_target_passes(self):
+        assert (
+            validate_no_underscore_in_target("agent-index.example.com") == "agent-index.example.com"
+        )
+
+    def test_trailing_dot_tolerated(self):
+        assert (
+            validate_no_underscore_in_target("agent-index.example.com.")
+            == "agent-index.example.com."
+        )
+
+    def test_label_starting_with_underscore_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("_index.example.com")
+        assert exc.value.field == "target"
+        assert "_index" in str(exc.value)
+
+    def test_label_containing_underscore_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("agent_index.example.com")
+        assert exc.value.field == "target"
+        assert "agent_index" in str(exc.value)
+
+    def test_multiple_underscored_labels_all_reported(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("_a._b.example.com")
+        msg = str(exc.value)
+        assert "_a" in msg
+        assert "_b" in msg
+
+    def test_allow_underscore_downgrades_to_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        assert result == "_index.example.com"
+        assert any("_index" in record.message for record in caplog.records)
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_allow_underscore_on_clean_target_is_silent(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = validate_no_underscore_in_target("clean.example.com", allow_underscore=True)
+        assert result == "clean.example.com"
+        assert not caplog.records
+
+    def test_empty_target_raises_regardless_of_flag(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("", allow_underscore=True)
+        assert exc.value.field == "target"
+
+
+class TestValidateWellKnownPath:
+    """Tests for validate_well_known_path.
+
+    The well-known SvcParamKey value flows from DNS into a URL the
+    discoverer fetches. Untrusted input must not be able to slip path
+    traversal, query strings, fragments, or embedded slashes through to
+    the URL — even though validate_fetch_url pins the host, the path is
+    still attacker-influenceable without this check.
+    """
+
+    def test_accepts_iana_registered_examples(self):
+        # Pull from IANA RFC 8615 examples to show the validator
+        # accepts the actual shape of real well-known names.
+        for name in (
+            "agent-card.json",
+            "oauth-authorization-server",
+            "did-configuration",
+            "change-password",
+            "openid-credential-issuer",
+            "openid-federation",
+            "matrix",
+        ):
+            assert validate_well_known_path(name) == name
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            validate_well_known_path("")
+
+    def test_rejects_path_traversal(self):
+        for evil in (
+            "..",
+            "../etc/passwd",
+            "..%2Fetc",
+            "agent-card.json/..",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_query_or_fragment(self):
+        for evil in (
+            "agent-card.json?token=x",
+            "agent-card.json#section",
+            "agent-card.json?",
+            "agent-card.json#",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_embedded_slash(self):
+        for evil in (
+            "agent/card.json",
+            "/agent-card.json",
+            "agent-card.json/extra",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_percent_encoded(self):
+        for evil in (
+            "agent%2Fcard.json",
+            "%2E%2E",
+            "agent-card%00.json",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_oversize(self):
+        with pytest.raises(ValidationError):
+            validate_well_known_path("a" * 129)
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValidationError):
+            validate_well_known_path(None)  # type: ignore[arg-type]

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -373,14 +373,49 @@ class TestValidateNoUnderscoreInTarget:
         assert "_a" in msg
         assert "_b" in msg
 
-    def test_allow_underscore_downgrades_to_warning(self, caplog):
-        import logging
+    def test_allow_underscore_requires_env_gate(self, monkeypatch):
+        """The bypass is operator-gated. ``allow_underscore=True`` alone
+        is insufficient — ``DNS_AID_ALLOW_UNDERSCORE_TARGET`` must also
+        be set in the environment so a calling LLM or MCP client can't
+        unilaterally downgrade the draft §Known Organization MUST."""
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
 
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValidationError):
+            validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+
+    def test_allow_underscore_with_env_gate_allows(self, monkeypatch):
+        """With env gate set, allow_underscore=True is honoured and
+        emits a structured WARN for log aggregation."""
+        from unittest.mock import patch
+
+        from dns_aid.utils import validation as validation_module
+
+        monkeypatch.setenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", "1")
+        with patch.object(validation_module, "logger") as mock_logger:
             result = validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
         assert result == "_index.example.com"
-        assert any("_index" in record.message for record in caplog.records)
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
+        mock_logger.warning.assert_called_once()
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert kwargs["target"] == "_index.example.com"
+        assert kwargs["warning_class"] == "dns_aid.underscore_bypass"
+        assert kwargs["env_gate"] == "DNS_AID_ALLOW_UNDERSCORE_TARGET"
+
+    def test_allow_underscore_without_env_logs_distinct_warning(self, monkeypatch):
+        """When the caller asks for the bypass but the env gate is
+        unset, surface that with a distinct warning_class so operators
+        can distinguish 'I forgot to set the env' from 'genuine
+        validation error'."""
+        from unittest.mock import patch
+
+        from dns_aid.utils import validation as validation_module
+
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+        with patch.object(validation_module, "logger") as mock_logger:
+            with pytest.raises(ValidationError):
+                validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        mock_logger.warning.assert_called_once()
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert kwargs["warning_class"] == "dns_aid.underscore_bypass_env_missing"
 
     def test_allow_underscore_on_clean_target_is_silent(self, caplog):
         import logging
@@ -444,11 +479,40 @@ class TestValidateWellKnownPath:
             with pytest.raises(ValidationError):
                 validate_well_known_path(evil)
 
-    def test_rejects_embedded_slash(self):
+    def test_rejects_embedded_slash_in_bare_suffix(self):
+        """Bare suffixes can't contain slashes — that's the single-segment
+        constraint. Absolute paths starting with '/' are a separate, supported
+        shape (see test_accepts_absolute_paths)."""
         for evil in (
             "agent/card.json",
+            "agent-card.json/extra",  # trailing junk
+            "//double-leading-slash",  # absolute but with empty first segment
+            "/seg//empty",  # empty segment in absolute path
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_accepts_absolute_paths_per_draft_figure_3(self):
+        """Per draft Figure 3, well-known values may be absolute paths —
+        not just bare suffixes under /.well-known/. Examples from the
+        draft itself: `/.well-known/agent-card.json`, `/not-well-known/
+        other-card.json`."""
+        for ok in (
+            "/.well-known/agent-card.json",
+            "/not-well-known/other-card.json",
             "/agent-card.json",
-            "agent-card.json/extra",
+            "/openid-credential-issuer",
+            "/v1/agents/card.json",
+        ):
+            assert validate_well_known_path(ok) == ok
+
+    def test_rejects_absolute_path_with_traversal(self):
+        """`..` segments must still be refused in absolute form."""
+        for evil in (
+            "/.well-known/../etc/passwd",
+            "/..",
+            "/../../etc",
+            "/segment/../escape",
         ):
             with pytest.raises(ValidationError):
                 validate_well_known_path(evil)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -14,6 +14,7 @@ from dns_aid.utils.validation import (
     validate_domain,
     validate_endpoint,
     validate_fqdn,
+    validate_no_underscore_in_target,
     validate_port,
     validate_protocol,
     validate_ttl,
@@ -336,3 +337,59 @@ class TestValidateBackend:
         with pytest.raises(ValidationError) as exc:
             validate_backend("")
         assert exc.value.field == "backend"
+
+
+class TestValidateNoUnderscoreInTarget:
+    """Tests for the SVCB TargetName no-underscore rule (draft-02 §Known Organization)."""
+
+    def test_clean_target_passes(self):
+        assert (
+            validate_no_underscore_in_target("agent-index.example.com") == "agent-index.example.com"
+        )
+
+    def test_trailing_dot_tolerated(self):
+        assert (
+            validate_no_underscore_in_target("agent-index.example.com.")
+            == "agent-index.example.com."
+        )
+
+    def test_label_starting_with_underscore_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("_index.example.com")
+        assert exc.value.field == "target"
+        assert "_index" in str(exc.value)
+
+    def test_label_containing_underscore_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("agent_index.example.com")
+        assert exc.value.field == "target"
+        assert "agent_index" in str(exc.value)
+
+    def test_multiple_underscored_labels_all_reported(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("_a._b.example.com")
+        msg = str(exc.value)
+        assert "_a" in msg
+        assert "_b" in msg
+
+    def test_allow_underscore_downgrades_to_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        assert result == "_index.example.com"
+        assert any("_index" in record.message for record in caplog.records)
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_allow_underscore_on_clean_target_is_silent(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = validate_no_underscore_in_target("clean.example.com", allow_underscore=True)
+        assert result == "clean.example.com"
+        assert not caplog.records
+
+    def test_empty_target_raises_regardless_of_flag(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("", allow_underscore=True)
+        assert exc.value.field == "target"

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -504,6 +504,46 @@ class TestVerify:
             assert result.dnssec_valid is False
 
     @pytest.mark.asyncio
+    async def test_verify_dane_without_dnssec_demotes_to_unknown(self):
+        """A TLSA record served without DNSSEC has no integrity guarantee.
+
+        Even though ``_check_dane`` would return ``True`` (TLSA found),
+        the absence of a DNSSEC validation means we cannot trust the
+        TLSA record itself. The validator demotes ``dane_valid`` to
+        ``None`` (unknown), and the security_score's gated +15 does
+        not fire.
+        """
+        from dns_aid.core.models import DNSSECDetail, TLSDetail
+
+        with (
+            patch("dns_aid.core.validator._check_svcb_record") as mock_svcb,
+            patch("dns_aid.core.validator._check_dnssec_detail") as mock_dnssec_detail,
+            patch("dns_aid.core.validator._check_dane") as mock_dane,
+            patch("dns_aid.core.validator._check_endpoint") as mock_endpoint,
+            patch("dns_aid.core.validator._check_tls") as mock_tls,
+        ):
+            mock_svcb.return_value = {
+                "target": "agent.example.com",
+                "port": 443,
+                "valid": True,
+            }
+            mock_dnssec_detail.return_value = DNSSECDetail(validated=False)
+            mock_dane.return_value = True  # TLSA record present
+            mock_endpoint.return_value = {"reachable": True, "latency_ms": 50.0}
+            mock_tls.return_value = TLSDetail()
+
+            result = await verify("chat.example.com")
+
+            assert result.dnssec_valid is False
+            assert result.dane_valid is None, (
+                "DANE without DNSSEC must be demoted to unknown, not True"
+            )
+            assert result.dane_note is not None
+            assert "DNSSEC" in result.dane_note
+            # 20 (record) + 20 (svcb) + 0 (dnssec) + 0 (DANE gated) + 15 (endpoint)
+            assert result.security_score == 55
+
+    @pytest.mark.asyncio
     async def test_verify_endpoint_unreachable(self):
         """Test verify when endpoint is unreachable."""
         from dns_aid.core.models import DNSSECDetail, TLSDetail

--- a/uv.lock
+++ b/uv.lock
@@ -740,8 +740,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pygments", marker = "extra == 'all'", specifier = ">=2.20.0" },
     { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.20.0" },
-    { name = "pyjwt", marker = "extra == 'all'", specifier = ">=2.12.0" },
-    { name = "pyjwt", marker = "extra == 'mcp'", specifier = ">=2.12.0" },
+    { name = "pyjwt", marker = "extra == 'all'", specifier = ">=2.13.0" },
+    { name = "pyjwt", marker = "extra == 'mcp'", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'all'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'all'", specifier = ">=0.23.0" },
@@ -1792,11 +1792,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Aligns the `bap` SvcParamKey with the draft-02 §FutureWork (Bulk Agent
Protocol) shape: a single versioned protocol identifier per record
(e.g. `mcp2.1`, `a2a1.0`), not a comma-separated list. The canonical
agent-protocol carrier remains `alpn`; `bap` adds version info when
present.

Multi-protocol agents under draft-02 are published as **multiple SVCB
records at the same flat owner**, each with its own `alpn` and
(optionally) its own `bap`. The pre-draft-02 multi-value-on-one-record
shape doesn't survive the migration.

Stacked on #156 (the docs/testbed flip). Auto-rebases against `main`
once #156 merges.

## What lands

### Models (`core/models.py`)
- `SvcbRecord.bap` and `AgentRecord.bap`: `list[str]` → `str | None`.
- `to_params()` writes `bap=<value>` directly (no `",".join(...)`).
- Field docstrings explicitly note that multi-protocol publishing is
  multiple `AgentRecord`s at the same flat owner, NOT a list on one
  record.

### Publisher / CLI / MCP
- `publish()` SDK kwarg: `bap: list[str] | None` → `bap: str | None`.
- CLI `--bap` help text and value-passing updated.
- MCP `publish_agent_to_dns` `bap` kwarg and docstring updated.

### Discoverer (`core/discoverer.py`)
- `bap` is parsed from SVCB SvcParams as a scalar. If a pre-draft-02
  publisher wrote a comma-separated value, the parser collapses to
  the first entry, preserving a sensible scalar.

### A2A integration (`core/a2a_card.py`)
- `A2AAgentCard.to_publish_params()` defaults `bap` to `"a2a1.0"`
  (was `["a2a/1"]`). Callers wanting a different version override
  before passing to `publish()`.

### SDK search adapter (`sdk/client.py`)
- `_adapt_search_payload` accepts three legacy shapes from directory
  rows (scalar string, comma-separated string, list) and collapses
  all to the draft-02 scalar form before the `SearchResponse`
  Pydantic validate. Pre-draft-02 directory rows continue to parse
  cleanly under draft-02 clients.

## What this PR does NOT do

- **No multi-protocol-via-multiple-records support.** Per the wire
  format, that requires append-vs-replace semantics on the backend
  abstraction. Tracked as a follow-up; for now, callers publishing
  an agent that speaks multiple protocols issue multiple `publish()`
  calls.
- **No `sig` / `connect-*` / `enroll-uri` fate.** Still a follow-up
  issue after the migration PRs land.
- **No removal of legacy comma-separated tolerance.** The parser and
  adapter remain forgiving so dns-aid-core under draft-02 reads
  pre-draft-02 records cleanly. A future PR can tighten this once
  the ecosystem has migrated.

## Test plan

- [x] `ruff format --check src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/dns_aid` — clean (81 source files)
- [x] `pytest tests/unit/` — 1751 passed; 3 pre-existing flakes
- [x] `pytest tests/integration/ -m "not live"` — 30 passed
- [ ] CI green on PR

### New test coverage

- `TestAgentRecord.test_svcb_params_bap_emits_as_scalar` — emitted
  bap value contains no comma.
- `TestAgentRecord.test_svcb_params_bap_absent_when_none` — unset
  bap produces no key65402 entry.
- `TestDiscoveryWithCapUri.test_discovery_collapses_legacy_comma_bap_to_scalar`
  — parser collapses pre-draft-02 multi-value records to first entry.
- `TestSearchAdapter.test_bap_*` — SDK adapter normalizes all three
  legacy directory shapes (scalar string, comma-separated string,
  list) to the draft-02 scalar form.