### PR TITLE
docs: reflect repository move to the vendor-neutral dns-aid org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Repository moved to the vendor-neutral `dns-aid` GitHub organization** (`github.com/dns-aid/dns-aid-core`), ahead of Linux Foundation graduation. Previous `infobloxopen/dns-aid-core` URLs redirect automatically, so existing clones, links, and badges continue to work. Contributors should update their git remotes (`git remote set-url <remote> https://github.com/dns-aid/dns-aid-core.git`). The PyPI Trusted Publisher and MCP Registry namespace are being updated to match the new organization.
+
 ## [0.23.0] - 2026-05-26
 
 ### Added — Production-grade OpenTelemetry integration (spec 005)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -40,7 +40,7 @@ DNS-AID currently has **three maintainers**, all Infoblox-affiliated (bus factor
 - **Conservative architecture** — the codebase deliberately favors stdlib, well-known third-party libraries (`dnspython`, `httpx`), and standard DNS records (RFC 9460 SVCB, RFC 4033-4035 DNSSEC, RFC 6698 DANE) over bespoke abstractions. New maintainers should be productive in days, not months.
 - **Comprehensive automation** — CI runs lint, type-check, unit tests across Python 3.11/3.12/3.13, mock integration tests, CodeQL SAST, Bandit, OpenSSF Scorecard, dependency audit, SBOM generation, and Sigstore-signed releases on every PR. New contributors get fast, machine-checked feedback.
 - **DCO + SPDX** enforced on every commit — keeps provenance unambiguous as the contributor base grows.
-- **Backed by Infoblox** — the project is hosted under the [`infobloxopen`](https://github.com/infobloxopen) organization. Infoblox provides the DNS expertise that motivated DNS-AID and has committed engineering time to its development.
+- **Vendor-neutral hosting** — the project is hosted under the vendor-neutral [`dns-aid`](https://github.com/dns-aid) GitHub organization (formerly `infobloxopen`), reflecting its trajectory toward Linux Foundation governance. Infoblox is the founding contributor: it provides the DNS expertise that motivated DNS-AID and has committed engineering time to its development.
 
 **Goals before LF graduation**
 
@@ -48,7 +48,7 @@ DNS-AID currently has **three maintainers**, all Infoblox-affiliated (bus factor
 - Documented succession process for the project lead role
 - External (non-Infoblox) committer with merge rights on at least one subsystem
 
-If you are interested in contributing in a maintainer capacity, please open a discussion at [dns-aid-core/discussions](https://github.com/infobloxopen/dns-aid-core/discussions) or contact the project lead directly.
+If you are interested in contributing in a maintainer capacity, please open a discussion at [dns-aid-core/discussions](https://github.com/dns-aid/dns-aid-core/discussions) or contact the project lead directly.
 
 ## Release process and namespace ownership
 
@@ -60,5 +60,5 @@ For full transparency:
 
 ## Contact
 
-- GitHub Issues: [dns-aid-core/issues](https://github.com/infobloxopen/dns-aid-core/issues)
-- Discussions: [dns-aid-core/discussions](https://github.com/infobloxopen/dns-aid-core/discussions)
+- GitHub Issues: [dns-aid-core/issues](https://github.com/dns-aid/dns-aid-core/issues)
+- Discussions: [dns-aid-core/discussions](https://github.com/dns-aid/dns-aid-core/discussions)

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.infobloxopen/dns-aid",
+  "name": "io.github.dns-aid/dns-aid",
   "description": "Discover and publish AI agents via DNS using SVCB records (RFC 9460)",
   "repository": {
-    "url": "https://github.com/infobloxopen/dns-aid-core",
+    "url": "https://github.com/dns-aid/dns-aid-core",
     "source": "github"
   },
-  "version": "0.18.1",
+  "version": "0.23.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "dns-aid",
-      "version": "0.18.1",
+      "version": "0.23.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
The repo was transferred from `infobloxopen` to the vendor-neutral `dns-aid` GitHub organization ahead of Linux Foundation graduation. This is a **minimal** docs update covering only what is inaccurate or worth documenting — GitHub auto-redirects all old URLs, so nothing is broken and a full URL sweep would be churn.

## Changes
- `MAINTAINERS.md` — reframe governance: hosting is now the vendor-neutral `dns-aid` org (Infoblox is the *founding contributor*, not the host); update the contact/discussion/issue links to the new org.
- `CHANGELOG.md` — `[Unreleased]` note documenting the move, the redirect behavior, and the remote-update command.

## Deliberately left unchanged
- Historical CHANGELOG compare-links (`infobloxopen/...`) — historical record; redirects resolve them.
- README badges, `pyproject.toml` URLs, `CITATION.cff`, deep doc links — all redirect; not worth the churn for a minimal change.
- `CODEOWNERS` — uses individual handles (`@iracic82`, `@ivanglabbeek`), not org-team handles, so the transfer does not affect it.

## Out of scope (handled separately, external accounts)
- PyPI Trusted Publisher → repointing to `dns-aid/dns-aid-core`.
- MCP Registry namespace (`server.json` `name` → `io.github.dns-aid/dns-aid`) + republish.

## Test plan
- [x] No functional/code changes; docs only
- [x] Edited files free of stale org refs except intentional "formerly infobloxopen" note and historical changelog links