### PR TITLE
ci: publish to MCP Registry on release (OIDC) + README mcp-name tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,3 +100,40 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+
+  publish-to-mcp-registry:
+    name: Publish to MCP Registry
+    # Runs after PyPI so the just-published README (with the mcp-name tag) is
+    # live for the registry's PyPI-ownership validation.
+    needs: publish-to-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC for `mcp-publisher login github-oidc`
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Install mcp-publisher (pinned + checksum-verified)
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
+          MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
+        run: |
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/mcp-publisher
+
+      - name: Sync server.json version to the release tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Authenticate via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
 [![PyPI](https://img.shields.io/pypi/v/dns-aid)](https://pypi.org/project/dns-aid/)
 
+<!-- mcp-name: io.github.dns-aid/dns-aid -->
+
 **DNS-based Agent Identification and Discovery**
 
 Reference implementation of the DNS-AID specification, developed at the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.


### PR DESCRIPTION
## Summary
Wires MCP Registry publishing into the release workflow so the listing stays in sync automatically on every release, the same way PyPI trusted publishing works. Also adds the `mcp-name` README tag the registry requires.

Chosen approach (option B): the README tag rides the **next** normal release — no release-just-for-a-tag.

## Why this is needed
The registry validates PyPI package ownership by requiring `mcp-name: io.github.dns-aid/dns-aid` to appear in the **published PyPI package README**. The tag was missing, so a manual `mcp-publisher publish` failed with a 400. PyPI READMEs are immutable per version, so the tag only reaches PyPI via a new release.

## Changes
- `README.md` — add `<!-- mcp-name: io.github.dns-aid/dns-aid -->` (invisible to readers, present in the PyPI long-description the registry checks).
- `.github/workflows/release.yml` — new `publish-to-mcp-registry` job:
  - `needs: publish-to-pypi` so the tagged README is live before validation.
  - Installs **pinned + SHA-256-verified** `mcp-publisher` v1.7.9 (no unpinned download).
  - Syncs `server.json` version to the release tag via `jq` (safe `env:` var, not inlined).
  - `mcp-publisher login github-oidc` — OIDC proves `dns-aid` org ownership via the repo; no stored token, no public-membership requirement.
  - `mcp-publisher publish`.

## Effect
- No MCP publish happens until the next `v*` release (option B). On that release: PyPI publishes → README with the tag goes live → MCP job validates and publishes `io.github.dns-aid/dns-aid` automatically.

## Test plan
- [x] `release.yml` valid YAML (jobs: build, publish-to-pypi, publish-to-mcp-registry)
- [x] `jq` version-sync verified locally (sets `.version` + `.packages[0].version` from the tag)
- [x] mcp-publisher v1.7.9 SHA-256 pinned (`ab128162...`)
- [x] README tag present in the PyPI long-description path