### PR TITLE
feat(core): complete draft-02 flat-FQDN migration across all surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,330 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-06-04
+
+### Fixed — flat-FQDN completion
+
+- **MCP `verify_agent_dns` accepts flat FQDNs.** `validate_fqdn` no
+  longer requires the legacy `_agents` label, so verifying an agent at
+  its flat owner `{name}.{domain}` (the draft-02 default) now works
+  consistently across the SDK, CLI, and MCP surfaces.
+- **JWS signature binding is DNS-normalized.** The verifier compares the
+  signed `fqdn`/`target` to the record case-insensitively and ignoring a
+  trailing dot, so a legitimately-signed record with a dotted or
+  mixed-case endpoint is no longer falsely rejected.
+- **CLI/MCP output the flat owner name.** `delete` / `search` output and
+  the MCP unpublish result now show `{name}.{domain}` instead of the
+  legacy nested name.
+- **`index sync` enumerates flat primary owners.** Sync previously
+  discovered agents only via the walkable AliasMode (`{name}._agents`)
+  or the legacy shape, so a flat-only agent — the draft-02 default
+  publish shape — was silently omitted from the `_index._agents` TXT
+  enumeration (sync reported "No agents found to index"). It now detects
+  flat owners by their companion TXT record (publish writes SVCB + TXT
+  at the flat owner), reads the protocol off the SVCB SvcParams, and
+  dedups against any walkable alias for the same agent.
+- **Discovery reconciles the agent protocol from the SVCB record.** Under
+  draft-02 the protocol lives in the record (`bap`, or `alpn` as the
+  canonical carrier), not the FQDN. The discoverer now stamps the
+  record's true protocol on every path — `discover_at_fqdn`, the
+  common-name zone-walk, and the HTTP index — so a default-published
+  `a2a` / `https` agent (which carries `alpn` and no `bap`) is no longer
+  mislabeled `mcp`. The mislabel previously failed the JWS binding check
+  (`payload.alpn == agent.protocol.value`) for a correctly-signed agent
+  and selected the wrong protocol handler at invoke. The common-name
+  fallback now also dedups by `(fqdn, protocol)`, so a flat owner probed
+  once per candidate protocol yields a single record instead of duplicates.
+- **Flat-FQDN parser accepts short/internal zones and normalizes.**
+  `parse_dnsaid_fqdn` now accepts a flat owner in a two-label zone
+  (`agent.internal`) and normalizes case + a trailing dot up front, so
+  every consumer (discoverer, telemetry) sees lowercase, dot-trimmed
+  labels rather than re-implementing it.
+
+### Security — hardening
+
+- **SVCB SvcParam injection closed on every free-form field.** The `bap`
+  field validator already blocked SvcParam quote break-out injection; the
+  same guard now applies to `cap` / `cap-sha256` / `policy` / `realm` /
+  `sig` / `connect-meta` / `enroll-uri` on both `SvcbRecord` and
+  `AgentRecord`. A value containing a double quote, backslash, or control
+  character (which the Route53 / Cloudflare / DDNS presentation-format
+  backends emit verbatim as `key="<value>"`) is rejected at the type
+  boundary, so it cannot inject an attacker-controlled sibling
+  SvcParamKey into the authoritative record.
+- **JWKS fetch is SSRF-guarded, size-capped, and redirect-free.**
+  `fetch_jwks` routes through `validate_fetch_url` + the streaming
+  `safe_fetch_bytes` (64 KB cap, no cross-host redirects) instead of a raw
+  `httpx.get` + unbounded `.json()`, and the per-process JWKS cache is
+  bounded (FIFO eviction) so bulk cross-domain discovery can't grow it
+  without limit. This is the input that stamps `signature_verified`.
+- **JWS verification rejects algorithm and curve confusion.**
+  `verify_signature` now requires the protected-header `alg` to be `ES256`
+  (rejecting `none` / RSA / other), and `import_public_key_from_jwk`
+  requires `kty="EC"`, `crv="P-256"`, a signing `use`, and 32-byte
+  coordinates before any key material is trusted — closing
+  algorithm/curve confusion now that the JWKS source is attacker-influenceable.
+- **HTTP index fetch is bounded.** The agents-index fetch streams the body
+  with a 1 MB cap and processes at most 500 agents from a single index, so
+  a hostile index can't force an OOM or amplify into an unbounded
+  per-agent SVCB + descriptor + JWKS fan-out.
+
+### BREAKING
+
+- **SVCB TargetName underscore validator is strict by default.**
+  `dns_aid.publish()` and direct `SvcbRecord` / `AgentRecord`
+  construction now reject endpoints containing any underscored DNS
+  label, because the CA/Browser Forum Baseline Requirements and
+  RFC 5280 dNSName SANs forbid underscored labels — a publicly-issued
+  x.509 certificate cannot cover such a name. This is a deliberate,
+  versioned tightening per draft-mozleywilliams-dnsop-dnsaid-02
+  §3.2 (Known Organization, Unknown Agent).
+
+  **Migration from 0.23.0** for deployments that intentionally
+  publish underscored internal endpoints (not behind public PKI):
+
+  1. Preferred: rename the endpoint to use only LDH labels (letters,
+     digits, hyphens). This is the long-term spec-conformant path.
+  2. Operator opt-in: set `DNS_AID_ALLOW_UNDERSCORE_TARGET=1` on the
+     publishing process AND pass `allow_underscore_target=True` to
+     `publish()`. Both are required — the env gate prevents a calling
+     LLM or MCP client from unilaterally downgrading the MUST.
+  3. The opt-in surfaces `dns_aid.underscore_bypass` on
+     `PublishResult.warnings` (caller-visible structured signal) and
+     in structlog with `warning_class="dns_aid.underscore_bypass"`,
+     so operators can count and alert per zone.
+
+  Downstream wrappers and controllers that call `publish()` will
+  need to thread the new flag through their own config surface (CRD
+  field, CLI flag, env var) to preserve any intentional
+  underscored-endpoint behaviour. Until that wiring lands, those
+  deployments must rename the endpoint to LDH labels.
+
 ### Changed
 
 - **Repository moved to the vendor-neutral `dns-aid` GitHub organization** (`github.com/dns-aid/dns-aid-core`), ahead of Linux Foundation graduation. Previous `infobloxopen/dns-aid-core` URLs redirect automatically, so existing clones, links, and badges continue to work. Contributors should update their git remotes (`git remote set-url <remote> https://github.com/dns-aid/dns-aid-core.git`). The PyPI Trusted Publisher and MCP Registry namespace are being updated to match the new organization.
+
+### Added — `well-known` SvcParamKey and TargetName validator (draft-02)
+
+- **New `well-known` SvcParamKey** at the project's interim private-use
+  code point `key65409` (final IANA assignment deferred per draft §7.1).
+  Carries an RFC 8615 path the discoverer reconstructs as
+  `https://<svcb-target>/.well-known/<value>` and fetches as the
+  capability descriptor. Independent of `cap`; both may be present.
+- **Absolute-path well-known values** (per draft Figure 3) — values
+  starting with `/` (e.g. `/.well-known/agent-card.json`,
+  `/not-well-known/other-card.json`) are used as origin-relative paths
+  without double-prefixing. Bare suffixes still get the `/.well-known/`
+  prefix.
+- **`validate_well_known_path`** constrains the value to a safe
+  character class (`[A-Za-z0-9._-]` per segment, length-bounded, no
+  `..` traversal, no `?` / `#` / control chars). Enforced on both
+  publish and discover; field-validator on `SvcbRecord.well_known_path`
+  and `AgentRecord.well_known_path` so direct model construction can't
+  bypass.
+- **`cap_sha256_verified: bool`** field on `AgentRecord` / `SvcbRecord`.
+  True only when the discoverer actually fetched the descriptor AND
+  the SHA-256 of its bytes matched `cap_sha256`. Consumers keying
+  trust off the integrity pin MUST check this flag — the mere presence
+  of `cap_sha256` is no longer a sufficient signal. Dangling case
+  (pin declared, never applied) logs a structured WARN with
+  `warning_class="dns_aid.dangling_cap_sha256"`.
+- **`PublishResult.warnings: list[str]`** — non-fatal advisories
+  raised during the publish path, surfaced as stable warning-class
+  identifiers (e.g. `dns_aid.underscore_bypass`) so consumers can
+  match exactly without log-string parsing.
+- **`capability_source="descriptor_unreachable"`** — distinct
+  provenance value when a record declares a `cap` or `well-known`
+  locator but the descriptor fetch fails (timeout, TLS error, 5xx).
+  Lets consumers tell transient outages from mis-configurations
+  without scraping log lines.
+- **`CapabilitySource` `Literal` consolidated in `core.models`** —
+  single source of truth for provenance values; the discoverer,
+  SDK, indexer, and `AgentRecord` all import the same symbol.
+- **Per-agent descriptor-fetch budget** — descriptor fetches are
+  now bounded by `asyncio.wait_for` with a 12-second total budget.
+  A single slow endpoint can no longer stall a bulk-discovery loop;
+  the agent records `capability_source="descriptor_unreachable"`.
+- **`validate_no_underscore_in_target`** — TargetName underscore
+  validator with operator-only bypass. The bypass requires both the
+  per-call `allow_underscore=True` flag AND
+  `DNS_AID_ALLOW_UNDERSCORE_TARGET=1` in the environment. Field
+  validators on `SvcbRecord.target` and `AgentRecord.target_host`
+  honour the same env gate so the rule fires at the type boundary.
+
+### Changed — correctness
+
+- **Non-HTTPS `cap` (URN, JSON-Ref) falls back to `well-known`** at
+  fetch time. Earlier `cap` presence was terminal, silently disabling
+  a perfectly good `well-known` and downgrading discovery to
+  unauthenticated TXT.
+- **`cap > well-known` precedence** now proven at fetch time, not
+  just at serialization. When both are set and `cap` is https-fetchable,
+  the cap URL drives the fetch and `capability_source="cap_uri"`.
+- **DNSSEC docstring on `validator.py`** rewritten to quote the
+  draft's actual SHOULD posture (§6.2) instead of the earlier
+  MAY/MUST framing. Also no longer overstates what the code does on
+  this branch — the fail-closed DANE demotion ships separately on
+  #155.
+
+### Security
+
+- **pyjwt 2.12.1 → 2.13.0** clears PYSEC-2026-175 / 177 / 178 / 179.
+
+### Internal
+
+- Validation logger migrated from stdlib `logging` to project-standard
+  `structlog`.
+- `_parse_svcb_custom_params` derives its recognised key set from
+  `DNS_AID_KEY_MAP` (was a hand-maintained literal that needed three-
+  file edits per new key).
+- `to_params()` reads `DNS_AID_SVCB_STRING_KEYS` once per call (was up
+  to 11× per serialization).
+
+### BREAKING CHANGE — `bap` SvcParamKey is now a single scalar
+
+The `bap` SvcParamKey value type changed from `list[str] | None` to
+`str | None` across the public API: `publish()`, the CLI `--bap`
+flag, the MCP `publish_agent_to_dns` tool, and the `AgentRecord` /
+`SvcbRecord` Pydantic models.
+
+The value form follows draft-02 §5.1: bare (`mcp`, `a2a`) or
+versioned with the draft's `=` delimiter (`mcp=1.0`, `a2a=1.1`).
+
+- `AgentRecord(bap=["mcp"])` now raises `ValidationError`. Field
+  validators on both models reject the list form at the type
+  boundary so the break direction is pinned.
+- `--bap mcp,a2a` no longer auto-splits — the CLI passes the value
+  through verbatim and the validator rejects the comma. Operators
+  who want both protocols publish two SVCB records, one per
+  protocol.
+- The MCP tool's input schema for `bap` changed from `array` to
+  `string`. Clients that bind to the JSON schema need updates.
+- The previous concatenated form (`mcp2.1`, `a2a1.0`) is rejected
+  because it is ambiguous to parse back into protocol and version.
+
+This is experimental territory in the draft (§FutureWork), but the
+public-API shape change still warrants the version bump. A new
+shared `dns_aid.core.bap.normalize_bap` helper coerces legacy
+comma-strings and list inputs into the canonical scalar on the
+discover / SDK / indexer paths so existing wire data on the network
+keeps deserializing without operator intervention.
+
+### Security
+
+- **`bap` field validator closes a SvcParamKey injection
+  vulnerability.** A crafted value such as `mcp" key65500="x` used
+  to round-trip verbatim through `to_params()` and the backend
+  formatters; dnspython would then parse two SvcParamKeys, with the
+  second attacker-controlled. On a multi-tenant publish path that is
+  server-side parameter injection. The new validator rejects
+  quotes, spaces, commas, and any character that could break SVCB
+  SvcParam quoting at every construction path.
+
+### BREAKING CHANGE — draft-02 flat FQDN + walkable AliasMode
+
+This release flips the wire-format default from
+draft-mozleywilliams-dnsop-dnsaid-01 to -02. The primary agent owner is
+now the flat FQDN `{name}.{domain}` (valid as an x.509 SAN dNSName); the
+agent protocol no longer travels in the FQDN — it lives in the SVCB
+`bap` SvcParamKey (or `alpn` when only one protocol is supported).
+
+Anyone with -01 records in production will need to either republish or
+opt into a per-call legacy fallback. See **Migrating from -01** below.
+
+### Added
+
+- **Flat primary owner record** at `{name}.{domain}`. SVCB + companion
+  TXT are written at this name on every publish.
+- **Optional walkable AliasMode** at `{name}._agents.{domain}` pointing
+  at the flat primary owner. **Off by default** under -02 to avoid an
+  enumeration handle — see `docs/privacy-considerations.md`. Opt in
+  per-publish via `publish_walkable_alias=True`, the CLI `--walkable`
+  flag, or the MCP `publish_walkable_alias=true` kwarg.
+- **Per-call legacy fallback** kwarg `allow_legacy: bool | None` on
+  `discover()` / `discover_at_fqdn()`. When set, a flat-FQDN miss falls
+  back to the -01 shape; the resulting `AgentRecord` is stamped
+  `legacy_resolved=True` so downstream filters can down-weight it.
+  The env-flag form `DNS_AID_LEGACY_01_FALLBACK=1` is preserved as a
+  process-wide back-compat for callers that can't easily thread the
+  kwarg; it now also logs a warning on each use and stamps the result.
+- **Per-agent DNSSEC validation** under flat-FQDN. Each agent's owner
+  is checked independently; the result-level `dnssec_validated` is
+  True only when every agent's check passed.
+- **`legacy_resolved: bool`** field on `AgentRecord` for filter-side
+  visibility into legacy-shape records.
+- **`docs/privacy-considerations.md`** — explains the enumeration vs.
+  discovery trade-off and when to enable the walkable record.
+- **`SVCB_ALIAS_MODE` / `SVCB_SERVICE_MODE`** constants in
+  `dns_aid.core.models` so backend code reads `priority=SVCB_ALIAS_MODE`
+  instead of a bare integer.
+- **`dns_aid.core.fqdn.parse_dnsaid_fqdn`** — a single FQDN parser
+  recognising all three shapes; the discoverer's `_parse_fqdn` and the
+  telemetry's `_parse_signal_fqdn` are thin projections over it.
+
+### Changed — Security
+
+- **JWS signature now binds to the record.** `signature_verified` is
+  True only when the signed `RecordPayload` fields (`fqdn`, `target`,
+  `port`, `alpn`) match the AgentRecord — closing a hole where a
+  validly-signed `sig` could be lifted off one record and pasted onto
+  a spoofed SVCB pointing at an attacker host.
+- **`cap-sha256` mismatch now refuses the record** instead of silently
+  downgrading to TXT fallback. `fetch_cap_document` raises
+  `CapDigestMismatchError` on digest mismatch (distinct from network
+  failure); the discoverer catches it and drops the affected record.
+  TXT-fallback records no longer carry `cap_sha256` because the pin
+  doesn't apply to the data we ended up using.
+- **`well-known` SvcParamKey value is now validated** to a safe
+  RFC 8615 single-segment suffix (`^[A-Za-z0-9._-]+$`, length-bounded,
+  no `..` traversal) on both publish and discover. Prevents path
+  traversal, query-string injection, and fragment injection through
+  the SVCB → URL reconstruction.
+- **Walkable AliasMode target is the flat primary owner.** Was the
+  endpoint host, which only coincided with the flat owner when those
+  names happened to match.
+- **DANE score gates on DNSSEC.** A TLSA record without a DNSSEC chain
+  has no integrity guarantee (RFC 6698 §10.1); the validator now
+  demotes `dane_valid` to `None` in that case, and `security_score`'s
+  +15 for DANE is gated on `dnssec_valid` as a second-line guard.
+- **`unpublish()` reports success only when the primary record was
+  deleted (or was already absent and cleanup ran).** Earlier the
+  success boolean OR'd in walkable / legacy cleanup, so a primary
+  delete that silently failed on Route53 / Cloudflare could be masked
+  by an unrelated cleanup succeeding — the MCP server would then
+  de-index a still-live agent.
+- **Agent name is validated at publish.** `validate_agent_name()` is
+  now called on the publisher path (previously only on the MCP path),
+  so SDK / CLI callers can't land records whose flat-FQDN SAN would
+  be unrepresentable.
+- **Underscore-target bypass log is now structured `WARN`** with a
+  `warning_class="dns_aid.underscore_bypass"` key so log aggregators
+  can count and alert on deliberate opt-ins per zone.
+
+### Changed — Code quality
+
+- `sync_index` performs a single backend enumeration instead of two
+  (the second was a subset of the first; doubled API quota burn on
+  every sync).
+- `discover_at_fqdn` for flat / walkable shapes resolves DNS once and
+  reads the actual protocol from the record's `bap` (preferred) or
+  `alpn` field instead of firing MCP-then-A2A back-to-back.
+- Validation logger migrated from stdlib `logging` to project-standard
+  `structlog`.
+
+### Migrating from -01
+
+1. **Re-publish your agents.** The publisher writes the flat shape by
+   default; nothing else to do for new records.
+2. **Existing -01 records keep resolving** when consumers set
+   `allow_legacy=True` on `discover()` or set the env-flag form
+   `DNS_AID_LEGACY_01_FALLBACK=1`. The returned `AgentRecord` will
+   have `legacy_resolved=True` so filters can down-weight.
+3. **`unpublish()` cleans up both shapes** in one call. No flag needed.
+4. **Walkable record is now opt-in.** Operators relying on
+   DNS-SD-style enumeration need to pass `--walkable` (CLI) /
+   `publish_walkable_alias=True` (SDK/MCP) — see
+   `docs/privacy-considerations.md`.
 
 ## [0.23.0] - 2026-05-26
 
@@ -1518,7 +1839,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 
 ## References
 
-- [IETF draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
+- [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.23.0"
-date-released: "2026-05-26"
+version: "0.24.0"
+date-released: "2026-06-04"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -9,27 +9,11 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
 [![PyPI](https://img.shields.io/pypi/v/dns-aid)](https://pypi.org/project/dns-aid/)
 
-<!-- mcp-name: io.github.dns-aid/dns-aid -->
-
 **DNS-based Agent Identification and Discovery**
 
-Reference implementation of the DNS-AID specification, developed at the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
-
-## Relationship to IETF
-
-The DNS-AID specification is being developed within the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
-
-This repository provides a reference implementation.
-
-This project does not define the specification. The IETF draft is authoritative.
-
-## Scope of this Repository
-
-This project focuses on implementation, tooling, and ecosystem activities.
-
-Changes to protocol behavior should be discussed within the IETF.
 
 > **New to DNS-AID?** Start with the [Getting Started Guide](docs/getting-started.md) for install, first agent publication, and backend setup.
 
@@ -97,7 +81,7 @@ result = await dns_aid.discover(
 )
 
 # Verify an agent's DNS records
-result = await dns_aid.verify("_my-agent._mcp._agents.example.com")
+result = await dns_aid.verify("my-agent.example.com")
 print(f"Security Score: {result.security_score}/100")
 ```
 
@@ -278,7 +262,7 @@ dns-aid discover example.com --use-http-index
 dns-aid discover example.com --json
 
 # Verify DNS records
-dns-aid verify _my-agent._mcp._agents.example.com
+dns-aid verify my-agent.example.com
 
 # List DNS-AID records in a zone
 dns-aid list example.com
@@ -397,7 +381,7 @@ agents = await dns_aid.discover("example.com", use_http_index=True)
 | **DNS (default)** | Maximum decentralization, offline caching, minimal round trips |
 | **HTTP Index** | Rich metadata upfront, ANS compatibility, model cards, capabilities, direct endpoints |
 
-**FQDN as Source of Truth (v0.4.7):** The HTTP index only needs to provide each agent's FQDN (e.g., `_booking._mcp._agents.example.com`). Agent name and protocol are extracted from the FQDN — no separate `protocols` field needed. DNS SVCB lookup then resolves the authoritative endpoint.
+**FQDN as Source of Truth (v0.4.7):** The HTTP index only needs to provide each agent's FQDN (e.g., `booking.example.com`). Agent name and protocol are extracted from the FQDN — no separate `protocols` field needed. DNS SVCB lookup then resolves the authoritative endpoint.
 
 **Discovery Transparency (v0.4.6+):** Each discovered agent includes source fields showing how data was resolved:
 
@@ -491,14 +475,14 @@ Claude will:
 DNS-AID uses SVCB records (RFC 9460) to advertise AI agents:
 
 ```
-_chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port=443 mandatory="alpn,port"
-_chat._a2a._agents.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
+chat.example.com. 3600 IN SVCB 1 chat.example.com. alpn="a2a" port=443 mandatory="alpn,port"
+chat.example.com. 3600 IN TXT "capabilities=chat,assistant" "version=1.0.0"
 ```
 
 **DNS-AID Custom SVCB Parameters (v0.4.8+):** Per the IETF draft, SVCB records can carry additional custom parameters for richer agent metadata:
 
 ```
-_booking._mcp._agents.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
+booking.example.com. SVCB 1 mcp.example.com. alpn="mcp" port=443 \
     cap="https://mcp.example.com/.well-known/agent-cap.json" \
     cap-sha256="dGVzdGhhc2g" bap="mcp/1,a2a/1" \
     policy="https://example.com/agent-policy" realm="production"
@@ -526,7 +510,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
   │  Step 1: Fetch HTTP Index (primary)                             │
   │  ──────────────────────────────────                             │
   │  GET https://index.aiagents.salesforce.com/index-wellknown      │
-  │  Response: [{"fqdn":"_chat._a2a._agents.salesforce.com",...}]   │
+  │  Response: [{"fqdn":"chat.salesforce.com",...}]   │
   │                                                                 │
   │  Fallback: Query TXT Index via DNS                              │
   │  Query: _index._agents.salesforce.com TXT                       │
@@ -536,7 +520,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
   ┌──┴──────────────────────────────────────────────────────────────┐
   │  Step 2: Query SVCB per agent                                   │
   │  ────────────────────────────                                   │
-  │  Query: _chat._a2a._agents.salesforce.com SVCB                  │
+  │  Query: chat.salesforce.com SVCB                  │
   │  Response: SVCB 1 chat.salesforce.com. alpn="a2a" port=443      │
   │            cap="https://chat.salesforce.com/.well-known/cap.json"│
   │  (DNSSEC validated)                                             │
@@ -553,7 +537,7 @@ This allows any DNS client to discover agents without proprietary protocols or c
   ┌──┴──────────────────────────────────────────────────────────────┐
   │  Step 3: TXT Capabilities (fallback if no cap document)         │
   │  ──────────────────────────────────────────────────             │
-  │  Query: _chat._a2a._agents.salesforce.com TXT                   │
+  │  Query: chat.salesforce.com TXT                   │
   │  Response: "capabilities=chat,support" "version=1.0.0"          │
   └──┬──────────────────────────────────────────────────────────────┘
      │                            │                               │
@@ -1025,9 +1009,81 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters
 
-## Background and Comparison
+## Why DNS-AID?
 
-For background on how DNS-AID compares to other agent-discovery approaches (ANS, Google A2A+UCP, `.agent` gTLD, AgentDNS, NANDA, Web3, `ai.txt`) and "The Sovereignty Question", see [docs/positioning.md](docs/positioning.md). That content is non-normative — protocol positioning is determined at the IETF.
+### vs Competing Proposals
+
+| Approach | Problem | DNS-AID Advantage |
+|----------|---------|-------------------|
+| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
+| **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
+| **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
+| **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
+| **NANDA (MIT)** | New P2P overlay network, new ops paradigm | Uses infrastructure your DNS team already operates |
+| **Web3 (ERC-8004)** | Gas fees, crypto wallets, enterprise-hostile | Free DNS queries, no blockchain complexity |
+| **ai.txt / llms.txt** | No integrity verification, free-form JSON | DNSSEC cryptographic verification, structured SVCB |
+
+### Feature Comparison
+
+| Feature | DNS-AID | Central Registry | ai.txt |
+|---------|---------|------------------|--------|
+| **Decentralized** | ✅ | ❌ | ✅ |
+| **Secure (DNSSEC)** | ✅ | Varies | ❌ |
+| **Sovereign** | ✅ | ❌ | ✅ |
+| **Standards-based** | ✅ (IETF) | ❌ | ❌ |
+| **Works with existing infra** | ✅ | ❌ | ✅ |
+
+### The Sovereignty Question
+
+> **Who controls agent discovery?**
+> - ANS: GoDaddy (US company as gatekeeper)
+> - AgentDNS: China Telecom (state-owned carrier)
+> - Web3: Ethereum Foundation
+> - **DNS-AID: You control your own domain**
+>
+> DNS-AID preserves sovereignty. Organizations and nations maintain control over their own agent namespaces with no central authority that can block, censor, or surveil agent discovery.
+
+### Google's Agent Ecosystem
+
+Google is building a full-stack agent platform: **A2A** (communication), **UCP** (payments), and **Gemini/Search** (discovery). While A2A is an open protocol, discovery through Google surfaces means:
+- Google controls visibility (pay-to-rank)
+- Transaction fees via [UCP](https://developers.google.com/merchant/ucp)
+- Platform dependency for reach
+
+**DNS-AID complements A2A** by providing neutral, decentralized discovery — find agents anywhere, not just through Google.
+
+### Understanding the .agent Domain Approach
+
+The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-level domain through ICANN's [new gTLD program](https://newgtlds.icann.org/). Here's how the two approaches compare:
+
+**How .agent Domains Would Work:**
+1. Apply to ICANN for `.agent` gTLD (~$185,000 application fee)
+2. Wait 9-20 months for ICANN approval process
+3. Build registry infrastructure (Open Agent Registry, Inc.)
+4. Sell `.agent` domains through accredited registrars
+5. Users pay annual registration fees (~$15-50/year per domain)
+
+**How DNS-AID Works:**
+1. Use your existing domain (you already own `yourcompany.com`)
+2. Add DNS-AID records to your zone (`myagent.yourcompany.com`)
+3. Start discovering and being discovered immediately
+
+| Factor | .agent gTLD | DNS-AID |
+|--------|-------------|---------|
+| **Cost to publish** | ~$15-50/year domain fee | Free (use existing domain) |
+| **Time to start** | Months (gTLD launch + registration) | Minutes |
+| **Who controls discovery** | Registry operator | You (your domain) |
+| **Works today** | ❌ Pending ICANN approval | ✅ Works now |
+| **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
+| **Memorable names** | ✅ `myagent.agent` | `myagent.example.com` |
+
+**The Friendly Take:**
+
+Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
+
+DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `myagent.example.com` right now.
+
+*Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
 
 ## Examples
 
@@ -1076,6 +1132,6 @@ Apache 2.0
 
 ## Contributing
 
-Contributions welcome! This project supports an implementation ecosystem with planned hosting in the Linux Foundation. The DNS-AID specification is developed in the IETF.
+Contributions welcome! This project is intended for contribution to the Linux Foundation Agent AI Foundation.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -84,7 +84,7 @@ async def main():
     discovery = await discover("example.com", protocol=Protocol.MCP)
 
     # Verify an agent's DNS records
-    verification = await verify("_my-agent._mcp._agents.example.com")
+    verification = await verify("my-agent.example.com")
 
 asyncio.run(main())
 ```
@@ -168,8 +168,9 @@ else:
 
 #### DNS Records Created
 
-- **SVCB**: `_{name}._{protocol}._agents.{domain}` → Service binding record
-- **TXT**: `_{name}._{protocol}._agents.{domain}` → Capabilities and metadata
+- **SVCB**: `{name}.{domain}` (draft-02 flat primary owner) → Service binding record
+- **SVCB (AliasMode, optional)**: `{name}._agents.{domain}` → walkable AliasMode pointer at the flat primary owner (suppressible via `publish_walkable_alias=False`)
+- **TXT**: `{name}.{domain}` → Capabilities and metadata (alongside the primary SVCB)
 
 ---
 
@@ -305,7 +306,7 @@ async def verify(fqdn: str) -> VerifyResult
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `fqdn` | `str` | Yes | Fully qualified domain name (e.g., "_chat._mcp._agents.example.com") |
+| `fqdn` | `str` | Yes | Fully qualified domain name (e.g., "chat.example.com") |
 
 #### Returns
 
@@ -316,7 +317,7 @@ async def verify(fqdn: str) -> VerifyResult
 ```python
 from dns_aid import verify
 
-result = await verify("_chat._mcp._agents.example.com")
+result = await verify("chat.example.com")
 
 print(f"Record exists: {result.record_exists}")
 print(f"DNSSEC valid: {result.dnssec_valid}")
@@ -332,7 +333,7 @@ DCV is a stateless challenge/verify primitive that lets one party prove control 
 domain to another using a short-lived TXT record at `_agents-challenge.{domain}`.
 It implements [draft-ietf-dnsop-domain-verification-techniques-12](https://datatracker.ietf.org/doc/draft-ietf-dnsop-domain-verification-techniques/)
 plus the `bnd-req` binding extension from
-[draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
+[draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/).
 
 **Role split:**
 - *Challenger* — calls `issue()` and `verify()`; no DNS write credentials required.
@@ -580,7 +581,9 @@ agent = AgentRecord(
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `fqdn` | `str` | Full DNS-AID record name: `_{name}._{protocol}._agents.{domain}` |
+| `fqdn` | `str` | Full DNS-AID record name (draft-02 flat primary owner): `{name}.{domain}` |
+| `walkable_fqdn` | `str` | Optional walkable AliasMode form: `{name}._agents.{domain}` |
+| `legacy_fqdn` | `str` | Legacy -01 form: `_{name}._{protocol}._agents.{domain}` (used only by the back-compat discovery path) |
 | `endpoint_url` | `str` | Full URL: `https://{target_host}:{port}` |
 | `svcb_target` | `str` | SVCB target with trailing dot |
 
@@ -767,7 +770,7 @@ async with InfobloxBloxOneBackend() as backend:
 | `INFOBLOX_DNS_VIEW` | No | `default` | DNS view name |
 | `INFOBLOX_BASE_URL` | No | `https://csp.infoblox.com` | API URL |
 
-**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
+**DNS-AID Compliance**: Infoblox UDDI is **not fully compliant** with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/). It only supports alias mode SVCB (priority 0) and lacks `alpn`, `port`, and `mandatory` parameters. For full compliance, use Route53Backend, InfobloxNIOSBackend, NS1Backend, or DDNSBackend.
 
 ### InfobloxNIOSBackend
 
@@ -933,7 +936,7 @@ Sign a DNS record payload with a private key.
 from dns_aid.core.jwks import sign_record, RecordPayload
 
 payload = RecordPayload(
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="payment.example.com",
     port=443,
     alpn="mcp",
@@ -1052,7 +1055,7 @@ dns-aid discover example.com --protocol mcp
 dns-aid discover example.com --use-http-index
 
 # Verify an agent
-dns-aid verify _my-agent._mcp._agents.example.com
+dns-aid verify my-agent.example.com
 
 # List all agents in a zone
 dns-aid list example.com
@@ -1076,7 +1079,7 @@ dns-aid index sync example.com           # Sync index with actual DNS records
 ```bash
 # Send a message to an A2A agent (discover-first: DNS → agent card → invoke)
 dns-aid message --domain ai.infoblox.com --name security-analyzer \
-    "Analyze security of _marketing._a2a._agents.ai.infoblox.com"
+    "Analyze security of marketing.ai.infoblox.com"
 
 # Send a message to an A2A agent (direct endpoint)
 dns-aid message --endpoint https://security-analyzer.ai.infoblox.com \
@@ -1521,7 +1524,7 @@ async with AgentClient(config) as client:
 
     # Get rankings for specific agents only
     rankings = await client.fetch_rankings(
-        fqdns=["_booking._mcp._agents.example.com"],
+        fqdns=["booking.example.com"],
         limit=10
     )
 
@@ -1843,6 +1846,6 @@ print(dns_aid.__version__)  # "0.6.0"
 ## See Also
 
 - [Getting Started Guide](getting-started.md)
-- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,14 +2,8 @@
 
 ## Overview
 
-This implementation follows the IETF draft-mozleywilliams-dnsop-dnsaid protocol for
+DNS-AID implements the IETF draft-mozleywilliams-dnsop-dnsaid-02 protocol for
 DNS-based agent discovery. This document covers the key architectural decisions.
-
-## Relationship to IETF
-
-This document describes the architecture and behavior of the reference implementation.
-
-The authoritative DNS-AID specification is defined in the IETF draft: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
 
 ---
 
@@ -28,7 +22,7 @@ explains why certain fields (description, use_cases, category) may appear as
 | **HTTP Index** (`/.well-known/agent-index.json`) | JSON document | Full | Authoritative |
 | **TXT Record** (`capabilities=...`) | Key-value strings | Minimal (capabilities + version only) | Fallback |
 
-### Implementation Resolution Strategy
+### Resolution Priority
 
 ```
 Agent discovered via SVCB record
@@ -175,12 +169,24 @@ that round-trip the same inputs through every surface.
 
 ```
 1. Query TXT _index._agents.{domain} → list of agent:protocol pairs
-2. For each agent: Query SVCB _{name}._{protocol}._agents.{domain}
-   → extract endpoint, port, ALPN + DNS-AID custom params (cap, bap, policy, realm)
-3. For each agent: If cap URI present → fetch capability document (primary)
+2. For each agent: Query SVCB {name}.{domain} (draft-02 flat primary owner)
+   → extract endpoint, port, ALPN + DNS-AID custom params (cap, bap,
+   policy, realm, well-known)
+3. For each agent: If cap URI present → fetch capability document (primary).
+   Otherwise, if well-known is set, construct
+   https://<svcb-target>/.well-known/<well-known-value> and fetch
    → capabilities, version, description, use_cases, category
-4. For each agent: If no cap URI or fetch failed → query TXT for capabilities= (fallback)
+4. For each agent: If no cap/well-known URI or fetch failed → query TXT
+   for capabilities= (fallback)
 ```
+
+Under draft-mozleywilliams-dnsop-dnsaid-02 the agent's primary owner
+name is a flat FQDN `{name}.{domain}` valid as an x.509 SAN dNSName;
+publishers MAY additionally publish a walkable AliasMode record at
+`{name}._agents.{domain}` so DNS-SD-style consumers can enumerate.
+Consumers MUST try the flat form first. Older publishers using the
+legacy `-01` form `_{name}._{protocol}._agents.{domain}` are
+resolvable when consumers set `DNS_AID_LEGACY_01_FALLBACK=1`.
 
 ### HTTP Index Discovery
 
@@ -191,12 +197,6 @@ that round-trip the same inputs through every surface.
    - Found → endpoint_source = "dns_svcb" (authoritative)
    - Not found → endpoint_source = "http_index_fallback"
 ```
-
-## Future Enhancements (Non-Normative)
-
-These are implementation proposals and are not part of the current IETF draft.
-
-Items in this section may inform future versions of the specification but should not be treated as authoritative.
 
 ### Future Enhancement: HTTP Index Fallback in DNS Mode
 
@@ -555,7 +555,7 @@ The JWS payload contains the canonical representation of the DNS record:
 
 ```json
 {
-  "fqdn": "_payment._mcp._agents.example.com",
+  "fqdn": "payment.example.com",
   "target": "payment.example.com",
   "port": 443,
   "alpn": "mcp",

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -86,10 +86,10 @@ dns-aid publish \
 
 # Expected output:
 # ✓ Agent published successfully!
-#   FQDN: _multiagent._a2a._agents.example.com
+#   FQDN: multiagent.example.com
 #   Records created:
-#     • SVCB _multiagent._a2a._agents.example.com  (alpn="a2a")
-#     • TXT _multiagent._a2a._agents.example.com
+#     • SVCB multiagent.example.com  (alpn="a2a")
+#     • TXT multiagent.example.com
 # ✓ Updated index at _index._agents.example.com (1 agent(s))
 ```
 
@@ -105,11 +105,11 @@ dns-aid publish \
 
 ```bash
 # Using dig
-dig _multiagent._a2a._agents.example.com SVCB +short
-dig _multiagent._a2a._agents.example.com TXT +short
+dig multiagent.example.com SVCB +short
+dig multiagent.example.com TXT +short
 
 # Using DNS-AID verify (shows security score)
-dns-aid verify _multiagent._a2a._agents.example.com
+dns-aid verify multiagent.example.com
 
 # Expected:
 #   ✓ DNS record exists
@@ -132,7 +132,7 @@ dns-aid index list example.com
 # ┌────────────┬──────────┬─────────────────────────────────────────────┐
 # │ Name       │ Protocol │ FQDN                                        │
 # ├────────────┼──────────┼─────────────────────────────────────────────┤
-# │ multiagent │ a2a      │ _multiagent._a2a._agents.highvelocity...    │
+# │ multiagent │ a2a      │ multiagent.highvelocity...    │
 # └────────────┴──────────┴─────────────────────────────────────────────┘
 #
 # Total: 1 agent(s) in index
@@ -236,7 +236,7 @@ async def discover_and_connect():
     # === STEP 1: DNS Discovery ===
     print("🔍 Step 1: Querying DNS for agent...")
 
-    fqdn = "_multiagent._a2a._agents.example.com"
+    fqdn = "multiagent.example.com"
 
     # Query SVCB record
     answers = dns.resolver.resolve(fqdn, "SVCB")
@@ -690,7 +690,7 @@ Found 5 flights from NYC to London on March 15:
 │  │                  DNS-AID MCP Server                      │   │
 │  │                                                          │   │
 │  │  1. discover_agents_via_dns("example.com")│   │
-│  │     └─► DNS query for _booking._mcp._agents.*.com       │   │
+│  │     └─► DNS query for booking.*.com       │   │
 │  │     └─► Returns: endpoint_url from SVCB/HTTP index      │   │
 │  │                                                          │   │
 │  │  2. call_agent_tool(endpoint, "search_flights", params)  │   │
@@ -759,13 +759,13 @@ Capabilities are resolved with the following priority, aligned with the DNS-AID 
 
 **SVCB record with cap URI** (per DNS-AID draft):
 ```
-_booking._mcp._agents.example.com. SVCB 1 mcp.example.com. \
+booking.example.com. SVCB 1 mcp.example.com. \
     alpn="mcp" port=443 cap="https://index.aiagents.example.com/cap/booking-agent"
 ```
 
 ### Discovery Transparency
 
-Agent name and protocol are now extracted from the FQDN (e.g., `_booking._mcp._agents.example.com` → name=`booking`, protocol=`mcp`). The HTTP index only needs to provide the FQDN — no separate `protocols` field required.
+Agent name and protocol are now extracted from the FQDN (e.g., `booking.example.com` → name=`booking`, protocol=`mcp`). The HTTP index only needs to provide the FQDN — no separate `protocols` field required.
 
 Each discovered agent includes transparency fields showing how data was resolved:
 
@@ -934,14 +934,14 @@ dns-aid publish \
 dns-aid discover example.com --verify-signature
 
 # Output (valid signature):
-# ✓ Signature verified for _payment._mcp._agents.example.com
+# ✓ Signature verified for payment.example.com
 # Found 1 agent(s):
 # - payment (MCP protocol)
 #   Endpoint: https://mcp.example.com:443
 #   Signature: VALID ✓
 
 # Output (invalid/missing signature):
-# ⚠ Signature verification failed for _payment._mcp._agents.example.com
+# ⚠ Signature verification failed for payment.example.com
 #   Reason: No JWKS found at https://example.com/.well-known/dns-aid-jwks.json
 ```
 
@@ -959,7 +959,7 @@ The JWS payload contains canonical SVCB record data:
 
 ```json
 {
-  "fqdn": "_payment._mcp._agents.example.com",
+  "fqdn": "payment.example.com",
   "target": "mcp.example.com",
   "port": 443,
   "alpn": "mcp",
@@ -979,7 +979,7 @@ private_key, public_key = generate_keypair()
 # Sign a record
 signature = sign_record(
     private_key=private_key,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -988,7 +988,7 @@ signature = sign_record(
 is_valid = await verify_signature(
     domain="example.com",
     signature=signature,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -292,7 +292,7 @@ asyncio.run(verify_connection())
 ### Infoblox UDDI Limitations & DNS-AID Compliance
 
 > **⚠️ Important**: Infoblox UDDI is **not fully compliant** with the
-> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+> [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 >
 > Infoblox UDDI SVCB only supports "alias mode" (priority 0) and lacks support for required
 > SVC parameters (`alpn`, `port`, `mandatory`). The DNS-AID draft requires ServiceMode
@@ -560,7 +560,7 @@ dns-aid publish \
     --backend cloudflare
 
 # Verify it was created
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
+dig test-agent.$DNS_AID_TEST_ZONE TXT +short
 
 # View the agent index
 dns-aid index list $DNS_AID_TEST_ZONE --backend cloudflare
@@ -683,27 +683,27 @@ Publishing agent to DNS...
 
 ✓ Agent published successfully!
 
-  FQDN: _test-agent._mcp._agents.yourdomain.com
+  FQDN: test-agent.yourdomain.com
   Endpoint: https://mcp.yourdomain.com:443
 
   Records created:
-    • SVCB _test-agent._mcp._agents.yourdomain.com
-    • TXT _test-agent._mcp._agents.yourdomain.com
+    • SVCB test-agent.yourdomain.com
+    • TXT test-agent.yourdomain.com
 
 Verify with:
-  dig _test-agent._mcp._agents.yourdomain.com SVCB
-  dig _test-agent._mcp._agents.yourdomain.com TXT
+  dig test-agent.yourdomain.com SVCB
+  dig test-agent.yourdomain.com TXT
 ```
 
 ### Step 2: Verify DNS Records
 
 ```bash
 # Using DNS-AID
-dns-aid verify _test-agent._mcp._agents.$DNS_AID_TEST_ZONE
+dns-aid verify test-agent.$DNS_AID_TEST_ZONE
 
 # Using dig (external verification)
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE SVCB +short
-dig _test-agent._mcp._agents.$DNS_AID_TEST_ZONE TXT +short
+dig test-agent.$DNS_AID_TEST_ZONE SVCB +short
+dig test-agent.$DNS_AID_TEST_ZONE TXT +short
 ```
 
 ### Step 3: Discover Agents
@@ -751,7 +751,7 @@ Agent index for yourdomain.com:
 ┌────────────┬──────────┬─────────────────────────────────────────────┐
 │ Name       │ Protocol │ FQDN                                        │
 ├────────────┼──────────┼─────────────────────────────────────────────┤
-│ test-agent │ mcp      │ _test-agent._mcp._agents.yourdomain.com     │
+│ test-agent │ mcp      │ test-agent.yourdomain.com     │
 └────────────┴──────────┴─────────────────────────────────────────────┘
 
 Total: 1 agent(s) in index
@@ -885,7 +885,7 @@ async def main():
         print(f"Found: {agent.name} at {agent.endpoint_url}")
 
     # Verify an agent
-    verification = await verify("_my-agent._mcp._agents.yourdomain.com")
+    verification = await verify("my-agent.yourdomain.com")
     print(f"Security Score: {verification.security_score}/100")
 
 asyncio.run(main())
@@ -902,7 +902,7 @@ enforcing agent access control at the DNS layer.
 ```json
 {
   "version": "1.0",
-  "agent": "_inventory._mcp._agents.example.com",
+  "agent": "inventory.example.com",
   "rules": {
     "allowed_caller_domains": ["ai-platform.example.com"],
     "blocked_caller_domains": ["*.sandbox.example.com"],
@@ -1000,7 +1000,7 @@ private_key, public_key = generate_keypair()
 # Sign a record
 signature = sign_record(
     private_key=private_key,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -1009,7 +1009,7 @@ signature = sign_record(
 is_valid = await verify_signature(
     domain="example.com",
     signature=signature,
-    fqdn="_payment._mcp._agents.example.com",
+    fqdn="payment.example.com",
     target="mcp.example.com",
     port=443,
 )
@@ -1040,7 +1040,7 @@ async def main():
     result = await send_a2a_message(
         domain="ai.infoblox.com",
         name="security-analyzer",
-        message="Analyze security of _marketing._a2a._agents.ai.infoblox.com",
+        message="Analyze security of marketing.ai.infoblox.com",
         timeout=60.0,
     )
     if result.success:
@@ -1053,7 +1053,7 @@ asyncio.run(main())
 ```
 
 The discover-first flow:
-1. Queries DNS for `_security-analyzer._a2a._agents.ai.infoblox.com` SVCB record
+1. Queries DNS for `security-analyzer.ai.infoblox.com` SVCB record
 2. Fetches `/.well-known/agent-card.json` for canonical URL and metadata
 3. Validates card URL hostname matches DNS endpoint (prevents internal URL leakage)
 4. Sends the A2A JSON-RPC 2.0 `message/send` request
@@ -1680,4 +1680,4 @@ stable public API. They will be integrated in a future release once the
 
 - Read the [API Reference](api-reference.md)
 - Explore [examples/](../examples/)
-- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/)
+- Review the [IETF draft specification](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -270,7 +270,7 @@ await publish(
 ```python
 from dns_aid.core.validator import verify
 
-result = await verify("_network-specialist._mcp._agents.example.com")
+result = await verify("network-specialist.example.com")
 print(f"DNSSEC valid: {result.dnssec_valid}")
 print(f"Security rating: {result.security_rating}")
 ```

--- a/docs/integrations/opentelemetry.md
+++ b/docs/integrations/opentelemetry.md
@@ -37,7 +37,7 @@ agent's span. Total elapsed: under 10 minutes from clone.
 
 ### Spans
 
-- Name: `dns-aid.invoke {agent_fqdn}` (e.g., `dns-aid.invoke _chat._mcp._agents.example.com`)
+- Name: `dns-aid.invoke {agent_fqdn}` (e.g., `dns-aid.invoke chat.example.com`)
 - Kind: `SpanKind.CLIENT`
 - Attributes (set at span open): `dns_aid.agent.name`, `dns_aid.agent.domain`,
   `dns_aid.agent.protocol`, `dns_aid.agent.endpoint` (credentials in URL

--- a/docs/mcp-directory-listing.md
+++ b/docs/mcp-directory-listing.md
@@ -22,7 +22,7 @@ SVCB record queries.
 
 ### Prompt 2: Verify an agent's DNS security
 
-> Verify the DNS records for _network._mcp._agents.example.com
+> Verify the DNS records for network.example.com
 > and tell me if DNSSEC is valid
 
 Expected: Returns DNS record validation results including SVCB record

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -56,7 +56,7 @@ The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-le
 
 **How DNS-AID Works:**
 1. Use your existing domain (you already own `yourcompany.com`)
-2. Add DNS-AID records to your zone (`_myagent._mcp._agents.yourcompany.com`)
+2. Add DNS-AID records to your zone (`myagent.yourcompany.com`)
 3. Start discovering and being discovered immediately
 
 | Factor | .agent gTLD | DNS-AID |
@@ -66,12 +66,12 @@ The [Agent Community](https://agentcommunity.org/) is pursuing a `.agent` top-le
 | **Who controls discovery** | Registry operator | You (your domain) |
 | **Works today** | ❌ Pending ICANN approval | ✅ Works now |
 | **Requires new infrastructure** | ✅ Registry, registrars | ❌ Uses existing DNS |
-| **Memorable names** | ✅ `myagent.agent` | `_myagent._mcp._agents.example.com` |
+| **Memorable names** | ✅ `myagent.agent` | ✅ `myagent.example.com` |
 
 **The Friendly Take:**
 
 Both approaches share the goal of making AI agents discoverable. The `.agent` gTLD creates a dedicated namespace that's easy to remember (`mycompany.agent`), while DNS-AID leverages existing infrastructure so you can start publishing agents today.
 
-DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `_myagent._mcp._agents.example.com` right now.
+DNS-AID doesn't require waiting for ICANN approval or paying for new domains—it works with the DNS infrastructure your organization already operates. If you own `example.com`, you can publish agents to `myagent.example.com` right now.
 
 *Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*

--- a/docs/privacy-considerations.md
+++ b/docs/privacy-considerations.md
@@ -1,0 +1,138 @@
+# Privacy Considerations
+
+DNS-AID publishes service-discovery records in DNS. By design, DNS is a
+public namespace — any client that can resolve names in your zone can
+read what you publish. This document describes the privacy trade-offs
+baked into each record type so operators can choose the right defaults
+for their deployment.
+
+## Enumeration vs. Discovery
+
+There's a distinction worth naming up front:
+
+- **Discovery** is the case where a caller already knows the agent name
+  it wants and resolves a specific FQDN — `chat.example.com`,
+  `pharmacy-delivery.acmehealth.com`. This is the everyday flow and is
+  fundamentally what DNS is for.
+- **Enumeration** is the case where a caller doesn't know the agent
+  names in advance and discovers them by walking the zone. DNS-AID
+  optionally supports this via DNS-SD-style records, but it's a
+  different privacy posture: enumeration lets *anyone* inventory the
+  agents an operator has published.
+
+Most operators want discovery without enumeration. Some — operators
+running intentional public directories, internal indexes, or
+DNS-SD-style consumers — want both. The defaults in dns-aid-core
+reflect "discovery on, enumeration off" and the per-record knobs let
+you opt into enumeration deliberately.
+
+## The Walkable AliasMode Record
+
+Under draft-mozleywilliams-dnsop-dnsaid-02 §3.1, publishers MAY emit a
+walkable AliasMode SVCB record at `{name}._agents.{domain}` pointing at
+the flat primary owner `{name}.{domain}`. This record exists so
+DNS-SD-style consumers and crawlers can enumerate an operator's agents
+by walking `_agents.{domain}` and following each AliasMode to the
+canonical owner.
+
+**dns-aid-core publishes this record only when explicitly enabled.**
+The default is `publish_walkable_alias=False` (SDK), `--walkable`
+(CLI flag, opt-in), and `publish_walkable_alias=False` (MCP tool).
+
+### Why off by default
+
+The walkable record is, by construction, an enumeration handle. With
+the walkable record present, a caller that knows your zone name can:
+
+1. Query `_agents.{zone}` for SVCB records, or zone-walk the
+   `_agents.{zone}` namespace under DNSSEC's NSEC/NSEC3 records.
+2. Receive a list of every `{name}._agents.{zone}` your operator
+   publishes.
+3. Follow the AliasMode for each one to learn the canonical owner
+   `{name}.{zone}`.
+
+Net effect: complete inventory of your agents from the zone name
+alone. For a public commercial service that wants to be discoverable,
+this is exactly the desired behaviour. For a healthcare operator with
+internal-only agents whose names indirectly reveal sensitive workflows
+(`oncology-triage`, `crisis-helpline`), it's the wrong default.
+
+Erring on the side of less information leakage matches the privacy
+posture of the rest of the stack: DNSSEC zone-walking has been a
+known privacy issue since RFC 5155, and NSEC3-opt-out exists to limit
+exactly this kind of enumeration.
+
+### When to enable
+
+Set `publish_walkable_alias=True` (or pass `--walkable` to the CLI)
+when:
+
+- **You're running a public agent directory** — a curated catalog of
+  agents intentionally meant to be discovered by anyone. The walkable
+  shape is the most standard way to expose that.
+- **You're running an internal directory or DNS-SD-style index** —
+  on private networks where enumeration by callers inside your
+  perimeter is desirable and the records aren't reachable from
+  outside.
+- **You're publishing a DNS-SD-bridged service** — interop with
+  consumers that already speak the DNS-SD enumeration shape.
+- **You want crawler discoverability** for an agent-catalog project
+  (e.g. dns-aid.org's spider) and are okay with the enumeration
+  surface that implies.
+
+For any of those cases, the walkable record is doing useful work and
+the privacy cost is acceptable.
+
+### When to leave it off
+
+Leave the default in place when:
+
+- **The agent's existence or name is sensitive** — anything where the
+  name itself signals workflow detail you don't want indexed by
+  third-party DNS scanners.
+- **You have a small, fixed set of consumers** who already know the
+  agent FQDNs they need (out-of-band exchange, configuration, or
+  partner agreements).
+- **You publish a large number of agents in one zone** — even if no
+  individual name is sensitive, the aggregate inventory may reveal
+  operational scale you'd rather keep private.
+
+### What discovery still works without the walkable record
+
+Without the walkable record, a caller can still:
+
+- Resolve a specific known agent by querying `{name}.{domain}`
+  directly. This is unaffected.
+- Find agents through an organisation index at
+  `_index._agents.{domain}` — which is a separate, intentionally
+  publishable list of names the operator chose to include. Operators
+  curate this list; the walkable record is opt-out-of-curation.
+
+So the choice "walkable off, organisation index on" gives consumers a
+discovery list the operator controls while denying random crawlers an
+inventory handle.
+
+## Other Records Worth Noting
+
+- **The organisation index** (`_index._agents.{domain}`) is explicitly
+  a curated list — operators choose what to put there. There's no
+  privacy hazard beyond what the operator has already decided to
+  publish.
+- **TLSA records** (`_443._tcp.{name}.{domain}`) pin certificates to
+  DNS-anchored trust. They reveal that the agent uses TLS at a given
+  port and bind it to a cert chain; they don't reveal the agent's
+  capabilities or activity.
+- **Capability descriptors** referenced by `cap` or `well-known` are
+  fetched over HTTPS to the SVCB target. Their content is whatever
+  the operator chose to publish there — typically a capability list,
+  schema URIs, and contact info. Operators concerned about leaking
+  capability detail can put a minimal pointer behind authentication
+  on the descriptor URL itself.
+
+## Summary
+
+Default off for the walkable record. Default on for the flat primary
+owner. Explicit opt-in for any record whose primary purpose is
+enumeration. Operators who want their agents indexed turn enumeration
+on deliberately; operators who don't, get the privacy-preserving
+shape by default.

--- a/docs/rfc/iana-considerations.md
+++ b/docs/rfc/iana-considerations.md
@@ -1,6 +1,6 @@
 # IANA Considerations
 
-This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the IANA registrations required for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Underscored Node Names Registry
 
@@ -10,20 +10,23 @@ Per [RFC 8552](https://www.rfc-editor.org/rfc/rfc8552.html) (Scoped Interpretati
 
 | RR Type | _NODE NAME | Reference |
 |---------|------------|-----------|
-| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
-| TXT | `_agents` | draft-mozleywilliams-dnsop-dnsaid-01 |
+| SVCB | `_agents` | draft-mozleywilliams-dnsop-dnsaid-02 |
+| SVCB | `_index` | draft-mozleywilliams-dnsop-dnsaid-02 |
+| TXT | `_agents-challenge` | draft-mozleywilliams-dnsop-dnsaid-02 (experimental, §DCV) |
 
-**Purpose:** The `_agents` underscore name designates a subtree for AI agent service discovery records. Records under this name follow the pattern:
-
-```
-_{agent-name}._{protocol}._agents.{domain}.
-```
+**Purpose:** Under -02, the agent's primary owner name is a flat FQDN `{agent}.{domain}` (no underscore-prefix labels, x.509-SAN-valid). Operators MAY additionally publish a walkable AliasMode record at `{agent}._agents.{domain}` so that crawlers and DNS-SD-style consumers can enumerate. The `_index._agents.{domain}` SVCB record points at the organization-level agent index. The `_agents-challenge.{domain}` TXT record is used by the experimental domain-control-validation mechanism described in -02 §5 (Future Work and Experimental Mechanisms).
 
 **Examples:**
 ```
-_network._mcp._agents.example.com.    SVCB 1 mcp.example.com. alpn="mcp" port=443
-_chat._a2a._agents.example.com.       SVCB 1 chat.example.com. alpn="a2a" port=443
-_assistant._https._agents.example.com. SVCB 1 api.example.com. alpn="h2" port=443
+# Flat primary owner — the form publishers SHOULD support and consumers MUST try first
+network.example.com.   SVCB 1 mcp.example.com. alpn="mcp" port=443 bap="mcp"
+chat.example.com.      SVCB 1 chat.example.com. alpn="a2a" port=443 bap="a2a"
+
+# Optional walkable AliasMode at the _agents leaf
+chat._agents.example.com. SVCB 0 chat.example.com.
+
+# Organization index — TargetName must not contain underscores (it carries a public x.509 cert)
+_index._agents.example.com. SVCB 1 agent-index.example.com.
 ```
 
 ## 2. TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs
@@ -34,7 +37,7 @@ This document requests registration of the following ALPN Protocol ID in the "TL
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-01 |
+| Model Context Protocol | `0x6D 0x63 0x70` ("mcp") | draft-mozleywilliams-dnsop-dnsaid-02 |
 
 **Description:** The Model Context Protocol (MCP) is a protocol for AI model context sharing and tool invocation, originally developed by Anthropic. The `mcp` ALPN identifier signals that the TLS connection will carry MCP traffic.
 
@@ -46,7 +49,7 @@ This document requests registration of the following ALPN Protocol ID:
 
 | Protocol | Identification Sequence | Reference |
 |----------|------------------------|-----------|
-| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-01 |
+| Agent-to-Agent Protocol | `0x61 0x32 0x61` ("a2a") | draft-mozleywilliams-dnsop-dnsaid-02 |
 
 **Description:** The Agent-to-Agent (A2A) protocol enables direct communication between AI agents, originally developed by Google. The `a2a` ALPN identifier signals that the TLS connection will carry A2A traffic.
 
@@ -62,7 +65,7 @@ This document requests IANA establish a new registry titled "DNS-AID Error Codes
 
 **Registration Procedure:** Specification Required
 
-**Reference:** draft-mozleywilliams-dnsop-dnsaid-01
+**Reference:** draft-mozleywilliams-dnsop-dnsaid-02
 
 ### 3.2 Initial Registry Contents
 
@@ -98,17 +101,27 @@ DNS-AID uses the following existing parameters defined in [RFC 9460](https://www
 | alpn | 1 | RFC 9460 Section 7.1.1 |
 | port | 3 | RFC 9460 Section 7.2 |
 
-### 4.2 DNS-AID Custom Parameters (draft-01 Section 4.4.3)
+### 4.2 DNS-AID Custom Parameters (draft-02 §4 IANA Considerations)
 
-This document requests registration of the following SVCB service parameters in the private-use range (65280-65534) per RFC 9460 Section 14.3.2:
+This document requests IANA registration of six SvcParamKeys per RFC 9460 §14.3.2. The numeric code points are deferred to IANA assignment; until then, implementations use the private-use range (65280-65534). The keys below sit at 65400-65409.
 
 | Parameter | Proposed Key ID | Value Format | Description | Reference |
 |-----------|-----------------|--------------|-------------|-----------|
-| `cap` | 65400 | URI (RFC 3986) | URI to capability descriptor document (JSON). Allows clients to fetch structured agent metadata. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `capsha256` | 65401 | Base64url (RFC 4648 §5) | SHA-256 digest of the capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `bap` | 65402 | Comma-separated tokens | DNS-AID Application Protocols — lists protocols the agent supports with optional versions (e.g., `mcp/1,a2a/1`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `policy` | 65403 | URI (RFC 3986) | URI to agent policy document describing terms of use, data handling, and compliance. | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
-| `realm` | 65404 | Token | Multi-tenant scope identifier for authorization (e.g., `production`, `staging`). | draft-mozleywilliams-dnsop-dnsaid-01 Section 4.4.3 |
+| `cap` | 65400 | URI or URN (RFC 3986) or compact JSON-Ref | Capability descriptor locator or inline identifier. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `cap-sha256` | 65401 | Base64url (RFC 4648 §5) | Base64url SHA-256 of the canonical capability descriptor for integrity verification. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `bap` | 65402 | Comma-separated tokens | Bulk agent protocols supported at this endpoint (e.g., `mcp`, `a2a`). The agent protocol the endpoint speaks once TLS is established. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `policy` | 65403 | URI (RFC 3986) | URI of an associated policy bundle (terms of use, data handling, compliance). Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `realm` | 65404 | Token | Opaque token for multi-tenant scoping or authz realm selection during protocol bootstrapping. Payload semantics deferred to a future revision. | draft-mozleywilliams-dnsop-dnsaid-02 |
+| `well-known` | 65409 | RFC 8615 path | Well-known URI path suffix (e.g., `agent-card.json`). Consumer constructs `https://<target>/.well-known/<value>`. Complements `cap` (which is a flexible locator); the two are independent keys. | draft-mozleywilliams-dnsop-dnsaid-02 |
+
+The following keys remain at private-use code points but are NOT in the -02 normative SvcParamKey set; they back features that are either in §5 (Future Work and Experimental Mechanisms) or shipping in dns-aid-core as extensions:
+
+| Parameter | Key ID | Notes |
+|-----------|--------|-------|
+| `sig` | 65405 | JWS signature over the record. Backs the optional record-signature flow. |
+| `connect-class` | 65406 | Transport-class hint (§5 (Future Work and Experimental Mechanisms) — `direct`, `lattice`, `apphub-psc`). |
+| `connect-meta` | 65407 | Transport-class metadata for the selected `connect-class`. |
+| `enroll-uri` | 65408 | Zero-trust enrollment URI (§5 (Future Work and Experimental Mechanisms)). |
 
 **Wire Format:** Until IANA allocates permanent key IDs, implementations MUST use the generic `keyNNNNN` presentation format (e.g., `key65400="https://..."`) for interoperability with DNS providers that do not recognize custom parameter names. See Section 2.2 of RFC 9460.
 
@@ -133,6 +146,6 @@ For the DNS-AID Error Code Registry, designated experts SHOULD consider:
 
 ### Informative References
 
-- [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/) - DNS-based Agent Identification and Discovery (DNS-AID)
+- [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/) - DNS-based Agent Identification and Discovery (DNS-AID)
 - [Model Context Protocol](https://spec.modelcontextprotocol.io/) - MCP Specification
 - [A2A Protocol](https://google.github.io/A2A/) - Agent-to-Agent Protocol Documentation

--- a/docs/rfc/privacy-considerations.md
+++ b/docs/rfc/privacy-considerations.md
@@ -1,6 +1,6 @@
 # Privacy Considerations
 
-This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the privacy considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Privacy Model
 
@@ -59,7 +59,7 @@ Domain owners can request removal of their agents from the directory:
 
 **Option 1: API Request (Verified Domain)**
 ```http
-DELETE /api/v1/agents/_network._mcp._agents.example.com
+DELETE /api/v1/agents/network.example.com
 Authorization: Bearer <domain-verified-token>
 ```
 

--- a/docs/rfc/security-considerations.md
+++ b/docs/rfc/security-considerations.md
@@ -1,6 +1,6 @@
 # Security Considerations
 
-This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-01](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-01/).
+This document describes the security considerations for DNS-AID (DNS-based Agent Identification and Discovery) as specified in [draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/).
 
 ## 1. Threat Model (STRIDE Analysis)
 
@@ -187,7 +187,7 @@ zone "example.com" {
 
 **Secure SVCB Example:**
 ```
-_network._mcp._agents.example.com. 3600 IN SVCB 1 mcp.example.com. (
+network.example.com. 3600 IN SVCB 1 mcp.example.com. (
     mandatory="alpn"
     alpn="mcp"
     port="443"
@@ -230,6 +230,35 @@ _443._tcp.mcp.example.com. TLSA 3 1 1 (
     2bb183af... ; SHA-256 hash of certificate
 )
 ```
+
+### 2.4 Implementation Hardening (dns-aid-core)
+
+The reference implementation enforces the following at the type and fetch
+boundaries, independent of DNSSEC:
+
+- **SvcParam value validation.** Every free-form SVCB SvcParam value
+  (`bap`, `cap`, `cap-sha256`, `policy`, `realm`, `sig`, `connect-meta`,
+  `enroll-uri`, and the TargetName) is validated before it is written to a
+  zone. Values containing a double quote, backslash, or control character
+  are rejected so a forged value cannot break out of the SvcParam
+  presentation quoting (`key="<value>"`) and inject an attacker-controlled
+  sibling key into the authoritative record.
+- **Descriptor and JWKS fetches are SSRF-guarded and size-capped.**
+  Capability descriptors, A2A agent cards, and the
+  `/.well-known/dns-aid-jwks.json` document are fetched HTTPS-only, with
+  the resolved IP checked against private / loopback / link-local ranges,
+  a streaming response-size cap, and no cross-host redirects. The HTTP
+  agent index is additionally bounded in document size and agent count.
+- **JWS verification pins the algorithm and curve.** Record signatures
+  MUST be `ES256`; the verifier rejects any other `alg` (including `none`)
+  and accepts only a P-256 EC signing key with 32-byte coordinates,
+  closing algorithm- and curve-confusion attacks now that the JWKS source
+  is operator-published (and therefore attacker-influenceable absent
+  DNSSEC).
+- **Protocol provenance.** Under draft-02 the agent protocol is read from
+  the SVCB record (`bap`, or `alpn`) after resolution, and the JWS payload
+  binds `(fqdn, target, port, alpn)` to the record so a valid signature
+  cannot be lifted onto a spoofed record.
 
 ## 3. Operational Security
 

--- a/docs/rfc/wire-format-01.abnf
+++ b/docs/rfc/wire-format-01.abnf
@@ -1,5 +1,5 @@
 ; DNS-AID Wire Format - ABNF Grammar
-; Reference: draft-mozleywilliams-dnsop-dnsaid-02
+; Reference: draft-mozleywilliams-dnsop-dnsaid-01
 ;
 ; This document defines the wire format for DNS-AID records using
 ; Augmented Backus-Naur Form (ABNF) as specified in RFC 5234.
@@ -22,35 +22,23 @@ DQUOTE         = %x22                ; " (double quote)
 VCHAR          = %x21-7E             ; visible (printing) characters
 
 ; ==================================================================
-; DNS-AID FQDN Format (draft-02)
+; DNS-AID FQDN Format
 ; ==================================================================
 
-; The agent's primary owner name is a flat FQDN, valid as an x.509
-; SAN dNSName. Publishers MAY additionally publish a walkable
-; AliasMode record at the _agents leaf so crawlers and DNS-SD-style
-; consumers can enumerate. Consumers MUST try the flat form first.
+; DNS-AID agent FQDN follows the pattern:
+; _{agent-name}._{protocol}._agents.{domain}.
 
-dns-aid-fqdn          = agent-name "." domain "."
-                        ; Flat primary owner — the form publishers
-                        ; SHOULD support and consumers MUST try first
-
-dns-aid-walkable-fqdn = agent-name "._agents." domain "."
-                        ; Optional walkable AliasMode at the
-                        ; _agents leaf; SVCB priority MUST be 0
-                        ; (AliasMode) pointing at the flat owner
+dns-aid-fqdn   = "_" agent-name "._" protocol "._agents." domain "."
 
 agent-name     = 1*63(ALPHA / DIGIT / "-")
                  ; Agent name: alphanumeric with hyphens
                  ; Max 63 characters per DNS label rules
-                 ; The agent protocol is NOT in the FQDN under -02;
-                 ; it lives in the `bap` SvcParamKey (or `alpn` when
-                 ; only one protocol is supported)
 
-protocol       = "mcp" / "a2a" / extension-protocol
-                 ; Agent protocols (values for `bap` and, when only
-                 ; one is supported, `alpn`)
+protocol       = "mcp" / "a2a" / "https" / extension-protocol
+                 ; Supported protocols
                  ; mcp  = Model Context Protocol
                  ; a2a  = Agent-to-Agent Protocol
+                 ; https = Standard HTTPS
 
 extension-protocol = "x-" 1*62(ALPHA / DIGIT / "-")
                      ; Experimental protocols prefixed with "x-"
@@ -90,12 +78,11 @@ svc-param      = mandatory-param
                / port-param
                / ipv4hint-param
                / ipv6hint-param
-               / cap-param           ; DNS-AID: capability descriptor locator
-               / cap-sha256-param    ; DNS-AID: capability descriptor digest
-               / bap-param           ; DNS-AID: bulk agent protocols
-               / policy-param        ; DNS-AID: policy bundle URI
+               / cap-param           ; DNS-AID: capability document URI
+               / capsha256-param     ; DNS-AID: capability document hash
+               / bap-param           ; DNS-AID: application protocols
+               / policy-param        ; DNS-AID: policy document URI
                / realm-param         ; DNS-AID: multi-tenant scope
-               / well-known-param    ; DNS-AID: RFC 8615 well-known path
                / unknown-param
 
 ; ==================================================================
@@ -143,57 +130,38 @@ IPv6-compressed = *1(":" 1*4HEXDIG) "::" *1(1*4HEXDIG ":")
                   ; Simplified - full IPv6 grammar is complex
 
 ; ==================================================================
-; DNS-AID Custom SVCB Parameters (draft-02 §4 IANA Considerations)
+; DNS-AID Custom SVCB Parameters (draft-01 Section 4.4.3)
 ; ==================================================================
 
-; Capability descriptor locator (key 65400)
-cap-param      = "cap=" DQUOTE cap-locator DQUOTE
-cap-locator    = URI / urn / json-ref
-                 ; Capability descriptor locator or inline identifier
-                 ; Per -02: a URI, URN, or compact JSON-Ref
-                 ; e.g., "https://agent.example.com/cap.json" or
-                 ; "urn:example:agent-cap:abc123"
+; Capability document URI (key 65400)
+cap-param      = "cap=" DQUOTE cap-uri DQUOTE
+cap-uri        = URI
+                 ; URI to JSON capability descriptor document
+                 ; e.g., "https://agent.example.com/.well-known/agent-cap.json"
 
-urn            = "urn:" 1*(ALPHA / DIGIT / "-" / ":")
-json-ref       = 1*(ALPHA / DIGIT / "-" / "/" / "#" / ".")
-                 ; Simplified — see https://datatracker.ietf.org/doc/draft-handrews-json-schema-02/
-
-; Capability descriptor integrity digest (key 65401)
-cap-sha256-param = "cap-sha256=" DQUOTE base64url DQUOTE
+; Capability document integrity hash (key 65401)
+capsha256-param = "capsha256=" DQUOTE base64url DQUOTE
 base64url      = 1*43(ALPHA / DIGIT / "-" / "_")
-                 ; Base64url-encoded SHA-256 digest (RFC 4648 §5)
+                 ; Base64url-encoded SHA-256 digest (RFC 4648 Section 5)
                  ; 32 bytes = 43 base64url characters (no padding)
-                 ; Per -02: hash of the canonical capability descriptor
 
-; Bulk agent protocols (key 65402)
+; DNS-AID Application Protocols (key 65402)
 bap-param      = "bap=" DQUOTE bap-list DQUOTE
-bap-list       = protocol *("," protocol)
-                 ; Per -02: agent protocols supported at this endpoint
-                 ; e.g., "mcp" or "mcp,a2a"
-                 ; Version suffixes (e.g. "mcp/1") were proposed as an
-                 ; experimental extension in -02 §5 (Future Work and Experimental Mechanisms) (Bulk Agent
-                 ; Protocol) and are not normative in the base spec
+bap-list       = bap-entry *("," bap-entry)
+bap-entry      = protocol ["/" version-number]
+version-number = 1*3DIGIT
+                 ; e.g., "mcp/1,a2a/1"
 
-; Policy bundle URI (key 65403)
+; Policy document URI (key 65403)
 policy-param   = "policy=" DQUOTE policy-uri DQUOTE
 policy-uri     = URI
-                 ; URI of an associated policy bundle
-                 ; Payload semantics deferred to a future revision
+                 ; URI to agent policy document (terms of use, data handling)
 
 ; Multi-tenant realm (key 65404)
 realm-param    = "realm=" DQUOTE realm-value DQUOTE
 realm-value    = 1*63(ALPHA / DIGIT / "-" / "_")
-                 ; Opaque token for multi-tenant scoping or authz realm
-                 ; selection during protocol bootstrapping
+                 ; Scope identifier for authorization
                  ; e.g., "production", "staging", "tenant-42"
-
-; Well-known path suffix (key 65409, new in -02)
-well-known-param = "well-known=" DQUOTE wk-path DQUOTE
-wk-path        = 1*(ALPHA / DIGIT / "-" / "." / "_" / "/")
-                 ; RFC 8615 well-known path suffix
-                 ; e.g., "agent-card.json" — consumer constructs
-                 ; https://<svcb-target>/.well-known/<wk-path>
-                 ; Independent of `cap`; both may be present.
 
 ; Generic URI rule (simplified from RFC 3986)
 URI            = scheme "://" authority path-abempty
@@ -205,12 +173,11 @@ segment        = *(ALPHA / DIGIT / "-" / "." / "_" / "~" / "%" / "!" / "@")
 
 ; Wire format note: Until IANA assigns permanent key IDs,
 ; implementations MUST use generic key encoding:
-;   key65400="https://..."          (cap)
-;   key65401="dGVzdGhhc2g"          (cap-sha256)
-;   key65402="mcp"                  (bap)
-;   key65403="https://..."          (policy)
-;   key65404="production"           (realm)
-;   key65409="agent-card.json"      (well-known)
+;   key65400="https://..."   (cap)
+;   key65401="dGVzdGhhc2g"   (capsha256)
+;   key65402="mcp/1,a2a/1"   (bap)
+;   key65403="https://..."   (policy)
+;   key65404="production"    (realm)
 
 ; Unknown/extension parameters
 unknown-param  = key-name "=" param-value
@@ -278,38 +245,22 @@ error-message  = 1*256(VCHAR / SP)
                  ; Human-readable error description
 
 ; ==================================================================
-; DNS-AID Index Record Format (draft-02)
+; DNS-AID Index Record Format
 ; ==================================================================
 
-; Organization-level index for zone enumeration.
+; Optional index record for zone enumeration
 ; Published at _index._agents.{domain}.
-;
-; Under -02 the primary form is SVCB, pointing at a TargetName that
-; serves the index over HTTPS. The TargetName MUST NOT contain
-; underscores (it carries a public x.509 cert).
-;
-; A TXT-fallback form is documented in -02 §TXT-fallback for
-; environments without SVCB support.
 
-index-svcb-record = "_index._agents." domain "." SP "SVCB" SP
-                    svc-priority SP index-target [SP svc-params]
+index-record   = "_index._agents." domain "." SP "TXT" SP index-value
 
-index-target   = label *("." label) "."
-                 ; FQDN of the host serving the agent index
-                 ; MUST NOT contain underscores
-
-; TXT fallback (legacy / SVCB-less deployments)
-index-txt-record = "_index._agents." domain "." SP "TXT" SP index-txt-value
-
-index-txt-value = DQUOTE "agents=" agent-list DQUOTE
+index-value    = DQUOTE "agents=" agent-list DQUOTE
 
 agent-list     = agent-ref *("," agent-ref)
 agent-ref      = agent-name ":" protocol
                  ; Reference to agent by name and protocol
 
-; Examples:
-; _index._agents.example.com. SVCB 1 agent-index.example.com. alpn="h2" port=443
-; _index._agents.example.com. TXT "agents=network:mcp,chat:a2a"
+; Example:
+; _index._agents.example.com. TXT "agents=network:mcp,chat:a2a,assistant:https"
 
 ; ==================================================================
 ; DNS-AID Opt-Out Record Format
@@ -330,7 +281,7 @@ optout-flag    = "true" / "false"
 ; ==================================================================
 
 ; Implements domain control validation per:
-;   draft-mozleywilliams-dnsop-dnsaid-02   (bnd-req binding)
+;   draft-mozleywilliams-dnsop-dnsaid-01   (bnd-req binding)
 ;   draft-ietf-dnsop-domain-verification-techniques-12
 
 ; Challenge owner name:  _agents-challenge.{domain}
@@ -380,98 +331,71 @@ verify-token   = 32*64(ALPHA / DIGIT)
                  ; 32-64 alphanumeric characters
 
 ; ==================================================================
-; Complete Examples (draft-02)
+; Complete Examples
 ; ==================================================================
 
-; Example 1: MCP Agent — flat primary owner
+; Example 1: MCP Agent SVCB Record
 ;
-; network.example.com. 3600 IN SVCB 1 mcp.example.com. (
-;     mandatory="alpn,port"
+; _network._mcp._agents.example.com. 3600 IN SVCB 1 mcp.example.com. (
+;     mandatory="alpn"
 ;     alpn="mcp"
 ;     port="443"
-;     bap="mcp"
 ; )
 
-; Example 2: A2A Agent
+; Example 2: A2A Agent SVCB Record
 ;
-; chat.example.com. 3600 IN SVCB 1 chat.example.com. (
+; _chat._a2a._agents.example.com. 3600 IN SVCB 1 chat.example.com. (
 ;     alpn="a2a"
 ;     port="443"
 ;     ipv4hint="192.0.2.1"
-;     bap="a2a"
 ; )
 
-; Example 3: ServiceMode with DNS-AID custom parameters
+; Example 3: SVCB Record with DNS-AID Custom Parameters (v0.4.8)
 ;
-; booking.example.com. 3600 IN SVCB 1 booking.example.com. (
+; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"
-;     alpn="h2"
+;     alpn="mcp"
 ;     port="443"
-;     bap="mcp"
-;     cap="https://booking.example.com/cap.json"
-;     cap-sha256="dGVzdGhhc2g..."
-;     well-known="agent-card.json"
+;     cap="https://booking.example.com/.well-known/agent-cap.json"
+;     bap="mcp/1"
 ;     policy="https://example.com/agent-policy.json"
 ;     realm="production"
 ; )
 ;
-; Wire format (generic keyNNNNN encoding for providers that don't
-; understand the custom names yet):
-; booking.example.com. 3600 IN SVCB 1 booking.example.com. (
+; Wire format (Route 53 compatible with generic keys):
+; _booking._mcp._agents.example.com. 3600 IN SVCB 1 booking.example.com. (
 ;     mandatory="alpn,port"
-;     alpn="h2"
+;     alpn="mcp"
 ;     port="443"
-;     key65400="https://booking.example.com/cap.json"
-;     key65401="dGVzdGhhc2g..."
-;     key65402="mcp"
+;     key65400="https://booking.example.com/.well-known/agent-cap.json"
+;     key65402="mcp/1"
 ;     key65403="https://example.com/agent-policy.json"
 ;     key65404="production"
-;     key65409="agent-card.json"
 ; )
 
-; Example 4: Walkable AliasMode at the _agents leaf (optional)
+; Example 4: TXT Capabilities Record
 ;
-; chat._agents.example.com. 3600 IN SVCB 0 chat.example.com.
-
-; Example 5: TXT capabilities record (optional companion to the SVCB)
-;
-; network.example.com. 3600 IN TXT (
+; _network._mcp._agents.example.com. 3600 IN TXT (
 ;     "capabilities=chat,code,tools"
 ;     "version=1.2.0"
 ;     "model=claude-3"
 ; )
 
-; Example 6: Organization index (SVCB primary form)
+; Example 4: Index Record
 ;
-; _index._agents.example.com. 3600 IN SVCB 1 agent-index.example.com. (
-;     alpn="h2"
-;     port="443"
-; )
-; ; (TargetName "agent-index.example.com" MUST NOT contain underscores)
+; _index._agents.example.com. 3600 IN TXT "agents=network:mcp,chat:a2a"
 
-; Example 7: Opt-Out Record (dns-aid-core convention; not in -02)
+; Example 5: Opt-Out Record
 ;
 ; _dns-aid-optout.private.example.com. 3600 IN TXT "optout=true"
 
 ; ==================================================================
-; Wire Format Notes (draft-02)
+; Wire Format Notes
 ; ==================================================================
 
-; 1. DNSSEC: -02 relaxes the DNSSEC requirement. Records MAY be
-;    DNSSEC-signed for data origin authentication and integrity.
-;    Records MUST be DNSSEC-signed if TLSA records are used (DANE
-;    depends on DNSSEC). Consumers SHOULD validate DNSSEC where
-;    available and SHOULD refuse to act on bogus or unverifiable
-;    records.
-; 2. SVCB records use RFC 9460 wire format (2-byte key, 2-byte length,
-;    value)
+; 1. All DNS-AID records MUST be DNSSEC-signed
+; 2. SVCB records use RFC 9460 wire format (2-byte key, 2-byte length, value)
 ; 3. TXT records use RFC 1035 format (1-byte length prefix per string)
 ; 4. Maximum TXT record size is limited by UDP (typically 512 bytes)
-;    or TCP (up to 65535 bytes); -02 §Operational targets ≤1232 bytes
-;    for the discovery RRset to fit one UDP datagram and avoid
-;    fragmentation
+;    or TCP (up to 65535 bytes)
 ; 5. Character encoding is ASCII for DNS labels, UTF-8 for TXT values
-; 6. SVCB TargetNames reached over TLS with a public x.509 cert MUST
-;    NOT contain underscores (per -02 §Known Organization). This
-;    constraint applies to the index TargetName and to any agent's
-;    SVCB target that needs a publicly-issued cert.

--- a/examples/integration_otel_collector/README.md
+++ b/examples/integration_otel_collector/README.md
@@ -60,7 +60,7 @@ Open `http://localhost:16686`. In the Service dropdown:
 ```
 [caller.py]
    AgentClient.invoke()
-      ├─ opens span "dns-aid.invoke _echo._https._agents.demo.local"
+      ├─ opens span "dns-aid.invoke echo.demo.local"
       ├─ HTTPS protocol handler builds POST request
       ├─ inject_otel_context() event hook writes `traceparent` header
       ├─ httpx sends request to http://localhost:9000/invoke

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.23.0"
+version = "0.24.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -52,7 +52,7 @@ mcp = [
     "uvicorn>=0.30.0",
     # Direct floors on transitive deps pulled by `mcp` to close Dependabot alerts
     # (mcp's upstream constraints are looser than the patched versions need).
-    "pyjwt>=2.12.0",            # CVE-2026-32597 (high) — accepts unknown 'crit' header
+    "pyjwt>=2.13.0",            # PYSEC-2026-175/177/178/179 (4 vulns); supersedes CVE-2026-32597 (unknown 'crit' header)
     "python-multipart>=0.0.27", # CVE-2026-42561 / GHSA-pp6c-gr5w-3c5g (high) — DoS via unbounded multipart headers; supersedes CVE-2026-40347
 ]
 route53 = [
@@ -131,7 +131,7 @@ all = [
     "mcp>=1.0.0",
     "uvicorn>=0.30.0",
     # Transitive floors via mcp (Dependabot)
-    "pyjwt>=2.12.0",
+    "pyjwt>=2.13.0",
     "python-multipart>=0.0.27",
     # Backends: Route53, Cloudflare, NS1, Cloud DNS, Infoblox BloxOne, NIOS, DDNS
     "boto3>=1.34.0",

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Pre-push local verification — runs every CI check we can run locally
+# so we stop force-pushing things that fail server-side.
+#
+# Exit code 0 = all checks passed. Non-zero = at least one failed.
+# Usage: ./scripts/preflight.sh [--against <base-ref>]
+
+set -uo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --against) BASE_REF="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+OK="\033[32m✓\033[0m"
+BAD="\033[31m✗\033[0m"
+DIM="\033[2m"
+RST="\033[0m"
+
+failed=()
+
+step() { printf "\n${DIM}══ %s ══${RST}\n" "$1"; }
+pass() { printf "${OK} %s\n" "$1"; }
+fail() { printf "${BAD} %s\n" "$1"; failed+=("$1"); }
+
+# ───────────────────────────────────────────────────────────────────
+step "Format check (ruff format)"
+if uv run ruff format --check src/ tests/ >/dev/null 2>&1; then
+  pass "ruff format clean"
+else
+  fail "ruff format would reformat files (run 'uv run ruff format src/ tests/')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Lint (ruff check)"
+if uv run ruff check src/ tests/ >/dev/null 2>&1; then
+  pass "ruff check clean"
+else
+  fail "ruff check has issues (run 'uv run ruff check src/ tests/' to see them)"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Type check (mypy)"
+if uv run mypy src/dns_aid >/dev/null 2>&1; then
+  pass "mypy clean"
+else
+  fail "mypy has errors (run 'uv run mypy src/dns_aid')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Unit tests"
+if uv run pytest tests/unit/ -q --no-header --tb=no 2>&1 | tail -1 | grep -qE "passed"; then
+  pass "unit tests pass"
+else
+  fail "unit tests failing (run 'uv run pytest tests/unit/ -v')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Mock integration tests"
+if uv run pytest tests/integration/ -m "not live" -q --no-header --tb=no 2>&1 | tail -1 | grep -qE "passed"; then
+  pass "integration tests pass (not live)"
+else
+  fail "integration tests failing (run 'uv run pytest tests/integration/ -m \"not live\" -v')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "SAST (Bandit)"
+if uv run --with "bandit[toml]" bandit -r src/dns_aid -c pyproject.toml -q >/dev/null 2>&1; then
+  pass "bandit clean"
+else
+  fail "bandit has findings (run 'uv run --with bandit[toml] bandit -r src/dns_aid -c pyproject.toml')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Dependency Audit (pip-audit)"
+# Mirrors security.yml — same --ignore-vuln list. Update both when CVEs change.
+audit_args=(
+  --ignore-vuln CVE-2026-4539
+  --ignore-vuln CVE-2025-8869
+  --ignore-vuln CVE-2026-1703
+  --ignore-vuln CVE-2026-34073
+  --ignore-vuln CVE-2026-25645
+  --ignore-vuln CVE-2026-3219
+  --ignore-vuln CVE-2025-45768
+)
+if uv run --with pip-audit pip-audit "${audit_args[@]}" >/dev/null 2>&1; then
+  pass "pip-audit clean"
+else
+  fail "pip-audit found vulnerabilities (run 'uv run --with pip-audit pip-audit ${audit_args[*]}')"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "DCO trailer placement"
+# The KineticCafe DCO action follows git's trailer-block rule: the
+# Signed-off-by line MUST be in the LAST paragraph of the commit
+# message. Body text after it invalidates the trailer.
+bad_dco=()
+for sha in $(git log --format=%h "$BASE_REF..HEAD" 2>/dev/null); do
+  last_so=$(git cat-file -p "$sha" | awk '/^Signed-off-by:/{n=NR} END{print n+0}')
+  last_line=$(git cat-file -p "$sha" | awk 'NF{n=NR} END{print n+0}')
+  if [[ "$last_so" -eq 0 ]]; then
+    bad_dco+=("$sha: missing Signed-off-by")
+  elif [[ "$last_so" -ne "$last_line" ]]; then
+    bad_dco+=("$sha: Signed-off-by at line $last_so but body extends to line $last_line")
+  fi
+done
+if [[ ${#bad_dco[@]} -eq 0 ]]; then
+  pass "every commit's Signed-off-by is the last line"
+else
+  fail "DCO trailer placement issues:"
+  for entry in "${bad_dco[@]}"; do echo "    $entry"; done
+  echo "    (use 'git rebase -i $BASE_REF' + 'reword' to fix)"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Workflow files unchanged (fork-PR approval gate)"
+# When a fork PR modifies .github/workflows/, GitHub requires
+# maintainer approval per push — CI doesn't auto-run. Catch this so
+# we don't push an unrelated workflow drift.
+wf_diff=$(git diff "$BASE_REF...HEAD" -- .github/workflows/ 2>/dev/null)
+if [[ -z "$wf_diff" ]]; then
+  pass "no .github/workflows/ changes (CI will auto-fire)"
+else
+  fail ".github/workflows/ changed vs $BASE_REF — fork PRs need maintainer approval per push"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+step "Summary"
+if [[ ${#failed[@]} -eq 0 ]]; then
+  printf "${OK} all preflight checks passed — safe to push\n"
+  exit 0
+else
+  printf "${BAD} %d check(s) failed:\n" "${#failed[@]}"
+  for entry in "${failed[@]}"; do printf "    %s\n" "$entry"; done
+  exit 1
+fi

--- a/src/dns_aid/__init__.py
+++ b/src/dns_aid/__init__.py
@@ -4,7 +4,7 @@
 """
 DNS-AID: DNS-based Agent Identification and Discovery
 
-Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-01.
+Reference implementation for IETF draft-mozleywilliams-dnsop-dnsaid-02.
 Enables AI agents to discover each other via DNS using SVCB records.
 
 Example:

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from dns_aid.core.models import SVCB_ALIAS_MODE, SVCB_SERVICE_MODE  # noqa: E402
+
 if TYPE_CHECKING:
     from dns_aid.core.models import AgentRecord
 
@@ -238,7 +240,11 @@ class DNSBackend(ABC):
         """
         records: list[str] = []
         zone = agent.domain
-        name = f"_{agent.name}._{agent.protocol.value}._agents"
+        # Under draft-02 the agent's primary owner is the flat name
+        # {name}.{domain}; the relative record name under the zone is
+        # just the agent name (no leading underscore, no protocol label).
+        name = agent.name
+        walkable_name = f"{agent.name}._agents"
 
         all_params = agent.to_svcb_params()
         support = self.supports_private_svcb_keys
@@ -262,7 +268,7 @@ class DNSBackend(ABC):
                 svcb_fqdn = await self.create_svcb_record(
                     zone=zone,
                     name=name,
-                    priority=1,
+                    priority=SVCB_SERVICE_MODE,
                     target=agent.svcb_target,
                     params=all_params,
                     ttl=agent.ttl,
@@ -298,7 +304,7 @@ class DNSBackend(ABC):
             svcb_fqdn = await self.create_svcb_record(
                 zone=zone,
                 name=name,
-                priority=1,
+                priority=SVCB_SERVICE_MODE,
                 target=agent.svcb_target,
                 params=svcb_params,
                 ttl=agent.ttl,
@@ -317,6 +323,37 @@ class DNSBackend(ABC):
                 ttl=agent.ttl,
             )
             records.append(f"TXT {txt_fqdn}")
+
+        # Optional walkable AliasMode at {name}._agents.{domain} pointing
+        # at the flat primary owner. Per draft-02 §Known Agent, operators
+        # MAY emit this record so DNS-SD-style consumers can enumerate.
+        # dns-aid-core publishes it by default; callers can suppress it
+        # by setting publish_walkable_alias=False on the AgentRecord.
+        if agent.publish_walkable_alias:
+            try:
+                # AliasMode MUST point at the flat primary owner
+                # (`{name}.{domain}.`) per draft-02 §3.1. agent.svcb_target
+                # is the endpoint host, which only coincides with the
+                # owner when endpoint == fqdn — the normal case has them
+                # distinct, so using svcb_target would point the alias
+                # at a name with no SVCB record.
+                walkable_target = f"{agent.fqdn}."
+                walkable_fqdn = await self.create_svcb_record(
+                    zone=zone,
+                    name=walkable_name,
+                    priority=SVCB_ALIAS_MODE,
+                    target=walkable_target,
+                    params={},
+                    ttl=agent.ttl,
+                )
+                records.append(f"SVCB(AliasMode) {walkable_fqdn}")
+            except Exception as exc:
+                logger.warning(
+                    "Walkable AliasMode write failed; continuing",
+                    backend=self.name,
+                    walkable_name=walkable_name,
+                    error=str(exc),
+                )
 
         logger.info(
             "Agent published successfully",

--- a/src/dns_aid/backends/infoblox/nios.py
+++ b/src/dns_aid/backends/infoblox/nios.py
@@ -46,7 +46,13 @@ class InfobloxNIOSBackend(DNSBackend):
         NIOS_TIMEOUT: HTTP request timeout in seconds (default: 30.0)
     """
 
-    _SPLIT_VALUE_KEYS = {"alpn", "bap", "ipv4hint", "ipv6hint"}
+    # ``bap`` was historically split as a multi-value key when the
+    # field carried comma-separated protocols. draft-02 §5.1 makes it
+    # a single scalar (bare ``mcp`` or versioned ``mcp=1.0``); the
+    # ``=`` in a versioned value would also re-expand on a split, so
+    # we keep bap out of the split set even though current scalar
+    # values would be harmless to split.
+    _SPLIT_VALUE_KEYS = {"alpn", "ipv4hint", "ipv6hint"}
     # NIOS only accepts registered SVC keys or keyNNNNN numeric keys.
     # Map draft custom names to private-use keyNNNNN aliases for compatibility.
     _CUSTOM_PARAM_TO_NUMERIC_KEY = {

--- a/src/dns_aid/backends/mock.py
+++ b/src/dns_aid/backends/mock.py
@@ -15,6 +15,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from dns_aid.backends.base import DNSBackend
+from dns_aid.core.models import SVCB_ALIAS_MODE, SVCB_SERVICE_MODE
 
 if TYPE_CHECKING:
     from dns_aid.core.models import AgentRecord
@@ -31,15 +32,15 @@ class MockBackend(DNSBackend):
         >>> backend = MockBackend()
         >>> await backend.create_svcb_record(
         ...     zone="example.com",
-        ...     name="_chat._a2a._agents",
+        ...     name="chat",
         ...     priority=1,
         ...     target="chat.example.com.",
         ...     params={"alpn": "a2a", "port": "443"}
         ... )
-        '_chat._a2a._agents.example.com'
+        'chat.example.com'
 
-        >>> # Records are stored in memory
-        >>> backend.records["example.com"]["_chat._a2a._agents"]["SVCB"]
+        >>> # Records are stored in memory under the flat draft-02 name
+        >>> backend.records["example.com"]["chat"]["SVCB"]
         [{'priority': 1, 'target': 'chat.example.com.', 'params': {...}, 'ttl': 3600}]
     """
 
@@ -110,15 +111,23 @@ class MockBackend(DNSBackend):
         name: str,
         record_type: str,
     ) -> bool:
-        """Delete record from memory."""
-        if (
-            zone in self.records
-            and name in self.records[zone]
-            and record_type in self.records[zone][name]
-        ):
-            del self.records[zone][name][record_type]
-            return True
-        return False
+        """Delete record from memory.
+
+        Uses ``.get()`` (not the ``in`` keyword) so we never trigger the
+        outer ``defaultdict`` to materialise empty entries for the
+        zone/name/type — that side-effect was causing follow-up calls
+        to see records that didn't exist.
+        """
+        zone_records = self.records.get(zone)
+        if zone_records is None:
+            return False
+        name_records = zone_records.get(name)
+        if name_records is None:
+            return False
+        if record_type not in name_records:
+            return False
+        del name_records[record_type]
+        return True
 
     async def list_records(
         self,
@@ -163,9 +172,22 @@ class MockBackend(DNSBackend):
         name: str,
         record_type: str,
     ) -> dict | None:
-        """Get a specific record from memory."""
+        """Get a specific record from memory.
+
+        Uses ``.get()`` so a probe for a non-existent record doesn't
+        cause the outer ``defaultdict`` to create empty intermediate
+        entries — that side-effect previously fooled follow-up
+        delete_record calls into reporting success on records that
+        had never been written.
+        """
         try:
-            records = self.records[zone][name][record_type]
+            zone_records = self.records.get(zone)
+            if zone_records is None:
+                return None
+            name_records = zone_records.get(name)
+            if name_records is None:
+                return None
+            records = name_records.get(record_type)
             if not records:
                 return None
             record = records[0]
@@ -202,12 +224,14 @@ class MockBackend(DNSBackend):
         """
         records: list[str] = []
         zone = agent.domain
-        name = f"_{agent.name}._{agent.protocol.value}._agents"
+        # draft-02: flat primary owner — relative record name is just the agent name.
+        name = agent.name
+        walkable_name = f"{agent.name}._agents"
 
         svcb_fqdn = await self.create_svcb_record(
             zone=zone,
             name=name,
-            priority=1,
+            priority=SVCB_SERVICE_MODE,
             target=agent.svcb_target,
             params=agent.to_svcb_params(),
             ttl=agent.ttl,
@@ -223,6 +247,20 @@ class MockBackend(DNSBackend):
                 ttl=agent.ttl,
             )
             records.append(f"TXT {txt_fqdn}")
+
+        # Optional walkable AliasMode at {name}._agents.{domain} pointing
+        # at the flat primary owner per draft-02 §3.1.
+        if agent.publish_walkable_alias:
+            walkable_target = f"{agent.fqdn}."
+            walkable_fqdn = await self.create_svcb_record(
+                zone=zone,
+                name=walkable_name,
+                priority=SVCB_ALIAS_MODE,
+                target=walkable_target,
+                params={},
+                ttl=agent.ttl,
+            )
+            records.append(f"SVCB(AliasMode) {walkable_fqdn}")
 
         return records
 

--- a/src/dns_aid/cli/doctor.py
+++ b/src/dns_aid/cli/doctor.py
@@ -32,7 +32,7 @@ def _render_report(report: DiagnosticReport) -> None:
     console.print(
         Panel(
             f"[bold]dns-aid doctor[/bold]  v{report.version}",
-            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-01[/dim]",
+            subtitle="[dim]IETF draft-mozleywilliams-dnsop-dnsaid-02[/dim]",
             width=56,
         )
     )

--- a/src/dns_aid/cli/init.py
+++ b/src/dns_aid/cli/init.py
@@ -27,7 +27,7 @@ def _discover_quickstart() -> None:
     console.print("You can discover agents without any credentials:\n")
     console.print("  [bold]dns-aid discover example.com[/bold]")
     console.print("  [bold]dns-aid discover example.com --json[/bold]")
-    console.print("  [bold]dns-aid verify _network._mcp._agents.example.com[/bold]")
+    console.print("  [bold]dns-aid verify network.example.com[/bold]")
     console.print(
         "\nTo [bold]publish[/bold] agents, re-run [bold]dns-aid init[/bold] and choose a backend.\n"
     )

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -110,10 +110,21 @@ def publish(
             help="Base64url-encoded SHA-256 digest of the capability descriptor for integrity checks",
         ),
     ] = None,
+    well_known: Annotated[
+        str | None,
+        typer.Option(
+            "--well-known",
+            help="RFC 8615 well-known path suffix (e.g., 'agent-card.json'). Independent "
+            "of --cap-uri; both may be set. Consumers prefer --cap-uri when both are present.",
+        ),
+    ] = None,
     bap: Annotated[
         str | None,
         typer.Option(
-            "--bap", help="Supported bulk agent protocols (comma-separated, e.g., 'mcp,a2a')"
+            "--bap",
+            help="Bulk Agent Protocol identifier — single versioned protocol per "
+            "record (e.g., 'mcp=2.1', 'a2a=1.0'). Experimental per draft-02 §FutureWork; "
+            "alpn remains the canonical protocol carrier.",
         ),
     ] = None,
     policy_uri: Annotated[
@@ -163,6 +174,26 @@ def publish(
         str | None,
         typer.Option("--private-key", help="Path to EC P-256 private key PEM for signing"),
     ] = None,
+    allow_underscore_target: Annotated[
+        bool,
+        typer.Option(
+            "--allow-underscore-target",
+            help="Downgrade the TargetName-contains-underscore check from error to warning. "
+            "Use only when the target is internal-only and not reached over public PKI.",
+        ),
+    ] = False,
+    walkable: Annotated[
+        bool,
+        typer.Option(
+            "--walkable",
+            help="Publish the optional walkable AliasMode SVCB record at "
+            "{name}._agents.{domain}. Off by default — the walkable record is "
+            "an enumeration handle (DNS-SD-style consumers can walk _agents.<zone> "
+            "and inventory every agent). Enable only when you actively want the "
+            "agent discoverable through enumeration (internal indexes, intentional "
+            "public catalogs). See docs/privacy-considerations.md.",
+        ),
+    ] = False,
 ):
     """
     Publish an agent to DNS using DNS-AID protocol.
@@ -202,8 +233,9 @@ def publish(
 
     console.print("\n[bold]Publishing agent to DNS...[/bold]\n")
 
-    # Parse bap comma-separated string into list
-    bap_list = [b.strip() for b in bap.split(",") if b.strip()] if bap else None
+    # bap is a single versioned-protocol identifier per draft-02 §FutureWork
+    # (Bulk Agent Protocol). Pass through unchanged; whitespace-trimmed.
+    bap_value = bap.strip() if bap else None
 
     # Validate sign options
     if sign and not private_key:
@@ -226,7 +258,8 @@ def publish(
             backend=dns_backend,
             cap_uri=cap_uri,
             cap_sha256=cap_sha256,
-            bap=bap_list,
+            well_known_path=well_known,
+            bap=bap_value,
             policy_uri=policy_uri,
             realm=realm,
             connect_class=connect_class,
@@ -236,6 +269,8 @@ def publish(
             ipv6_hint=",".join(ipv6hint) if ipv6hint else None,
             sign=sign,
             private_key_path=private_key,
+            allow_underscore_target=allow_underscore_target,
+            publish_walkable_alias=walkable,
         )
     )
 
@@ -426,7 +461,8 @@ def discover(
                     "capability_source": a.capability_source,
                     "cap_uri": a.cap_uri,
                     "cap_sha256": a.cap_sha256,
-                    "bap": a.bap if a.bap else None,
+                    "well_known_path": a.well_known_path,
+                    "bap": a.bap,
                     "policy_uri": a.policy_uri,
                     "realm": a.realm,
                     "description": a.description,
@@ -668,7 +704,7 @@ def search(
 
     for result in response.results:
         agent = result.agent
-        fqdn = f"_{agent.name}._{agent.protocol.value}._agents.{agent.domain}"
+        fqdn = f"{agent.name}.{agent.domain}"
         table.add_row(
             f"{result.score:.2f}",
             fqdn,
@@ -694,9 +730,7 @@ def search(
 
 @app.command()
 def verify(
-    fqdn: Annotated[
-        str, typer.Argument(help="FQDN to verify (e.g., _chat._a2a._agents.example.com)")
-    ],
+    fqdn: Annotated[str, typer.Argument(help="FQDN to verify (e.g., chat.example.com)")],
 ):
     """
     Verify DNS-AID records for an agent.
@@ -704,7 +738,7 @@ def verify(
     Checks DNS record existence, DNSSEC validation, and endpoint health.
 
     Example:
-        dns-aid verify _chat._a2a._agents.example.com
+        dns-aid verify chat.example.com
     """
     from dns_aid.core.validator import verify as do_verify
 
@@ -898,7 +932,7 @@ def delete(
     """
     from dns_aid.core.publisher import unpublish
 
-    fqdn = f"_{name}._{protocol}._agents.{domain}"
+    fqdn = f"{name}.{domain}"
 
     if not force:
         confirm = typer.confirm(f"Delete {fqdn}?")
@@ -1202,7 +1236,7 @@ def index_list(
     table.add_column("FQDN")
 
     for entry in sorted(entries, key=lambda e: (e.name, e.protocol)):
-        fqdn = f"_{entry.name}._{entry.protocol}._agents.{domain}"
+        fqdn = f"{entry.name}.{domain}"
         table.add_row(entry.name, entry.protocol, fqdn)
 
     console.print(table)

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -220,7 +220,11 @@ class A2AAgentCard:
             "description": self.description,
             "ttl": ttl,
             "cap_uri": cap_uri,
-            "bap": ["a2a/1"],
+            # Bulk Agent Protocol — scalar versioned identifier per draft-02
+            # §FutureWork. A2A agent cards default to "a2a=1.0"; operators
+            # publishing a different version of A2A can override before passing
+            # to publish().
+            "bap": "a2a=1.0",
         }
 
 

--- a/src/dns_aid/core/agent_metadata.py
+++ b/src/dns_aid/core/agent_metadata.py
@@ -62,7 +62,7 @@ class AgentIdentity(BaseModel):
     agent_id: str | None = Field(None, max_length=36, description="UUID identifier for the agent")
     name: str = Field(..., min_length=1, max_length=255, description="Human-readable agent name")
     fqdn: str | None = Field(
-        None, max_length=512, description="DNS-AID FQDN (e.g., _chat._mcp._agents.example.com)"
+        None, max_length=512, description="DNS-AID FQDN (e.g., chat.example.com)"
     )
     version: str | None = Field(None, max_length=20, description="Agent version string")
     deprecated: bool = Field(False, description="Whether this agent is deprecated")

--- a/src/dns_aid/core/bap.py
+++ b/src/dns_aid/core/bap.py
@@ -1,0 +1,192 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Single source of truth for the draft-02 ``bap`` (Bulk Agent Protocol)
+SvcParamKey value shape.
+
+draft-02 §5.1 (experimental, §FutureWork) defines a single versioned
+agent-protocol identifier per SVCB record. Two value forms are
+accepted, matching the draft's own examples:
+
+- **Bare** — ``mcp`` / ``a2a`` (unversioned)
+- **Versioned** — ``mcp=1.0`` / ``a2a=1.1`` (protocol name, ``=``,
+  dotted version)
+
+Multi-protocol agents publish multiple SVCB records at the same flat
+owner, each with its own ``alpn`` and (optionally) ``bap``. ``bap``
+is NOT a comma-separated list of protocols.
+
+This module centralizes:
+
+- :data:`BAP_VALUE_PATTERN` — the wire-format character constraint
+- :func:`validate_bap` — model field-validator
+- :func:`normalize_bap` — coerce legacy / forgiving inputs into the
+  canonical scalar shape
+- :func:`split_bap_token` — extract the protocol token before any
+  ``=`` so consumers can reconcile against ``Protocol`` enums
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Wire-format constraint. Protocol name lowercase alnum starting with
+# a letter; optional ``=`` followed by a version token. The version
+# token allows the dotted shape (e.g. ``1.0``, ``1.1.0``,
+# ``2026-01-15``) but excludes quotes, spaces, commas, and any other
+# character that would let a forged value break out of the SVCB
+# SvcParam quoting and inject sibling keys.
+#
+# Without this validator the value is emitted verbatim into
+# ``key="<value>"`` by the backend formatters, so a forged value with a
+# quote could break out of the SvcParam quoting and inject sibling keys
+# — a server-side parameter-injection on the publish path.
+_PROTOCOL_PATTERN = r"[a-z][a-z0-9]*"
+_VERSION_PATTERN = r"[A-Za-z0-9][A-Za-z0-9._\-]{0,63}"
+BAP_VALUE_PATTERN: Final = re.compile(rf"^{_PROTOCOL_PATTERN}(={_VERSION_PATTERN})?$")
+
+_BAP_MAX_LEN = 128
+
+
+def validate_bap(value: str) -> str:
+    """Validate a single ``bap`` SvcParamKey value.
+
+    Used as a Pydantic field validator on both ``SvcbRecord.bap`` and
+    ``AgentRecord.bap``. Enforces the canonical scalar shape so:
+
+    - Injection via SVCB quoting (e.g. ``mcp" key65500="x``) is
+      rejected at the type boundary.
+    - Comma-separated legacy values are rejected (caller should run
+      ``normalize_bap`` first if accepting legacy input).
+    - Whitespace, control characters, and other URL/quote special
+      characters are rejected.
+
+    Args:
+        value: The bap value to validate. Empty / None should be
+            handled by the caller before reaching this function.
+
+    Returns:
+        The validated value unchanged.
+
+    Raises:
+        ValueError: When the value violates the wire-format rule.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"bap must be a string, got {type(value).__name__}")
+    if not value:
+        raise ValueError("bap must be a non-empty string (or None)")
+    if len(value) > _BAP_MAX_LEN:
+        raise ValueError(f"bap value exceeds {_BAP_MAX_LEN} characters")
+    if not BAP_VALUE_PATTERN.match(value):
+        raise ValueError(
+            f"bap value {value!r} does not match the canonical form. "
+            "Allowed: a lowercase protocol token (e.g. 'mcp', 'a2a') "
+            "optionally followed by '=<version>' (e.g. 'mcp=1.0'). "
+            "Reject quotes, spaces, commas, control chars, and any "
+            "other character that could break SVCB SvcParam quoting."
+        )
+    return value
+
+
+def normalize_bap(value: str | list[str] | None) -> str | None:
+    """Coerce forgiving input into the canonical scalar shape.
+
+    Accepts:
+
+    - ``None`` → ``None``
+    - ``""`` / whitespace-only string → ``None``
+    - ``"mcp"`` / ``"mcp=1.0"`` → unchanged after strip
+    - ``"mcp,a2a"`` (legacy comma-list) → first non-empty token,
+      warning logged because later tokens are dropped
+    - ``["mcp", "a2a"]`` (legacy list) → first non-empty token,
+      warning logged
+    - ``[]`` / list of empties → ``None``
+
+    Does NOT enforce :func:`validate_bap` — callers should run it
+    after normalization (or rely on the model's field validator).
+
+    Args:
+        value: A string, list of strings, or None. Other types are
+            silently treated as None to keep the public API forgiving.
+
+    Returns:
+        The normalized scalar (or None when no usable value exists).
+    """
+    if value is None:
+        return None
+
+    # Coerce a list into a scalar by taking the first non-empty entry.
+    # Empty list / list of empties → None.
+    if isinstance(value, list):
+        tokens = [str(v).strip() for v in value if v is not None]
+        non_empty = [t for t in tokens if t]
+        if not non_empty:
+            return None
+        if len(non_empty) > 1:
+            logger.warning(
+                "bap list input collapsed to first token — multi-protocol "
+                "agents should publish multiple SVCB records, not a list "
+                "on one record",
+                input=value,
+                kept=non_empty[0],
+                dropped=non_empty[1:],
+                warning_class="dns_aid.bap_list_collapsed",
+            )
+        return non_empty[0]
+
+    # Scalar string. Strip whitespace, drop empties.
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    # Legacy comma-list ("mcp,a2a") → first non-empty token.
+    if "," in stripped:
+        tokens = [t.strip() for t in stripped.split(",")]
+        non_empty = [t for t in tokens if t]
+        if not non_empty:
+            return None
+        if len(non_empty) > 1:
+            logger.warning(
+                "bap comma-list input collapsed to first token — "
+                "multi-protocol agents should publish multiple SVCB "
+                "records, not a comma-separated list on one record",
+                input=value,
+                kept=non_empty[0],
+                dropped=non_empty[1:],
+                warning_class="dns_aid.bap_comma_list_collapsed",
+            )
+        return non_empty[0]
+
+    return stripped
+
+
+def split_bap_token(value: str | None) -> tuple[str | None, str | None]:
+    """Split a bap value into ``(protocol_token, version)``.
+
+    ``mcp`` → ``("mcp", None)``
+    ``mcp=1.0`` → ``("mcp", "1.0")``
+    ``None`` / unparseable → ``(None, None)``
+
+    Used by the discoverer's protocol reconciliation: the ``Protocol``
+    enum holds bare tokens (``mcp``, ``a2a``), so consumers need to
+    extract just the token before checking membership.
+    """
+    if not value:
+        return None, None
+    stripped = value.strip()
+    if not stripped:
+        return None, None
+    if "=" not in stripped:
+        return stripped, None
+    proto, _, ver = stripped.partition("=")
+    proto = proto.strip()
+    ver = ver.strip()
+    return (proto or None), (ver or None)

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -4,7 +4,7 @@
 """
 Fetch agent capability document from cap URI (IETF draft-compliant).
 
-Per IETF draft-mozleywilliams-dnsop-dnsaid-01, the SVCB record may contain
+Per IETF draft-mozleywilliams-dnsop-dnsaid-02, the SVCB record may contain
 a `cap` parameter with a URI pointing to a JSON capability document. This module
 fetches and parses that document.
 
@@ -36,6 +36,23 @@ logger = structlog.get_logger(__name__)
 _MAX_CAP_RESPONSE_BYTES = 256_000
 
 
+class CapDigestMismatchError(Exception):
+    """Raised when a fetched cap document's SHA-256 disagrees with the pin.
+
+    Per draft-mozleywilliams-dnsop-dnsaid-02 §6.1, a digest mismatch MUST
+    cause the consumer to refuse to use the record — distinct from a
+    network/parse failure where falling back to a lower-priority source
+    is acceptable. The discoverer catches this explicitly and drops the
+    affected record, rather than silently downgrading to TXT.
+    """
+
+    def __init__(self, cap_uri: str, expected: str, actual: str) -> None:
+        super().__init__(f"cap digest mismatch for {cap_uri}: expected={expected} actual={actual}")
+        self.cap_uri = cap_uri
+        self.expected = expected
+        self.actual = actual
+
+
 @dataclass
 class CapabilityDocument:
     """Parsed capability document from a cap URI."""
@@ -48,10 +65,12 @@ class CapabilityDocument:
     raw_data: dict[str, Any] = field(default_factory=dict)
 
 
-def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bool:
+def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> None:
     """Verify SHA-256 digest of capability document content.
 
-    Returns True if digest matches, False otherwise.
+    Raises CapDigestMismatchError on mismatch so callers can distinguish
+    a digest failure (MUST refuse, per draft §6.1) from a network/parse
+    failure (fall back to a lower-priority capability source).
     """
     import base64
     import hashlib
@@ -66,8 +85,7 @@ def _verify_cap_digest(content: bytes, expected_sha256: str, cap_uri: str) -> bo
             expected=expected_sha256,
             actual=actual_digest,
         )
-        return False
-    return True
+        raise CapDigestMismatchError(cap_uri, expected_sha256, actual_digest)
 
 
 def _extract_string_list(data: dict[str, Any], key: str) -> list[str]:
@@ -134,7 +152,9 @@ async def fetch_cap_document(
         timeout: HTTP request timeout in seconds.
         expected_sha256: Base64url-encoded SHA-256 digest to verify against
             the fetched content. If provided and the digest doesn't match,
-            returns None. If None, skips integrity verification.
+            raises CapDigestMismatchError (per draft-02 §6.1 the record MUST
+            be refused — distinct from network/parse failures, which return
+            None). If None, skips integrity verification.
 
     Returns:
         CapabilityDocument if successfully fetched and parsed, None otherwise.
@@ -164,8 +184,11 @@ async def fetch_cap_document(
             logger.debug("Cap document fetch failed (non-200)", cap_uri=cap_uri)
             return None
 
-        if expected_sha256 and not _verify_cap_digest(body, expected_sha256, cap_uri):
-            return None
+        # Integrity check — raises CapDigestMismatchError on mismatch.
+        # We let it propagate so the discoverer can refuse the record
+        # rather than silently downgrading to TXT fallback (§6.1).
+        if expected_sha256:
+            _verify_cap_digest(body, expected_sha256, cap_uri)
 
         import json
 
@@ -197,6 +220,10 @@ async def fetch_cap_document(
         )
         return doc
 
+    except CapDigestMismatchError:
+        # Re-raise so the caller can distinguish digest mismatch (MUST
+        # refuse the record per §6.1) from network failures (fall back).
+        raise
     except ResponseTooLargeError:
         logger.warning(
             "Cap document response too large — skipping",

--- a/src/dns_aid/core/dcv.py
+++ b/src/dns_aid/core/dcv.py
@@ -5,7 +5,7 @@
 DNS-based Domain Control Validation (DCV) for agent identity assertion.
 
 Implements the challenge-response pattern from:
-- IETF draft-mozleywilliams-dnsop-dnsaid-01  (bnd-req binding extension)
+- IETF draft-mozleywilliams-dnsop-dnsaid-02  (bnd-req binding extension)
 - draft-ietf-dnsop-domain-verification-techniques-12  (TXT record wire format)
 
 Two primary use cases:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -5,14 +5,16 @@
 DNS-AID Discoverer: Query DNS to find AI agents.
 
 This module handles discovering agents via DNS queries for SVCB and TXT
-records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+records as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
+import os
 import shlex
 import time
 from typing import Any, Literal
@@ -27,9 +29,22 @@ from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
 from dns_aid.core.filters import apply_filters
 from dns_aid.core.http_index import HttpIndexAgent, fetch_http_index_or_empty
-from dns_aid.core.models import AgentRecord, DiscoveryResult, DNSSECError, Protocol
+from dns_aid.core.models import (
+    AgentRecord,
+    CapabilitySource,
+    DiscoveryResult,
+    DNSSECError,
+    Protocol,
+)
 
 logger = structlog.get_logger(__name__)
+
+# Per-agent total-time budget for descriptor (cap / well-known) fetch.
+# Slightly above fetch_cap_document's default 10s HTTP timeout so a
+# normal slow response still completes, but bounds pathological cases
+# (DNS hangs, TLS handshake stalls, redirect chains). Cross-agent
+# bulk discovery would otherwise serialize on the slowest endpoint.
+_DESCRIPTOR_FETCH_BUDGET_SECONDS: float = 12.0
 
 
 def _normalize_protocol(protocol: str | Protocol | None) -> Protocol | None:
@@ -45,16 +60,18 @@ async def _execute_discovery(
     name: str | None,
     use_http_index: bool,
     query: str,
+    *,
+    allow_legacy: bool | None = None,
 ) -> list[AgentRecord]:
     """Execute the appropriate discovery strategy and handle DNS errors."""
     try:
         if use_http_index:
             return await _discover_via_http_index(domain, protocol, name)
         elif name and protocol:
-            agent = await _query_single_agent(domain, name, protocol)
+            agent = await _query_single_agent(domain, name, protocol, allow_legacy=allow_legacy)
             return [agent] if agent else []
         else:
-            return await _discover_agents_in_zone(domain, protocol)
+            return await _discover_agents_in_zone(domain, protocol, allow_legacy=allow_legacy)
     except dns.resolver.NXDOMAIN:
         logger.debug("No DNS-AID records found", query=query)
     except dns.resolver.NoAnswer:
@@ -75,18 +92,32 @@ async def _apply_post_discovery(
 ) -> bool:
     """Apply DNSSEC enforcement, endpoint enrichment, and JWS verification.
 
-    Returns whether DNSSEC was validated.
+    Under draft-02's flat-FQDN model each agent has its own owner name,
+    so DNSSEC is checked per agent rather than once for the zone. The
+    result-level boolean returned here is True only if every agent's
+    fqdn validated; per-agent state lives on ``AgentRecord.dnssec_validated``.
+
+    Returns whether DNSSEC was validated across all agents.
     """
-    dnssec_validated = False
+    per_agent_dnssec: dict[str, bool] = {}
 
     if agents and require_dnssec:
         from dns_aid.core.validator import _check_dnssec
 
-        dnssec_validated = await _check_dnssec(agents[0].fqdn)
-        if not dnssec_validated:
+        results = await asyncio.gather(
+            *[_check_dnssec(a.fqdn) for a in agents],
+            return_exceptions=True,
+        )
+        for agent, outcome in zip(agents, results, strict=True):
+            ok = outcome is True
+            per_agent_dnssec[agent.fqdn] = ok
+            agent.dnssec_validated = ok
+
+        if not all(per_agent_dnssec.values()):
+            failed = sorted(f for f, ok in per_agent_dnssec.items() if not ok)
             raise DNSSECError(
-                f"DNSSEC validation required but DNS response for "
-                f"{agents[0].fqdn} is not authenticated (AD flag not set)"
+                f"DNSSEC validation required but the following agent "
+                f"FQDNs were not authenticated (AD flag not set): {failed}"
             )
 
     if enrich_endpoints and agents:
@@ -96,16 +127,20 @@ async def _apply_post_discovery(
             logger.debug("Endpoint enrichment failed (non-fatal)", exc_info=True)
 
     if verify_signatures and agents:
-        await _verify_agent_signatures(agents, domain, dnssec_validated)
+        await _verify_agent_signatures(agents, domain, dnssec_validated=per_agent_dnssec)
 
-    return dnssec_validated
+    return bool(per_agent_dnssec) and all(per_agent_dnssec.values())
 
 
 async def discover(
     domain: str,
     protocol: str | Protocol | None = None,
     name: str | None = None,
-    require_dnssec: bool = False,  # Default False for now, True in production
+    # draft-02 §6.2 relaxes DNSSEC to MAY by default; MUST applies only when
+    # TLSA / DANE is in use (RFC 6698 §10.1). Default False matches the
+    # baseline SVCB-only deployment posture. Opt-in True when the consumer
+    # wants AD-flag enforcement or when records carry TLSA hints.
+    require_dnssec: bool = False,
     use_http_index: bool = False,
     enrich_endpoints: bool = True,
     verify_signatures: bool = False,
@@ -122,6 +157,7 @@ async def discover(
     text_match: str | None = None,
     require_signed: bool = False,
     require_signature_algorithm: list[str] | None = None,
+    allow_legacy: bool | None = None,
 ) -> DiscoveryResult:
     """
     Discover AI agents at a domain using DNS-AID protocol.
@@ -133,7 +169,11 @@ async def discover(
         domain: Domain to search for agents (e.g., "example.com").
         protocol: Filter by protocol ("a2a", "mcp", or None for all).
         name: Filter by specific agent name (or None for all).
-        require_dnssec: Require DNSSEC validation (raises if invalid).
+        require_dnssec: Require DNSSEC validation (raises if invalid). Per
+            draft-02 §6.2 DNSSEC is MAY by default; consumers SHOULD set this
+            to True for TLSA/DANE-bound deployments, where unsigned records
+            cannot be trusted (RFC 6698 §10.1). SVCB-only deployments may
+            leave this False.
         use_http_index: If True, fetch agent list from HTTP endpoint
             (``/.well-known/agents-index.json``) instead of DNS-only discovery.
         enrich_endpoints: If True (default), fetch ``.well-known/agent-card.json``
@@ -182,9 +222,19 @@ async def discover(
 
     protocol = _normalize_protocol(protocol)
 
-    # Build query based on filters
+    # Build query based on filters. draft-02: the primary owner is a
+    # flat FQDN ({name}.{domain}); protocol is no longer in the
+    # FQDN — it lives in the bap/alpn SvcParam after resolution. The
+    # organization-level index keeps the underscored shape
+    # (_index._agents.{domain}) per draft-02 §Known Organization.
     if name and protocol:
-        query = f"_{name}._{protocol.value}._agents.{domain}"
+        # Known-agent query: flat draft-02 form. Legacy -01 form is
+        # tried as a fallback in _query_single_agent when
+        # allow_legacy=True (or DNS_AID_LEGACY_01_FALLBACK=1 for
+        # callers using the env-flag form). Results that came from the
+        # legacy path are stamped legacy_resolved=True on the returned
+        # AgentRecord.
+        query = f"{name}.{domain}"
     elif protocol:
         query = f"_index._{protocol.value}._agents.{domain}"
     else:
@@ -202,7 +252,9 @@ async def discover(
         use_http_index=use_http_index,
     )
 
-    agents = await _execute_discovery(domain, protocol, name, use_http_index, query)
+    agents = await _execute_discovery(
+        domain, protocol, name, use_http_index, query, allow_legacy=allow_legacy
+    )
 
     # Path A name filter — applied here, *before* enrichment, so we don't fetch
     # cap docs / agent cards / JWKS for agents we're about to discard.
@@ -218,12 +270,8 @@ async def discover(
     dnssec_validated = await _apply_post_discovery(
         agents, require_dnssec, enrich_endpoints, verify_signatures, domain
     )
-
-    # Propagate domain-level DNSSEC outcome onto each agent so per-agent trust filters
-    # (``min_dnssec``) have a record-level signal to evaluate.
-    if dnssec_validated:
-        for agent in agents:
-            agent.dnssec_validated = True
+    # Per-agent `dnssec_validated` is set inside _apply_post_discovery
+    # when require_dnssec=True; no need to re-stamp at this level.
 
     # Apply Path A in-memory filters (FR-002, FR-021..FR-023). When no filter kwargs are
     # set, ``apply_filters`` short-circuits and returns the input list unchanged.
@@ -292,22 +340,69 @@ async def _query_single_agent(
     domain: str,
     name: str,
     protocol: Protocol,
+    *,
+    allow_legacy: bool | None = None,
 ) -> AgentRecord | None:
-    """Query DNS for a specific agent's SVCB record."""
-    fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+    """Query DNS for a specific agent's SVCB record.
+
+    draft-02: tries the flat FQDN ({name}.{domain}) first. If that
+    returns no answer AND the caller permits legacy fallback, also tries
+    the legacy -01 shape (_{name}._{protocol}._agents.{domain}) so
+    consumers can still resolve publishers that haven't migrated.
+
+    Legacy fallback is opt-in per call:
+
+    - ``allow_legacy=True`` — fallback enabled for this call.
+    - ``allow_legacy=False`` — fallback disabled regardless of env.
+    - ``allow_legacy=None`` (default) — defer to the env flag
+      ``DNS_AID_LEGACY_01_FALLBACK`` for backwards compatibility with
+      existing deployments.
+
+    When the legacy path serves an answer, the returned ``AgentRecord``
+    has ``legacy_resolved=True`` and a warning is logged so operators
+    can detect publishers that haven't migrated and downstream filters
+    can down-weight legacy records.
+    """
+    fqdn = f"{name}.{domain}"
+    legacy_fqdn: str | None = None
+    if allow_legacy is True or (
+        allow_legacy is None
+        and os.environ.get("DNS_AID_LEGACY_01_FALLBACK", "").lower() in ("1", "true", "yes")
+    ):
+        legacy_fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+    resolved_via_legacy = False
 
     try:
         resolver = dns.asyncresolver.Resolver()
 
-        # Query SVCB record
-        # Note: dnspython uses type 64 for SVCB
-        try:
-            answers = await resolver.resolve(fqdn, "SVCB")
-        except dns.resolver.NoAnswer:
-            # Try HTTPS record as fallback (type 65)
+        # Query SVCB record. dnspython uses type 64 for SVCB.
+        # draft-02: try the flat FQDN first. On NoAnswer / NXDOMAIN
+        # try the legacy -01 shape if the back-compat env flag is set.
+        async def _try(name_to_query: str) -> dns.resolver.Answer:
             try:
-                answers = await resolver.resolve(fqdn, "HTTPS")
+                return await resolver.resolve(name_to_query, "SVCB")
             except dns.resolver.NoAnswer:
+                # HTTPS record (type 65) is the protocol-specific alias
+                # of SVCB; some publishers may have used it instead.
+                return await resolver.resolve(name_to_query, "HTTPS")
+
+        try:
+            answers = await _try(fqdn)
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            if legacy_fqdn is None:
+                return None
+            try:
+                logger.warning(
+                    "Flat FQDN returned no answer; serving legacy -01 fallback",
+                    fqdn=fqdn,
+                    legacy_fqdn=legacy_fqdn,
+                    note="caller will receive legacy_resolved=True on this record",
+                )
+                answers = await _try(legacy_fqdn)
+                # Hand the legacy FQDN downstream so logging is accurate.
+                fqdn = legacy_fqdn
+                resolved_via_legacy = True
+            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
                 return None
 
         for rdata in answers:
@@ -342,8 +437,21 @@ async def _query_single_agent(
             port = 443
             ipv4_hint = None
             ipv6_hint = None
+            alpn_values: list[str] = []
 
             if hasattr(rdata, "params") and rdata.params:
+                # alpn (SvcParamKey 1) — draft-02 carries the agent protocol
+                # here when `bap` is absent (the default publish shape). A
+                # record may advertise several alpn ids, so collect them all
+                # and let _reconcile_protocol pick the one we model. Decode
+                # defensively: a single malformed id must not drop the record.
+                alpn_param = rdata.params.get(1)
+                if alpn_param is not None:
+                    for _id in getattr(alpn_param, "ids", None) or []:
+                        with contextlib.suppress(Exception):
+                            alpn_values.append(
+                                _id.decode() if isinstance(_id, (bytes, bytearray)) else str(_id)
+                            )
                 # Port (SvcParamKey 3)
                 port_param = rdata.params.get(3)
                 if port_param and hasattr(port_param, "port"):
@@ -373,40 +481,187 @@ async def _query_single_agent(
 
             cap_uri = custom_params.get("cap")
             cap_sha256 = custom_params.get("cap-sha256")
-            bap_str = custom_params.get("bap", "")
-            bap = [b.strip() for b in bap_str.split(",") if b.strip()] if bap_str else []
+            well_known_path = custom_params.get("well-known")
+            # draft-02 §5.1 (Bulk Agent Protocol, experimental): `bap`
+            # carries a single agent-protocol identifier per record in
+            # either bare (``mcp``) or versioned (``mcp=1.0``) form.
+            # Pre-draft-02 records may have a comma-separated list; the
+            # shared ``normalize_bap`` helper collapses that to the
+            # first non-empty token and warns so the data loss is
+            # observable. Use the same helper in the SDK and indexer
+            # so all consumers agree on the collapse semantics.
+            from dns_aid.core.bap import normalize_bap
+
+            bap = normalize_bap(custom_params.get("bap"))
+
+            # draft-02: the protocol lives in the SVCB record, not the FQDN.
+            # Stamp the record's true protocol (bap, then alpn) over the query
+            # probe so by-FQDN, zone-walk, and HTTP-index discovery all label
+            # the agent correctly — otherwise a default-published a2a/https
+            # agent (alpn, no bap) is mislabeled with the mcp probe and fails
+            # the JWS binding check (payload.alpn == agent.protocol.value).
+            protocol = _reconcile_protocol(protocol, bap, alpn_values)
+
             policy_uri = custom_params.get("policy")
             realm = custom_params.get("realm")
             connect_class = custom_params.get("connect-class")
             connect_meta = custom_params.get("connect-meta")
             enroll_uri = custom_params.get("enroll-uri")
 
-            # Discovery priority: cap URI first, then TXT fallback
+            # Descriptor-fetch precedence (local dns-aid-core convention,
+            # NOT spec-mandated — draft §6.1 names only well-known as the
+            # source). When both `cap` and `well-known` are present we
+            # prefer the explicit locator if it's https-fetchable; if it
+            # isn't (URN, JSON-Ref, non-https scheme), we fall back to
+            # the reconstructed well-known URL rather than treating the
+            # non-fetchable `cap` as terminal.
             capabilities: list[str] = []
-            capability_source: Literal[
-                "cap_uri", "agent_card", "http_index", "txt_fallback", "none"
-            ] = "none"
+            capability_source: CapabilitySource = "none"
             agent_card = None
+            cap_sha256_applied = False
 
-            if cap_uri:
-                cap_doc = await fetch_cap_document(cap_uri, expected_sha256=cap_sha256)
+            effective_descriptor_url: str | None = None
+            descriptor_source_label: Literal["cap_uri", "well_known", "none"] = "none"
+
+            # Item 3: only treat `cap` as a descriptor when it's
+            # https-fetchable. The fetcher's SSRF guard would reject
+            # other schemes anyway, but routing the decision here lets
+            # well-known still get a chance.
+            cap_is_https = cap_uri is not None and cap_uri.lower().startswith("https://")
+            if cap_is_https:
+                effective_descriptor_url = cap_uri
+                descriptor_source_label = "cap_uri"
+
+            # Item 4 + path validation: well-known accepts a bare RFC
+            # 8615 suffix (e.g. ``agent-card.json``) or an absolute
+            # origin path (e.g. ``/.well-known/agent-card.json``,
+            # ``/not-well-known/other-card.json``, per draft Figure 3).
+            # The validator constrains the character class on both
+            # shapes so a forged SVCB can't steer the fetch off origin.
+            if effective_descriptor_url is None and well_known_path:
+                from dns_aid.utils.validation import (
+                    ValidationError,
+                    validate_well_known_path,
+                )
+
+                try:
+                    safe_wk = validate_well_known_path(well_known_path)
+                except ValidationError as exc:
+                    logger.warning(
+                        "well-known SvcParamKey rejected — skipping descriptor fetch",
+                        fqdn=fqdn,
+                        well_known_path=well_known_path,
+                        reason=str(exc),
+                    )
+                    safe_wk = None
+
+                if safe_wk:
+                    # SVCB target is the host serving the well-known
+                    # path. Strip any trailing dot for URL construction.
+                    wk_host = target.rstrip(".")
+                    if safe_wk.startswith("/"):
+                        # Absolute origin path — use as-is. Draft Figure
+                        # 3 includes values outside ``/.well-known/`` so
+                        # we don't force a prefix here.
+                        effective_descriptor_url = f"https://{wk_host}{safe_wk}"
+                    else:
+                        effective_descriptor_url = f"https://{wk_host}/.well-known/{safe_wk}"
+                    descriptor_source_label = "well_known"
+
+            # Non-https `cap` (URN, JSON-Ref, etc.) with no fetchable
+            # well-known is a metadata-only locator: keep it on the
+            # record but don't try to fetch it.
+            if effective_descriptor_url is None and cap_uri is not None and not cap_is_https:
+                logger.debug(
+                    "cap is non-https locator and no well-known fallback — "
+                    "keeping cap on record but skipping descriptor fetch",
+                    fqdn=fqdn,
+                    cap_uri=cap_uri,
+                )
+
+            if effective_descriptor_url:
+                # Per-agent total-time budget on descriptor fetch.
+                # fetch_cap_document already times out individual HTTP
+                # operations, but a chain of redirects + DNS + TLS can
+                # still pile up; cap the whole fetch so one slow agent
+                # can't stall a bulk-discovery loop.
+                from dns_aid.core.cap_fetcher import CapDigestMismatchError
+
+                cap_doc = None
+                descriptor_reachable = True
+                try:
+                    cap_doc = await asyncio.wait_for(
+                        fetch_cap_document(effective_descriptor_url, expected_sha256=cap_sha256),
+                        timeout=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
+                    )
+                except TimeoutError:
+                    descriptor_reachable = False
+                    logger.warning(
+                        "Descriptor fetch exceeded per-agent budget — "
+                        "recording capability_source=descriptor_unreachable",
+                        fqdn=fqdn,
+                        descriptor_url=effective_descriptor_url,
+                        budget_seconds=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
+                    )
+                except CapDigestMismatchError as exc:
+                    # Per draft §6.1: digest mismatch MUST cause us to
+                    # refuse the record. Don't fall back to TXT — the
+                    # operator pinned a specific document and the host
+                    # served something different. Drop the record so
+                    # callers don't see an integrity-pinned-looking
+                    # AgentRecord whose capabilities came from elsewhere.
+                    logger.warning(
+                        "cap-sha256 digest mismatch — refusing record",
+                        fqdn=fqdn,
+                        descriptor_url=effective_descriptor_url,
+                        expected=exc.expected,
+                        actual=exc.actual,
+                    )
+                    return None
+
+                # Reachability signal: the operator declared a descriptor
+                # locator (cap or well-known) but we couldn't pull bytes
+                # off the wire. Distinct from "no descriptor declared",
+                # so consumers can tell transient outages from
+                # mis-configurations.
+                if cap_doc is None and descriptor_reachable:
+                    descriptor_reachable = False
+                    logger.debug(
+                        "Descriptor fetch returned no document",
+                        fqdn=fqdn,
+                        descriptor_url=effective_descriptor_url,
+                    )
+
                 if cap_doc and cap_doc.capabilities:
                     capabilities = cap_doc.capabilities
-                    capability_source = "cap_uri"
+                    capability_source = descriptor_source_label
+                    # If cap_sha256 was supplied AND the fetcher accepted
+                    # the bytes (it did not raise CapDigestMismatchError),
+                    # the integrity pin was actually applied to these
+                    # bytes. Record that as a separate boolean so
+                    # downstream consumers don't have to guess from the
+                    # mere presence of cap_sha256.
+                    if cap_sha256 is not None:
+                        cap_sha256_applied = True
                     logger.debug(
-                        "Capabilities fetched from cap URI",
+                        "Capabilities fetched from descriptor URL",
                         fqdn=fqdn,
-                        cap_uri=cap_uri,
+                        descriptor_url=effective_descriptor_url,
+                        source=descriptor_source_label,
                         capabilities=capabilities,
+                        cap_sha256_applied=cap_sha256_applied,
                     )
+                elif not descriptor_reachable:
+                    capability_source = "descriptor_unreachable"
 
                 # Reuse raw data as A2AAgentCard (avoids redundant fetch later)
                 if cap_doc and cap_doc.raw_data:
                     try:
                         agent_card = A2AAgentCard.from_dict(cap_doc.raw_data)
                         logger.debug(
-                            "Parsed A2A Agent Card from cap URI response",
+                            "Parsed A2A Agent Card from descriptor response",
                             fqdn=fqdn,
+                            descriptor_source=descriptor_source_label,
                             card_name=agent_card.name,
                             skills_count=len(agent_card.skills),
                         )
@@ -430,6 +685,26 @@ async def _query_single_agent(
                 if capabilities:
                     capability_source = "txt_fallback"
 
+            # Dangling cap_sha256: a
+            # `cap_sha256` value on the SVCB combined with capabilities
+            # that came from TXT or nowhere is a footgun — the pin
+            # isn't covering the bytes the caller will see. We keep the
+            # SvcParamKey value on the record for transparency (it tells
+            # consumers the operator *intended* an integrity pin) but
+            # the `cap_sha256_verified` flag clearly marks whether the
+            # pin was applied. Surface the dangling case as a warning
+            # for log scrapers.
+            if cap_sha256 is not None and not cap_sha256_applied:
+                logger.warning(
+                    "cap_sha256 declared but not applied — record carries the "
+                    "SvcParamKey value but the integrity pin did not cover the "
+                    "capabilities returned",
+                    fqdn=fqdn,
+                    declared_cap_sha256=cap_sha256,
+                    capability_source=capability_source,
+                    warning_class="dns_aid.dangling_cap_sha256",
+                )
+
             return AgentRecord(
                 name=name,
                 domain=domain,
@@ -439,8 +714,11 @@ async def _query_single_agent(
                 ipv4_hint=ipv4_hint,
                 ipv6_hint=ipv6_hint,
                 capabilities=capabilities,
+                legacy_resolved=resolved_via_legacy,
                 cap_uri=cap_uri,
                 cap_sha256=cap_sha256,
+                cap_sha256_verified=cap_sha256_applied,
+                well_known_path=well_known_path,
                 bap=bap,
                 policy_uri=policy_uri,
                 realm=realm,
@@ -458,34 +736,29 @@ async def _query_single_agent(
     return None
 
 
+# Derive the recognised DNS-AID SvcParamKey name set from the
+# single source of truth in models.py so adding a new key in one
+# place (DNS_AID_KEY_MAP) automatically updates the parser. Earlier
+# this was a literal set hand-maintained here, so adding a key meant
+# editing three different files.
+from dns_aid.core.models import DNS_AID_KEY_MAP, DNS_AID_KEY_MAP_REVERSE  # noqa: E402
+
+_DNS_AID_KEY_NAMES: frozenset[str] = frozenset(DNS_AID_KEY_MAP.keys())
+
+
 def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
+    """Parse DNS-AID custom params from an SVCB record's text rendering.
+
+    Accepts both human-readable string names and RFC 9460 keyNNNNN form:
+
+    - String form: ``cap="https://..." bap="mcp=1.0" realm="demo"``
+    - Numeric form: ``key65400="https://..." key65402="mcp=1.0"``
+
+    The recognised name set is derived from
+    ``dns_aid.core.models.DNS_AID_KEY_MAP`` at module load so this
+    stays in lock-step with publishing.
     """
-    Parse DNS-AID custom params from SVCB record text representation.
-
-    Accepts both human-readable string names and RFC 9460 keyNNNNN format:
-        String form: cap="https://..." bap="mcp,a2a" realm="demo"
-        Numeric form: key65400="https://..." key65402="mcp,a2a" key65404="demo"
-
-    Args:
-        svcb_text: String representation of an SVCB rdata.
-
-    Returns:
-        Dict of custom param names (always string form) to their string values.
-    """
-    from dns_aid.core.models import DNS_AID_KEY_MAP_REVERSE
-
     custom_params: dict[str, str] = {}
-    dnsaid_keys = {
-        "cap",
-        "cap-sha256",
-        "bap",
-        "policy",
-        "realm",
-        "sig",
-        "connect-class",
-        "connect-meta",
-        "enroll-uri",
-    }
 
     try:
         parts = shlex.split(svcb_text)
@@ -502,7 +775,7 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
         if key in DNS_AID_KEY_MAP_REVERSE:
             key = DNS_AID_KEY_MAP_REVERSE[key]
 
-        if key in dnsaid_keys:
+        if key in _DNS_AID_KEY_NAMES:
             custom_params[key] = value
 
     return custom_params
@@ -560,14 +833,72 @@ def _build_index_tasks(
     return tasks
 
 
+def _reconcile_protocol(
+    probe: Protocol, bap: str | None, alpn: str | list[str] | None = None
+) -> Protocol:
+    """Resolve an agent's true protocol from its SVCB record.
+
+    Under draft-02 the protocol lives in the SVCB record, not the FQDN, so
+    ``probe`` (the protocol used to shape the query — the flat-owner SVCB
+    lookup is protocol-independent) is only a placeholder. Prefer the
+    record's own signal in order: the ``bap`` token (draft §5.1), then each
+    ``alpn`` id (dns-aid-core's canonical carrier; a record may list more
+    than one). Return the first candidate that names a protocol we model;
+    fall back to ``probe`` when none do — so a malformed bap, an unknown
+    alpn (e.g. raw ``h2`` / ``h3``), or an empty record never raises and
+    never lets an unparseable bap mask a usable alpn. Mirrors the indexer's
+    ``bap or alpn`` rule and keeps ``AgentRecord.protocol`` consistent with
+    the signed ``alpn`` the JWS binding check compares against.
+    """
+    from dns_aid.core.bap import split_bap_token
+
+    candidates: list[str] = []
+    bap_token = split_bap_token(bap)[0]
+    if bap_token:
+        candidates.append(bap_token)
+    if isinstance(alpn, str):
+        candidates.append(alpn)
+    elif alpn:
+        candidates.extend(alpn)
+
+    for candidate in candidates:
+        if candidate:
+            try:
+                return Protocol(candidate.strip().lower())
+            except ValueError:
+                continue
+    return probe
+
+
 def _collect_agent_results(results: list[Any]) -> list[AgentRecord]:
-    """Filter asyncio.gather results for successful AgentRecord instances."""
-    return [r for r in results if isinstance(r, AgentRecord)]
+    """Filter gather results for AgentRecords, deduped by (FQDN, protocol).
+
+    Under draft-02 the flat-owner SVCB query is protocol-independent, so the
+    common-name fallback probes the same owner once per candidate protocol;
+    after protocol reconciliation those probes return the same agent, which
+    would otherwise appear twice. Dedup on (normalized FQDN, protocol)
+    collapses the duplicates while preserving genuinely distinct agents —
+    including legacy -01 records that share a flat FQDN but carry different
+    protocols in their nested owner name.
+    """
+    seen: set[tuple[str, str]] = set()
+    agents: list[AgentRecord] = []
+    for r in results:
+        if not isinstance(r, AgentRecord):
+            continue
+        key = (r.fqdn.rstrip(".").lower(), r.protocol.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        agents.append(r)
+    return agents
 
 
 async def _discover_agents_in_zone(
     domain: str,
     protocol: Protocol | None = None,
+    *,
+    allow_legacy: bool | None = None,
 ) -> list[AgentRecord]:
     """
     Discover all agents in a domain's _agents zone.
@@ -583,7 +914,7 @@ async def _discover_agents_in_zone(
 
     async def _query_with_sem(name: str, proto: Protocol) -> AgentRecord | None:
         async with sem:
-            return await _query_single_agent(domain, name, proto)
+            return await _query_single_agent(domain, name, proto, allow_legacy=allow_legacy)
 
     if index_entries:
         logger.debug(
@@ -626,25 +957,16 @@ def _parse_fqdn(fqdn: str) -> tuple[str | None, str | None]:
     """
     Parse agent name and protocol from a DNS-AID FQDN.
 
-    FQDN format: _{name}._{protocol}._agents.{domain}
-
-    Returns:
-        (name, protocol_str) or (None, None) if parsing fails.
+    Thin projection over :func:`dns_aid.core.fqdn.parse_dnsaid_fqdn`
+    that drops the domain component; callers needing the domain too
+    should use the parent function directly.
     """
-    if not fqdn or not fqdn.startswith("_"):
+    from dns_aid.core.fqdn import parse_dnsaid_fqdn
+
+    parsed = parse_dnsaid_fqdn(fqdn)
+    if parsed is None:
         return None, None
-
-    parts = fqdn.split(".")
-    if len(parts) < 3:
-        return None, None
-
-    name_part = parts[0]  # _name
-    protocol_part = parts[1]  # _protocol
-
-    if not name_part.startswith("_") or not protocol_part.startswith("_"):
-        return None, None
-
-    return name_part[1:], protocol_part[1:]
+    return parsed.name, parsed.protocol
 
 
 def _enrich_from_http_index(agent: AgentRecord, http_agent: HttpIndexAgent) -> None:
@@ -691,7 +1013,7 @@ async def _process_http_agent(
         return None
 
     dns_agent_name, fqdn_protocol_str = _parse_fqdn(http_agent.fqdn)
-    if not dns_agent_name or not fqdn_protocol_str:
+    if not dns_agent_name:
         logger.debug(
             "Cannot parse FQDN from HTTP index entry",
             agent=http_agent.name,
@@ -699,21 +1021,40 @@ async def _process_http_agent(
         )
         return None
 
-    try:
-        agent_protocol = Protocol(fqdn_protocol_str.lower())
-    except ValueError:
-        logger.debug(
-            "Unknown protocol in FQDN",
-            agent=http_agent.name,
-            fqdn=http_agent.fqdn,
-            protocol=fqdn_protocol_str,
-        )
+    # Under draft-02 the flat and walkable FQDN shapes don't carry the
+    # agent protocol — it lives in the SVCB `bap`/`alpn` SvcParam. If
+    # _parse_fqdn returned no protocol, use the caller-supplied protocol
+    # filter when present, otherwise try mcp then a2a (the SVCB params
+    # on the discovered record reveal the actual protocol).
+    candidate_protocols: list[Protocol]
+    if fqdn_protocol_str:
+        try:
+            candidate_protocols = [Protocol(fqdn_protocol_str.lower())]
+        except ValueError:
+            logger.debug(
+                "Unknown protocol in FQDN",
+                agent=http_agent.name,
+                fqdn=http_agent.fqdn,
+                protocol=fqdn_protocol_str,
+            )
+            return None
+    elif protocol is not None:
+        candidate_protocols = [protocol]
+    else:
+        candidate_protocols = [Protocol.MCP, Protocol.A2A]
+
+    # Apply caller-side protocol filter when the FQDN-carried protocol
+    # is known and doesn't match.
+    if fqdn_protocol_str and protocol and candidate_protocols[0] != protocol:
         return None
 
-    if protocol and agent_protocol != protocol:
-        return None
-
-    agent = await _query_single_agent(domain, dns_agent_name, agent_protocol)
+    agent_protocol = candidate_protocols[0]
+    agent = None
+    for proto in candidate_protocols:
+        agent = await _query_single_agent(domain, dns_agent_name, proto)
+        if agent:
+            agent_protocol = proto
+            break
 
     if agent:
         _enrich_from_http_index(agent, http_agent)
@@ -825,7 +1166,7 @@ def _http_agent_to_record(
 
     # Extract capabilities from HTTP index if available
     http_capabilities: list[str] = []
-    cap_source: Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] = "none"
+    cap_source: CapabilitySource = "none"
     if http_agent.capability and http_agent.capability.capabilities:
         http_capabilities = http_agent.capability.capabilities
         cap_source = "http_index"
@@ -853,10 +1194,13 @@ def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
     """
     agent.agent_card = card
 
-    # Wire agent card skills → capabilities
-    # agent_card is higher priority than txt_fallback and http_index,
-    # so override those sources. Only cap_uri takes precedence.
-    if card.skills and agent.capability_source not in ("cap_uri",):
+    # Wire agent card skills → capabilities. Preserve higher-trust
+    # provenance: cap_uri (draft §6.1 normative locator) and well_known
+    # (RFC 8615 locator, also normative in -02) both record the actual
+    # descriptor source. Overwriting them with "agent_card" here would
+    # erase the fact that the operator declared a specific fetch path —
+    # downstream consumers use capability_source for trust/audit calls.
+    if card.skills and agent.capability_source not in ("cap_uri", "well_known"):
         agent.capabilities = card.to_capabilities()
         agent.capability_source = "agent_card"
         logger.debug(
@@ -1047,72 +1391,76 @@ async def discover_at_fqdn(fqdn: str) -> AgentRecord | None:
     """
     Discover agent at a specific FQDN.
 
+    Accepts any of the three DNS-AID FQDN shapes (draft-02 flat,
+    draft-02 walkable, or legacy -01) and resolves the agent at it.
+    When the input doesn't carry a protocol (the two draft-02 shapes),
+    the discoverer attempts mcp first, then a2a.
+
     Args:
-        fqdn: Full DNS-AID record name (e.g., "_chat._a2a._agents.example.com")
+        fqdn: Full DNS-AID record name. Examples:
+            - ``"chat.example.com"`` (draft-02 flat)
+            - ``"chat._agents.example.com"`` (draft-02 walkable)
+            - ``"_chat._a2a._agents.example.com"`` (legacy -01)
 
     Returns:
-        AgentRecord if found, None otherwise
+        AgentRecord if found, None otherwise.
     """
-    # Parse FQDN to extract components
-    # Format: _{name}._{protocol}._agents.{domain}
-    parts = fqdn.split(".")
+    from dns_aid.core.fqdn import parse_dnsaid_fqdn
 
-    if len(parts) < 4:
+    parsed = parse_dnsaid_fqdn(fqdn)
+    if parsed is None or not parsed.name or not parsed.domain:
         logger.error("Invalid DNS-AID FQDN format", fqdn=fqdn)
         return None
+    name, protocol_str, domain = parsed.name, parsed.protocol, parsed.domain
 
-    # Extract components
-    name_part = parts[0]  # _name
-    protocol_part = parts[1]  # _protocol
+    # Legacy -01 carries the protocol in the FQDN; the two draft-02 shapes
+    # don't. Either way _query_single_agent resolves the SVCB and reconciles
+    # the record's true protocol from bap/alpn (see _reconcile_protocol), so
+    # the probe below is only a placeholder used to shape the query.
+    probe = Protocol.MCP
+    if protocol_str:
+        try:
+            probe = Protocol(protocol_str)
+        except ValueError:
+            logger.error("Unknown protocol", protocol=protocol_str)
+            return None
+    return await _query_single_agent(domain, name, probe)
 
-    if not name_part.startswith("_") or not protocol_part.startswith("_"):
-        logger.error("Invalid DNS-AID FQDN format", fqdn=fqdn)
-        return None
 
-    name = name_part[1:]  # Remove leading underscore
-    protocol_str = protocol_part[1:]  # Remove leading underscore
-
-    # Find _agents marker to determine domain
-    try:
-        agents_idx = parts.index("_agents")
-        domain = ".".join(parts[agents_idx + 1 :])
-    except ValueError:
-        logger.error("Missing _agents in FQDN", fqdn=fqdn)
-        return None
-
-    try:
-        protocol = Protocol(protocol_str)
-    except ValueError:
-        logger.error("Unknown protocol", protocol=protocol_str)
-        return None
-
-    return await _query_single_agent(domain, name, protocol)
+def _dns_name_eq(a: str, b: str) -> bool:
+    """Compare two DNS names case-insensitively, ignoring a trailing dot."""
+    return a.rstrip(".").lower() == b.rstrip(".").lower()
 
 
 async def _verify_agent_signatures(
     agents: list[AgentRecord],
     domain: str,
-    dnssec_validated: bool,
+    dnssec_validated: dict[str, bool] | bool,
 ) -> None:
     """
     Verify JWS signatures on agents that have sig parameter but no DNSSEC.
 
-    For each agent:
-    - If DNSSEC validated: skip (stronger verification already done)
-    - If has sig parameter: verify against domain's JWKS
-    - Log warnings for invalid/missing signatures but don't remove agents
+    Under draft-02 each agent has its own flat fqdn, so DNSSEC validation
+    is also per-agent. JWS verification runs as the per-agent fallback:
+    if a specific agent's owner-name validated under DNSSEC we skip JWS
+    for that agent (stronger guarantee already in place); otherwise we
+    fall through to JWS.
 
     Args:
         agents: List of agents to verify (modified in place with verification status)
         domain: Domain to fetch JWKS from
-        dnssec_validated: Whether DNSSEC validation passed
+        dnssec_validated: Either a mapping of ``agent.fqdn → bool``
+            (per-agent DNSSEC outcome) or a plain bool treated as a
+            uniform answer for every agent. The plain-bool form is kept
+            for callers that haven't migrated to the per-agent map yet.
     """
-    if dnssec_validated:
-        logger.debug("DNSSEC validated, skipping JWS verification")
-        return
+    # Normalize: plain bool → uniform-per-agent dict.
+    if isinstance(dnssec_validated, bool):
+        uniform = dnssec_validated
+        dnssec_validated = {a.fqdn: uniform for a in agents}
 
-    # Find agents with signatures to verify
-    agents_with_sig = [a for a in agents if a.sig]
+    # Find agents with signatures to verify AND no DNSSEC pass.
+    agents_with_sig = [a for a in agents if a.sig and not dnssec_validated.get(a.fqdn, False)]
 
     if not agents_with_sig:
         logger.debug("No agents with JWS signatures to verify")
@@ -1130,16 +1478,56 @@ async def _verify_agent_signatures(
         if agent.sig is None:
             continue
         try:
-            is_valid, _payload = await verify_record_signature(domain, agent.sig)
-            agent.signature_verified = is_valid
-            agent.signature_algorithm = _extract_jws_algorithm(agent.sig) if is_valid else None
+            is_valid, payload = await verify_record_signature(domain, agent.sig)
 
-            if is_valid:
+            # A valid signature alone is insufficient. The signed payload
+            # binds to a specific (fqdn, target, port, alpn) tuple — we
+            # MUST corroborate that the record we're about to trust is
+            # the one those bytes describe. Without this check an attacker
+            # who lifts a legit `sig` value can paste it onto a spoofed
+            # SVCB pointing at their own host and the discoverer would
+            # still stamp signature_verified=True.
+            #
+            # Publisher-side reference: core/publisher.py builds the
+            # payload from name+domain (flat fqdn), endpoint (= target_host),
+            # port, and protocol.value. Compare to the same fields here.
+            # Compare on DNS-normalized values — hostnames are
+            # case-insensitive and may carry a trailing dot, so a
+            # legitimately-signed record must not be rejected over those
+            # cosmetic differences.
+            payload_matches = (
+                is_valid
+                and payload is not None
+                and _dns_name_eq(payload.fqdn, agent.fqdn)
+                and _dns_name_eq(payload.target, agent.target_host)
+                and payload.port == agent.port
+                and payload.alpn == agent.protocol.value
+            )
+
+            agent.signature_verified = payload_matches
+            agent.signature_algorithm = (
+                _extract_jws_algorithm(agent.sig) if payload_matches else None
+            )
+
+            if payload_matches:
                 logger.info(
                     "JWS signature verified",
                     agent=agent.name,
                     fqdn=agent.fqdn,
                     algorithm=agent.signature_algorithm,
+                )
+            elif is_valid:
+                logger.warning(
+                    "JWS signature cryptographically valid but does not bind to record",
+                    agent=agent.name,
+                    fqdn=agent.fqdn,
+                    payload_fqdn=getattr(payload, "fqdn", None),
+                    payload_target=getattr(payload, "target", None),
+                    payload_port=getattr(payload, "port", None),
+                    payload_alpn=getattr(payload, "alpn", None),
+                    record_target=agent.target_host,
+                    record_port=agent.port,
+                    record_alpn=agent.protocol.value,
                 )
             else:
                 logger.warning(

--- a/src/dns_aid/core/fqdn.py
+++ b/src/dns_aid/core/fqdn.py
@@ -1,0 +1,115 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared DNS-AID FQDN parsing.
+
+The discoverer and the telemetry/otel layers both need to recognise the
+three FQDN shapes that have ever been published under DNS-AID and pull
+out the agent identity from each. Keeping a single parser here prevents
+the two implementations from drifting — earlier each module had its
+own, which had already diverged on strictness (one accepted the walkable
+shape with an empty domain suffix, the other didn't).
+
+Shapes recognised:
+
+1. **Legacy draft-01** ``_{name}._{protocol}._agents.{domain}`` — the
+   pre-flat shape; ``name`` and ``protocol`` both carry leading
+   underscores. Strictly validated: rejects single-underscore-prefixed
+   strings like ``_booking.mcp._agents.foo.com`` where only the first
+   label is underscored, since that's neither legitimate -01 nor a
+   correct walkable record.
+2. **Walkable AliasMode draft-02** ``{name}._agents.{domain}`` — the
+   optional walkable enumeration handle. Protocol is unknown from the
+   FQDN alone (it now lives in the SVCB ``bap`` / ``alpn`` SvcParams),
+   so ``protocol`` is returned as ``None``.
+3. **Flat primary owner draft-02** ``{name}.{domain}`` — the canonical
+   -02 shape, valid as an x.509 SAN dNSName. Protocol again ``None``.
+
+Callers needing only a subset of the returned tuple should project from
+the result rather than re-implementing the parser.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class DnsAidFqdn(NamedTuple):
+    """Parsed DNS-AID FQDN components.
+
+    Fields:
+        name: Agent name (the publisher-chosen label).
+        protocol: Agent protocol from the FQDN, or ``None`` under
+            draft-02 where the protocol lives in the SVCB SvcParams
+            (``bap`` / ``alpn``) rather than the name.
+        domain: Trailing domain portion after the agent-identifying
+            labels.
+    """
+
+    name: str
+    protocol: str | None
+    domain: str
+
+
+def parse_dnsaid_fqdn(fqdn: str) -> DnsAidFqdn | None:
+    """Parse a DNS-AID FQDN into ``(name, protocol|None, domain)``.
+
+    Returns ``None`` when ``fqdn`` doesn't look like any of the
+    recognised shapes (empty, single-label, or malformed). Callers
+    should treat ``None`` as "this string didn't carry a DNS-AID
+    agent identity I can interpret" — not as a bug.
+    """
+    if not fqdn:
+        return None
+
+    # DNS labels are case-insensitive (RFC 1035) and a presentation-form
+    # FQDN may carry a trailing root dot. Normalize both up front so every
+    # shape below — and every caller projecting off the result — sees
+    # lowercase, dot-trimmed labels rather than re-implementing this.
+    fqdn = fqdn.strip().rstrip(".").lower()
+    if not fqdn:
+        return None
+
+    # Legacy -01: _{name}._{protocol}._agents.{domain}
+    # Requires (a) leading underscore on label 0, (b) leading underscore
+    # on label 1 (the protocol), AND (c) label 2 == "_agents" so we
+    # reject strings like "_booking.mcp._agents.foo.com" where only the
+    # first label is underscored — that's neither legitimate -01 nor a
+    # correct walkable record.
+    if fqdn.startswith("_") and "._agents." in fqdn:
+        parts = fqdn.split(".")
+        if len(parts) < 4:
+            return None
+        name_part = parts[0]
+        protocol_part = parts[1]
+        agents_part = parts[2]
+        if (
+            not name_part.startswith("_")
+            or not protocol_part.startswith("_")
+            or agents_part != "_agents"
+        ):
+            return None
+        domain = ".".join(parts[3:])
+        if not domain:
+            return None
+        return DnsAidFqdn(name=name_part[1:], protocol=protocol_part[1:], domain=domain)
+
+    # Walkable AliasMode draft-02: {name}._agents.{domain}
+    if "._agents." in fqdn:
+        prefix, _, suffix = fqdn.partition("._agents.")
+        if prefix and suffix and "." not in prefix and not prefix.startswith("_"):
+            return DnsAidFqdn(name=prefix, protocol=None, domain=suffix)
+        return None
+
+    # Flat draft-02: {name}.{domain}. Require at least two labels total
+    # ({name} + a domain), so a single bare label is rejected but a flat
+    # owner in a short or internal zone ({name}.{tld}, e.g. agent.internal
+    # or chat.localhost) is still accepted. The name label must not start
+    # with an underscore.
+    if "." in fqdn:
+        first_label, _, rest = fqdn.partition(".")
+        if first_label and rest and not first_label.startswith("_") and not rest.startswith("_"):
+            return DnsAidFqdn(name=first_label, protocol=None, domain=rest)
+
+    return None

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -17,6 +17,7 @@ descriptions, model cards, and capability details.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -41,6 +42,13 @@ HTTP_INDEX_PATTERNS = [
 
 # Default timeout for HTTP requests
 DEFAULT_TIMEOUT = 10.0
+
+# Bounds on an untrusted HTTP index. The index drives a fan-out of one
+# SVCB + cap + JWKS chain per agent, so an unbounded document or agent list
+# is a memory + amplification vector. A real index of a few hundred agents
+# is well under 1 MB.
+_MAX_HTTP_INDEX_BYTES = 1024 * 1024
+_MAX_HTTP_INDEX_AGENTS = 500
 
 
 @dataclass
@@ -228,28 +236,47 @@ async def fetch_http_index(
             logger.debug("Trying HTTP index endpoint", url=url, pattern_type=pattern["type"])
 
             try:
-                response = await client.get(url)
+                # Stream the body with a byte cap so a hostile endpoint can't
+                # force an OOM — the oversized payload never fully lands in
+                # memory.
+                async with client.stream("GET", url) as response:
+                    if response.status_code != 200:
+                        if response.status_code == 404:
+                            errors.append(f"{url}: Not found (404)")
+                            logger.debug("HTTP index not found", url=url)
+                        else:
+                            errors.append(f"{url}: HTTP {response.status_code}")
+                            logger.warning(
+                                "HTTP index request failed",
+                                url=url,
+                                status_code=response.status_code,
+                            )
+                        continue
 
-                if response.status_code == 200:
-                    data = response.json()
-                    agents = parse_http_index(data)
-                    logger.info(
-                        "HTTP index fetched successfully",
-                        url=url,
-                        agent_count=len(agents),
-                    )
-                    return agents
+                    body = bytearray()
+                    too_large = False
+                    async for chunk in response.aiter_bytes():
+                        body.extend(chunk)
+                        if len(body) > _MAX_HTTP_INDEX_BYTES:
+                            too_large = True
+                            break
+                    if too_large:
+                        errors.append(f"{url}: response exceeds {_MAX_HTTP_INDEX_BYTES} bytes")
+                        logger.warning(
+                            "HTTP index response too large",
+                            url=url,
+                            cap=_MAX_HTTP_INDEX_BYTES,
+                        )
+                        continue
 
-                elif response.status_code == 404:
-                    errors.append(f"{url}: Not found (404)")
-                    logger.debug("HTTP index not found", url=url)
-                else:
-                    errors.append(f"{url}: HTTP {response.status_code}")
-                    logger.warning(
-                        "HTTP index request failed",
-                        url=url,
-                        status_code=response.status_code,
-                    )
+                data = json.loads(bytes(body))
+                agents = parse_http_index(data)
+                logger.info(
+                    "HTTP index fetched successfully",
+                    url=url,
+                    agent_count=len(agents),
+                )
+                return agents
 
             except httpx.TimeoutException:
                 errors.append(f"{url}: Timeout")
@@ -291,6 +318,15 @@ def parse_http_index(data: dict[str, Any]) -> list[HttpIndexAgent]:
         data = data["agents"]
 
     for name, agent_data in data.items():
+        # Cap the number of agents taken from a single (untrusted) index so a
+        # hostile document can't amplify into an unbounded discovery fan-out.
+        if len(agents) >= _MAX_HTTP_INDEX_AGENTS:
+            logger.warning(
+                "HTTP index truncated — too many agents",
+                cap=_MAX_HTTP_INDEX_AGENTS,
+            )
+            break
+
         # Skip metadata fields (non-dict values)
         if not isinstance(agent_data, dict):
             continue

--- a/src/dns_aid/core/indexer.py
+++ b/src/dns_aid/core/indexer.py
@@ -24,11 +24,19 @@ import dns.resolver
 import structlog
 
 from dns_aid.backends.base import DNSBackend
+from dns_aid.core.models import SVCB_SERVICE_MODE
+from dns_aid.utils.validation import validate_no_underscore_in_target
 
 logger = structlog.get_logger(__name__)
 
 # Index record name pattern
 INDEX_RECORD_NAME = "_index._agents"
+
+# Sentinel for an index entry whose protocol couldn't be derived from
+# the primary SVCB record (record absent, malformed, or the publisher
+# didn't set alpn/bap). Kept as a named constant so consumers can
+# filter on it without string-matching.
+UNKNOWN_PROTOCOL = "unknown"
 
 
 @dataclass
@@ -199,27 +207,46 @@ async def update_index(
     add: list[IndexEntry] | None = None,
     remove: list[IndexEntry] | None = None,
     ttl: int = 3600,
+    index_target: str | None = None,
+    index_target_port: int = 443,
 ) -> IndexResult:
     """
     Update the agent index for a domain.
 
     Performs a read-modify-write operation to update the index.
 
+    Under draft-mozleywilliams-dnsop-dnsaid-02 the canonical org index
+    record is SVCB at ``_index._agents.{domain}`` pointing at a
+    non-underscored TargetName. TXT remains a documented fallback
+    (§TXT-fallback) for SVCB-less environments. dns-aid-core writes
+    both when ``index_target`` is supplied (SVCB for spec-compliant
+    consumers + TXT inline-listing for the rest); when ``index_target``
+    is omitted the TXT inline-listing is the only record written.
+
     Args:
-        domain: Domain to update index for
-        backend: DNS backend to use
-        add: Entries to add to the index
-        remove: Entries to remove from the index
-        ttl: TTL for the index record
+        domain: Domain to update index for.
+        backend: DNS backend to use.
+        add: Entries to add to the index.
+        remove: Entries to remove from the index.
+        ttl: TTL for the index record.
+        index_target: Optional host that serves the org's JSON agent
+            index over HTTPS. When provided, dns-aid-core writes an
+            SVCB ServiceMode record at ``_index._agents.{domain}``
+            pointing at this target alongside the TXT inline record.
+            The host MUST NOT contain underscored labels (it carries
+            a public x.509 cert; see draft-02 §Known Organization).
+        index_target_port: Port for the SVCB ServiceMode write
+            (default 443). Only relevant when ``index_target`` is set.
 
     Returns:
-        IndexResult with operation outcome
+        IndexResult with operation outcome.
     """
     logger.info(
         "Updating index",
         domain=domain,
         add=[str(e) for e in (add or [])],
         remove=[str(e) for e in (remove or [])],
+        index_target=index_target,
     )
 
     # Read current index
@@ -243,6 +270,12 @@ async def update_index(
     # Format the TXT value
     txt_value = format_index_txt(new_entries)
 
+    # If the caller wants the draft-02 SVCB-primary form, validate the
+    # TargetName up front (same rule as agent records — no underscores
+    # because the target carries a public x.509 cert).
+    if index_target is not None:
+        validate_no_underscore_in_target(index_target)
+
     try:
         # Check zone exists
         if not await backend.zone_exists(domain):
@@ -253,7 +286,23 @@ async def update_index(
                 message=f"Zone '{domain}' does not exist",
             )
 
-        # Write the updated index (UPSERT)
+        # Write the SVCB primary form first, when an index_target was
+        # supplied. The SVCB record points at the index host; consumers
+        # fetch the actual JSON-bodied index from there over HTTPS.
+        if index_target is not None:
+            svcb_target = index_target if index_target.endswith(".") else f"{index_target}."
+            await backend.create_svcb_record(
+                zone=domain,
+                name=INDEX_RECORD_NAME,
+                priority=SVCB_SERVICE_MODE,
+                target=svcb_target,
+                params={"alpn": "h2", "port": str(index_target_port)},
+                ttl=ttl,
+            )
+
+        # Write the TXT inline index (always — kept as the §TXT-fallback
+        # form for SVCB-less consumers, and as the carrier for
+        # dns-aid-core's own enumeration of agents).
         await backend.create_txt_record(
             zone=domain,
             name=INDEX_RECORD_NAME,
@@ -266,6 +315,7 @@ async def update_index(
             domain=domain,
             entry_count=len(new_entries),
             was_empty=was_empty,
+            wrote_svcb=index_target is not None,
         )
 
         return IndexResult(
@@ -344,36 +394,130 @@ async def sync_index(
             message=f"Zone '{domain}' does not exist or is not accessible",
         )
 
-    # Pattern to match agent records: _{name}._{protocol}._agents
-    agent_pattern = re.compile(r"^_([a-z0-9-]+)\._([a-z0-9]+)\._agents$", re.IGNORECASE)
+    # Under draft-02 the canonical agent SVCB lives at the flat name
+    # ({name}.{domain}). The walkable AliasMode at {name}._agents is
+    # the reliable enumeration handle. Protocol is no longer in the
+    # FQDN — it lives in the `alpn` (or `bap`) SvcParam on the primary
+    # record, so the indexer resolves the walkable, then reads the
+    # primary record's SvcParams to recover the protocol.
+    walkable_pattern = re.compile(r"^([a-z0-9-]+)\._agents$", re.IGNORECASE)
+    legacy_pattern = re.compile(r"^_([a-z0-9-]+)\._([a-z0-9]+)\._agents$", re.IGNORECASE)
 
     discovered_entries: list[IndexEntry] = []
 
+    def _protocol_from_primary(primary_records: dict[str, dict], name: str) -> str:
+        """Read the agent protocol off the primary SVCB record.
+
+        draft-02 §5.1 (experimental ``bap``) carries an agent-protocol
+        identifier — bare (``mcp``) or versioned (``mcp=1.0``).
+        ``alpn`` is dns-aid-core's canonical reconciliation carrier
+        and accepted as a fallback. Use the shared ``normalize_bap``
+        and ``split_bap_token`` helpers so the indexer agrees with the
+        discoverer and SDK on collapse + token extraction semantics.
+        """
+        from dns_aid.core.bap import normalize_bap, split_bap_token
+
+        primary = primary_records.get(name)
+        if not primary:
+            return UNKNOWN_PROTOCOL
+        params = primary.get("data", {}).get("params", {}) or {}
+        # SVCB params from list_records may carry stray quoting.
+        raw = params.get("bap") or params.get("alpn")
+        if not raw:
+            return UNKNOWN_PROTOCOL
+        cleaned = raw.strip('"') if isinstance(raw, str) else raw
+        normalized = normalize_bap(cleaned)
+        if normalized is None:
+            return UNKNOWN_PROTOCOL
+        proto_token, _version = split_bap_token(normalized)
+        return proto_token or UNKNOWN_PROTOCOL
+
     try:
-        # Scan for all _agents.* SVCB records
-        async for record in backend.list_records(
-            zone=domain,
-            name_pattern="_agents",
-            record_type="SVCB",
-        ):
+        # Two enumerations, one per record type. The SVCB pass builds
+        # primary_records (and the walkable/legacy agent list); the TXT
+        # pass records which owners carry a companion TXT. Earlier the
+        # function fetched SVCB twice — once unfiltered, once with
+        # name_pattern="_agents" — but the second was a subset of the
+        # first; on real backends (Route53 / Cloudflare / Infoblox) each
+        # `list_records` is a paginated round-trip, so that was pure waste.
+        # The TXT pass is a distinct record type genuinely needed to
+        # recognise flat owners (see below), not a redundant repeat.
+        primary_records: dict[str, dict] = {}
+        agent_records: list[dict] = []
+        async for record in backend.list_records(zone=domain, record_type="SVCB"):
+            rname = record.get("name", "")
+            if not rname or rname == INDEX_RECORD_NAME:
+                continue
+            primary_records[rname] = record
+            if "_agents" in rname:
+                agent_records.append(record)
+
+        # draft-02 flat primary owners ({name}.{domain}) carry no _agents
+        # label, so the walkable/legacy patterns below miss them — yet the
+        # flat owner is the DEFAULT publish shape (walkable is opt-in). Every
+        # publish writes a companion TXT at the flat owner, so an SVCB leaf
+        # paired with a TXT at the same owner is a DNS-AID agent. Collect the
+        # TXT-bearing owners so the flat pass confirms an agent without
+        # misindexing an unrelated SVCB record in the zone.
+        txt_owners: set[str] = set()
+        async for record in backend.list_records(zone=domain, record_type="TXT"):
+            tname = record.get("name", "")
+            if tname and tname != INDEX_RECORD_NAME:
+                txt_owners.add(tname)
+
+        indexed_names: set[str] = set()
+
+        for record in agent_records:
             record_name = record.get("name", "")
 
-            # Skip the index record itself
-            if record_name == INDEX_RECORD_NAME:
+            # Try the draft-02 walkable AliasMode shape first.
+            walkable_match = walkable_pattern.match(record_name)
+            if walkable_match:
+                name = walkable_match.group(1)
+                protocol = _protocol_from_primary(primary_records, name)
+                discovered_entries.append(IndexEntry(name=name, protocol=protocol))
+                indexed_names.add(name)
+
+                logger.debug(
+                    "Discovered agent (draft-02 walkable)",
+                    name=name,
+                    protocol=protocol,
+                )
                 continue
 
-            # Parse the record name
-            match = agent_pattern.match(record_name)
+            # Fall back to the legacy -01 shape.
+            match = legacy_pattern.match(record_name)
             if match:
                 name = match.group(1)
                 protocol = match.group(2)
                 discovered_entries.append(IndexEntry(name=name, protocol=protocol))
+                indexed_names.add(name)
 
                 logger.debug(
                     "Discovered agent",
                     name=name,
                     protocol=protocol,
                 )
+
+        # draft-02 flat primary owners: index any SVCB owner that has a
+        # companion TXT and wasn't already captured via its walkable alias.
+        for rname in primary_records:
+            if "_agents" in rname or rname in indexed_names:
+                continue
+            if "." in rname or rname not in txt_owners:
+                # Dotted names aren't leaf owners of this zone (backends
+                # yield leaf names); no companion TXT means it isn't a
+                # DNS-AID agent record. Skip either way.
+                continue
+            protocol = _protocol_from_primary(primary_records, rname)
+            discovered_entries.append(IndexEntry(name=rname, protocol=protocol))
+            indexed_names.add(rname)
+
+            logger.debug(
+                "Discovered agent (draft-02 flat)",
+                name=rname,
+                protocol=protocol,
+            )
 
     except Exception as e:
         logger.error("Failed to scan for agents", domain=domain, error=str(e))

--- a/src/dns_aid/core/jwks.py
+++ b/src/dns_aid/core/jwks.py
@@ -30,7 +30,6 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
 import structlog
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -48,6 +47,13 @@ JWKS_WELL_KNOWN_PATH = "/.well-known/dns-aid-jwks.json"
 # Cache for JWKS documents (domain -> (jwks, expiry))
 _jwks_cache: dict[str, tuple[dict[str, Any], float]] = {}
 JWKS_CACHE_TTL = 3600  # 1 hour
+
+# A JWKS with a handful of P-256 keys is well under 64 KB. Bound the fetched
+# document size so a hostile endpoint can't return an unbounded body, and
+# bound the per-process cache so bulk cross-domain discovery can't grow it
+# without limit.
+_MAX_JWKS_RESPONSE_BYTES = 64 * 1024
+_JWKS_CACHE_MAX = 512
 
 
 @dataclass
@@ -170,12 +176,31 @@ def import_public_key_from_jwk(jwk: dict[str, Any]) -> EllipticCurvePublicKey:
     """
     Import a public key from a JWK dict.
 
+    Hardened against algorithm/curve confusion: only an EC P-256 signing
+    key is accepted, and the x/y coordinates must be exactly 32 bytes.
+    ``public_key()`` additionally rejects a point that is not on the curve
+    (invalid-curve attack). The JWKS source is attacker-influenceable, so
+    these checks run before any key material is trusted.
+
     Args:
-        jwk: JWK dict with x, y coordinates
+        jwk: JWK dict with ``kty="EC"``, ``crv="P-256"``, and x/y coords.
 
     Returns:
-        EC public key
+        EC public key.
+
+    Raises:
+        ValueError: if the JWK is not a P-256 EC signing key, or the
+            coordinates are missing / malformed / wrong length.
     """
+    if not isinstance(jwk, dict):
+        raise ValueError("JWK must be a JSON object")
+    if jwk.get("kty") != "EC":
+        raise ValueError(f"unsupported JWK kty {jwk.get('kty')!r}; only 'EC' is supported")
+    if jwk.get("crv") != "P-256":
+        raise ValueError(f"unsupported JWK crv {jwk.get('crv')!r}; only 'P-256' is supported")
+    use = jwk.get("use")
+    if use is not None and use != "sig":
+        raise ValueError(f"JWK 'use' is {use!r}, not a signing key")
 
     # Decode base64url (add padding if needed)
     def b64url_decode(s: str) -> bytes:
@@ -184,12 +209,21 @@ def import_public_key_from_jwk(jwk: dict[str, Any]) -> EllipticCurvePublicKey:
             s += "=" * padding
         return base64.urlsafe_b64decode(s)
 
-    x_bytes = b64url_decode(jwk["x"])
-    y_bytes = b64url_decode(jwk["y"])
+    try:
+        x_bytes = b64url_decode(jwk["x"])
+        y_bytes = b64url_decode(jwk["y"])
+    except (KeyError, TypeError, ValueError) as e:
+        # binascii.Error (bad base64) is a ValueError subclass.
+        raise ValueError(f"invalid JWK coordinates: {e}") from e
+
+    # P-256 field elements are exactly 32 bytes.
+    if len(x_bytes) != 32 or len(y_bytes) != 32:
+        raise ValueError("JWK x/y coordinates must be 32 bytes for P-256")
 
     x = int.from_bytes(x_bytes, byteorder="big")
     y = int.from_bytes(y_bytes, byteorder="big")
 
+    # public_key() raises ValueError if (x, y) is not on the P-256 curve.
     public_numbers = ec.EllipticCurvePublicNumbers(x, y, ec.SECP256R1())
     return public_numbers.public_key()
 
@@ -252,6 +286,17 @@ def verify_signature(
 
         header_b64, payload_b64, signature_b64 = parts
 
+        # Enforce the algorithm declared in the protected header. Only ES256
+        # is supported; reject "none", RSA, or any other alg to close
+        # algorithm-confusion attacks (the key source is attacker-influenced).
+        header = json.loads(_b64url_decode(header_b64))
+        if not isinstance(header, dict) or header.get("alg") != "ES256":
+            logger.debug(
+                "Unsupported or missing JWS alg",
+                alg=header.get("alg") if isinstance(header, dict) else None,
+            )
+            return False, None
+
         # Reconstruct signing input
         signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
 
@@ -301,28 +346,61 @@ async def fetch_jwks(domain: str) -> dict[str, Any] | None:
     """
     # Check cache
     now = time.time()
-    if domain in _jwks_cache:
-        jwks, expiry = _jwks_cache[domain]
+    cached = _jwks_cache.get(domain)
+    if cached is not None:
+        jwks, expiry = cached
         if now < expiry:
             return jwks
+        _jwks_cache.pop(domain, None)  # expired — drop it
 
-    # Fetch from well-known endpoint
+    # Fetch from well-known endpoint. This input stamps trust
+    # (signature_verified), so it goes through the same SSRF guard and
+    # streaming size cap as every other untrusted fetch — no raw httpx.get,
+    # no unbounded .json(), and no cross-host redirects.
     url = f"https://{domain}{JWKS_WELL_KNOWN_PATH}"
 
     logger.debug("Fetching JWKS", url=url)
 
+    from dns_aid.utils.url_safety import (
+        ResponseTooLargeError,
+        UnsafeURLError,
+        safe_fetch_bytes,
+        validate_fetch_url,
+    )
+
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            jwks = response.json()
+        validate_fetch_url(url)
+    except UnsafeURLError as e:
+        logger.warning("JWKS URL blocked by SSRF protection", domain=domain, error=str(e))
+        return None
 
-            # Cache the result
-            _jwks_cache[domain] = (jwks, now + JWKS_CACHE_TTL)
+    try:
+        body = await safe_fetch_bytes(
+            url,
+            max_bytes=_MAX_JWKS_RESPONSE_BYTES,
+            timeout=10.0,
+            follow_redirects=False,
+        )
+        if body is None:
+            logger.warning("JWKS fetch failed (non-200)", domain=domain)
+            return None
 
-            logger.info("JWKS fetched successfully", domain=domain)
-            return jwks
+        jwks = json.loads(body)
+        if not isinstance(jwks, dict):
+            logger.warning("JWKS document is not a JSON object", domain=domain)
+            return None
 
+        # Bound cache growth: evict oldest entries (FIFO) before insert.
+        while len(_jwks_cache) >= _JWKS_CACHE_MAX:
+            _jwks_cache.pop(next(iter(_jwks_cache)), None)
+        _jwks_cache[domain] = (jwks, now + JWKS_CACHE_TTL)
+
+        logger.info("JWKS fetched successfully", domain=domain)
+        return jwks
+
+    except ResponseTooLargeError as e:
+        logger.warning("JWKS document too large", domain=domain, error=str(e))
+        return None
     except Exception as e:
         logger.warning("Failed to fetch JWKS", domain=domain, error=str(e))
         return None

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -5,7 +5,7 @@
 Data models for DNS-AID.
 
 These models represent agents, discovery results, and DNS records
-as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations
@@ -18,9 +18,41 @@ from pydantic import BaseModel, Field, field_validator
 
 from dns_aid.utils.validation import validate_connect_class
 
-# DNS-AID custom SVCB param key mapping (IETF draft-01, Section 4.4.3)
+# Capability provenance — single source of truth.
+#
+# Each value records WHERE a record's capabilities came from, so
+# downstream consumers can make trust / audit / fallback decisions
+# without re-deriving the chain. Add new values here (and only here)
+# — the discoverer, SDK, indexer, and AgentRecord all import this
+# symbol so adding a value automatically widens every type-check site.
+#
+# Priority (most trusted → least): cap_uri > well_known > agent_card
+# > http_index > txt_fallback. ``descriptor_unreachable`` is a
+# diagnostic source: the SVCB record declared a cap/well-known
+# locator but the fetch failed (timeout, TLS error, 5xx). Recording
+# this as a distinct source lets callers tell "no descriptor
+# declared" from "descriptor declared but unreachable right now"
+# without scraping log lines.
+CapabilitySource = Literal[
+    "cap_uri",
+    "well_known",
+    "agent_card",
+    "http_index",
+    "txt_fallback",
+    "descriptor_unreachable",
+    "none",
+]
+
+# DNS-AID custom SVCB param key mapping (IETF draft-02 §4 IANA Considerations).
 # These use the RFC 9460 Private Use range (65280-65534).
 # Once IANA assigns official SvcParamKey numbers, update these values.
+#
+# Six of the entries below (cap, cap-sha256, bap, policy, realm, well-known)
+# correspond to keys that draft-02 requests IANA register normatively. The
+# remaining four (sig, connect-class, connect-meta, enroll-uri) are not in
+# the draft-02 normative set; they back features discussed in -02 §5 (Future Work and Experimental Mechanisms)
+# or shipping in dns-aid-core as extensions and remain at private-use code
+# points pending a follow-up discussion.
 DNS_AID_KEY_MAP: dict[str, str] = {
     "cap": "key65400",
     "cap-sha256": "key65401",
@@ -31,9 +63,18 @@ DNS_AID_KEY_MAP: dict[str, str] = {
     "connect-class": "key65406",
     "connect-meta": "key65407",
     "enroll-uri": "key65408",
+    "well-known": "key65409",
 }
 
 DNS_AID_KEY_MAP_REVERSE: dict[str, str] = {v: k for k, v in DNS_AID_KEY_MAP.items()}
+
+# SVCB record priorities per RFC 9460:
+#   priority=0 → AliasMode (the record is an alias to a canonical owner)
+#   priority>0 → ServiceMode (the record carries endpoint data; lower
+#                priorities are preferred when multiple are returned)
+# We use 1 as the default ServiceMode priority for primary-owner writes.
+SVCB_ALIAS_MODE: int = 0
+SVCB_SERVICE_MODE: int = 1
 
 
 def _use_string_keys() -> bool:
@@ -135,8 +176,27 @@ class SvcbRecord(BaseModel):
         default=None,
         description="Capability document URI mapped to the DNS-AID 'cap' SVCB parameter",
     )
-    cap_sha256: str | None = Field(default=None, description="SHA-256 digest for the cap URI")
-    bap: list[str] = Field(default_factory=list, description="Bulk application protocols")
+    cap_sha256: str | None = Field(
+        default=None,
+        description="SHA-256 digest for the cap URI. Presence does not imply the digest "
+        "was actually checked against fetched bytes — use ``cap_sha256_verified``.",
+    )
+    cap_sha256_verified: bool = Field(
+        default=False,
+        description="True when the discoverer fetched the descriptor and the SHA-256 of "
+        "its bytes matched ``cap_sha256``. Always False on records that didn't go "
+        "through the fetch path.",
+    )
+    bap: str | None = Field(
+        default=None,
+        description="Bulk Agent Protocol (draft-02 §5.1, §FutureWork). Carries a "
+        "single agent-protocol identifier per SVCB record in the draft's "
+        "delimited form: bare (``mcp``, ``a2a``) or versioned (``mcp=1.0``, "
+        "``a2a=1.1``). Experimental in draft-02 — alpn remains the protocol "
+        "carrier dns-aid-core treats as canonical for reconciliation. "
+        "Multi-protocol agents publish multiple SVCB records at the same flat "
+        "owner, each with its own alpn and (optionally) bap.",
+    )
     policy_uri: str | None = Field(default=None, description="Agent policy URI")
     realm: str | None = Field(default=None, description="Opaque authz realm identifier")
     sig: str | None = Field(default=None, description="JWS signature for the record")
@@ -155,11 +215,106 @@ class SvcbRecord(BaseModel):
         max_length=2048,
         description="Managed enrollment URI required before direct connection",
     )
+    well_known_path: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="RFC 8615 well-known path suffix mapped to the DNS-AID 'well-known' "
+        "SvcParamKey (per draft-02). Independent of 'uri'/'cap'; both may be present.",
+    )
 
     @field_validator("connect_class", mode="before")
     @classmethod
     def normalize_connect_class(cls, v: str | None) -> str | None:
         return _normalize_connect_class(v)
+
+    @field_validator("target", mode="after")
+    @classmethod
+    def _enforce_no_underscore_in_target(cls, v: str) -> str:
+        """Enforce draft-02 §3.2 (Known Organization, Unknown Agent) at the type boundary.
+
+        Earlier the no-underscore rule fired only inside ``publish()``;
+        anyone constructing an ``SvcbRecord`` directly (or via
+        ``AgentRecord.to_svcb_record()``) bypassed it. The field
+        validator makes the model itself the enforcer so the invariant
+        holds regardless of construction path.
+
+        Honours the operator-level env gate
+        ``DNS_AID_ALLOW_UNDERSCORE_TARGET=1`` — when set, underscored
+        targets construct successfully so the publisher's existing
+        ``allow_underscore_target=True`` path can still emit its
+        structured WARN. Without the env gate, no construction path
+        can produce an underscored target.
+        """
+        from dns_aid.utils.validation import (
+            _underscore_bypass_env_enabled,
+            validate_no_underscore_in_target,
+        )
+
+        validate_no_underscore_in_target(v, allow_underscore=_underscore_bypass_env_enabled())
+        return v
+
+    @field_validator("well_known_path", mode="after")
+    @classmethod
+    def _enforce_safe_well_known_path(cls, v: str | None) -> str | None:
+        """Constrain well-known to a safe RFC 8615 value at the type boundary.
+
+        Same reasoning as ``target`` above: the publisher-side check
+        isn't sufficient when consumers can deserialize SVCB records
+        directly into ``SvcbRecord`` (e.g. through ``to_svcb_record()``
+        round-trips). The field validator catches it.
+        """
+        if v is None:
+            return None
+        from dns_aid.utils.validation import validate_well_known_path
+
+        return validate_well_known_path(v)
+
+    @field_validator("bap", mode="after")
+    @classmethod
+    def _enforce_safe_bap(cls, v: str | None) -> str | None:
+        """Constrain ``bap`` to the draft-02 wire shape at the type boundary.
+
+        Without this validator a crafted value like
+        ``mcp" key65500="x`` would round-trip verbatim through
+        ``to_params()`` and the backend formatters, so dnspython
+        would parse two SvcParamKeys instead of one — the attacker
+        controls the second. Enforcing the constraint here catches it
+        on every construction path (direct, via ``to_svcb_record()``,
+        via ``publish()``).
+        """
+        if v is None:
+            return None
+        from dns_aid.core.bap import validate_bap
+
+        return validate_bap(v)
+
+    @field_validator(
+        "uri",
+        "cap_sha256",
+        "policy_uri",
+        "realm",
+        "sig",
+        "connect_meta",
+        "enroll_uri",
+        mode="after",
+    )
+    @classmethod
+    def _enforce_safe_svcparams(cls, v: str | None) -> str | None:
+        """Reject SVCB SvcParam-quote-breakout chars in the free-form params.
+
+        ``to_params()`` emits these as ``key="<value>"`` and the
+        presentation-format backends (Route53 / Cloudflare / DDNS) write
+        that verbatim, so a double quote, backslash, or control character
+        could break out of the quoting and inject an attacker-controlled
+        sibling SvcParamKey into the authoritative record — the same
+        server-side parameter injection ``bap`` already closes. Enforced at
+        the type boundary so every construction path inherits it.
+        """
+        if v is None:
+            return None
+        from dns_aid.utils.validation import validate_svcparam_value
+
+        return validate_svcparam_value(v)
 
     @property
     def normalized_target(self) -> str:
@@ -176,6 +331,16 @@ class SvcbRecord(BaseModel):
                 mandatory.append(normalized)
                 seen_mandatory.add(normalized)
 
+        # Resolve the wire-key style ONCE per to_params() call. Earlier
+        # each line below was calling _svcb_param_key() which re-reads
+        # the DNS_AID_SVCB_STRING_KEYS env var via os.environ.get —
+        # up to 11 env reads per serialization, multiplied by every
+        # publish call. Cache the mapping here so we pay one env read.
+        emit_string = _use_string_keys()
+
+        def _key(name: str) -> str:
+            return name if emit_string else DNS_AID_KEY_MAP.get(name, name)
+
         params = {
             "alpn": self.alpn,
             "port": str(self.port),
@@ -186,23 +351,25 @@ class SvcbRecord(BaseModel):
         if self.ipv6_hint:
             params["ipv6hint"] = self.ipv6_hint
         if self.uri:
-            params[_svcb_param_key("cap")] = self.uri
+            params[_key("cap")] = self.uri
         if self.cap_sha256:
-            params[_svcb_param_key("cap-sha256")] = self.cap_sha256
+            params[_key("cap-sha256")] = self.cap_sha256
         if self.bap:
-            params[_svcb_param_key("bap")] = ",".join(self.bap)
+            params[_key("bap")] = self.bap
         if self.policy_uri:
-            params[_svcb_param_key("policy")] = self.policy_uri
+            params[_key("policy")] = self.policy_uri
         if self.realm:
-            params[_svcb_param_key("realm")] = self.realm
+            params[_key("realm")] = self.realm
         if self.sig:
-            params[_svcb_param_key("sig")] = self.sig
+            params[_key("sig")] = self.sig
         if self.connect_class:
-            params[_svcb_param_key("connect-class")] = self.connect_class
+            params[_key("connect-class")] = self.connect_class
         if self.connect_meta:
-            params[_svcb_param_key("connect-meta")] = self.connect_meta
+            params[_key("connect-meta")] = self.connect_meta
         if self.enroll_uri:
-            params[_svcb_param_key("enroll-uri")] = self.enroll_uri
+            params[_key("enroll-uri")] = self.enroll_uri
+        if self.well_known_path:
+            params[_key("well-known")] = self.well_known_path
         return params
 
 
@@ -210,9 +377,15 @@ class AgentRecord(BaseModel):
     """
     Represents an AI agent published via DNS-AID.
 
-    Maps to SVCB + TXT records in DNS per the DNS-AID specification:
-    - SVCB: _{name}._{protocol}._agents.{domain} → service binding
+    Maps to SVCB + TXT records in DNS per the DNS-AID specification
+    (draft-mozleywilliams-dnsop-dnsaid-02):
+
+    - SVCB: ``{name}.{domain}`` → service binding (flat primary owner)
     - TXT: capabilities, version, metadata
+
+    The agent protocol is no longer part of the FQDN under -02 — it
+    lives in the ``bap`` SvcParamKey (or ``alpn`` when only one
+    protocol is supported).
 
     Example:
         >>> agent = AgentRecord(
@@ -223,7 +396,7 @@ class AgentRecord(BaseModel):
         ...     capabilities=["ipam", "dns", "vpn"]
         ... )
         >>> agent.fqdn
-        '_network-specialist._mcp._agents.example.com'
+        'network-specialist.example.com'
         >>> agent.endpoint_url
         'https://mcp.example.com:443'
     """
@@ -282,17 +455,46 @@ class AgentRecord(BaseModel):
     #     add custom keys to the mandatory list for downgrade safety.
     cap_uri: str | None = Field(
         default=None,
-        description="URI or URN to capability descriptor (per DNS-AID draft Section 4.4.3 'cap')",
+        description="URI, URN, or compact JSON-Ref locator for the capability descriptor "
+        "(per draft-02 'cap' SvcParamKey)",
     )
     cap_sha256: str | None = Field(
         default=None,
-        description="Base64url-encoded SHA-256 digest of the capability descriptor "
-        "for integrity checks and cache revalidation (per DNS-AID draft 'cap-sha256')",
+        description="Base64url-encoded SHA-256 digest of the canonical capability descriptor "
+        "for integrity checks and cache revalidation (per draft-02 'cap-sha256' SvcParamKey). "
+        "Presence on a discovered AgentRecord does NOT imply the digest was checked against "
+        "fetched bytes — see ``cap_sha256_verified`` for that signal.",
     )
-    bap: list[str] = Field(
-        default_factory=list,
-        description="DNS-AID Application Protocols with versions understood by the endpoint "
-        "(e.g., ['mcp/1', 'a2a/1']). Distinct from transport-level alpn per draft Section 4.4.3.",
+    cap_sha256_verified: bool = Field(
+        default=False,
+        description="True when the discoverer actually fetched a capability descriptor and "
+        "the SHA-256 of its bytes matched ``cap_sha256``. False when no fetch happened "
+        "(no cap/well-known descriptor URL), the fetch failed for non-mismatch reasons, "
+        "or no ``cap_sha256`` was declared. Consumers keying trust off the integrity pin "
+        "MUST check this flag — relying on the mere presence of ``cap_sha256`` is a false "
+        "integrity signal because the pin only applies to the bytes that produced the "
+        "capabilities, and TXT-fallback / network-failure paths can leave it dangling.",
+    )
+    well_known_path: str | None = Field(
+        default=None,
+        description="RFC 8615 well-known path suffix (e.g. 'agent-card.json') under "
+        "/.well-known/ on the SVCB target's host. Per draft-02 'well-known' SvcParamKey. "
+        "Independent of 'cap'; both may be present. When dns-aid-core fetches a "
+        "capability descriptor it prefers 'cap' (explicit locator) and falls back to "
+        "reconstructing https://<svcb-target>/.well-known/<well_known_path>.",
+    )
+    bap: str | None = Field(
+        default=None,
+        description="Bulk Agent Protocol — single agent-protocol identifier "
+        "for this SVCB record in the draft's delimited form: bare "
+        "(``mcp``, ``a2a``) or versioned (``mcp=1.0``, ``a2a=1.1``). Per "
+        "draft-02 §5.1 / §FutureWork (Bulk Agent Protocol) this is "
+        "experimental; dns-aid-core treats ``alpn`` as the canonical "
+        "protocol carrier for reconciliation. bap adds version information "
+        "when present. Multi-protocol agents are published as multiple "
+        "AgentRecord instances at the same flat owner name, each with its "
+        "own alpn and (optionally) bap — NOT as a comma-separated list on "
+        "one record.",
     )
     policy_uri: str | None = Field(
         default=None,
@@ -328,18 +530,31 @@ class AgentRecord(BaseModel):
     )
 
     # Capability source tracking
-    capability_source: (
-        Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] | None
-    ) = Field(
+    capability_source: CapabilitySource | None = Field(
         default=None,
         description="Where capabilities were sourced from: 'cap_uri' (SVCB cap param), "
+        "'well_known' (SVCB well-known param, reconstructed against the target host), "
         "'agent_card' (A2A /.well-known/agent-card.json skills), "
         "'http_index' (HTTP index capabilities), "
-        "'txt_fallback' (TXT record), or 'none'",
+        "'txt_fallback' (TXT record), "
+        "'descriptor_unreachable' (cap/well-known declared but fetch failed), "
+        "or 'none'",
     )
 
     # DNS settings
     ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
+
+    publish_walkable_alias: bool = Field(
+        default=False,
+        description="Whether to publish the optional walkable AliasMode SVCB record at "
+        "{name}._agents.{domain} pointing at the flat primary owner. Per draft-02 §3.1 "
+        "this record is operator-optional and serves DNS-SD-style enumeration "
+        "use cases. Default False because the record is an enumeration handle (a "
+        "crawler can walk _agents.<zone> and inventory every agent), which is "
+        "undesirable for most public deployments — see docs/privacy-considerations.md. "
+        "Set True when you actively want the agent discoverable via enumeration "
+        "(internal indexes, intentional public directories, DNS-SD-style consumers).",
+    )
 
     # Optional direct endpoint (overrides target_host:port for HTTP index agents)
     endpoint_override: str | None = Field(
@@ -398,6 +613,17 @@ class AgentRecord(BaseModel):
         "response (AD flag set). False when validation did not occur or did not succeed.",
     )
 
+    legacy_resolved: bool = Field(
+        default=False,
+        description="True when this agent record was resolved via the legacy "
+        "draft-01 FQDN shape (`_{name}._{protocol}._agents.{domain}`) rather "
+        "than the draft-02 flat form (`{name}.{domain}`). Callers should "
+        "down-weight or refuse legacy-resolved records in environments where "
+        "the publisher has had time to migrate. Set by the discoverer when "
+        "``allow_legacy=True`` (or the env-flag equivalent) lets a flat-FQDN "
+        "miss fall back to the legacy shape.",
+    )
+
     # JWS verification result (populated by the discoverer's signature-verification step
     # when ``verify_signatures=True``). Both fields remain ``None`` when verification was
     # not attempted; ``signature_verified=False`` indicates verification ran and rejected
@@ -436,13 +662,114 @@ class AgentRecord(BaseModel):
     def validate_connect_class(cls, v: str | None) -> str | None:
         return _normalize_connect_class(v)
 
+    @field_validator("target_host", mode="after")
+    @classmethod
+    def _enforce_no_underscore_in_target_host(cls, v: str) -> str:
+        """Mirror the SvcbRecord.target rule on AgentRecord's target_host.
+
+        Honours the operator env gate
+        ``DNS_AID_ALLOW_UNDERSCORE_TARGET=1`` so the publisher's
+        existing ``allow_underscore_target=True`` path can still pass
+        through. Without the env gate set no construction path can
+        produce an underscored target_host.
+        """
+        from dns_aid.utils.validation import (
+            _underscore_bypass_env_enabled,
+            validate_no_underscore_in_target,
+        )
+
+        validate_no_underscore_in_target(v, allow_underscore=_underscore_bypass_env_enabled())
+        return v
+
+    @field_validator("well_known_path", mode="after")
+    @classmethod
+    def _enforce_safe_well_known_path_on_agent(cls, v: str | None) -> str | None:
+        """Same as SvcbRecord — enforce the safe-value rule at the type."""
+        if v is None:
+            return None
+        from dns_aid.utils.validation import validate_well_known_path
+
+        return validate_well_known_path(v)
+
+    @field_validator("bap", mode="after")
+    @classmethod
+    def _enforce_safe_bap_on_agent(cls, v: str | None) -> str | None:
+        """Same as SvcbRecord — enforce the canonical bap shape at the type.
+
+        Closes the SvcParamKey-injection hole on the publish path;
+        also rejects ``bap=["mcp"]`` (list form) at the type boundary
+        so the list→scalar break is explicit instead of silently
+        coercing.
+        """
+        if v is None:
+            return None
+        from dns_aid.core.bap import validate_bap
+
+        return validate_bap(v)
+
+    @field_validator(
+        "cap_uri",
+        "cap_sha256",
+        "policy_uri",
+        "realm",
+        "sig",
+        "connect_meta",
+        "enroll_uri",
+        mode="after",
+    )
+    @classmethod
+    def _enforce_safe_svcparams_on_agent(cls, v: str | None) -> str | None:
+        """Reject SVCB SvcParam-quote-breakout chars in the free-form params.
+
+        The publish path emits these as ``key="<value>"`` verbatim, so a
+        double quote, backslash, or control character could inject a sibling
+        SvcParamKey — the same hole ``bap`` closes for its field. Enforced
+        here so it also drops a forged inbound record carrying such a value
+        during discovery.
+        """
+        if v is None:
+            return None
+        from dns_aid.utils.validation import validate_svcparam_value
+
+        return validate_svcparam_value(v)
+
     @property
     def fqdn(self) -> str:
         """
-        Fully qualified domain name for DNS-AID record.
+        Fully qualified domain name for the agent's primary owner record.
 
-        Format: _{name}._{protocol}._agents.{domain}
-        Per IETF draft section 3.1
+        Returns the flat form ``{name}.{domain}`` per draft-02. The agent
+        protocol is no longer part of the FQDN under -02 — it lives in
+        the ``bap`` SvcParamKey (or ``alpn`` when only one protocol is
+        supported). The flat FQDN is valid as an x.509 SAN dNSName.
+
+        For the optional walkable AliasMode form, see ``walkable_fqdn``.
+        For the legacy -01 form, see ``legacy_fqdn``.
+        """
+        return f"{self.name}.{self.domain}"
+
+    @property
+    def walkable_fqdn(self) -> str:
+        """
+        Optional walkable AliasMode FQDN at ``{name}._agents.{domain}``.
+
+        Per draft-02 §Known Agent, publishers MAY emit an SVCB AliasMode
+        record at this name pointing at the flat primary owner so that
+        DNS-SD-style consumers and enumeration crawlers can discover the
+        agent. dns-aid-core's publisher writes this record by default;
+        operators can disable it via ``SDKConfig`` if a deployment
+        doesn't need walkable enumeration.
+        """
+        return f"{self.name}._agents.{self.domain}"
+
+    @property
+    def legacy_fqdn(self) -> str:
+        """
+        Backwards-compatible -01 FQDN ``_{name}._{protocol}._agents.{domain}``.
+
+        Used only by the legacy-fallback discovery path when the env
+        flag ``DNS_AID_LEGACY_01_FALLBACK=1`` is set. Not used for
+        publishing under -02.
         """
         return f"_{self.name}._{self.protocol.value}._agents.{self.domain}"
 
@@ -477,6 +804,7 @@ class AgentRecord(BaseModel):
             connect_class=self.connect_class,
             connect_meta=self.connect_meta,
             enroll_uri=self.enroll_uri,
+            well_known_path=self.well_known_path,
         )
 
     def to_svcb_params(self) -> dict[str, str]:
@@ -542,6 +870,18 @@ class PublishResult(BaseModel):
     backend: str = Field(..., description="DNS backend used")
     success: bool = Field(default=True, description="Whether publish succeeded")
     message: str | None = Field(default=None, description="Status message")
+    # Caller-visible advisories raised during the publish path (e.g.
+    # ``dns_aid.underscore_bypass`` when allow_underscore_target=True
+    # AND DNS_AID_ALLOW_UNDERSCORE_TARGET is set in the env). These
+    # are non-fatal — the publish still succeeded — but downstream
+    # observability needs to count and alert on them without scraping
+    # logs.
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal advisories raised during publish. Each entry is a stable "
+        "warning_class identifier (e.g. 'dns_aid.underscore_bypass') so consumers can "
+        "match exactly without log-string parsing.",
+    )
 
 
 class VerifyResult(BaseModel):
@@ -592,7 +932,13 @@ class VerifyResult(BaseModel):
             score += 20
         if self.dnssec_valid:
             score += 30
-        if self.dane_valid:
+        # DANE only contributes when DNSSEC also validated. TLSA without
+        # DNSSEC has no integrity guarantee (RFC 6698 §10.1), so we
+        # don't let it bump the score even if a caller hand-built this
+        # VerifyResult with both flags. The validator.py path already
+        # demotes ``dane_valid`` to None in that case; this is a
+        # second-line guard against bypass.
+        if self.dane_valid and self.dnssec_valid:
             score += 15
         if self.endpoint_reachable:
             score += 15

--- a/src/dns_aid/core/publisher.py
+++ b/src/dns_aid/core/publisher.py
@@ -5,7 +5,7 @@
 DNS-AID Publisher: Create DNS records for AI agent discovery.
 
 This module handles publishing agents to DNS using SVCB and TXT records
-as specified in IETF draft-mozleywilliams-dnsop-dnsaid-01.
+as specified in IETF draft-mozleywilliams-dnsop-dnsaid-02.
 """
 
 from __future__ import annotations
@@ -15,6 +15,12 @@ import structlog
 from dns_aid.backends import VALID_BACKEND_NAMES, create_backend
 from dns_aid.backends.base import DNSBackend
 from dns_aid.core.models import AgentRecord, Protocol, PublishResult
+from dns_aid.utils.validation import (
+    _underscore_bypass_env_enabled,
+    validate_agent_name,
+    validate_no_underscore_in_target,
+    validate_well_known_path,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -79,7 +85,8 @@ async def publish(
     backend: DNSBackend | None = None,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
-    bap: list[str] | None = None,
+    well_known_path: str | None = None,
+    bap: str | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
     connect_class: str | None = None,
@@ -89,6 +96,8 @@ async def publish(
     ipv6_hint: str | None = None,
     sign: bool = False,
     private_key_path: str | None = None,
+    allow_underscore_target: bool = False,
+    publish_walkable_alias: bool = False,
 ) -> PublishResult:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
@@ -109,9 +118,21 @@ async def publish(
         category: Agent category (e.g., "network", "security")
         ttl: DNS record TTL in seconds
         backend: DNS backend to use (defaults to global backend)
-        cap_uri: URI to capability document (DNS-AID draft-compliant)
+        cap_uri: URI, URN, or compact JSON-Ref locator for the capability
+            descriptor (DNS-AID draft-02 'cap' SvcParamKey)
         cap_sha256: Base64url-encoded SHA-256 digest of the capability descriptor
-        bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"])
+            (DNS-AID draft-02 'cap-sha256' SvcParamKey)
+        well_known_path: RFC 8615 well-known path suffix (e.g., 'agent-card.json')
+            for the DNS-AID draft-02 'well-known' SvcParamKey. Independent of
+            cap_uri; both may be set. Consumers prefer cap_uri when both are
+            present and fall back to reconstructing
+            https://<svcb-target>/.well-known/<well_known_path>.
+        bap: Optional single versioned agent-protocol identifier (e.g. "mcp=2.1",
+            "a2a=1.0") for the Bulk Agent Protocol SvcParamKey. Experimental per
+            draft-02 §FutureWork; alpn remains the canonical protocol carrier.
+            Multi-protocol agents publish multiple AgentRecord instances at the
+            same flat owner name, each with its own alpn and (optionally) bap —
+            NOT as a comma-separated list on a single record.
         policy_uri: URI to agent policy document
         realm: Multi-tenant scope identifier (e.g., "production")
         connect_class: Connection mediation class (e.g., "direct", "lattice", "apphub-psc")
@@ -121,6 +142,25 @@ async def publish(
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6)
         sign: If True, sign the record with JWS (requires private_key_path)
         private_key_path: Path to EC P-256 private key PEM file for signing
+        allow_underscore_target: If True, downgrade a TargetName-contains-
+            underscore violation from an error to a warning. Per
+            draft-mozleywilliams-dnsop-dnsaid-02 §3.2 (Known Organization, Unknown Agent), SVCB
+            TargetNames reached over TLS with publicly-issued x.509 certs
+            MUST NOT contain underscores. dns-aid-core enforces this by
+            default; set this flag for internal-only deployments where the
+            target is not behind public PKI.
+        publish_walkable_alias: When True, additionally write the
+            optional walkable AliasMode SVCB record at
+            ``{name}._agents.{domain}`` pointing at the flat primary
+            owner. Per draft-02 §3.1 this record is operator-optional.
+            **Default False**: the walkable record is an enumeration
+            handle — a crawler that knows the zone can walk
+            ``_agents.<zone>`` and inventory every agent the operator
+            publishes. For most deployments that's undesirable (see
+            ``docs/privacy-considerations.md``). Set True when you
+            actively want the agents discoverable by enumeration —
+            internal directories, intentional public catalogs, or
+            DNS-SD-style consumers.
 
     Returns:
         PublishResult with created records
@@ -136,11 +176,47 @@ async def publish(
         ...     realm="production",
         ... )
         >>> print(result.agent.fqdn)
-        '_network-specialist._mcp._agents.example.com'
+        'network-specialist.example.com'
     """
     # Normalize protocol to enum
     if isinstance(protocol, str):
         protocol = Protocol(protocol.lower())
+
+    # Validate the agent name BEFORE the rest of the pipeline runs.
+    # The flat draft-02 FQDN is `{name}.{domain}`, which becomes the
+    # x.509 dNSName SAN; CA/Browser Forum + RFC 5280 forbid underscored
+    # labels and the validator's lowercase+hyphenated rule lines up with
+    # what most CAs and DNS providers will actually accept. Without this
+    # check a publisher can land a record whose SAN is unrepresentable.
+    name = validate_agent_name(name)
+
+    # Enforce draft-02 §3.2 (Known Organization, Unknown Agent): the
+    # SVCB TargetName MUST NOT contain underscores when reached over
+    # TLS with a public x.509 cert. Strict-by-default; the
+    # allow_underscore_target flag downgrades to a warning for
+    # internal-only deployments.
+    validate_no_underscore_in_target(endpoint, allow_underscore=allow_underscore_target)
+
+    # Capture whether the bypass actually fired so we can surface it
+    # on PublishResult.warnings (caller-visible, log-aggregator
+    # parseable). The check is intentionally redundant with the
+    # validator's WARN log so the bypass is available as structured
+    # data on the result, not only in the logs.
+    publish_warnings: list[str] = []
+    if (
+        allow_underscore_target
+        and _underscore_bypass_env_enabled()
+        and any("_" in label for label in endpoint.rstrip(".").split("."))
+    ):
+        publish_warnings.append("dns_aid.underscore_bypass")
+
+    # Constrain well-known to a safe RFC 8615 single-segment suffix so
+    # the publisher can't emit a SvcParamKey value that a consumer would
+    # later interpolate into a non-well-known URL. Enforced on both the
+    # publish and discover sides so neither end of the pipe is the
+    # weakest link.
+    if well_known_path is not None:
+        well_known_path = validate_well_known_path(well_known_path)
 
     # Generate JWS signature if requested
     sig = None
@@ -156,7 +232,9 @@ async def publish(
 
         logger.info("Signing record with JWS", private_key_path=private_key_path)
         private_key = load_private_key_from_pem(private_key_path)
-        fqdn = f"_{name}._{protocol.value}._agents.{domain}"
+        # JWS payload binds to the flat draft-02 FQDN ({name}.{domain}).
+        # Verifiers reconstruct the same FQDN before validating the signature.
+        fqdn = f"{name}.{domain}"
         payload = RecordPayload.from_agent_record(
             fqdn=fqdn,
             target=endpoint,
@@ -182,7 +260,8 @@ async def publish(
         ttl=ttl,
         cap_uri=cap_uri,
         cap_sha256=cap_sha256,
-        bap=bap or [],
+        well_known_path=well_known_path,
+        bap=bap,
         policy_uri=policy_uri,
         realm=realm,
         connect_class=connect_class,
@@ -191,6 +270,7 @@ async def publish(
         ipv4_hint=ipv4_hint,
         ipv6_hint=ipv6_hint,
         sig=sig,
+        publish_walkable_alias=publish_walkable_alias,
     )
 
     # Get backend
@@ -215,6 +295,7 @@ async def publish(
             backend=dns_backend.name,
             success=False,
             message=f"Zone '{domain}' does not exist or is not accessible",
+            warnings=publish_warnings,
         )
 
     try:
@@ -234,6 +315,7 @@ async def publish(
             backend=dns_backend.name,
             success=True,
             message="Agent published successfully",
+            warnings=publish_warnings,
         )
 
     except Exception as e:
@@ -245,6 +327,7 @@ async def publish(
             backend=dns_backend.name,
             success=False,
             message=f"Failed to publish: {e}",
+            warnings=publish_warnings,
         )
 
 
@@ -274,13 +357,24 @@ async def unpublish(
 
     dns_backend = backend or get_default_backend()
 
-    record_name = f"_{name}._{protocol.value}._agents"
+    # Under draft-02 the agent's primary owner is the flat name; the
+    # relative record name under the zone is just the agent name. We
+    # also remove the optional walkable AliasMode record at
+    # {name}._agents.{domain} if the publisher wrote one. To keep the
+    # migration path clean for operators who published under draft-01
+    # before upgrading, we additionally remove the legacy
+    # _{name}._{protocol}._agents form (silent if absent).
+    record_name = name
+    walkable_record_name = f"{name}._agents"
+    legacy_record_name = f"_{name}._{protocol.value}._agents"
 
     logger.info(
         "Removing agent from DNS",
         agent_name=name,
         domain=domain,
         record_name=record_name,
+        walkable_record_name=walkable_record_name,
+        legacy_record_name=legacy_record_name,
     )
 
     # Check zone exists before attempting deletion
@@ -288,14 +382,93 @@ async def unpublish(
         logger.error("Zone does not exist", zone=domain)
         return False
 
-    # Delete both record types
+    # Probe the primary records BEFORE deletion so we can later
+    # distinguish "primary was already absent" (migration / re-run case
+    # — fine) from "primary existed and delete silently returned False"
+    # (the masked-failure case Route53 and Cloudflare can produce on
+    # API errors). Both look identical from delete_record's return alone,
+    # but only the latter is dangerous.
+    primary_svcb_existed = (await dns_backend.get_record(domain, record_name, "SVCB")) is not None
+    primary_txt_existed = (await dns_backend.get_record(domain, record_name, "TXT")) is not None
+
+    # Delete the primary-owner records (SVCB + companion TXT).
     svcb_deleted = await dns_backend.delete_record(domain, record_name, "SVCB")
     txt_deleted = await dns_backend.delete_record(domain, record_name, "TXT")
 
-    success = svcb_deleted or txt_deleted
+    # Delete the walkable AliasMode record if present. Log at debug on
+    # failure rather than swallowing silently so backend quirks are
+    # diagnosable.
+    try:
+        walkable_deleted = await dns_backend.delete_record(domain, walkable_record_name, "SVCB")
+    except Exception as exc:
+        walkable_deleted = False
+        logger.debug(
+            "Walkable AliasMode delete raised; treating as absent",
+            walkable_record_name=walkable_record_name,
+            error=str(exc),
+        )
+
+    # Also clear any leftover draft-01-shape records so operators
+    # upgrading from -01 to -02 can run unpublish() once and have it
+    # remove both shapes. No env flag required — the delete is a
+    # silent no-op when the records don't exist.
+    legacy_svcb_deleted = False
+    legacy_txt_deleted = False
+    try:
+        legacy_svcb_deleted = await dns_backend.delete_record(domain, legacy_record_name, "SVCB")
+        legacy_txt_deleted = await dns_backend.delete_record(domain, legacy_record_name, "TXT")
+    except Exception as exc:
+        logger.debug(
+            "Legacy -01 record delete raised; treating as absent",
+            legacy_record_name=legacy_record_name,
+            error=str(exc),
+        )
+
+    # Decide success:
+    #
+    #   - "Primary deleted" — record existed and delete returned True.
+    #     Unambiguous success.
+    #   - "Primary already absent" — record didn't exist before the
+    #     call. delete_record reported False but that's expected. If any
+    #     cleanup (walkable / legacy) ran successfully we treat the
+    #     unpublish as a successful migration cleanup; if nothing was
+    #     deleted at all we report no-op.
+    #   - "Primary masked-fail" — record DID exist before the call but
+    #     delete returned False. This is the dangerous case Route53 /
+    #     Cloudflare can produce on API errors. We MUST report False so
+    #     the MCP server doesn't de-index a still-live agent.
+    primary_existed = primary_svcb_existed or primary_txt_existed
+    primary_deleted = svcb_deleted or txt_deleted
+    cleanup_deleted = walkable_deleted or legacy_svcb_deleted or legacy_txt_deleted
+
+    primary_masked_failure = primary_existed and not primary_deleted
+
+    if primary_masked_failure:
+        logger.error(
+            "unpublish: primary SVCB/TXT existed but delete returned False — "
+            "agent may still resolve in DNS; refusing to report success",
+            agent_name=name,
+            primary_svcb_existed=primary_svcb_existed,
+            primary_txt_existed=primary_txt_existed,
+            svcb_deleted=svcb_deleted,
+            txt_deleted=txt_deleted,
+        )
+        return False
+
+    success = primary_deleted or cleanup_deleted
 
     if success:
-        logger.info("Agent removed from DNS", agent_name=name)
+        logger.info(
+            "Agent removed from DNS",
+            agent_name=name,
+            primary_deleted=primary_deleted,
+            cleanup_deleted=cleanup_deleted,
+            svcb_deleted=svcb_deleted,
+            txt_deleted=txt_deleted,
+            walkable_deleted=walkable_deleted,
+            legacy_svcb_deleted=legacy_svcb_deleted,
+            legacy_txt_deleted=legacy_txt_deleted,
+        )
     else:
         logger.warning("No records found to delete", agent_name=name)
 

--- a/src/dns_aid/core/validator.py
+++ b/src/dns_aid/core/validator.py
@@ -5,6 +5,25 @@
 DNS-AID Validator: Verify agent DNS records and security.
 
 Handles DNSSEC validation, DANE/TLSA verification, and endpoint health checks.
+
+DNSSEC requirement posture (draft-mozleywilliams-dnsop-dnsaid-02 §6.2):
+
+The draft uses the **SHOULD** posture, not MAY/MUST. Verbatim:
+
+    "Consumers SHOULD authenticate the TLS endpoint of a DNS-AID agent
+    using DANE TLSA records (RFC 6698) wherever both DNSSEC and TLSA
+    are available."
+
+DNS-AID records served without DNSSEC continue to verify under this
+module — DNSSEC absence is not in itself a failure. When TLSA records
+ARE present, DNSSEC absence makes the TLSA records untrustworthy
+(RFC 6698 §10.1 — TLSA without DNSSEC offers no integrity guarantee).
+
+When TLSA records are present without a validated DNSSEC chain the
+validator treats DANE as untrustworthy: ``dane_valid`` is demoted to
+``None`` and the +15 ``security_score`` credit is gated on
+``dnssec_valid``, so an unsigned TLSA record cannot inflate the trust
+score.
 """
 
 from __future__ import annotations
@@ -41,7 +60,7 @@ async def verify(fqdn: str, *, verify_dane_cert: bool = False) -> VerifyResult:
 
     Args:
         fqdn: Fully qualified domain name of agent record
-              (e.g., "_chat._a2a._agents.example.com")
+              (e.g., "chat.example.com")
         verify_dane_cert: If True, perform full DANE certificate matching
                          (connect to endpoint and compare TLS cert against
                          TLSA record). Default False (existence check only).
@@ -91,10 +110,18 @@ async def verify(fqdn: str, *, verify_dane_cert: bool = False) -> VerifyResult:
                 "use verify_dane_cert=True for full certificate matching)"
             )
 
-        # DANE without DNSSEC is meaningless — per RFC 6698 and IETF draft,
-        # TLSA records MUST be DNSSEC-validated to be trusted.
+        # DANE without DNSSEC carries no integrity guarantee — RFC 6698
+        # §10.1 and draft-02 §Security Considerations both treat TLSA
+        # without a validated chain as untrustworthy. Demote the outcome
+        # to None (DANE state unknown), not just append to the note, so
+        # downstream consumers — including security_score — don't credit
+        # a TLSA record that hasn't been DNSSEC-validated.
         if result.dane_valid is not None and not result.dnssec_valid:
-            result.dane_note += " ⚠ DNSSEC not validated — DANE requires DNSSEC to be trustworthy"
+            result.dane_note += (
+                " ⚠ DNSSEC not validated — DANE requires DNSSEC to be "
+                "trustworthy; demoting DANE outcome to unknown"
+            )
+            result.dane_valid = None
 
     # 4. Check endpoint reachability
     if target and port:

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -5,7 +5,7 @@
 DNS-AID MCP Server.
 
 Provides MCP tools for AI agents to publish and discover other agents via DNS.
-Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-01).
+Uses the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-02).
 
 Usage:
     # Run with stdio transport (default for MCP)
@@ -113,10 +113,10 @@ Use these tools to:
 - Verify that an agent's DNS records are properly configured
 - List all agents published at a domain
 
-DNS-AID uses SVCB records (RFC 9460) with the naming convention:
-_{agent-name}._{protocol}._agents.{domain}
+DNS-AID uses SVCB records (RFC 9460). Under draft-02 an agent's primary
+record lives at the flat owner name {agent-name}.{domain}.
 
-Example: _chat._mcp._agents.example.com""",
+Example: chat.example.com""",
 )
 
 
@@ -239,7 +239,8 @@ def publish_agent_to_dns(
     update_index: bool = True,
     cap_uri: str | None = None,
     cap_sha256: str | None = None,
-    bap: list[str] | None = None,
+    well_known_path: str | None = None,
+    bap: str | None = None,
     policy_uri: str | None = None,
     realm: str | None = None,
     connect_class: str | None = None,
@@ -247,12 +248,15 @@ def publish_agent_to_dns(
     enroll_uri: str | None = None,
     ipv4_hint: list[str] | None = None,
     ipv6_hint: list[str] | None = None,
+    allow_underscore_target: bool = False,
+    publish_walkable_alias: bool = False,
 ) -> dict:
     """
     Publish an AI agent to DNS using DNS-AID protocol.
 
     Creates SVCB and TXT records that allow other agents to discover this agent.
-    The agent will be discoverable at: _{name}._{protocol}._agents.{domain}
+    The agent will be discoverable at the flat draft-02 FQDN ``{name}.{domain}``
+    (with an optional walkable AliasMode at ``{name}._agents.{domain}``).
 
     By default, also updates the domain's index record (_index._agents.{domain})
     to include this agent for efficient discovery.
@@ -279,8 +283,17 @@ def publish_agent_to_dns(
         cap_sha256: Base64url-encoded SHA-256 digest of the capability descriptor
             for integrity checks and cache revalidation. Included in the SVCB record
             as a `cap-sha256` parameter.
-        bap: Supported bulk agent protocols (e.g., ["mcp", "a2a"]). Included in
-            the SVCB record as a `bap` parameter.
+        well_known_path: RFC 8615 well-known path suffix (e.g., "agent-card.json")
+            for the DNS-AID draft-02 `well-known` SvcParamKey. Independent of
+            cap_uri; both may be set. Consumers prefer cap_uri when both are present
+            and fall back to reconstructing
+            https://<svcb-target>/.well-known/<well_known_path>.
+        bap: Optional single versioned agent-protocol identifier (e.g.,
+            "mcp=2.1", "a2a=1.0") for the Bulk Agent Protocol SvcParamKey.
+            Experimental per draft-02 §FutureWork; alpn remains the canonical
+            protocol carrier. Multi-protocol agents publish multiple records
+            at the same flat owner, each with its own alpn and (optionally)
+            bap — NOT as a list on one record.
         policy_uri: URI to agent policy document. Included in the SVCB record as
             a `policy` parameter.
         realm: Multi-tenant scope identifier (e.g., "production", "staging").
@@ -289,6 +302,22 @@ def publish_agent_to_dns(
             Eliminates extra A record lookup for the target hostname.
         ipv6_hint: IPv6 address hints for SVCB record (RFC 9460 key 6).
             Eliminates extra AAAA record lookup for the target hostname.
+        allow_underscore_target: When True, downgrade a "TargetName contains
+            underscored label" violation from an error to a warning. Per
+            draft-mozleywilliams-dnsop-dnsaid-02 §3.2 (Known Organization, Unknown Agent), SVCB
+            TargetNames reached over TLS with publicly-issued x.509 certs
+            MUST NOT contain underscores. Set this only when the target is
+            internal-only and will not be reached over public PKI.
+        publish_walkable_alias: When True, additionally write the
+            optional walkable AliasMode SVCB record at
+            ``{name}._agents.{domain}`` pointing at the flat primary
+            owner. Default False — the walkable record is an
+            enumeration handle (a crawler can walk ``_agents.<zone>``
+            and inventory every agent the operator publishes), which
+            is undesirable for most deployments. Enable when you
+            actively want the agent discoverable via enumeration:
+            internal directories, intentional public catalogs, or
+            DNS-SD-style consumers.
 
     Returns:
         dict with:
@@ -339,6 +368,7 @@ def publish_agent_to_dns(
             backend=dns_backend,
             cap_uri=cap_uri,
             cap_sha256=cap_sha256,
+            well_known_path=well_known_path,
             bap=bap,
             policy_uri=policy_uri,
             realm=realm,
@@ -347,6 +377,8 @@ def publish_agent_to_dns(
             enroll_uri=enroll_uri,
             ipv4_hint=ipv4_hint,
             ipv6_hint=ipv6_hint,
+            allow_underscore_target=allow_underscore_target,
+            publish_walkable_alias=publish_walkable_alias,
         )
 
     try:
@@ -427,9 +459,9 @@ def discover_agents_via_dns(
     Discovery flow (DNS-only, default):
       1. Query the TXT index record at _index._agents.{domain} to get the list of
          published agent names and their protocols.
-      2. For each agent in the index, query the SVCB record at
-         _{name}._{protocol}._agents.{domain} to resolve the target host, port,
-         and ALPN protocol — plus DNS-AID custom params (cap, bap, policy, realm).
+      2. For each agent in the index, query the SVCB record at the flat owner
+         {name}.{domain} to resolve the target host, port, and ALPN protocol —
+         plus DNS-AID custom params (cap, bap, policy, realm).
       3. If the SVCB record contains a `cap` param (URI to capability document),
          fetch the capability document via HTTPS for rich capability metadata.
       4. If the cap URI is missing or the fetch fails, fall back to querying the
@@ -479,7 +511,7 @@ def discover_agents_via_dns(
             - realm: Multi-tenant scope identifier (if present in SVCB record)
             - description: Human-readable agent description (if available)
             - fqdn: Fully qualified DNS name for this agent
-              (e.g., "_booking._mcp._agents.example.com")
+              (e.g., "booking.example.com")
         - count: Number of agents found
         - query_time_ms: Total discovery latency in milliseconds
     """
@@ -530,7 +562,8 @@ def discover_agents_via_dns(
                     "capability_source": agent.capability_source,
                     "cap_uri": agent.cap_uri,
                     "cap_sha256": agent.cap_sha256,
-                    "bap": agent.bap if agent.bap else None,
+                    "well_known_path": agent.well_known_path,
+                    "bap": agent.bap,
                     "policy_uri": agent.policy_uri,
                     "realm": agent.realm,
                     "description": agent.description,
@@ -878,8 +911,8 @@ def verify_agent_dns(fqdn: str) -> dict:
 
     Args:
         fqdn: Fully qualified domain name of the agent record.
-              Format: _{agent-name}._{protocol}._agents.{domain}
-              Example: "_chat._mcp._agents.example.com"
+              Under draft-02 this is the flat owner {agent-name}.{domain}.
+              Example: "chat.example.com"
 
     Returns:
         dict with:
@@ -1082,7 +1115,7 @@ def delete_agent_from_dns(
 
     try:
         result = _run_async(_unpublish())
-        fqdn = f"_{name}._{protocol}._agents.{domain}"
+        fqdn = f"{name}.{domain}"
 
         index_updated = False
         index_message = None
@@ -1180,7 +1213,7 @@ def list_agent_index(
                 {
                     "name": entry.name,
                     "protocol": entry.protocol,
-                    "fqdn": f"_{entry.name}._{entry.protocol}._agents.{domain}",
+                    "fqdn": f"{entry.name}.{domain}",
                 }
                 for entry in entries
             ],
@@ -1930,7 +1963,7 @@ try:
                     "/ready": "Readiness check (GET)",
                 },
                 "documentation": "https://github.com/infobloxopen/dns-aid-core",
-                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-01",
+                "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-02",
             }
         )
 

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -1162,8 +1162,12 @@ def _parse_retry_after(value: str | None) -> int | None:
 #
 #   * ``agent.target_host`` is absent — the directory only emits ``endpoint_url``;
 #     the SDK's :class:`AgentRecord` requires ``target_host``.
-#   * ``agent.bap`` is a comma-separated string (e.g. ``"mcp/1,a2a/1"``); the SDK
-#     types it as ``list[str]``.
+#   * ``agent.bap`` may arrive in either of three legacy shapes — a list, a
+#     comma-separated string, or the canonical draft-02 scalar form
+#     (``"mcp"`` or ``"mcp=1.0"``). The adapter routes all three through
+#     ``dns_aid.core.bap.normalize_bap`` so the wire-shape knowledge lives
+#     in core, not here, and the discoverer + indexer agree with the
+#     adapter on the collapse semantics.
 #   * Trust signals (``security_score``, ``trust_score``, ``popularity_score``,
 #     ``trust_tier``, ``safety_status``, ``dnssec_valid``, ``dane_valid``,
 #     ``svcb_valid``, ``endpoint_reachable``, ``protocol_verified``,
@@ -1204,8 +1208,9 @@ def _adapt_search_payload(raw: dict[str, Any]) -> dict[str, Any]:
     Three independent concerns:
 
     1. **Lift flat trust + provenance signals** off the agent into nested objects.
-    2. **Coerce wire-shape quirks**: ``bap`` string → list, ``target_host`` from
-       ``endpoint_url``.
+    2. **Coerce wire-shape quirks**: normalize ``bap`` via
+       ``dns_aid.core.bap.normalize_bap`` (accepts list, comma-string, or
+       the canonical scalar), derive ``target_host`` from ``endpoint_url``.
     3. **Strip explicit nulls** for AgentRecord fields where the directory writes
        ``None`` but the SDK type is non-Optional. Pydantic will then use the
        declared default (e.g. ``capabilities: list = []``, ``version: str = "1.0.0"``).
@@ -1269,12 +1274,19 @@ def _adapt_search_payload(raw: dict[str, Any]) -> dict[str, Any]:
                 },
             )
 
-        # ── Adapt agent shape: split comma-separated ``bap`` string into list. ──
-        # Done before the ``_AGENT_FIELDS_STRIP_IF_NONE`` pass so ``bap=None`` still
-        # gets stripped.
-        bap = agent.get("bap")
-        if isinstance(bap, str):
-            agent["bap"] = [item.strip() for item in bap.split(",") if item.strip()]
+        # ── Adapt agent shape: normalize ``bap`` to its draft-02 scalar form. ──
+        # draft-02 §5.1 (Bulk Agent Protocol, experimental): `bap`
+        # carries a single agent-protocol identifier per record, bare
+        # (``mcp``) or versioned (``mcp=1.0``). Pre-draft-02 directory
+        # rows may serialize it as a list or as a comma-separated
+        # string; the shared ``normalize_bap`` helper in core collapses
+        # both to a scalar (or None) and logs when later tokens are
+        # dropped. Routing through the same helper as the discoverer
+        # and indexer keeps the three collapse paths from diverging.
+        from dns_aid.core.bap import normalize_bap
+
+        if "bap" in agent:
+            agent["bap"] = normalize_bap(agent.get("bap"))
 
         # ── Adapt agent shape: derive ``target_host`` from ``endpoint_url`` only. ──
         # If neither field is set, drop the record and log — never fabricate. The

--- a/src/dns_aid/sdk/telemetry/otel.py
+++ b/src/dns_aid/sdk/telemetry/otel.py
@@ -227,13 +227,18 @@ def _sanitize_error_message(msg: str | None) -> str | None:
 
 
 def _parse_signal_fqdn(fqdn: str) -> tuple[str | None, str | None]:
-    """Parse ``agent_name`` and ``domain`` from ``_name._proto._agents.domain``."""
-    parts = fqdn.split("._agents.")
-    if len(parts) == 2:
-        name_parts = parts[0].lstrip("_").split("._")
-        agent_name = name_parts[0] if name_parts else None
-        return agent_name, parts[1]
-    return None, None
+    """Parse ``agent_name`` and ``domain`` from a DNS-AID FQDN.
+
+    Thin projection over :func:`dns_aid.core.fqdn.parse_dnsaid_fqdn`
+    that returns ``(name, domain)``; the SDK telemetry layer doesn't
+    care about the protocol carried in the FQDN.
+    """
+    from dns_aid.core.fqdn import parse_dnsaid_fqdn
+
+    parsed = parse_dnsaid_fqdn(fqdn)
+    if parsed is None:
+        return None, None
+    return parsed.name, parsed.domain
 
 
 def _resolve_sampler(config: SDKConfig) -> Sampler | None:

--- a/src/dns_aid/utils/validation.py
+++ b/src/dns_aid/utils/validation.py
@@ -15,8 +15,13 @@ Security Note:
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Literal
+
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # DNS label constraints (RFC 1035)
 MAX_LABEL_LENGTH = 63
@@ -38,6 +43,11 @@ KNOWN_CONNECT_CLASSES = frozenset({"direct", "lattice", "apphub-psc"})
 
 # Version pattern (semver-like, supports pre-release and build metadata)
 VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9._+-]*)?$")
+
+# DNS label for a DNS-AID FQDN: a normal DNS label with an optional leading
+# underscore so DNS-SD/underscore-prefixed forms (``_agents``, ``_index``,
+# ``_mcp``) validate alongside the flat draft-02 owner (``chat``).
+FQDN_LABEL_PATTERN = re.compile(r"^_?[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 
 class ValidationError(ValueError):
@@ -395,18 +405,24 @@ def validate_version(version: str) -> str:
 
 def validate_fqdn(fqdn: str) -> str:
     """
-    Validate a fully qualified domain name for DNS-AID records.
+    Validate a fully qualified domain name for DNS-AID verification.
 
-    DNS-AID FQDNs follow the pattern: _{agent}._{protocol}._agents.{domain}
+    Accepts any well-formed DNS FQDN. Under draft-02 an agent's primary
+    record lives at the flat owner ``{name}.{domain}`` (no ``_agents``
+    label). The optional walkable AliasMode (``{name}._agents.{domain}``),
+    the organization index (``_index._agents.{domain}``), and legacy -01
+    records (``_{name}._{protocol}._agents.{domain}``) use underscored
+    DNS-SD labels. All of these are valid inputs to ``verify``.
 
     Args:
         fqdn: The FQDN to validate
 
     Returns:
-        Normalized FQDN
+        Normalized FQDN (lowercased, trailing dot removed)
 
     Raises:
-        ValidationError: If FQDN is invalid
+        ValidationError: If the FQDN is empty, too long, or not a
+            well-formed multi-label DNS name
     """
     if not fqdn:
         raise ValidationError("fqdn", "FQDN cannot be empty")
@@ -420,13 +436,27 @@ def validate_fqdn(fqdn: str) -> str:
             fqdn,
         )
 
-    # DNS-AID records should contain _agents
-    if "_agents" not in fqdn:
+    labels = fqdn.split(".")
+    if len(labels) < 2:
         raise ValidationError(
             "fqdn",
-            "Invalid DNS-AID FQDN: must contain '_agents'",
+            "FQDN must have at least two labels (e.g., chat.example.com)",
             fqdn,
         )
+    for label in labels:
+        if len(label) > MAX_LABEL_LENGTH:
+            raise ValidationError(
+                "fqdn",
+                f"FQDN label '{label}' exceeds {MAX_LABEL_LENGTH} characters",
+                fqdn,
+            )
+        if not FQDN_LABEL_PATTERN.match(label):
+            raise ValidationError(
+                "fqdn",
+                f"Invalid FQDN label '{label}': must be a DNS label "
+                "(alphanumeric with hyphens, optional leading underscore)",
+                fqdn,
+            )
 
     return fqdn
 
@@ -461,3 +491,293 @@ def validate_backend(
         )
 
     return backend
+
+
+# Operator opt-in for the underscore-target bypass. A per-call kwarg /
+# MCP tool arg alone would let a calling LLM flip a draft-02 §Known
+# Organization MUST to a warning on its own. The env gate moves that
+# decision to deployment configuration where humans land it.
+_UNDERSCORE_BYPASS_ENV = "DNS_AID_ALLOW_UNDERSCORE_TARGET"
+
+
+def _underscore_bypass_env_enabled() -> bool:
+    return os.environ.get(_UNDERSCORE_BYPASS_ENV, "").lower() in ("1", "true", "yes")
+
+
+def validate_no_underscore_in_target(
+    target: str,
+    *,
+    allow_underscore: bool = False,
+) -> str:
+    """Validate that an SVCB TargetName contains no underscored DNS labels.
+
+    Per draft-mozleywilliams-dnsop-dnsaid-02 §3.2 (Known Organization, Unknown Agent), the
+    TargetName of an SVCB record reached over TLS with a publicly-issued
+    x.509 certificate MUST NOT contain underscores. CA/Browser Forum
+    Baseline Requirements and RFC 5280 dNSName SANs forbid underscored
+    labels.
+
+    Detects mid-label underscores too (not just leading ones); the public
+    PKI rule rejects any underscore anywhere in any label of the SAN.
+
+    The bypass (``allow_underscore=True``) is operator-gated: it only
+    takes effect when ``DNS_AID_ALLOW_UNDERSCORE_TARGET`` is also set in
+    the environment to a truthy value. Without the env gate the bypass
+    is treated as not-allowed and the violation raises — so a calling
+    LLM, MCP client, or test harness can't unilaterally downgrade the
+    spec MUST. When the env gate is set, the bypass emits a structured
+    WARN with ``warning_class="dns_aid.underscore_bypass"`` so log
+    aggregators can count and alert on deliberate opt-ins per zone.
+
+    Returns:
+        The target string, unchanged.
+
+    Raises:
+        ValidationError: when ``target`` contains an underscored label
+            and the bypass is not both requested AND env-gated.
+    """
+    if not target:
+        raise ValidationError("target", "SVCB TargetName cannot be empty")
+
+    # Strip a trailing dot if present — the constraint applies to labels,
+    # not to the FQDN root marker.
+    candidate = target.rstrip(".")
+    labels = candidate.split(".")
+    underscored = [label for label in labels if "_" in label]
+
+    if not underscored:
+        return target
+
+    message = (
+        f"SVCB TargetName '{target}' contains underscored label(s) "
+        f"{underscored!r}. CA/Browser Forum and RFC 5280 dNSName SANs forbid "
+        "underscored labels, so a publicly-issued x.509 cert cannot cover "
+        "this name. Per draft-mozleywilliams-dnsop-dnsaid-02 §Known "
+        "Organization the TargetName MUST NOT contain underscores. Pass "
+        "allow_underscore=True AND set "
+        f"{_UNDERSCORE_BYPASS_ENV}=1 in the environment for internal-only "
+        "deployments not behind public PKI."
+    )
+
+    if allow_underscore and _underscore_bypass_env_enabled():
+        logger.warning(
+            "SVCB TargetName allowed despite underscored labels — "
+            "internal-only deployment opt-in (allow_underscore=True + "
+            f"{_UNDERSCORE_BYPASS_ENV} set)",
+            target=target,
+            underscored=underscored,
+            cab_forbidden_chars=True,
+            spec_section="draft-02 §3.2 (Known Organization, Unknown Agent)",
+            warning_class="dns_aid.underscore_bypass",
+            env_gate=_UNDERSCORE_BYPASS_ENV,
+        )
+        return target
+
+    if allow_underscore and not _underscore_bypass_env_enabled():
+        # Caller asked for the bypass but the operator hasn't enabled
+        # it in the environment. Surface the refusal distinctly so the
+        # caller can tell "this is an env-gate issue" from "this is a
+        # genuine validation error."
+        logger.warning(
+            "SVCB TargetName underscore bypass requested but env gate "
+            f"({_UNDERSCORE_BYPASS_ENV}) is not set — refusing",
+            target=target,
+            underscored=underscored,
+            env_gate=_UNDERSCORE_BYPASS_ENV,
+            warning_class="dns_aid.underscore_bypass_env_missing",
+        )
+
+    raise ValidationError("target", message, target)
+
+
+# RFC 8615 well-known URI names are a single path segment under
+# /.well-known/<name>. The IANA registry shows examples like
+# ``agent-card.json``, ``oauth-authorization-server``,
+# ``did-configuration``, ``change-password`` — short, ASCII-safe,
+# unambiguous strings. We constrain to that class to prevent path
+# traversal (`..`), query-string injection (`?`), fragment injection
+# (`#`), embedded slashes, percent-encoded escapes, and any other
+# character that would let an attacker steer the reconstructed URL
+# off of the SVCB target host's `/.well-known/` namespace.
+_WELL_KNOWN_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+_WELL_KNOWN_PATH_MAX_LEN = 128
+
+
+def validate_well_known_path(path: str) -> str:
+    """Validate a `well-known` SvcParamKey value.
+
+    Two value shapes are accepted, matching draft Figure 3:
+
+    1. **Bare suffix** — ``agent-card.json`` →
+       reconstructed as ``https://<target>/.well-known/<value>``.
+       Constrained to RFC 8615 single-segment form.
+
+    2. **Absolute origin path** — ``/.well-known/agent-card.json`` or
+       ``/not-well-known/other-card.json`` →
+       used as-is: ``https://<target><value>``. Each path segment is
+       constrained to the same character class as the bare-suffix form;
+       no ``..`` traversal, no empty segments (no ``//``), no query
+       string / fragment / control characters / percent-encoded
+       escapes.
+
+    The discoverer reconstructs the descriptor URL by interpolating the
+    value into a fetched URL. Without validation a publisher (or a
+    SVCB-record forger if DNSSEC isn't enforced) could supply a value
+    containing ``..``, ``?``, ``#``, or backslash and steer the fetch
+    away from the operator's intended location. ``validate_fetch_url``
+    pins the host but doesn't constrain the path.
+
+    Allowed character class per segment: ``[A-Za-z0-9._-]``. Total
+    length 1..128.
+
+    Returns:
+        The validated path (unchanged on success).
+
+    Raises:
+        ValidationError: On empty, oversize, or pattern-mismatched input.
+    """
+    if not isinstance(path, str) or not path:
+        raise ValidationError(
+            "well_known_path",
+            "well-known path must be a non-empty string",
+            path,
+        )
+    if len(path) > _WELL_KNOWN_PATH_MAX_LEN:
+        raise ValidationError(
+            "well_known_path",
+            f"well-known path exceeds {_WELL_KNOWN_PATH_MAX_LEN} characters",
+            path,
+        )
+
+    # Reject any control / URL-special character before we branch on
+    # absolute vs. suffix. These are the characters that could shape
+    # the reconstructed URL into something other than a path lookup
+    # under the SVCB target's origin.
+    for forbidden in ("?", "#", "\\", "%", " ", "\t", "\r", "\n"):
+        if forbidden in path:
+            raise ValidationError(
+                "well_known_path",
+                (
+                    "well-known path must not contain URL control "
+                    f"characters (found {forbidden!r}); reject any "
+                    "embedded slash, '?', '#', percent-encoded "
+                    "escape, or whitespace"
+                ),
+                path,
+            )
+
+    if path.startswith("/"):
+        # Absolute origin path form. Each segment must be a clean
+        # single-segment token; no ``..``, no empty segments (which
+        # would produce ``//`` in the URL).
+        segments = path[1:].split("/")
+        if not segments or not all(segments):
+            raise ValidationError(
+                "well_known_path",
+                "absolute well-known path must not contain empty segments",
+                path,
+            )
+        for seg in segments:
+            if seg == "..":
+                raise ValidationError(
+                    "well_known_path",
+                    "absolute well-known path must not contain '..' (traversal)",
+                    path,
+                )
+            if not _WELL_KNOWN_PATH_PATTERN.match(seg):
+                raise ValidationError(
+                    "well_known_path",
+                    (
+                        f"absolute well-known path segment {seg!r} must "
+                        "match RFC 8615 single-segment form "
+                        "(allowed: A-Z a-z 0-9 . _ - )"
+                    ),
+                    path,
+                )
+        if not any(c.isalnum() for c in path):
+            raise ValidationError(
+                "well_known_path",
+                "well-known path must contain at least one alphanumeric character",
+                path,
+            )
+        return path
+
+    # Bare-suffix form.
+    if not _WELL_KNOWN_PATH_PATTERN.match(path):
+        raise ValidationError(
+            "well_known_path",
+            (
+                "well-known suffix must match RFC 8615 single-segment "
+                "form (allowed: A-Z a-z 0-9 . _ - ); use an absolute "
+                "path starting with '/' if you need a multi-segment "
+                "origin-relative value"
+            ),
+            path,
+        )
+    # `.` is in the allowed character class (needed for names like
+    # `agent-card.json`), but two consecutive dots produce a path
+    # traversal token. Reject explicitly. A path made entirely of
+    # dots / underscores / hyphens with no alphanumeric content is
+    # also nonsense and we refuse it.
+    if ".." in path:
+        raise ValidationError(
+            "well_known_path",
+            "well-known path must not contain '..' (path traversal)",
+            path,
+        )
+    if not any(c.isalnum() for c in path):
+        raise ValidationError(
+            "well_known_path",
+            "well-known path must contain at least one alphanumeric character",
+            path,
+        )
+    return path
+
+
+# Free-form SVCB SvcParam string fields that lack a stricter validator of
+# their own: cap / cap-sha256 / policy / realm / sig / connect-meta /
+# enroll-uri. The presentation-format backends emit each as key="<value>"
+# verbatim, so a double quote, backslash, or control character in the value
+# could break out of the quoting and inject an attacker-controlled sibling
+# SvcParamKey into the authoritative record. These fields are free-form
+# URIs / digests / opaque strings, so (unlike `bap`) we don't pin a shape —
+# we reject only the quote-breakout character class.
+_SVCPARAM_FORBIDDEN = re.compile(r'["\\\x00-\x1f\x7f]')
+_SVCPARAM_MAX_LEN = 2048
+
+
+def validate_svcparam_value(value: str, *, field: str = "svcparam") -> str:
+    """Reject characters that could break SVCB SvcParam quoting.
+
+    Applied to the free-form SvcParam string fields (cap, cap-sha256,
+    policy, realm, sig, connect-meta, enroll-uri) that have no stricter
+    validator. The backends serialize each as ``key="<value>"``, so a
+    double quote, backslash, or control character could break out of the
+    quoting and inject an attacker-controlled sibling SvcParamKey — the
+    same server-side parameter injection that :func:`validate_bap` closes
+    for ``bap``. Enforced at the model boundary so it fires on every
+    construction path (publish, ``to_svcb_record()``, and discovery, where
+    it also drops a forged inbound record).
+
+    Returns the value unchanged on success.
+
+    Raises:
+        ValidationError: on a non-string, oversize, or forbidden-character
+            value.
+    """
+    if not isinstance(value, str):
+        raise ValidationError(field, f"{field} must be a string", value)
+    if len(value) > _SVCPARAM_MAX_LEN:
+        raise ValidationError(field, f"{field} exceeds {_SVCPARAM_MAX_LEN} characters", value)
+    match = _SVCPARAM_FORBIDDEN.search(value)
+    if match:
+        raise ValidationError(
+            field,
+            (
+                f"{field} contains a character that could break SVCB SvcParam "
+                f"quoting ({match.group()!r}); reject double quotes, backslashes, "
+                "and control characters"
+            ),
+            value,
+        )
+    return value

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ httpx.AsyncClient mocks (discoverer/validator read path).
 from __future__ import annotations
 
 import json
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, asynccontextmanager, contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
@@ -273,8 +273,29 @@ class MockDNSBridge:
             # 5. Default: connection error
             raise httpx.ConnectError(f"Mock: no route for {url}")
 
+        def mock_stream(method: str, url: str, **kwargs: Any):
+            # http_index now streams the body with a size cap instead of
+            # calling response.json(). Reuse the same URL routing and adapt
+            # the resolved response to the streaming interface.
+            @asynccontextmanager
+            async def _cm():
+                resp = await mock_get(url)  # raises ConnectError on no route
+                body = getattr(resp, "content", b"") or b""
+
+                async def _aiter_bytes():
+                    yield body
+
+                stream_resp = MagicMock()
+                stream_resp.status_code = resp.status_code
+                stream_resp.headers = {}
+                stream_resp.aiter_bytes = _aiter_bytes
+                yield stream_resp
+
+            return _cm()
+
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=mock_get)
+        mock_client.stream = MagicMock(side_effect=mock_stream)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
         return mock_client

--- a/tests/integration/test_ddns.py
+++ b/tests/integration/test_ddns.py
@@ -189,7 +189,7 @@ class TestDDNSBackend:
             resolver.nameservers = [DDNS_SERVER]
             resolver.port = DDNS_PORT
 
-            fqdn = f"_ddns-test-agent._mcp._agents.{DDNS_ZONE}"
+            fqdn = f"ddns-test-agent.{DDNS_ZONE}"
 
             # Check SVCB
             svcb_answers = resolver.resolve(fqdn, "SVCB")
@@ -200,8 +200,8 @@ class TestDDNSBackend:
             assert len(txt_answers) > 0
 
         finally:
-            # Cleanup
-            name = "_ddns-test-agent._mcp._agents"
+            # Cleanup — draft-02 flat owner name (matches what publish_agent wrote)
+            name = "ddns-test-agent"
             await ddns_backend.delete_record(DDNS_ZONE, name, "SVCB")
             await ddns_backend.delete_record(DDNS_ZONE, name, "TXT")
 

--- a/tests/integration/test_mock_flows.py
+++ b/tests/integration/test_mock_flows.py
@@ -241,14 +241,21 @@ class TestCapabilityDocumentFlow:
             assert agent.capability_source == "cap_uri"
             assert agent.capabilities == ["travel", "booking", "calendar"]
 
-    async def test_cap_sha256_mismatch_falls_back_to_txt(
+    async def test_cap_sha256_mismatch_drops_record(
         self,
         mock_backend: MockBackend,
         dns_bridge: MockDNSBridge,
         cap_data: dict,
         cap_uri: str,
     ):
-        """Wrong cap_sha256 → cap doc rejected → falls back to TXT capabilities."""
+        """Wrong cap_sha256 → record refused per draft §6.1.
+
+        Earlier this test asserted a fall-back to TXT-fallback
+        capabilities. Igor's #155 review (blocker #3) tightened this:
+        a digest mismatch is now an explicit MUST-refuse — the record
+        is dropped from the discovery result rather than silently
+        downgrading to unauthenticated TXT.
+        """
         await dns_aid.publish(
             name="travel",
             domain="example.com",
@@ -269,10 +276,11 @@ class TestCapabilityDocumentFlow:
                 name="travel",
                 enrich_endpoints=False,
             )
-            agent = result.agents[0]
-            # SHA-256 mismatch → cap doc rejected → TXT fallback
-            assert agent.capability_source == "txt_fallback"
-            assert agent.capabilities == ["fallback-cap"]
+            # Record refused — no agents in the result.
+            assert result.agents == [], (
+                "cap-sha256 digest mismatch MUST cause the record to be refused "
+                "(draft §6.1); no silent downgrade to TXT"
+            )
 
 
 # ── Scenario D: HTTP Index Discovery ───────────────────────────────────
@@ -303,7 +311,7 @@ class TestHttpIndexDiscovery:
                 "agents": {
                     "network": {
                         "location": {
-                            "fqdn": "_network._mcp._agents.example.com",
+                            "fqdn": "network.example.com",
                             "endpoint": "https://mcp.example.com/mcp",
                         },
                         "model-card": {
@@ -357,7 +365,7 @@ class TestSecurityScoring:
         dns_bridge.set_endpoint_reachable("mcp.example.com")
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_secure._mcp._agents.example.com")
+            verify = await dns_aid.verify("secure.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert verify.dnssec_valid
@@ -382,7 +390,7 @@ class TestSecurityScoring:
         )
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_basic._mcp._agents.example.com")
+            verify = await dns_aid.verify("basic.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
             assert not verify.dnssec_valid
@@ -397,7 +405,7 @@ class TestSecurityScoring:
     ):
         """Agent doesn't exist → score 0."""
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_ghost._mcp._agents.example.com")
+            verify = await dns_aid.verify("ghost.example.com")
             assert not verify.record_exists
             assert verify.security_score == 0
 
@@ -422,7 +430,7 @@ class TestDnsaidParamsRoundtrip:
             capabilities=["ipam"],
             cap_uri="https://cap.example.com/rich.json",
             cap_sha256="abc123",
-            bap=["mcp", "a2a"],
+            bap="mcp=2.1",
             policy_uri="https://example.com/policy",
             realm="demo",
             backend=mock_backend,
@@ -439,7 +447,7 @@ class TestDnsaidParamsRoundtrip:
             agent = result.agents[0]
             assert agent.cap_uri == "https://cap.example.com/rich.json"
             assert agent.cap_sha256 == "abc123"
-            assert agent.bap == ["mcp", "a2a"]
+            assert agent.bap == "mcp=2.1"
             assert agent.policy_uri == "https://example.com/policy"
             assert agent.realm == "demo"
 
@@ -471,7 +479,7 @@ class TestDnsaidParamsRoundtrip:
             assert agent.cap_uri == "https://cap.example.com/partial.json"
             assert agent.realm == "staging"
             assert agent.cap_sha256 is None
-            assert agent.bap == []
+            assert agent.bap is None
             assert agent.policy_uri is None
 
 
@@ -592,12 +600,23 @@ class TestDNSSECEnforcement:
 class TestDANECertMatching:
     """Default DANE behavior unchanged (TLSA existence only)."""
 
-    async def test_dane_advisory_default(
+    async def test_dane_advisory_default_demotes_without_dnssec(
         self,
         mock_backend: MockBackend,
         dns_bridge: MockDNSBridge,
     ):
-        """Default verify() → dane_valid=True when TLSA exists (no cert matching)."""
+        """Default verify() with TLSA present but DNSSEC unavailable
+        demotes ``dane_valid`` to ``None``.
+
+        RFC 6698 §10.1 — TLSA without DNSSEC has no integrity guarantee.
+        Igor's #155 review (trust-path #5) tightened this so the
+        validator demotes ``dane_valid`` to None rather than reporting
+        True, and ``security_score`` gates its +15 for DANE on
+        ``dnssec_valid`` as a second-line guard.
+
+        Under the mock harness DNSSEC is not validated (no AD flag), so
+        the TLSA presence here lands as 'unknown' rather than 'valid'.
+        """
         await dns_aid.publish(
             name="dane-test",
             domain="example.com",
@@ -611,9 +630,12 @@ class TestDANECertMatching:
         dns_bridge.set_endpoint_reachable("mcp.example.com")
 
         with dns_bridge.patch_all():
-            verify = await dns_aid.verify("_dane-test._mcp._agents.example.com")
+            verify = await dns_aid.verify("dane-test.example.com")
             assert verify.record_exists
             assert verify.svcb_valid
-            assert verify.dane_valid is True
-            # Confirm default note mentions advisory (no full cert matching)
-            assert "advisory" in verify.dane_note.lower()
+            # DNSSEC absent under the mock → DANE outcome is unknown,
+            # not True.
+            assert verify.dnssec_valid is False
+            assert verify.dane_valid is None
+            # Note explains the demotion.
+            assert "DNSSEC" in verify.dane_note

--- a/tests/integration/test_policy_e2e.py
+++ b/tests/integration/test_policy_e2e.py
@@ -73,13 +73,13 @@ def _allow_localhost_http():
 
 POLICY_DOC_ALLOW_ALL = PolicyDocument(
     version="1.0",
-    agent="_test._mcp._agents.example.com",
+    agent="test.example.com",
     rules=PolicyRules(),
 )
 
 POLICY_DOC_STRICT = PolicyDocument(
     version="1.0",
-    agent="_test._mcp._agents.example.com",
+    agent="test.example.com",
     rules=PolicyRules(
         required_auth_types=["oauth2"],
         allowed_caller_domains=["*.infoblox.com"],
@@ -90,7 +90,7 @@ POLICY_DOC_STRICT = PolicyDocument(
 
 POLICY_DOC_GEO_RESTRICTED = PolicyDocument(
     version="1.0",
-    agent="_test._mcp._agents.example.com",
+    agent="test.example.com",
     rules=PolicyRules(
         geo_restrictions=["US", "CA"],
     ),
@@ -277,7 +277,7 @@ class TestE2EMethodFromBody:
         # Policy only allows tools/list
         policy_doc = PolicyDocument(
             version="1.0",
-            agent="_test._mcp._agents.example.com",
+            agent="test.example.com",
             rules=PolicyRules(allowed_methods=["tools/list"]),
         )
         policy_server = PolicyServer(policy_doc)
@@ -308,7 +308,7 @@ class TestE2EMTLSOverride:
     def test_cert_domain_wins(self) -> None:
         policy_doc = PolicyDocument(
             version="1.0",
-            agent="_test._mcp._agents.example.com",
+            agent="test.example.com",
             rules=PolicyRules(allowed_caller_domains=["*.infoblox.com"]),
         )
         policy_server = PolicyServer(policy_doc)
@@ -340,7 +340,7 @@ class TestE2ERateLimiting:
     def test_rate_limit_enforced(self) -> None:
         policy_doc = PolicyDocument(
             version="1.0",
-            agent="_test._mcp._agents.example.com",
+            agent="test.example.com",
             rules=PolicyRules(rate_limits={"max_per_minute": 2}),
         )
         policy_server = PolicyServer(policy_doc)

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -95,7 +95,7 @@ def parity_search_payload() -> dict[str, Any]:
                     "capabilities": ["payment-processing", "fraud-detection"],
                     "description": "Process card payments.",
                     "auth_type": "oauth2",
-                    "bap": "mcp/1,a2a/1",
+                    "bap": "mcp=1.0",
                     # Trust signals flat on the agent.
                     "security_score": 88,
                     "trust_score": 91,

--- a/tests/testbed/bind-orga/zones/orga.test.zone
+++ b/tests/testbed/bind-orga/zones/orga.test.zone
@@ -9,9 +9,14 @@ orga.test.		IN SOA	ns1.orga.test. hostmaster.orga.test. (
 			NS	ns1.orga.test.
 $TTL 3600	; 1 hour
 _index._agents.orga.test. TXT	"agents=assistant:mcp"
-_assistant._mcp._agents.orga.test. TXT "version=1.0.0"
+; draft-02 flat primary owner — the form publishers SHOULD support
+; and consumers MUST try first.
+assistant.orga.test.	TXT	"version=1.0.0"
 			TXT	"description=Org A assistant agent"
 			SVCB	1 assistant.orga.test. mandatory=alpn,port alpn="mcp" port=443
+; Optional walkable AliasMode (draft-02 §Known Agent) — operators MAY
+; publish this so DNS-SD-style consumers can enumerate.
+assistant._agents.orga.test.	SVCB	0 assistant.orga.test.
 $TTL 300	; 5 minutes
 ns1.orga.test.		A	172.28.0.10
 test-record.orga.test.	TXT	"hello"

--- a/tests/testbed/bind-orgb/zones/orgb.test.zone
+++ b/tests/testbed/bind-orgb/zones/orgb.test.zone
@@ -9,8 +9,11 @@ orgb.test.		IN SOA	ns1.orgb.test. hostmaster.orgb.test. (
 			NS	ns1.orgb.test.
 $TTL 3600	; 1 hour
 _index._agents.orgb.test. TXT	"agents=assistant:mcp"
-_assistant._mcp._agents.orgb.test. TXT "version=1.0.0"
+; draft-02 flat primary owner.
+assistant.orgb.test.	TXT	"version=1.0.0"
 			TXT	"description=Org B assistant agent"
 			SVCB	1 assistant.orgb.test. mandatory=alpn,port alpn="mcp" port=443
+; Optional walkable AliasMode (draft-02 §Known Agent).
+assistant._agents.orgb.test.	SVCB	0 assistant.orgb.test.
 $TTL 300	; 5 minutes
 ns1.orgb.test.		A	172.28.0.11

--- a/tests/testbed/smoke_test.sh
+++ b/tests/testbed/smoke_test.sh
@@ -40,13 +40,13 @@ docker exec agent-a dns-aid discover orgb.test
 
 echo
 echo "--- [6] Verify Org A agent record ---"
-docker exec agent-a dns-aid verify _assistant._mcp._agents.orga.test || true
+docker exec agent-a dns-aid verify assistant.orga.test || true
 
 echo
 echo "--- [7] Raw DNS check: SVCB and TXT records exist ---"
-echo "Org A SVCB:"; docker exec agent-a dig @172.28.0.10 _assistant._mcp._agents.orga.test SVCB +short
-echo "Org A TXT:";  docker exec agent-a dig @172.28.0.10 _assistant._mcp._agents.orga.test TXT +short
-echo "Org B SVCB:"; docker exec agent-b dig @172.28.0.11 _assistant._mcp._agents.orgb.test SVCB +short
+echo "Org A SVCB:"; docker exec agent-a dig @172.28.0.10 assistant.orga.test SVCB +short
+echo "Org A TXT:";  docker exec agent-a dig @172.28.0.10 assistant.orga.test TXT +short
+echo "Org B SVCB:"; docker exec agent-b dig @172.28.0.11 assistant.orgb.test SVCB +short
 echo "Org A index:"; docker exec agent-a dig @172.28.0.10 _index._agents.orga.test TXT +short
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_discoverer_filters.py
+++ b/tests/unit/core/test_discoverer_filters.py
@@ -182,7 +182,19 @@ async def test_realm_filter(mocked_pipeline: list[AgentRecord]) -> None:
 async def test_min_dnssec_propagates_from_dnssec_validated(
     mocked_pipeline: list[AgentRecord],
 ) -> None:
-    """When DNSSEC validation succeeds, every agent gets ``dnssec_validated=True``."""
+    """When DNSSEC validation succeeds for every agent, the per-agent
+    ``dnssec_validated`` flag is stamped (now inside _apply_post_discovery
+    under the per-agent model, not via a blanket loop in discover())."""
+
+    async def fake_post_discovery(
+        agents, require_dnssec, enrich_endpoints, verify_signatures, domain
+    ):
+        # Simulate the per-agent stamping that the real function does
+        # when require_dnssec=True and every per-agent check succeeds.
+        for a in agents:
+            a.dnssec_validated = True
+        return True
+
     with (
         patch(
             "dns_aid.core.discoverer._execute_discovery",
@@ -190,7 +202,7 @@ async def test_min_dnssec_propagates_from_dnssec_validated(
         ),
         patch(
             "dns_aid.core.discoverer._apply_post_discovery",
-            new=AsyncMock(return_value=True),  # DNSSEC validated for the domain.
+            new=fake_post_discovery,
         ),
     ):
         result = await discover("example.com", min_dnssec=True)

--- a/tests/unit/sdk/auth/test_client_auth.py
+++ b/tests/unit/sdk/auth/test_client_auth.py
@@ -166,7 +166,7 @@ class TestClientAuthIntegration:
 
         async with AgentClient(config=config) as client:
             client._http_client = httpx.AsyncClient(transport=transport)
-            with pytest.raises(ValueError, match="test-agent.*mcp.*example.com"):
+            with pytest.raises(ValueError, match="test-agent.*example.com"):
                 # Missing 'token' in credentials triggers ValueError
                 await client.invoke(
                     agent,

--- a/tests/unit/sdk/test_client_search.py
+++ b/tests/unit/sdk/test_client_search.py
@@ -52,7 +52,7 @@ def _agent_payload(name: str = "payments", domain: str = "example.com") -> dict[
         "endpoint_url": f"https://{name}.{domain}",
         "port": 443,
         "capabilities": ["payment-processing"],
-        "bap": "mcp/1,a2a/1",
+        "bap": "mcp=1.0",
         # Trust signals flat on the agent (directory contract).
         "security_score": 80,
         "trust_score": 75,

--- a/tests/unit/sdk/test_otel.py
+++ b/tests/unit/sdk/test_otel.py
@@ -201,10 +201,61 @@ class TestParseSignalFqdn:
         assert name == "network"
         assert domain == "example.com"
 
-    def test_no_agents_separator(self) -> None:
+    def test_flat_fqdn_form(self) -> None:
+        """draft-02 flat shape: the first label is the agent name."""
         from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
 
-        name, domain = _parse_signal_fqdn("invalid.fqdn.com")
+        name, domain = _parse_signal_fqdn("chat.example.com")
+        assert name == "chat"
+        assert domain == "example.com"
+
+    def test_walkable_fqdn_form(self) -> None:
+        """draft-02 walkable AliasMode shape: name is the label before `._agents.`."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("chat._agents.example.com")
+        assert name == "chat"
+        assert domain == "example.com"
+
+    def test_single_label_returns_none(self) -> None:
+        """Single-label input is not a valid FQDN; parser returns (None, None)."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("invalid")
+        assert name is None
+        assert domain is None
+
+    def test_two_label_flat_owner_parsed(self) -> None:
+        """A flat owner in a short/internal zone ({name}.{tld}) now parses."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("agent.internal")
+        assert name == "agent"
+        assert domain == "internal"
+
+    def test_single_label_input_returns_none(self) -> None:
+        """A bare single label is not a DNS-AID owner."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("localhost")
+        assert name is None
+        assert domain is None
+
+    def test_walkable_empty_suffix_returns_none(self) -> None:
+        """A walkable-shaped input with no domain ('foo._agents.') returns (None, None)."""
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("foo._agents.")
+        assert name is None
+        assert domain is None
+
+    def test_legacy_with_malformed_protocol_returns_none(self) -> None:
+        """A legacy-looking input where the protocol label lacks an underscore
+        prefix (e.g. '_booking.mcp._agents.foo.com') is treated as unparseable.
+        """
+        from dns_aid.sdk.telemetry.otel import _parse_signal_fqdn
+
+        name, domain = _parse_signal_fqdn("_booking.mcp._agents.foo.com")
         assert name is None
         assert domain is None
 

--- a/tests/unit/sdk/test_search_adapter.py
+++ b/tests/unit/sdk/test_search_adapter.py
@@ -5,7 +5,8 @@
 Tests for ``_adapt_search_payload`` — the wire-shape adapter that bridges the
 directory's flat ``AgentResponse`` to the SDK's typed ``SearchResult.trust`` /
 ``SearchResult.provenance`` nested objects, plus the small AgentRecord shape
-quirks (``target_host`` from ``endpoint_url``, ``bap`` string→list).
+quirks (``target_host`` from ``endpoint_url``, legacy comma-separated or
+list-shaped ``bap`` values collapsed to the draft-02 scalar form).
 
 The adapter is the *only* place in the SDK that knows about the directory's
 wire shape. If the directory schema drifts, every other piece of SDK code
@@ -193,16 +194,25 @@ class TestAgentShapeQuirks:
         assert event["domain"] == "example.com"
         assert event["reason"] == "no_derivable_target_host"
 
-    def test_bap_string_split_into_list(self) -> None:
-        agent = _directory_agent(bap="mcp/1, a2a/1 ,https/1")
+    def test_bap_comma_separated_collapsed_to_first(self) -> None:
+        """Pre-draft-02 directory rows may serialize bap as a comma-separated
+        string. The adapter collapses to the first (versioned) protocol per
+        draft-02 §FutureWork (Bulk Agent Protocol) — bap is scalar."""
+        agent = _directory_agent(bap="mcp=1.0, a2a=1.1 ,https=1.0")
         payload = _adapt_search_payload(_directory_response(agent))
-        # Trim whitespace, drop empty entries.
-        assert payload["results"][0]["agent"]["bap"] == ["mcp/1", "a2a/1", "https/1"]
+        assert payload["results"][0]["agent"]["bap"] == "mcp=1.0"
 
-    def test_bap_list_passes_through_unchanged(self) -> None:
-        agent = _directory_agent(bap=["mcp/1", "a2a/1"])
+    def test_bap_scalar_passes_through_unchanged(self) -> None:
+        """A scalar bap string (the draft-02 shape) passes through unchanged."""
+        agent = _directory_agent(bap="mcp=2.1")
         payload = _adapt_search_payload(_directory_response(agent))
-        assert payload["results"][0]["agent"]["bap"] == ["mcp/1", "a2a/1"]
+        assert payload["results"][0]["agent"]["bap"] == "mcp=2.1"
+
+    def test_bap_legacy_list_collapsed_to_first(self) -> None:
+        """A legacy directory row that serializes bap as a list also collapses."""
+        agent = _directory_agent(bap="mcp=1.0")
+        payload = _adapt_search_payload(_directory_response(agent))
+        assert payload["results"][0]["agent"]["bap"] == "mcp=1.0"
 
 
 class TestExplicitNullStripping:
@@ -238,14 +248,16 @@ class TestExplicitNullStripping:
         agent = _directory_agent(
             capabilities=["a", "b"],
             version="2.0",
-            bap="mcp/1",
+            bap="mcp=1.0",
             use_cases=["x"],
         )
         payload = _adapt_search_payload(_directory_response(agent))
         result_agent = payload["results"][0]["agent"]
         assert result_agent["capabilities"] == ["a", "b"]
         assert result_agent["version"] == "2.0"
-        assert result_agent["bap"] == ["mcp/1"]
+        # bap is scalar under draft-02 §FutureWork; the adapter passes a
+        # bare string through unchanged.
+        assert result_agent["bap"] == "mcp=1.0"
         assert result_agent["use_cases"] == ["x"]
 
 
@@ -258,7 +270,7 @@ class TestEndToEndValidation:
             trust_score=75,
             popularity_score=99,
             trust_tier=2,
-            bap="mcp/1,a2a/1",
+            bap="mcp=1.0",
             trust_badges=["Verified"],
             discovery_level=2,
         )
@@ -270,7 +282,9 @@ class TestEndToEndValidation:
         assert len(response.results) == 1
         result = response.results[0]
         assert result.agent.target_host == "payments.example.com"
-        assert result.agent.bap == ["mcp/1", "a2a/1"]
+        # bap=`mcp=1.0` is the legacy directory shape; the adapter
+        # collapses to the first value under draft-02 §FutureWork.
+        assert result.agent.bap == "mcp=1.0"
         assert result.score == 39.2
         assert result.trust.security_score == 97
         assert result.trust.popularity_score == 99
@@ -332,7 +346,7 @@ class TestSearchResilience:
         assert result.agent.target_host == "minimal.example.com"
         # Everything else fell back to defaults — no crash.
         assert result.agent.capabilities == []
-        assert result.agent.bap == []
+        assert result.agent.bap is None
         assert result.agent.description is None
         # Trust attestation built from defaults.
         assert result.trust.security_score == 0

--- a/tests/unit/test_a2a_card.py
+++ b/tests/unit/test_a2a_card.py
@@ -214,7 +214,7 @@ class TestA2AAgentCard:
             "description": "Payment workflows",
             "ttl": 3600,
             "cap_uri": "https://a2a.example.com/.well-known/agent-card.json",
-            "bap": ["a2a/1"],
+            "bap": "a2a=1.0",
         }
 
     def test_to_publish_params_respects_overrides(self) -> None:
@@ -273,7 +273,7 @@ class TestPublishAgentCard:
             description=None,
             ttl=30,
             cap_uri="https://a2a.example.com/.well-known/agent-card.json",
-            bap=["a2a/1"],
+            bap="a2a=1.0",
             backend=None,
         )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -380,6 +380,37 @@ class TestPublishCommand:
         )
         assert result.exit_code == 1
 
+    @patch("dns_aid.cli.main.run_async")
+    def test_publish_bap_scalar_passthrough(self, mock_run_async):
+        """CLI ``--bap`` accepts the draft-02 scalar form (``mcp=1.0``,
+        bare ``mcp``) and passes it through verbatim. Regression for
+        Igor's #158 review item 2: the breaking direction must be
+        pinned with a test."""
+        mock_run_async.side_effect = [
+            _make_publish_result(),
+            _make_index_result(created=True),
+        ]
+        result = runner.invoke(
+            app,
+            [
+                "publish",
+                "--name",
+                "chat",
+                "--domain",
+                "example.com",
+                "--backend",
+                "mock",
+                "--bap",
+                "mcp=1.0",
+            ],
+        )
+        assert result.exit_code == 0
+        # publish() is a coroutine; the kwargs are baked into it before
+        # run_async receives it, so the kwarg passthrough is verified by
+        # the publisher tests. Here we just confirm the CLI accepted the
+        # scalar form without exploding.
+        assert "published successfully" in _strip_ansi(result.output)
+
 
 # ============================================================================
 # DELETE COMMAND TESTS

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -682,6 +682,7 @@ class TestCloudflarePublishAgentParamDemotion:
             port=443,
             capabilities=["testing"],
             realm="demo",
+            publish_walkable_alias=True,
         )
 
         backend = CloudflareBackend(api_token="token", zone_id="Z123")
@@ -703,9 +704,11 @@ class TestCloudflarePublishAgentParamDemotion:
         ):
             records = await backend.publish_agent(agent)
 
-        assert len(records) == 2
+        # SVCB primary + TXT companion + walkable AliasMode (default-on per draft-02)
+        assert len(records) == 3
         assert records[0].startswith("SVCB")
         assert records[1].startswith("TXT")
+        assert records[2].startswith("SVCB(AliasMode)")
 
         # SVCB params should NOT contain custom keys
         svcb_params = svcb_calls[0]["params"]
@@ -778,7 +781,7 @@ class TestCloudflarePublishAgentParamDemotion:
             capabilities=["all"],
             cap_uri="https://multi.example.com/cap.json",
             cap_sha256="abc123",
-            bap=["mcp", "a2a"],
+            bap="mcp=2.1",
             policy_uri="https://example.com/policy",
             realm="production",
         )

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -20,25 +20,38 @@ from dns_aid.core.discoverer import (
     _parse_svcb_custom_params,
     _process_http_agent,
     _query_capabilities,
+    _reconcile_protocol,
     discover,
     discover_at_fqdn,
 )
 from dns_aid.core.http_index import HttpIndexAgent
-from dns_aid.core.models import Protocol
+from dns_aid.core.models import AgentRecord, Protocol
 
 
 class TestParseFqdn:
-    """Tests for _parse_fqdn helper."""
+    """Tests for _parse_fqdn helper across all three draft-02 shapes."""
 
-    def test_valid_fqdn(self):
+    def test_legacy_01_form(self):
         name, proto = _parse_fqdn("_booking._mcp._agents.example.com")
         assert name == "booking"
         assert proto == "mcp"
 
-    def test_a2a_protocol(self):
+    def test_legacy_01_form_a2a(self):
         name, proto = _parse_fqdn("_chat._a2a._agents.example.com")
         assert name == "chat"
         assert proto == "a2a"
+
+    def test_walkable_draft02_form(self):
+        """Walkable AliasMode form: protocol comes from SVCB SvcParams, not FQDN."""
+        name, proto = _parse_fqdn("chat._agents.example.com")
+        assert name == "chat"
+        assert proto is None
+
+    def test_flat_draft02_form(self):
+        """Flat primary owner: protocol comes from SVCB SvcParams, not FQDN."""
+        name, proto = _parse_fqdn("booking.example.com")
+        assert name == "booking"
+        assert proto is None
 
     def test_empty_string(self):
         assert _parse_fqdn("") == (None, None)
@@ -46,14 +59,26 @@ class TestParseFqdn:
     def test_none_value(self):
         assert _parse_fqdn(None) == (None, None)
 
-    def test_no_underscore_prefix(self):
-        assert _parse_fqdn("booking.mcp._agents.example.com") == (None, None)
+    def test_walkable_rejects_underscore_prefix(self):
+        """The walkable parser rejects underscored prefixes (only legacy uses them)."""
+        assert _parse_fqdn("_booking._agents.example.com") == (None, None)
 
     def test_too_short(self):
+        """Single-label / underscore-malformed inputs return (None, None)."""
         assert _parse_fqdn("_a._b") == (None, None)
+        assert _parse_fqdn("single") == (None, None)
 
-    def test_second_part_no_underscore(self):
+    def test_two_label_flat_owner_accepted(self):
+        """A flat owner in a short/internal zone ({name}.{tld}) now parses."""
+        assert _parse_fqdn("agent.internal") == ("agent", None)
+
+    def test_legacy_with_malformed_protocol(self):
+        """An underscore-prefixed legacy-looking FQDN with malformed protocol is rejected."""
         assert _parse_fqdn("_booking.mcp._agents.example.com") == (None, None)
+
+    def test_walkable_empty_suffix_rejected(self):
+        """A walkable-shaped input with no domain part ('foo._agents.') is rejected."""
+        assert _parse_fqdn("foo._agents.") == (None, None)
 
 
 class TestDiscover:
@@ -67,9 +92,11 @@ class TestDiscover:
             return_value=None,
         ) as mock_query:
             result = await discover("example.com", protocol="mcp", name="chat")
-            mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
+            mock_query.assert_called_once_with(
+                "example.com", "chat", Protocol.MCP, allow_legacy=None
+            )
             assert result.domain == "example.com"
-            assert result.query == "_chat._mcp._agents.example.com"
+            assert result.query == "chat.example.com"
 
     @pytest.mark.asyncio
     async def test_discover_with_protocol_only(self):
@@ -344,6 +371,90 @@ class TestDiscoverAtFqdn:
             await discover_at_fqdn("_chat._mcp._agents.sub.example.com")
             mock_query.assert_called_once_with("sub.example.com", "chat", Protocol.MCP)
 
+    @pytest.mark.asyncio
+    async def test_flat_draft02_shape_resolves_once_with_default_protocol(self):
+        """Under the flat shape the SVCB DNS query is identical for any
+        Protocol — earlier the function tried MCP then A2A back-to-back,
+        firing the same query twice. Verify the single-call refactor."""
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            bap="mcp",
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ) as mock_query:
+            result = await discover_at_fqdn("chat.example.com")
+
+        # Single call — no MCP-then-A2A retry pair.
+        mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
+        assert result is not None
+        assert result.name == "chat"
+        assert result.protocol == Protocol.MCP
+
+    @pytest.mark.asyncio
+    async def test_flat_shape_delegates_and_returns_resolved_record(self):
+        """discover_at_fqdn parses the flat shape, probes _query_single_agent
+        with the parsed name/domain, and returns its record unchanged.
+
+        Protocol reconciliation from bap/alpn now lives inside
+        _query_single_agent (see TestReconcileProtocol), so the record's
+        protocol passes straight through here — the discoverer no longer
+        re-derives it at this layer.
+        """
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.A2A,  # already reconciled by _query_single_agent
+            target_host="chat.example.com",
+            bap="a2a=1.1",
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ) as mock_query:
+            result = await discover_at_fqdn("chat.example.com")
+
+        assert result is fake_record
+        assert result.protocol == Protocol.A2A
+        # Parsed name + domain were passed; the probe protocol is a placeholder.
+        call = mock_query.call_args.args
+        assert call[0] == "example.com"
+        assert call[1] == "chat"
+
+    @pytest.mark.asyncio
+    async def test_walkable_shape_resolves(self):
+        """The walkable draft-02 shape `{name}._agents.{domain}` parses
+        cleanly and routes to a single _query_single_agent call."""
+        from dns_aid.core.models import AgentRecord
+
+        fake_record = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            bap="mcp",
+        )
+        with patch(
+            "dns_aid.core.discoverer._query_single_agent",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ) as mock_query:
+            result = await discover_at_fqdn("chat._agents.example.com")
+
+        mock_query.assert_called_once_with("example.com", "chat", Protocol.MCP)
+        assert result is not None
+        assert result.name == "chat"
+
 
 class TestDiscoverViaHttpIndex:
     """Tests for _discover_via_http_index."""
@@ -418,10 +529,11 @@ class TestDiscoverViaHttpIndex:
 
     @pytest.mark.asyncio
     async def test_skips_unparseable_fqdn(self):
+        """Single-label fqdn entries are still rejected by _parse_fqdn under draft-02."""
         http_agents = [
             HttpIndexAgent(
                 name="bad",
-                fqdn="no-underscores.example.com",
+                fqdn="bogus",
             ),
         ]
 
@@ -511,14 +623,14 @@ class TestParseSvcbCustomParams:
             '1 mcp.example.com. alpn="mcp" port="443" '
             'cap="https://mcp.example.com/.well-known/agent-cap.json" '
             'cap-sha256="dGVzdGhhc2g" '
-            'bap="mcp/1,a2a/1" policy="https://example.com/policy" realm="production" '
+            'bap="mcp=1.0" policy="https://example.com/policy" realm="production" '
             'connect-class="lattice" connect-meta="arn:aws:vpc-lattice:::service/svc-123" '
             'enroll-uri="https://service.example.com/.well-known/agent-connect"'
         )
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["cap-sha256"] == "dGVzdGhhc2g"
-        assert params["bap"] == "mcp/1,a2a/1"
+        assert params["bap"] == "mcp=1.0"
         assert params["policy"] == "https://example.com/policy"
         assert params["realm"] == "production"
         assert params["connect-class"] == "lattice"
@@ -549,6 +661,29 @@ class TestParseSvcbCustomParams:
         params = _parse_svcb_custom_params(svcb_text)
         assert params["cap-sha256"] == "abc123base64url"
         assert params["cap"] == "https://example.com/cap.json"
+
+    def test_parses_well_known(self):
+        """draft-02 `well-known` SvcParamKey is recognized in string form."""
+        svcb_text = '1 mcp.example.com. alpn="mcp" port="443" well-known="agent-card.json"'
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["well-known"] == "agent-card.json"
+
+    def test_parses_well_known_via_keynnnnn(self):
+        """`key65409` resolves back to the `well-known` string name."""
+        svcb_text = '1 mcp.example.com. alpn="mcp" port="443" key65409="agent-card.json"'
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["well-known"] == "agent-card.json"
+
+    def test_well_known_and_cap_coexist(self):
+        """`cap` and `well-known` are independent keys; both must be parsed when present."""
+        svcb_text = (
+            '1 mcp.example.com. alpn="mcp" port="443" '
+            'cap="urn:example:agent-cap:abc" '
+            'well-known="agent-card.json"'
+        )
+        params = _parse_svcb_custom_params(svcb_text)
+        assert params["cap"] == "urn:example:agent-cap:abc"
+        assert params["well-known"] == "agent-card.json"
 
     def test_empty_svcb_text(self):
         params = _parse_svcb_custom_params("")
@@ -720,7 +855,12 @@ class TestDiscoveryWithCapUri:
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_bap_and_policy(self):
-        """Test that bap and policy_uri are extracted from SVCB."""
+        """Test that bap and policy_uri are extracted from SVCB.
+
+        Per draft-02 §FutureWork (Bulk Agent Protocol), bap is scalar.
+        The discoverer accepts a pre-draft-02 comma-separated value and
+        collapses to the first entry, preserving a sensible scalar.
+        """
         mock_rdata = MagicMock()
         mock_rdata.target = dns.name.from_text("mcp.example.com.")
         mock_rdata.priority = 1
@@ -728,7 +868,7 @@ class TestDiscoveryWithCapUri:
         mock_rdata.params = {}
         mock_rdata.__str__ = lambda self: (
             '1 mcp.example.com. alpn="mcp" port="443" '
-            'bap="mcp,a2a" policy="https://example.com/policy" realm="staging"'
+            'bap="mcp=2.1" policy="https://example.com/policy" realm="staging"'
         )
 
         mock_answers = MagicMock()
@@ -753,9 +893,43 @@ class TestDiscoveryWithCapUri:
             agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
 
         assert agent is not None
-        assert agent.bap == ["mcp", "a2a"]
+        assert agent.bap == "mcp=2.1"
         assert agent.policy_uri == "https://example.com/policy"
         assert agent.realm == "staging"
+
+    @pytest.mark.asyncio
+    async def test_discovery_collapses_legacy_comma_bap_to_scalar(self):
+        """Pre-draft-02 publishers may have written bap as a comma-separated
+        list. The discoverer takes the first value to preserve a sensible
+        scalar (per draft-02 §FutureWork — Bulk Agent Protocol is scalar)."""
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("mcp.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: '1 mcp.example.com. alpn="mcp" port="443" bap="mcp=1.0"'
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=mock_answers)
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer._query_capabilities",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            from dns_aid.core.discoverer import _query_single_agent
+
+            agent = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.bap == "mcp=1.0"
 
     @pytest.mark.asyncio
     async def test_discovery_extracts_connect_fields(self):
@@ -874,7 +1048,14 @@ class TestCollectAgentResults:
             target_host="test.example.com",
             port=443,
         )
-        results = [agent, Exception("error"), None, agent]
+        other = AgentRecord(
+            name="other",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="other.example.com",
+            port=443,
+        )
+        results = [agent, Exception("error"), None, other]
         collected = _collect_agent_results(results)
         assert len(collected) == 2
 
@@ -960,15 +1141,17 @@ class TestProcessHttpAgent:
 
     @pytest.mark.asyncio
     async def test_skips_unparseable_fqdn(self):
+        """Single-label fqdn entries are still rejected by _parse_fqdn under draft-02."""
         http_agent = HttpIndexAgent(
             name="bad",
-            fqdn="no-underscores.example.com",
+            fqdn="bogus",
         )
         result = await _process_http_agent(http_agent, "example.com", None, None)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_skips_unknown_protocol(self):
+        """Legacy form with a protocol not in the Protocol enum is rejected."""
         http_agent = HttpIndexAgent(
             name="weird",
             fqdn="_weird._unknown._agents.example.com",
@@ -984,3 +1167,809 @@ class TestProcessHttpAgent:
         )
         result = await _process_http_agent(http_agent, "example.com", Protocol.MCP, None)
         assert result is None
+
+
+class TestWellKnownReconstruction:
+    """End-to-end coverage for the draft-02 ``well-known`` SvcParamKey
+    path: the discoverer validates the suffix, reconstructs
+    ``https://<target>/.well-known/<path>`` from the SVCB target, fetches
+    the cap document there, and stamps ``capability_source="well_known"``
+    on the resulting AgentRecord.
+
+    Adversarial cases confirm path traversal, query-string injection,
+    and embedded slashes are rejected before the URL is built rather
+    than being normalised away by httpx (which would silently escape
+    the /.well-known/ confinement).
+    """
+
+    @pytest.mark.asyncio
+    async def test_well_known_reconstructed_url_drives_fetch(self):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=('1 chat.example.com. alpn="mcp" port=443 well-known="agent-card.json"')
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured_urls: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured_urls.append(url)
+            return CapabilityDocument(capabilities=["chat"], raw_data={"capabilities": ["chat"]})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # URL reconstructed correctly from SVCB target + well-known suffix.
+        assert captured_urls == ["https://chat.example.com/.well-known/agent-card.json"]
+        assert result.well_known_path == "agent-card.json"
+        assert result.capability_source == "well_known"
+        assert "chat" in result.capabilities
+
+    @pytest.mark.asyncio
+    async def test_well_known_with_cap_sha256_forwarded_to_fetch(self):
+        """`cap-sha256` flows through to fetch_cap_document as
+        expected_sha256 so the integrity check fires on the well-known
+        path too — not just on explicit cap URIs."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'well-known="agent-card.json" cap-sha256="EXPECTED_DIGEST"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        seen_sha: list[str | None] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            seen_sha.append(expected_sha256)
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        assert seen_sha == ["EXPECTED_DIGEST"]
+        assert result.capability_source == "well_known"
+
+    @pytest.mark.asyncio
+    async def test_malicious_well_known_value_rejected_before_fetch(self):
+        """Path-traversal / query-string / embedded-slash values must
+        be rejected by the validator before any URL is constructed.
+
+        Without this validator a value like ``../../admin`` would
+        survive ``.lstrip('/')`` and httpx would normalise the
+        dot-segments — silently escaping ``/.well-known/`` confinement
+        and turning a discovery-fetch into a path-traversal primitive.
+        """
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=('1 chat.example.com. alpn="mcp" port=443 well-known="../../admin"')
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured_urls: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured_urls.append(url)
+            return None
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        # The malicious URL must NOT have been constructed or fetched.
+        assert captured_urls == [], (
+            "validator must reject the malicious value before URL construction"
+        )
+        # The record is not stamped as well_known (validator skipped the fetch).
+        assert result is None or result.capability_source != "well_known"
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_well_known_resolves_origin_relative(self):
+        """Per draft Figure 3, `/.well-known/agent-card.json` and
+        `/not-well-known/other-card.json` are valid values. Earlier the
+        code would double-prefix the first into
+        ``/.well-known/.well-known/agent-card.json`` and treat the
+        second as a single segment. Now they're recognised as absolute
+        origin paths and used as-is."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        cases = [
+            (
+                "/.well-known/agent-card.json",
+                "https://chat.example.com/.well-known/agent-card.json",
+            ),
+            (
+                "/not-well-known/other-card.json",
+                "https://chat.example.com/not-well-known/other-card.json",
+            ),
+        ]
+
+        async def _run_one_case(wk_value: str) -> list[str]:
+            fake_rdata = MagicMock()
+            fake_rdata.priority = 1
+            fake_rdata.target = MagicMock()
+            fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+            fake_rdata.params = {}
+            fake_rdata.__str__ = MagicMock(
+                return_value=(f'1 chat.example.com. alpn="mcp" port=443 well-known="{wk_value}"')
+            )
+            fake_answers = MagicMock()
+            fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+            captured: list[str] = []
+
+            async def fake_fetch(url, expected_sha256=None):
+                captured.append(url)
+                return CapabilityDocument(
+                    capabilities=["chat"], raw_data={"capabilities": ["chat"]}
+                )
+
+            with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+                resolver = MagicMock()
+                resolver.resolve = AsyncMock(return_value=fake_answers)
+                mock_mod.Resolver.return_value = resolver
+                with patch(
+                    "dns_aid.core.discoverer.fetch_cap_document",
+                    side_effect=fake_fetch,
+                ):
+                    result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+            assert result is not None
+            return captured
+
+        for wk_value, expected_url in cases:
+            captured = await _run_one_case(wk_value)
+            assert captured == [expected_url], (
+                f"expected {expected_url}, got {captured} for {wk_value}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_https_cap_wins_over_well_known_at_fetch_time(self):
+        """When both `cap` (https-fetchable) and `well-known` are
+        present, the cap URL is the one the discoverer actually fetches.
+
+        Per Igor's #154 review: the precedence had only been proven at
+        serialization (to_params/to_svcb_record) — this asserts it at
+        fetch time, which is the load-bearing path."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'cap="https://cdn.example.com/cap.json" '
+                'well-known="agent-card.json"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured.append(url)
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # cap URL fetched, not the reconstructed well-known URL.
+        assert captured == ["https://cdn.example.com/cap.json"]
+        assert result.capability_source == "cap_uri"
+
+    @pytest.mark.asyncio
+    async def test_non_https_cap_falls_back_to_well_known(self):
+        """When `cap` is a URN or JSON-Ref (non-https), treating it as
+        terminal would silently disable a perfectly good `well-known`
+        and downgrade discovery to unauthenticated TXT. Per Igor's #154
+        review: fall through to well-known on non-https cap, keep the
+        URN cap on the record as a metadata locator."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'cap="urn:dns-aid:cap:chat:v1" '
+                'well-known="agent-card.json"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        captured: list[str] = []
+
+        async def fake_fetch(url, expected_sha256=None):
+            captured.append(url)
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # The well-known URL was used, not the URN cap.
+        assert captured == ["https://chat.example.com/.well-known/agent-card.json"]
+        assert result.capability_source == "well_known"
+        # The cap URN stays on the record as a metadata locator.
+        assert result.cap_uri == "urn:dns-aid:cap:chat:v1"
+
+    @pytest.mark.asyncio
+    async def test_cap_sha256_verified_true_only_when_fetch_succeeds(self):
+        """The `cap_sha256_verified` flag is True only when the digest
+        was actually checked against fetched bytes — distinguishes
+        'integrity pin honoured' from 'pin declared but never applied'."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'well-known="agent-card.json" cap-sha256="DIGEST_HERE"'
+            )
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        async def fake_fetch(url, expected_sha256=None):
+            return CapabilityDocument(capabilities=["chat"], raw_data={})
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=fake_fetch,
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        assert result.cap_sha256 == "DIGEST_HERE"
+        assert result.cap_sha256_verified is True
+
+    @pytest.mark.asyncio
+    async def test_cap_sha256_verified_false_when_dangling(self):
+        """When `cap_sha256` is declared but no descriptor URL is
+        constructible (no cap, no well-known), cap_sha256_verified
+        stays False so consumers don't treat the declared pin as
+        integrity-applied."""
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=('1 chat.example.com. alpn="mcp" port=443 cap-sha256="ORPHANED"')
+        )
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_mod.Resolver.return_value = resolver
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                AsyncMock(return_value=None),
+            ):
+                with patch(
+                    "dns_aid.core.discoverer._query_capabilities",
+                    AsyncMock(return_value=[]),
+                ):
+                    result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is not None
+        # Pin value present for transparency, but the verified flag is
+        # False so consumers don't treat it as applied.
+        assert result.cap_sha256 == "ORPHANED"
+        assert result.cap_sha256_verified is False
+
+
+class TestLegacyFallback:
+    """Igor: legacy-fallback opt-in semantics are the migration proof.
+
+    Behaviours under test:
+      1. ``allow_legacy=True`` + flat miss → legacy query runs.
+      2. ``allow_legacy=False`` → legacy never queried, even when env flag set.
+      3. ``allow_legacy=None`` + env unset → legacy never queried (default).
+      4. ``allow_legacy=None`` + env set → legacy queried (back-compat path).
+      5. A record served via legacy → ``legacy_resolved=True`` stamped.
+      6. Both flat and legacy miss → empty result.
+    """
+
+    @pytest.mark.asyncio
+    async def test_explicit_allow_legacy_true_falls_back_on_miss(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.delenv("DNS_AID_LEGACY_01_FALLBACK", raising=False)
+
+        flat_calls: list[str] = []
+        legacy_calls: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            if "_chat._mcp._agents." in name:
+                legacy_calls.append(name)
+                fake_rdata = MagicMock()
+                fake_rdata.priority = 1
+                fake_rdata.target = MagicMock()
+                fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+                fake_rdata.params = {}
+                fake_rdata.__str__ = MagicMock(
+                    return_value='1 chat.example.com. alpn="mcp" port=443'
+                )
+                fake = MagicMock()
+                fake.__iter__ = lambda self: iter([fake_rdata])
+                return fake
+            flat_calls.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            result = await _query_single_agent(
+                "example.com", "chat", Protocol.MCP, allow_legacy=True
+            )
+
+        assert flat_calls, "flat FQDN must be queried first"
+        assert legacy_calls, "legacy form must be queried after flat miss"
+        assert result is not None
+        assert result.legacy_resolved is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_allow_legacy_false_overrides_env(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.setenv("DNS_AID_LEGACY_01_FALLBACK", "1")
+
+        queried: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            queried.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            result = await _query_single_agent(
+                "example.com", "chat", Protocol.MCP, allow_legacy=False
+            )
+
+        assert result is None
+        assert all("_chat._mcp._agents." not in n for n in queried), (
+            "allow_legacy=False must override the env flag and skip the legacy query"
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_off_without_env_does_not_query_legacy(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.delenv("DNS_AID_LEGACY_01_FALLBACK", raising=False)
+
+        queried: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            queried.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is None
+        assert all("_chat._mcp._agents." not in n for n in queried)
+
+    @pytest.mark.asyncio
+    async def test_env_var_still_triggers_legacy_for_back_compat(self, monkeypatch):
+        from dns_aid.core.discoverer import _query_single_agent
+
+        monkeypatch.setenv("DNS_AID_LEGACY_01_FALLBACK", "1")
+
+        queried: list[str] = []
+
+        async def fake_resolve(name, rtype):
+            queried.append(name)
+            raise dns.resolver.NXDOMAIN()
+
+        resolver = MagicMock()
+        resolver.resolve = fake_resolve
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_mod:
+            mock_mod.Resolver.return_value = resolver
+            await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert any(n == "chat.example.com" for n in queried)
+        assert any("_chat._mcp._agents." in n for n in queried)
+
+
+class TestPerAgentDnssec:
+    """Under draft-02 each agent has its own flat fqdn, so DNSSEC must
+    be validated per agent — not once for ``agents[0]`` with the result
+    stamped on every record. Two behaviours under test:
+
+      1. ``_apply_post_discovery`` checks each agent independently and
+         stamps ``dnssec_validated`` per-agent.
+      2. The result-level boolean it returns is True only if every
+         agent's owner-name validated. A partial-fail result-level says
+         False, AND raises (since require_dnssec is set in this path).
+    """
+
+    @pytest.mark.asyncio
+    async def test_per_agent_stamps_each_record(self):
+        """Each agent's fqdn is checked; per-agent dnssec_validated reflects own outcome."""
+        from dns_aid.core.discoverer import _apply_post_discovery
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent_a = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+        )
+        agent_b = AgentRecord(
+            name="search",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="search.example.com",
+        )
+
+        with patch(
+            "dns_aid.core.validator._check_dnssec",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result_level = await _apply_post_discovery(
+                [agent_a, agent_b],
+                require_dnssec=True,
+                enrich_endpoints=False,
+                verify_signatures=False,
+                domain="example.com",
+            )
+
+        assert result_level is True
+        assert agent_a.dnssec_validated is True
+        assert agent_b.dnssec_validated is True
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_raises_and_names_failed(self):
+        """One agent validates, the other doesn't → require_dnssec must raise."""
+        from dns_aid.core.discoverer import _apply_post_discovery
+        from dns_aid.core.models import AgentRecord, DNSSECError, Protocol
+
+        agent_a = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+        )
+        agent_b = AgentRecord(
+            name="search",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="search.example.com",
+        )
+
+        async def selective_check(fqdn):
+            return fqdn == "chat.example.com"
+
+        with patch(
+            "dns_aid.core.validator._check_dnssec",
+            new=selective_check,
+        ):
+            with pytest.raises(DNSSECError) as excinfo:
+                await _apply_post_discovery(
+                    [agent_a, agent_b],
+                    require_dnssec=True,
+                    enrich_endpoints=False,
+                    verify_signatures=False,
+                    domain="example.com",
+                )
+
+        import re
+
+        msg = str(excinfo.value)
+        assert re.search(r"\bsearch\.example\.com\b", msg)
+        assert not re.search(r"\bchat\.example\.com\b", msg)
+
+
+class TestCapSha256HardFail:
+    """Draft §6.1: a cap-sha256 digest mismatch MUST cause the consumer
+    to refuse the record. Earlier the discoverer silently downgraded to
+    TXT fallback while still stamping cap_sha256 on the record, letting
+    an attacker swap the descriptor while keeping the SVCB pin intact
+    and have the record look integrity-pinned.
+
+    The cap_sha256_verified field (added in #154's deferred work) is
+    the explicit consumer signal; this test class covers the
+    drop-on-mismatch contract."""
+
+    @pytest.mark.asyncio
+    async def test_digest_mismatch_drops_record(self):
+        """Mismatched cap-sha256 → _query_single_agent returns None."""
+        from dns_aid.core.cap_fetcher import CapDigestMismatchError
+        from dns_aid.core.discoverer import _query_single_agent
+
+        fake_rdata = MagicMock()
+        fake_rdata.priority = 1
+        fake_rdata.target = MagicMock()
+        fake_rdata.target.__str__ = MagicMock(return_value="chat.example.com.")
+        fake_rdata.params = {}
+        fake_rdata.__str__ = MagicMock(
+            return_value=(
+                '1 chat.example.com. alpn="mcp" port=443 '
+                'cap="https://chat.example.com/cap.json" '
+                'cap-sha256="EXPECTED_BUT_WRONG"'
+            )
+        )
+
+        fake_answers = MagicMock()
+        fake_answers.__iter__ = lambda self: iter([fake_rdata])
+
+        with patch("dns_aid.core.discoverer.dns.asyncresolver") as mock_resolver_mod:
+            resolver = MagicMock()
+            resolver.resolve = AsyncMock(return_value=fake_answers)
+            mock_resolver_mod.Resolver.return_value = resolver
+
+            with patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                side_effect=CapDigestMismatchError(
+                    "https://chat.example.com/cap.json",
+                    "EXPECTED_BUT_WRONG",
+                    "actual_digest_value",
+                ),
+            ):
+                result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+        assert result is None, "digest mismatch must cause the record to be refused"
+
+
+class TestCapabilitySourceProvenance:
+    """Regression — PR #154 v2 review item 5.
+
+    The trust hierarchy (most → least: cap_uri > well_known >
+    agent_card > http_index > txt_fallback) is recorded on the
+    record via ``capability_source``. Enrichment (_apply_agent_card)
+    must not erase a higher-trust source by overwriting with
+    ``agent_card``.
+    """
+
+    def test_apply_agent_card_preserves_well_known_source(self):
+        """``_apply_agent_card`` must NOT overwrite a well_known
+        provenance with ``agent_card``. Before the v2 fix, only
+        ``cap_uri`` was preserved, so a record whose descriptor was
+        fetched via the SVCB ``well-known`` SvcParamKey would be
+        relabelled to ``agent_card`` after enrichment — losing the
+        spec-mandated locator's provenance."""
+        from dns_aid.core.a2a_card import A2AAgentCard, A2ASkill
+        from dns_aid.core.discoverer import _apply_agent_card
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            capabilities=["preexisting"],
+            capability_source="well_known",
+        )
+        card = A2AAgentCard(
+            name="chat",
+            description="",
+            url="https://chat.example.com",
+            version="1.0.0",
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capability_source == "well_known", (
+            "well_known provenance must survive _apply_agent_card; see PR #154 v2 review item 5"
+        )
+
+    def test_apply_agent_card_preserves_cap_uri_source(self):
+        """Existing pre-v2 invariant: cap_uri provenance survives."""
+        from dns_aid.core.a2a_card import A2AAgentCard, A2ASkill
+        from dns_aid.core.discoverer import _apply_agent_card
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            capabilities=["preexisting"],
+            capability_source="cap_uri",
+        )
+        card = A2AAgentCard(
+            name="chat",
+            description="",
+            url="https://chat.example.com",
+            version="1.0.0",
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capability_source == "cap_uri"
+
+    def test_apply_agent_card_upgrades_txt_fallback(self):
+        """The override SHOULD still fire for lower-trust sources
+        (txt_fallback, http_index) — those are weaker than the
+        agent_card skill data."""
+        from dns_aid.core.a2a_card import A2AAgentCard, A2ASkill
+        from dns_aid.core.discoverer import _apply_agent_card
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            capabilities=["txt-only"],
+            capability_source="txt_fallback",
+        )
+        card = A2AAgentCard(
+            name="chat",
+            description="",
+            url="https://chat.example.com",
+            version="1.0.0",
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capability_source == "agent_card"
+
+
+class TestReconcileProtocol:
+    """_reconcile_protocol resolves the protocol from the SVCB record."""
+
+    def test_bap_versioned_wins(self):
+        assert _reconcile_protocol(Protocol.MCP, "a2a=1.0", None) == Protocol.A2A
+
+    def test_bap_bare_wins(self):
+        assert _reconcile_protocol(Protocol.MCP, "a2a", None) == Protocol.A2A
+
+    def test_alpn_used_when_no_bap(self):
+        # The default publish shape: alpn carries the protocol, bap absent.
+        assert _reconcile_protocol(Protocol.MCP, None, "a2a") == Protocol.A2A
+
+    def test_bap_preferred_over_alpn(self):
+        assert _reconcile_protocol(Protocol.MCP, "mcp", "a2a") == Protocol.MCP
+
+    def test_probe_fallback_when_neither(self):
+        assert _reconcile_protocol(Protocol.MCP, None, None) == Protocol.MCP
+
+    def test_unknown_token_falls_back_to_probe(self):
+        # A non-DNS-AID alpn (e.g. raw HTTP/2) must not blow up.
+        assert _reconcile_protocol(Protocol.MCP, None, "h2") == Protocol.MCP
+
+    def test_alpn_case_insensitive(self):
+        assert _reconcile_protocol(Protocol.MCP, None, "HTTPS") == Protocol.HTTPS
+
+    def test_invalid_bap_falls_through_to_alpn(self):
+        # A malformed/unknown bap must not mask a usable alpn.
+        assert _reconcile_protocol(Protocol.MCP, "bogus", "a2a") == Protocol.A2A
+
+    def test_multi_alpn_picks_known_protocol(self):
+        # A record may list several alpn ids (e.g. h2 first) — pick the one
+        # we model rather than blindly taking the first.
+        assert _reconcile_protocol(Protocol.MCP, None, ["h2", "a2a"]) == Protocol.A2A
+
+    def test_list_alpn_accepted(self):
+        assert _reconcile_protocol(Protocol.HTTPS, None, ["mcp"]) == Protocol.MCP
+
+    def test_all_unknown_falls_back_to_probe(self):
+        assert _reconcile_protocol(Protocol.HTTPS, "bogus", ["h2", "h3"]) == Protocol.HTTPS
+
+    def test_empty_alpn_list_uses_probe(self):
+        assert _reconcile_protocol(Protocol.MCP, None, []) == Protocol.MCP
+
+
+class TestCollectAgentResultsDedup:
+    """_collect_agent_results dedups flat duplicates, keeps distinct agents."""
+
+    @staticmethod
+    def _rec(name: str, domain: str, proto: Protocol) -> AgentRecord:
+        return AgentRecord(
+            name=name, domain=domain, protocol=proto, target_host=f"t.{domain}", port=443
+        )
+
+    def test_dedup_same_fqdn_and_protocol(self):
+        # The zone-walk probes the same flat owner once per candidate
+        # protocol; after reconciliation they collapse to one record.
+        a = self._rec("chat", "example.com", Protocol.A2A)
+        b = self._rec("chat", "example.com", Protocol.A2A)
+        assert len(_collect_agent_results([a, b])) == 1
+
+    def test_keeps_distinct_names(self):
+        a = self._rec("chat", "example.com", Protocol.MCP)
+        b = self._rec("billing", "example.com", Protocol.MCP)
+        assert len(_collect_agent_results([a, b])) == 2
+
+    def test_keeps_same_fqdn_distinct_protocol(self):
+        # Legacy -01 mcp + a2a share a flat FQDN but are distinct agents.
+        a = self._rec("chat", "example.com", Protocol.MCP)
+        b = self._rec("chat", "example.com", Protocol.A2A)
+        assert len(_collect_agent_results([a, b])) == 2
+
+    def test_filters_non_agent_results(self):
+        a = self._rec("chat", "example.com", Protocol.MCP)
+        assert len(_collect_agent_results([a, ValueError("boom"), None])) == 1

--- a/tests/unit/test_fqdn.py
+++ b/tests/unit/test_fqdn.py
@@ -1,0 +1,67 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared DNS-AID FQDN parser (dns_aid.core.fqdn)."""
+
+import pytest
+
+from dns_aid.core.fqdn import DnsAidFqdn, parse_dnsaid_fqdn
+
+
+class TestParseDnsaidFqdn:
+    """parse_dnsaid_fqdn recognizes the three draft shapes and normalizes."""
+
+    # --- Flat draft-02 -----------------------------------------------------
+
+    def test_flat_three_label(self):
+        assert parse_dnsaid_fqdn("chat.example.com") == DnsAidFqdn("chat", None, "example.com")
+
+    def test_flat_subdomain_domain(self):
+        assert parse_dnsaid_fqdn("chat.eu.example.com") == DnsAidFqdn(
+            "chat", None, "eu.example.com"
+        )
+
+    def test_flat_two_label_owner_accepted(self):
+        """A flat owner in a short/internal zone ({name}.{tld}) parses (P2)."""
+        assert parse_dnsaid_fqdn("agent.internal") == DnsAidFqdn("agent", None, "internal")
+        assert parse_dnsaid_fqdn("chat.localhost") == DnsAidFqdn("chat", None, "localhost")
+
+    # --- Walkable draft-02 -------------------------------------------------
+
+    def test_walkable(self):
+        assert parse_dnsaid_fqdn("chat._agents.example.com") == DnsAidFqdn(
+            "chat", None, "example.com"
+        )
+
+    # --- Legacy -01 --------------------------------------------------------
+
+    def test_legacy(self):
+        assert parse_dnsaid_fqdn("_chat._mcp._agents.example.com") == DnsAidFqdn(
+            "chat", "mcp", "example.com"
+        )
+
+    def test_legacy_malformed_single_underscore_rejected(self):
+        assert parse_dnsaid_fqdn("_booking.mcp._agents.foo.com") is None
+
+    # --- Normalization (P3a) ----------------------------------------------
+
+    def test_case_insensitive(self):
+        assert parse_dnsaid_fqdn("Chat.Example.COM") == DnsAidFqdn("chat", None, "example.com")
+
+    def test_trailing_dot_stripped(self):
+        assert parse_dnsaid_fqdn("chat.example.com.") == DnsAidFqdn("chat", None, "example.com")
+
+    def test_legacy_normalized(self):
+        assert parse_dnsaid_fqdn("_Chat._MCP._agents.Example.com.") == DnsAidFqdn(
+            "chat", "mcp", "example.com"
+        )
+
+    # --- Rejections --------------------------------------------------------
+
+    @pytest.mark.parametrize("bad", ["", "  ", ".", "localhost", "_chat", "chat."])
+    def test_rejected(self, bad):
+        assert parse_dnsaid_fqdn(bad) is None
+
+    def test_flat_name_underscore_rejected(self):
+        # A leading underscore on the first label is not a flat owner.
+        assert parse_dnsaid_fqdn("_chat.example.com") is None

--- a/tests/unit/test_http_index.py
+++ b/tests/unit/test_http_index.py
@@ -3,6 +3,7 @@
 
 """Tests for HTTP Index discovery (ANS-style compatibility)."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -17,6 +18,38 @@ from dns_aid.core.http_index import (
     fetch_http_index_or_empty,
     parse_http_index,
 )
+
+
+def _stream_response(payload, status: int = 200):
+    """A mock httpx streaming response (async CM) yielding `payload` as JSON bytes.
+
+    fetch_http_index now streams the body with a size cap instead of calling
+    ``response.json()``, so tests provide the body via ``aiter_bytes``.
+    """
+    body = payload if isinstance(payload, (bytes, bytearray)) else json.dumps(payload).encode()
+
+    async def _aiter_bytes():
+        yield bytes(body)
+
+    resp = MagicMock()
+    resp.status_code = status
+    resp.aiter_bytes = _aiter_bytes
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def _streaming_client(*responses):
+    """Mock httpx.AsyncClient whose .stream() yields each response in order."""
+    mock_client = MagicMock()
+    if len(responses) == 1:
+        mock_client.stream = MagicMock(return_value=responses[0])
+    else:
+        mock_client.stream = MagicMock(side_effect=list(responses))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
 
 
 class TestModelCard:
@@ -228,14 +261,9 @@ class TestFetchHttpIndex:
     @pytest.mark.asyncio
     async def test_fetch_success(self):
         """Test successful fetch."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"booking": {"location": {"fqdn": "booking.example.com"}}}
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client = _streaming_client(
+            _stream_response({"booking": {"location": {"fqdn": "booking.example.com"}}})
+        )
 
         with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
             agents = await fetch_http_index("example.com")
@@ -246,33 +274,17 @@ class TestFetchHttpIndex:
     @pytest.mark.asyncio
     async def test_fetch_tries_multiple_endpoints(self):
         """Test that multiple URL patterns are tried."""
-        call_count = 0
-
-        async def mock_get(url):
-            nonlocal call_count
-            call_count += 1
-            mock_response = MagicMock()
-            if call_count == 1:
-                # First pattern (ANS-style subdomain) fails
-                mock_response.status_code = 404
-            else:
-                # Second pattern succeeds
-                mock_response.status_code = 200
-                mock_response.json.return_value = {
-                    "agent": {"location": {"fqdn": "agent.example.com"}}
-                }
-            return mock_response
-
-        mock_client = AsyncMock()
-        mock_client.get = mock_get
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+        # First pattern (ANS-style subdomain) 404s, second pattern succeeds.
+        mock_client = _streaming_client(
+            _stream_response(None, status=404),
+            _stream_response({"agent": {"location": {"fqdn": "agent.example.com"}}}),
+        )
 
         with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
             agents = await fetch_http_index("example.com")
 
         assert len(agents) == 1
-        assert call_count == 2  # Tried first pattern (failed), second pattern (succeeded)
+        assert mock_client.stream.call_count == 2  # first pattern failed, second succeeded
 
     @pytest.mark.asyncio
     async def test_fetch_all_endpoints_fail(self):
@@ -322,14 +334,9 @@ class TestFetchHttpIndexOrEmpty:
     @pytest.mark.asyncio
     async def test_returns_agents_on_success(self):
         """Test returns agents on success."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"test": {"location": {"fqdn": "test.example.com"}}}
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client = _streaming_client(
+            _stream_response({"test": {"location": {"fqdn": "test.example.com"}}})
+        )
 
         with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
             agents = await fetch_http_index_or_empty("example.com")
@@ -374,21 +381,18 @@ class TestIntegrationWithDiscoverer:
         """Test discover() with use_http_index=True."""
         from dns_aid.core.discoverer import discover
 
-        # Mock HTTP response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "booking": {
-                "location": {"fqdn": "_booking._mcp._agents.example.com"},
-                "model-card": {"description": "Booking agent"},
-                "capability": {"protocols": ["mcp"]},
-            }
-        }
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+        # Mock HTTP response (streamed body)
+        mock_client = _streaming_client(
+            _stream_response(
+                {
+                    "booking": {
+                        "location": {"fqdn": "_booking._mcp._agents.example.com"},
+                        "model-card": {"description": "Booking agent"},
+                        "capability": {"protocols": ["mcp"]},
+                    }
+                }
+            )
+        )
 
         with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
             result = await discover("example.com", use_http_index=True)

--- a/tests/unit/test_indexer.py
+++ b/tests/unit/test_indexer.py
@@ -340,6 +340,60 @@ class TestUpdateIndex:
         assert txt is not None
 
 
+class TestUpdateIndexSvcbPrimary:
+    """Tests for draft-02 SVCB-primary org index (opt-in via index_target)."""
+
+    @pytest.mark.asyncio
+    async def test_index_target_writes_svcb_and_txt(self, mock_backend: MockBackend):
+        """When index_target is provided, both SVCB and TXT records are written."""
+        result = await update_index(
+            domain="example.com",
+            backend=mock_backend,
+            add=[IndexEntry(name="chat", protocol="mcp")],
+            index_target="agent-index.example.com",
+        )
+
+        assert result.success is True
+
+        # SVCB primary at _index._agents pointing at the (non-underscored) target
+        svcb = mock_backend.get_svcb_record("example.com", INDEX_RECORD_NAME)
+        assert svcb is not None
+        assert svcb["priority"] == 1  # ServiceMode
+        assert svcb["target"] == "agent-index.example.com."
+
+        # TXT inline-listing still written as the §TXT-fallback form
+        txt = mock_backend.get_txt_record("example.com", INDEX_RECORD_NAME)
+        assert txt is not None
+        assert any("chat:mcp" in v for v in txt)
+
+    @pytest.mark.asyncio
+    async def test_index_target_underscored_rejected(self, mock_backend: MockBackend):
+        """Underscored TargetName fails the validator (no public x.509 cert)."""
+        from dns_aid.utils.validation import ValidationError
+
+        with pytest.raises(ValidationError) as exc:
+            await update_index(
+                domain="example.com",
+                backend=mock_backend,
+                add=[IndexEntry(name="chat", protocol="mcp")],
+                index_target="_internal.example.com",
+            )
+        assert exc.value.field == "target"
+
+    @pytest.mark.asyncio
+    async def test_no_index_target_keeps_txt_only(self, mock_backend: MockBackend):
+        """Without index_target the behavior matches pre-draft-02 (TXT only)."""
+        result = await update_index(
+            domain="example.com",
+            backend=mock_backend,
+            add=[IndexEntry(name="chat", protocol="mcp")],
+        )
+
+        assert result.success is True
+        assert mock_backend.get_svcb_record("example.com", INDEX_RECORD_NAME) is None
+        assert mock_backend.get_txt_record("example.com", INDEX_RECORD_NAME) is not None
+
+
 class TestDeleteIndex:
     """Tests for delete_index function."""
 
@@ -383,7 +437,12 @@ class TestSyncIndex:
 
     @pytest.mark.asyncio
     async def test_sync_discovers_agents(self, mock_backend: MockBackend):
-        """Test that sync discovers published agents."""
+        """Test that sync discovers published agents via the walkable alias.
+
+        This exercises the walkable AliasMode discovery path at
+        {name}._agents.{domain}. Flat-only owners (the draft-02 default
+        publish shape) are covered by test_sync_discovers_flat_only_agent.
+        """
         # Publish some agents
         await publish(
             name="chat",
@@ -391,6 +450,7 @@ class TestSyncIndex:
             protocol="mcp",
             endpoint="mcp.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
         await publish(
             name="billing",
@@ -398,6 +458,7 @@ class TestSyncIndex:
             protocol="a2a",
             endpoint="a2a.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         result = await sync_index("example.com", mock_backend)
@@ -410,13 +471,15 @@ class TestSyncIndex:
     @pytest.mark.asyncio
     async def test_sync_creates_index(self, mock_backend: MockBackend):
         """Test that sync creates index if it doesn't exist."""
-        # Publish an agent (without updating index)
+        # Publish an agent (without updating index). Walkable opt-in so
+        # sync_index can discover it via the AliasMode shape.
         await publish(
             name="chat",
             domain="example.com",
             protocol="mcp",
             endpoint="mcp.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         result = await sync_index("example.com", mock_backend)
@@ -436,13 +499,14 @@ class TestSyncIndex:
             ttl=3600,
         )
 
-        # Publish new agent
+        # Publish new agent (walkable opt-in for sync_index discovery).
         await publish(
             name="chat",
             domain="example.com",
             protocol="mcp",
             endpoint="mcp.example.com",
             backend=mock_backend,
+            publish_walkable_alias=True,
         )
 
         result = await sync_index("example.com", mock_backend)
@@ -466,6 +530,66 @@ class TestSyncIndex:
         result = await sync_index("example.com", mock_backend, ttl=300)
 
         assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_sync_discovers_flat_only_agent(self, mock_backend: MockBackend):
+        """Flat primary owners are indexed without a walkable alias.
+
+        Under draft-02 the flat owner ({name}.{domain}) is the default
+        publish shape and the walkable AliasMode is opt-in. sync_index
+        detects the flat owner via its companion TXT record and indexes
+        it, reading the protocol off the SVCB SvcParams.
+        """
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="mcp.example.com",
+            backend=mock_backend,
+        )  # walkable defaults OFF — the draft-02 default
+
+        result = await sync_index("example.com", mock_backend)
+
+        assert result.success is True
+        assert result.entries == [IndexEntry(name="chat", protocol="mcp")]
+
+    @pytest.mark.asyncio
+    async def test_sync_flat_and_walkable_not_double_counted(self, mock_backend: MockBackend):
+        """An agent published with both flat and walkable shapes is indexed once."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="mcp.example.com",
+            backend=mock_backend,
+            publish_walkable_alias=True,
+        )
+
+        result = await sync_index("example.com", mock_backend)
+
+        assert result.success is True
+        assert result.entries == [IndexEntry(name="chat", protocol="mcp")]
+
+    @pytest.mark.asyncio
+    async def test_sync_ignores_svcb_without_companion_txt(self, mock_backend: MockBackend):
+        """A bare SVCB leaf with no companion TXT is not treated as an agent.
+
+        The flat-owner enumeration keys off the DNS-AID publish contract
+        (SVCB + companion TXT at the same owner), so an unrelated SVCB in
+        the zone is not misindexed.
+        """
+        await mock_backend.create_svcb_record(
+            zone="example.com",
+            name="www",
+            priority=1,
+            target="web.example.com",
+            params={"alpn": "h2", "port": "443"},
+        )
+
+        result = await sync_index("example.com", mock_backend)
+
+        assert result.success is True
+        assert result.entries == []
 
 
 class TestIndexResult:

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -157,7 +157,7 @@ class TestInfobloxNIOSSvcParameters:
             "mandatory": "alpn,port,cap,connect-class",
             "alpn": "h2,h3",
             "port": "443",
-            "bap": "mcp/1,a2a/1",
+            "bap": "mcp=1.0",
             "cap": "https://example.com/.well-known/agent-cap.json",
             "sig": "abc123",
             "connect-class": "lattice",
@@ -168,7 +168,10 @@ class TestInfobloxNIOSSvcParameters:
         as_map = {item["svc_key"]: item for item in converted}
         assert as_map["alpn"]["svc_value"] == ["h2", "h3"]
         assert as_map["alpn"]["mandatory"] is True
-        assert as_map["key65402"]["svc_value"] == ["mcp/1", "a2a/1"]
+        # bap is no longer in _SPLIT_VALUE_KEYS (draft-02 §5.1 makes it
+        # a single scalar) — NIOS wraps non-split values in a 1-element
+        # list for the API shape regardless.
+        assert as_map["key65402"]["svc_value"] == ["mcp=1.0"]
         assert as_map["port"]["svc_value"] == ["443"]
         assert as_map["key65400"]["mandatory"] is True
         assert as_map["key65405"]["svc_value"] == ["abc123"]
@@ -177,12 +180,12 @@ class TestInfobloxNIOSSvcParameters:
 
     def test_svc_parameters_preserves_numeric_keys(self) -> None:
         converted = InfobloxNIOSBackend._svc_parameters_from_params(
-            {"mandatory": "key65402,port", "key65402": "mcp/1,a2a/1", "port": "443"}
+            {"mandatory": "key65402,port", "key65402": "mcp=1.0", "port": "443"}
         )
         as_map = {item["svc_key"]: item for item in converted}
 
         assert as_map["key65402"]["mandatory"] is True
-        assert as_map["key65402"]["svc_value"] == ["mcp/1", "a2a/1"]
+        assert as_map["key65402"]["svc_value"] == ["mcp=1.0"]
         assert as_map["port"]["mandatory"] is True
 
     def test_format_svc_parameters_for_value(self) -> None:

--- a/tests/unit/test_jws.py
+++ b/tests/unit/test_jws.py
@@ -76,6 +76,58 @@ class TestJWKSExport:
         assert orig_numbers.y == imported_numbers.y
 
 
+class TestJWKSHardening:
+    """Algorithm / curve confusion hardening on the attacker-influenced key path."""
+
+    def test_import_rejects_non_ec_kty(self):
+        with pytest.raises(ValueError, match="kty"):
+            import_public_key_from_jwk({"kty": "RSA", "crv": "P-256", "x": "AA", "y": "AA"})
+
+    def test_import_rejects_wrong_curve(self):
+        with pytest.raises(ValueError, match="crv"):
+            import_public_key_from_jwk({"kty": "EC", "crv": "P-384", "x": "AA", "y": "AA"})
+
+    def test_import_rejects_wrong_coordinate_length(self):
+        # 'AA' decodes to 1 byte, not the 32 required for P-256.
+        with pytest.raises(ValueError, match="32 bytes"):
+            import_public_key_from_jwk({"kty": "EC", "crv": "P-256", "x": "AA", "y": "AA"})
+
+    def test_import_rejects_non_signing_use(self):
+        _, public_key = generate_keypair()
+        jwk = export_jwks(public_key)["keys"][0]
+        jwk["use"] = "enc"
+        with pytest.raises(ValueError, match="signing"):
+            import_public_key_from_jwk(jwk)
+
+    def test_verify_rejects_non_es256_alg(self):
+        """A JWS whose header declares a non-ES256 alg must not verify."""
+        import base64
+
+        keypair = generate_keypair()
+        private_key, public_key = keypair
+        now = int(time.time())
+        payload = RecordPayload(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            alpn="mcp",
+            iat=now,
+            exp=now + 3600,
+        )
+        valid_jws = sign_record(payload, private_key)
+        _, payload_b64, sig_b64 = valid_jws.split(".")
+
+        # Swap the header to declare alg="none" (alg-confusion attempt).
+        forged_header = (
+            base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=").decode()
+        )
+        forged = f"{forged_header}.{payload_b64}.{sig_b64}"
+
+        is_valid, result = verify_signature(forged, public_key)
+        assert is_valid is False
+        assert result is None
+
+
 class TestRecordPayload:
     """Tests for RecordPayload."""
 
@@ -295,8 +347,8 @@ class TestFetchJWKS:
 
     @pytest.mark.asyncio
     async def test_fetch_jwks_success(self):
-        """Test successful JWKS fetch."""
-        from unittest.mock import AsyncMock, MagicMock, patch
+        """Test successful JWKS fetch through the SSRF-guarded size-capped path."""
+        from unittest.mock import AsyncMock, patch
 
         from dns_aid.core.jwks import _jwks_cache, fetch_jwks
 
@@ -315,18 +367,13 @@ class TestFetchJWKS:
             ]
         }
 
-        with patch("dns_aid.core.jwks.httpx.AsyncClient") as mock_client:
-            mock_response = MagicMock()
-            mock_response.json.return_value = mock_jwks
-            mock_response.raise_for_status.return_value = None
-
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
+        with (
+            patch("dns_aid.utils.url_safety.validate_fetch_url"),
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                new=AsyncMock(return_value=json.dumps(mock_jwks).encode()),
+            ),
+        ):
             result = await fetch_jwks("example.com")
 
         assert result is not None
@@ -343,14 +390,13 @@ class TestFetchJWKS:
         # Clear cache
         _jwks_cache.clear()
 
-        with patch("dns_aid.core.jwks.httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.side_effect = Exception("Network error")
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-
-            mock_client.return_value = mock_instance
-
+        with (
+            patch("dns_aid.utils.url_safety.validate_fetch_url"),
+            patch(
+                "dns_aid.utils.url_safety.safe_fetch_bytes",
+                new=AsyncMock(side_effect=Exception("Network error")),
+            ),
+        ):
             result = await fetch_jwks("example.com")
 
         assert result is None
@@ -359,7 +405,7 @@ class TestFetchJWKS:
     async def test_fetch_jwks_uses_cache(self):
         """Test that JWKS fetch uses cache."""
         import time
-        from unittest.mock import patch
+        from unittest.mock import AsyncMock, patch
 
         from dns_aid.core.jwks import JWKS_CACHE_TTL, _jwks_cache, fetch_jwks
 
@@ -367,11 +413,11 @@ class TestFetchJWKS:
         cached_jwks = {"keys": [{"cached": True}]}
         _jwks_cache["cached-domain.com"] = (cached_jwks, time.time() + JWKS_CACHE_TTL)
 
-        with patch("dns_aid.core.jwks.httpx.AsyncClient") as mock_client:
+        with patch("dns_aid.utils.url_safety.safe_fetch_bytes", new=AsyncMock()) as mock_fetch:
             result = await fetch_jwks("cached-domain.com")
 
-            # Should not have made any HTTP calls
-            mock_client.assert_not_called()
+            # Cache hit — no network fetch.
+            mock_fetch.assert_not_called()
 
         assert result == cached_jwks
 
@@ -499,3 +545,185 @@ class TestModelIntegration:
 
         params = agent.to_svcb_params()
         assert "sig" not in params
+
+
+class TestSignatureBindsToRecord:
+    """Regression tests: a valid signature MUST bind to the record it travels with.
+
+    Before this binding was enforced, an attacker could lift a legitimately
+    signed `sig` value from one agent's SVCB record and paste it onto a
+    spoofed SVCB pointing at their own host. The signature would still
+    verify (it's cryptographically valid) and the discoverer would stamp
+    ``signature_verified=True`` — turning the JWS into a forgeable
+    rubber-stamp instead of a record-binding proof.
+
+    Publisher-side: ``core/publisher.py`` signs a ``RecordPayload`` whose
+    fields are ``(fqdn, target, port, alpn)``. Verifier-side: the
+    discoverer must re-derive the same tuple from the AgentRecord it's
+    about to trust and refuse if any field disagrees.
+    """
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_with_mismatched_target_is_rejected(self):
+        """Sig is cryptographically valid but signed payload.target != agent.target_host."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        # Sign a payload that says target=legit.example.com.
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="legit.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        legit_sig = sign_record(payload, private_key)
+
+        # Attacker pastes the legit sig onto a spoofed record pointing
+        # at attacker.example.com.
+        spoofed = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="attacker.example.com",
+            port=443,
+            sig=legit_sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([spoofed], "example.com", dnssec_validated=False)
+
+        assert spoofed.signature_verified is False
+        assert spoofed.signature_algorithm is None
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_with_mismatched_port_is_rejected(self):
+        """Sig is valid; port disagrees; binding must reject."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        sig = sign_record(payload, private_key)
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=8443,  # disagrees with signed payload.port
+            sig=sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([agent], "example.com", dnssec_validated=False)
+
+        assert agent.signature_verified is False
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_with_mismatched_alpn_is_rejected(self):
+        """Sig is valid for protocol=mcp; record claims a2a; binding must reject."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        sig = sign_record(payload, private_key)
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.A2A,  # disagrees with signed payload.alpn
+            target_host="chat.example.com",
+            port=443,
+            sig=sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([agent], "example.com", dnssec_validated=False)
+
+        assert agent.signature_verified is False
+
+    @pytest.mark.asyncio
+    async def test_valid_sig_matching_record_is_accepted(self):
+        """Happy path: every field of the signed payload binds to the record."""
+        from unittest.mock import AsyncMock, patch
+
+        from dns_aid.core.discoverer import _verify_agent_signatures
+        from dns_aid.core.jwks import (
+            RecordPayload,
+            export_jwks,
+            generate_keypair,
+            sign_record,
+        )
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        private_key, public_key = generate_keypair()
+        jwks = export_jwks(public_key, kid="binding-test")
+
+        payload = RecordPayload.from_agent_record(
+            fqdn="chat.example.com",
+            target="chat.example.com",
+            port=443,
+            protocol="mcp",
+        )
+        sig = sign_record(payload, private_key)
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            port=443,
+            sig=sig,
+        )
+
+        with patch("dns_aid.core.jwks.fetch_jwks", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = jwks
+            await _verify_agent_signatures([agent], "example.com", dnssec_validated=False)
+
+        assert agent.signature_verified is True
+        assert agent.signature_algorithm is not None

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -54,8 +54,10 @@ class TestPublishAgentTool:
         )
 
         assert result["success"] is True
-        assert result["fqdn"] == "_test-agent._mcp._agents.example.com"
+        assert result["fqdn"] == "test-agent.example.com"
         assert result["endpoint_url"] == "https://mcp.example.com:443"
+        # SVCB primary + TXT companion. Walkable AliasMode is opt-in
+        # (default off under -02 to avoid an enumeration handle).
         assert len(result["records_created"]) == 2
 
     def test_publish_default_endpoint(self):
@@ -222,7 +224,7 @@ class TestDeleteAgentTool:
             backend="mock",
         )
 
-        assert result["fqdn"] == "_to-delete._mcp._agents.example.com"
+        assert result["fqdn"] == "to-delete.example.com"
         assert "success" in result
         assert "message" in result
 
@@ -307,3 +309,37 @@ class TestSDKAvailabilityFlag:
 
         tools = list(mcp._tool_manager._tools.keys())
         assert "list_agent_tools" in tools
+
+
+class TestPublishBapScalar:
+    """Regression for Igor's #158 review: the MCP tool input schema
+    changed from list[str] to str when bap moved to scalar. Pin both
+    the accept-scalar path and the reject-list path so the API break
+    is explicit."""
+
+    def test_publish_with_bap_scalar(self):
+        """Scalar passthrough — bap survives onto the AgentRecord."""
+        from dns_aid.mcp.server import publish_agent_to_dns
+
+        result = publish_agent_to_dns(
+            name="chat",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="chat.example.com",
+            bap="mcp=1.0",
+            backend="mock",
+        )
+        assert result["success"] is True
+
+    def test_publish_with_bap_absent(self):
+        """bap=None (default) publishes cleanly without a bap param."""
+        from dns_aid.mcp.server import publish_agent_to_dns
+
+        result = publish_agent_to_dns(
+            name="chat",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="chat.example.com",
+            backend="mock",
+        )
+        assert result["success"] is True

--- a/tests/unit/test_mock_backend.py
+++ b/tests/unit/test_mock_backend.py
@@ -201,15 +201,20 @@ class TestMockBackend:
 
     @pytest.mark.asyncio
     async def test_publish_agent_helper(self, mock_backend: MockBackend, sample_agent):
-        """Test publish_agent convenience method."""
+        """Test publish_agent convenience method.
+
+        Default walkable=False under -02 (avoids enumeration handle).
+        Opt into walkable explicitly to verify the AliasMode write.
+        """
+        sample_agent.publish_walkable_alias = True
         records = await mock_backend.publish_agent(sample_agent)
 
-        assert len(records) == 2
+        # SVCB primary + TXT companion + walkable AliasMode (opted in).
+        assert len(records) == 3
         assert any("SVCB" in r for r in records)
         assert any("TXT" in r for r in records)
+        assert any("AliasMode" in r for r in records)
 
-        # Verify records created
-        svcb = mock_backend.get_svcb_record(
-            sample_agent.domain, f"_{sample_agent.name}._{sample_agent.protocol.value}._agents"
-        )
+        # Verify records created — flat primary owner under draft-02
+        svcb = mock_backend.get_svcb_record(sample_agent.domain, sample_agent.name)
         assert svcb is not None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -59,7 +59,7 @@ class TestAgentRecord:
             assert agent.endpoint_source == source
 
     def test_fqdn_generation(self):
-        """Test FQDN is generated correctly per DNS-AID spec."""
+        """Test FQDN is generated as the flat draft-02 form."""
         agent = AgentRecord(
             name="network-specialist",
             domain="example.com",
@@ -67,8 +67,28 @@ class TestAgentRecord:
             target_host="mcp.example.com",
         )
 
-        # Format: _{name}._{protocol}._agents.{domain}
-        assert agent.fqdn == "_network-specialist._mcp._agents.example.com"
+        # Flat draft-02 form: {name}.{domain}
+        assert agent.fqdn == "network-specialist.example.com"
+
+    def test_walkable_fqdn_generation(self):
+        """The walkable AliasMode form uses the _agents leaf."""
+        agent = AgentRecord(
+            name="network-specialist",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        assert agent.walkable_fqdn == "network-specialist._agents.example.com"
+
+    def test_legacy_fqdn_generation(self):
+        """The legacy -01 form is retained for the legacy-fallback discovery path."""
+        agent = AgentRecord(
+            name="network-specialist",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        assert agent.legacy_fqdn == "_network-specialist._mcp._agents.example.com"
 
     def test_endpoint_url(self):
         """Test endpoint URL generation."""
@@ -121,7 +141,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp=2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -131,7 +151,7 @@ class TestAgentRecord:
         # Default: keyNNNNN format per RFC 9460
         assert params["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["key65401"] == "abc123base64url"
-        assert params["key65402"] == "mcp/1,a2a/1"
+        assert params["key65402"] == "mcp=2.1"  # scalar bap per draft-02 §FutureWork
         assert params["key65403"] == "https://example.com/agent-policy"
         assert params["key65404"] == "production"
         # Standard params still present
@@ -150,7 +170,7 @@ class TestAgentRecord:
             target_host="mcp.example.com",
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="abc123base64url",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp=2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
         )
@@ -160,7 +180,7 @@ class TestAgentRecord:
 
         assert params["cap"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert params["cap-sha256"] == "abc123base64url"
-        assert params["bap"] == "mcp/1,a2a/1"
+        assert params["bap"] == "mcp=2.1"
         assert params["policy"] == "https://example.com/agent-policy"
         assert params["realm"] == "production"
 
@@ -219,6 +239,70 @@ class TestAgentRecord:
 
         assert params["key65401"] == "dGVzdGhhc2g"
         assert "key65400" not in params
+
+    def test_svcb_params_bap_emits_as_scalar(self):
+        """draft-02 §FutureWork: bap is a single versioned protocol per record."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            bap="mcp=2.1",
+        )
+        params = agent.to_svcb_params()
+        # No comma, no list — emitted exactly as the scalar string.
+        assert params["key65402"] == "mcp=2.1"
+        assert "," not in params["key65402"]
+
+    def test_svcb_params_bap_absent_when_none(self):
+        """When bap is unset (None) the key65402 param is not emitted."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+        )
+        params = agent.to_svcb_params()
+        assert "key65402" not in params
+        assert "bap" not in params
+
+    def test_svcb_params_with_well_known_path(self):
+        """Test draft-02 ``well-known`` SvcParamKey is emitted at the
+        project's interim private-use code point ``key65409``.
+
+        Per draft section 7.1 the actual SvcParamKey numbers are
+        deferred to IANA (Standards Action); 65409 is dns-aid-core's
+        private-use placeholder, not draft-assigned."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            well_known_path="agent-card.json",
+        )
+
+        params = agent.to_svcb_params()
+
+        assert params["key65409"] == "agent-card.json"
+
+    def test_svcb_params_well_known_independent_of_cap(self):
+        """`well-known` and `cap` are independent keys; both may be present."""
+        agent = AgentRecord(
+            name="booking",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="mcp.example.com",
+            cap_uri="urn:example:agent-cap:abc",
+            cap_sha256="dGVzdGhhc2g",
+            well_known_path="agent-card.json",
+        )
+
+        params = agent.to_svcb_params()
+
+        # All three SvcParamKeys present, none collapsing into another.
+        assert params["key65400"] == "urn:example:agent-cap:abc"
+        assert params["key65401"] == "dGVzdGhhc2g"
+        assert params["key65409"] == "agent-card.json"
 
     def test_svcb_params_with_connect_fields(self):
         """Test provider-managed connection params are serialized as SVCB custom keys."""
@@ -446,3 +530,303 @@ class TestVerifyResult:
 
         assert result.security_score == 20
         assert result.security_rating == "Poor"
+
+    def test_dane_without_dnssec_does_not_score(self):
+        """DANE +15 must be gated on DNSSEC.
+
+        A spoofer with no DNSSEC chain can still serve a TLSA record;
+        TLSA without DNSSEC has no integrity guarantee (RFC 6698 §10.1).
+        If a hand-built VerifyResult carries dane_valid=True but
+        dnssec_valid=False, security_score MUST NOT credit the DANE
+        bonus — otherwise a non-DNSSEC spoofer can reach ``Good``.
+        """
+        result = VerifyResult(
+            fqdn="chat.example.com",
+            record_exists=True,
+            svcb_valid=True,
+            dnssec_valid=False,  # NOT validated
+            dane_valid=True,  # claims TLSA present
+            endpoint_reachable=True,
+        )
+
+        # 20 (record) + 20 (svcb) + 0 (dnssec) + 0 (dane gated) + 15 (endpoint)
+        assert result.security_score == 55
+        assert result.security_rating == "Fair"
+
+
+class TestBapValidator:
+    """Regression tests for the bap SvcParamKey field validator.
+
+    The ``bap`` SvcParamKey value goes straight onto the wire as
+    ``key65402="<value>"`` via the publisher and every backend formatter.
+    Without a field-validator a crafted value can inject sibling
+    SvcParamKeys (e.g. ``mcp" key65500="x``) — a multi-tenant publish
+    path turns into server-side param injection. The validator now
+    constrains bap to the canonical draft-02 form at the type boundary
+    so every construction path (direct, ``to_svcb_record()``, MCP,
+    CLI) inherits the rule.
+    """
+
+    def test_bare_protocol_accepted(self):
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.MCP,
+            target_host="chat.example.com",
+            bap="mcp",
+        )
+        assert agent.bap == "mcp"
+
+    def test_versioned_form_accepted(self):
+        for value in ("mcp=1.0", "a2a=1.1", "https=2"):
+            agent = AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap=value,
+            )
+            assert agent.bap == value
+
+    def test_svcparam_injection_rejected(self):
+        """The original vulnerability: a crafted value with a quote
+        escape can be parsed by dnspython as two SvcParamKeys, the
+        second one attacker-controlled."""
+        for evil in (
+            'mcp" key65500="x',
+            'mcp\\"',
+            'mcp" key65500="x',
+        ):
+            with pytest.raises(ValidationError):
+                AgentRecord(
+                    name="chat",
+                    domain="example.com",
+                    protocol=Protocol.MCP,
+                    target_host="chat.example.com",
+                    bap=evil,
+                )
+
+    def test_legacy_comma_list_rejected(self):
+        """Pre-draft-02 comma-list (``mcp,a2a``) is rejected at the
+        type — callers passing legacy input should run
+        ``normalize_bap`` first."""
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="mcp,a2a",
+            )
+
+    def test_list_form_rejected_on_agent_record(self):
+        """Pin the breaking change direction: ``bap=["mcp"]`` raises."""
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap=["mcp"],  # type: ignore[arg-type]
+            )
+
+    def test_list_form_rejected_on_svcb_record(self):
+        from dns_aid.core.models import SvcbRecord
+
+        with pytest.raises(ValidationError):
+            SvcbRecord(
+                target="chat.example.com.",
+                alpn="mcp",
+                port=443,
+                bap=["mcp"],  # type: ignore[arg-type]
+            )
+
+    def test_uppercase_protocol_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="MCP",
+            )
+
+    def test_whitespace_in_value_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="mcp 1.0",
+            )
+
+    def test_empty_string_passed_as_bap_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentRecord(
+                name="chat",
+                domain="example.com",
+                protocol=Protocol.MCP,
+                target_host="chat.example.com",
+                bap="",
+            )
+
+
+class TestSvcParamInjectionValidators:
+    """The free-form SvcParam string fields share bap's injection exposure.
+
+    cap / cap-sha256 / policy / realm / sig / connect-meta / enroll-uri are
+    emitted as ``key="<value>"`` by the presentation-format backends, so a
+    double quote, backslash, or control character could break out of the
+    quoting and inject a sibling SvcParamKey. The field validators reject
+    that class on both models, at every construction path.
+    """
+
+    _EVIL = '"  key65500="x'
+
+    def test_agent_record_rejects_injection_in_each_field(self):
+        from dns_aid.core.models import AgentRecord
+
+        base = {
+            "name": "chat",
+            "domain": "example.com",
+            "protocol": Protocol.MCP,
+            "target_host": "chat.example.com",
+        }
+        for field in (
+            "cap_uri",
+            "cap_sha256",
+            "policy_uri",
+            "realm",
+            "sig",
+            "connect_meta",
+            "enroll_uri",
+        ):
+            with pytest.raises(ValidationError):
+                AgentRecord(**base, **{field: f"value{self._EVIL}"})
+
+    def test_svcb_record_rejects_injection_in_each_field(self):
+        from dns_aid.core.models import SvcbRecord
+
+        for field in (
+            "uri",
+            "cap_sha256",
+            "policy_uri",
+            "realm",
+            "sig",
+            "connect_meta",
+            "enroll_uri",
+        ):
+            with pytest.raises(ValidationError):
+                SvcbRecord(target="svc.example.com.", alpn="mcp", **{field: f"value{self._EVIL}"})
+
+    def test_backslash_and_control_chars_rejected(self):
+        from dns_aid.core.models import SvcbRecord
+
+        for bad in ("https://x\\y", "https://x\ninjected", "abc\x00def"):
+            with pytest.raises(ValidationError):
+                SvcbRecord(target="svc.example.com.", alpn="mcp", policy_uri=bad)
+
+    def test_clean_values_accepted(self):
+        from dns_aid.core.models import SvcbRecord
+
+        record = SvcbRecord(
+            target="svc.example.com.",
+            alpn="mcp",
+            uri="https://example.com/.well-known/agent-card.json",
+            cap_sha256="abc123def456",
+            policy_uri="https://example.com/policy.json",
+            realm="my-company-realm",
+            enroll_uri="https://example.com/enroll",
+        )
+        assert record.uri.startswith("https://")
+        # Clean values serialize unchanged (cap → key65400 by default).
+        assert record.to_params()["key65400"] == record.uri
+
+
+class TestNormalizeBap:
+    """Tests for the shared ``normalize_bap`` collapse helper.
+
+    The discoverer, SDK adapter, and indexer all route through this
+    one function so they agree on edge inputs (empty string vs None
+    vs whitespace-only vs leading-comma legacy etc.).
+    """
+
+    def test_none_passthrough(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap(None) is None
+
+    def test_empty_string_to_none(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap("") is None
+        assert normalize_bap("   ") is None
+        assert normalize_bap("\t\n") is None
+
+    def test_scalar_passthrough(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap("mcp") == "mcp"
+        assert normalize_bap("mcp=1.0") == "mcp=1.0"
+        assert normalize_bap("  mcp=1.0  ") == "mcp=1.0"
+
+    def test_comma_list_collapsed_to_first_non_empty(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap("mcp,a2a") == "mcp"
+        assert normalize_bap("mcp=1.0,a2a=1.1") == "mcp=1.0"
+        # Leading comma — Igor's #158 item 5 regression.
+        assert normalize_bap(",mcp=1.0") == "mcp=1.0"
+        # Trailing comma.
+        assert normalize_bap("mcp=1.0,") == "mcp=1.0"
+        # Comma-only / all empties.
+        assert normalize_bap(",,,") is None
+        assert normalize_bap(", ,") is None
+
+    def test_list_form_collapsed_to_first(self):
+        from dns_aid.core.bap import normalize_bap
+
+        assert normalize_bap(["mcp"]) == "mcp"
+        assert normalize_bap(["mcp", "a2a"]) == "mcp"
+        # Empty list, list of empties.
+        assert normalize_bap([]) is None
+        assert normalize_bap(["", " ", None]) is None  # type: ignore[list-item]
+        # Defensive: non-string elements survive via str().
+        assert normalize_bap([" mcp "]) == "mcp"
+
+    def test_non_string_non_list_input(self):
+        from dns_aid.core.bap import normalize_bap
+
+        # Forgiving public API: anything not a str/list/None returns None.
+        assert normalize_bap(42) is None  # type: ignore[arg-type]
+        assert normalize_bap({"mcp": True}) is None  # type: ignore[arg-type]
+
+
+class TestSplitBapToken:
+    """Tests for protocol/version token extraction."""
+
+    def test_bare_form(self):
+        from dns_aid.core.bap import split_bap_token
+
+        assert split_bap_token("mcp") == ("mcp", None)
+        assert split_bap_token("a2a") == ("a2a", None)
+
+    def test_versioned_form(self):
+        from dns_aid.core.bap import split_bap_token
+
+        assert split_bap_token("mcp=1.0") == ("mcp", "1.0")
+        assert split_bap_token("a2a=1.1") == ("a2a", "1.1")
+
+    def test_none_and_empty(self):
+        from dns_aid.core.bap import split_bap_token
+
+        assert split_bap_token(None) == (None, None)
+        assert split_bap_token("") == (None, None)
+        assert split_bap_token("   ") == (None, None)
+
+    def test_dangling_equals_returns_only_proto(self):
+        from dns_aid.core.bap import split_bap_token
+
+        # ``mcp=`` is unusual but defensive — keep the proto, no version.
+        assert split_bap_token("mcp=") == ("mcp", None)

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -8,6 +8,7 @@ import pytest
 from dns_aid.backends.mock import MockBackend
 from dns_aid.core.models import Protocol
 from dns_aid.core.publisher import publish, unpublish
+from dns_aid.utils.validation import ValidationError
 
 
 class TestPublish:
@@ -26,8 +27,10 @@ class TestPublish:
 
         assert result.success is True
         assert result.agent.name == "chat"
-        assert result.agent.fqdn == "_chat._a2a._agents.example.com"
-        assert len(result.records_created) == 2  # SVCB + TXT
+        assert result.agent.fqdn == "chat.example.com"
+        # SVCB primary + TXT companion. Walkable AliasMode is opt-in
+        # (default off under -02 to avoid an enumeration handle).
+        assert len(result.records_created) == 2
 
     @pytest.mark.asyncio
     async def test_publish_with_capabilities(self, mock_backend: MockBackend):
@@ -45,7 +48,7 @@ class TestPublish:
         assert result.agent.capabilities == ["ipam", "dns", "vpn"]
 
         # Check TXT record was created with capabilities
-        txt_values = mock_backend.get_txt_record("example.com", "_network._mcp._agents")
+        txt_values = mock_backend.get_txt_record("example.com", "network")
         assert txt_values is not None
         assert "capabilities=ipam,dns,vpn" in txt_values
 
@@ -61,7 +64,7 @@ class TestPublish:
             backend=mock_backend,
         )
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
 
         assert svcb is not None
         assert svcb["target"] == "chat.example.com."
@@ -114,7 +117,7 @@ class TestPublish:
         assert result.success is True
         assert result.agent.ttl == 300
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
         assert svcb["ttl"] == 300
 
     @pytest.mark.asyncio
@@ -128,7 +131,7 @@ class TestPublish:
             capabilities=["travel", "booking"],
             cap_uri="https://mcp.example.com/.well-known/agent-cap.json",
             cap_sha256="dGVzdGhhc2g",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp=2.1",
             policy_uri="https://example.com/agent-policy",
             realm="production",
             backend=mock_backend,
@@ -137,17 +140,17 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri == "https://mcp.example.com/.well-known/agent-cap.json"
         assert result.agent.cap_sha256 == "dGVzdGhhc2g"
-        assert result.agent.bap == ["mcp/1", "a2a/1"]
+        assert result.agent.bap == "mcp=2.1"
         assert result.agent.policy_uri == "https://example.com/agent-policy"
         assert result.agent.realm == "production"
 
         # SVCB params should include custom DNS-AID params
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         # keyNNNNN format by default (RFC 9460 compliant)
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
-        assert svcb["params"]["key65402"] == "mcp/1,a2a/1"
+        assert svcb["params"]["key65402"] == "mcp=2.1"
         assert svcb["params"]["key65403"] == "https://example.com/agent-policy"
         assert svcb["params"]["key65404"] == "production"
 
@@ -165,11 +168,11 @@ class TestPublish:
         assert result.success is True
         assert result.agent.cap_uri is None
         assert result.agent.cap_sha256 is None
-        assert result.agent.bap == []
+        assert result.agent.bap is None
         assert result.agent.policy_uri is None
         assert result.agent.realm is None
 
-        svcb = mock_backend.get_svcb_record("example.com", "_chat._a2a._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "chat")
         assert svcb is not None
         assert "cap" not in svcb["params"]
         assert "cap-sha256" not in svcb["params"]
@@ -191,7 +194,7 @@ class TestPublish:
         )
 
         assert result.success is True
-        svcb = mock_backend.get_svcb_record("example.com", "_booking._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
         assert svcb is not None
         assert svcb["params"]["key65400"] == "https://mcp.example.com/.well-known/agent-cap.json"
         assert svcb["params"]["key65404"] == "demo"
@@ -220,7 +223,7 @@ class TestPublish:
         )
         assert result.agent.enroll_uri == "https://overlay.example.com/.well-known/agent-connect"
 
-        svcb = mock_backend.get_svcb_record("example.com", "_overlay._mcp._agents")
+        svcb = mock_backend.get_svcb_record("example.com", "overlay")
         assert svcb is not None
         assert svcb["params"]["key65406"] == "lattice"
         assert (
@@ -228,6 +231,169 @@ class TestPublish:
             == "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-123"
         )
         assert svcb["params"]["key65408"] == "https://overlay.example.com/.well-known/agent-connect"
+
+
+class TestPublishWellKnown:
+    """Tests for the draft-02 `well-known` SvcParamKey on the publish path."""
+
+    @pytest.mark.asyncio
+    async def test_publish_with_well_known_path(self, mock_backend: MockBackend):
+        """Setting well_known_path emits key65409 on the SVCB record."""
+        result = await publish(
+            name="booking",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="booking.example.com",
+            well_known_path="agent-card.json",
+            backend=mock_backend,
+        )
+        assert result.success is True
+        assert result.agent.well_known_path == "agent-card.json"
+
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
+        assert svcb is not None
+        assert svcb["params"]["key65409"] == "agent-card.json"
+
+    @pytest.mark.asyncio
+    async def test_publish_cap_and_well_known_coexist(self, mock_backend: MockBackend):
+        """`cap` and `well-known` are independent — both may be set on one record."""
+        result = await publish(
+            name="booking",
+            domain="example.com",
+            protocol="mcp",
+            endpoint="booking.example.com",
+            cap_uri="urn:example:agent-cap:abc",
+            cap_sha256="dGVzdGhhc2g",
+            well_known_path="agent-card.json",
+            backend=mock_backend,
+        )
+        assert result.success is True
+        assert result.agent.cap_uri == "urn:example:agent-cap:abc"
+        assert result.agent.well_known_path == "agent-card.json"
+
+        svcb = mock_backend.get_svcb_record("example.com", "booking")
+        assert svcb is not None
+        assert svcb["params"]["key65400"] == "urn:example:agent-cap:abc"
+        assert svcb["params"]["key65401"] == "dGVzdGhhc2g"
+        assert svcb["params"]["key65409"] == "agent-card.json"
+
+
+class TestPublishTargetUnderscoreValidation:
+    """Tests for the draft-02 §Known-Organization no-underscore-in-target rule."""
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_rejected_by_default(self, mock_backend: MockBackend):
+        """Underscored TargetName fails publish unless explicitly allowed."""
+        with pytest.raises(ValidationError) as exc:
+            await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="_chat.example.com",
+                backend=mock_backend,
+            )
+        assert exc.value.field == "target"
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_allowed_with_flag_and_env(
+        self, mock_backend: MockBackend, monkeypatch
+    ):
+        """allow_underscore_target=True now requires the operator to
+        ALSO opt in via the env var. Both together let the publish
+        proceed with a structured WARN; one without the other raises."""
+        from unittest.mock import patch
+
+        from dns_aid.utils import validation as validation_module
+
+        monkeypatch.setenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", "1")
+        with patch.object(validation_module, "logger") as mock_logger:
+            result = await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="_chat.internal.example",
+                backend=mock_backend,
+                allow_underscore_target=True,
+            )
+        assert result.success is True
+        # The warn fires from each enforcement site (publisher entrypoint
+        # + AgentRecord field_validator + SvcbRecord field_validator) —
+        # all carrying the same warning_class, all keyed on the same
+        # target. That's noisy but coherent: every gate sees the bypass.
+        warn_calls = mock_logger.warning.call_args_list
+        assert len(warn_calls) >= 1
+        assert all(c.kwargs.get("warning_class") == "dns_aid.underscore_bypass" for c in warn_calls)
+        assert all("_chat" in c.kwargs.get("target", "") for c in warn_calls)
+        # PR #154 v2 review (Igor): the bypass must also surface on
+        # PublishResult.warnings as a stable warning_class identifier
+        # — log lines alone aren't a usable signal for log aggregators
+        # or downstream observability.
+        assert "dns_aid.underscore_bypass" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_strict_default_is_bc_break(
+        self, mock_backend: MockBackend, monkeypatch
+    ):
+        """BC-pin — PR #154 strict-by-default tightening.
+
+        Even without explicitly passing ``allow_underscore_target``, a
+        plain `publish()` with an underscored endpoint MUST raise. This
+        is the BREAKING behaviour called out in CHANGELOG [Unreleased]
+        — a deliberate, versioned change per draft-02 §3.2. If a future
+        commit accidentally relaxes the default, this test holds the
+        line.
+        """
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+        with pytest.raises(ValidationError):
+            await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="my_service.internal.example",
+                backend=mock_backend,
+            )
+
+    @pytest.mark.asyncio
+    async def test_clean_endpoint_no_warnings_emitted(self, mock_backend: MockBackend):
+        """A normal endpoint must not populate warnings — the field is
+        for advisories, not always-on noise."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+        assert result.success is True
+        assert result.warnings == []
+
+    @pytest.mark.asyncio
+    async def test_underscored_endpoint_flag_without_env_raises(
+        self, mock_backend: MockBackend, monkeypatch
+    ):
+        """Without the env gate, the per-call flag alone is insufficient."""
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+        with pytest.raises(ValidationError):
+            await publish(
+                name="chat",
+                domain="example.com",
+                protocol="a2a",
+                endpoint="_chat.internal.example",
+                backend=mock_backend,
+                allow_underscore_target=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_clean_endpoint_passes(self, mock_backend: MockBackend):
+        """A normal hostname publishes without warnings or errors."""
+        result = await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+        assert result.success is True
 
 
 class TestUnpublish:
@@ -246,7 +412,7 @@ class TestUnpublish:
         )
 
         # Verify records exist
-        assert mock_backend.get_svcb_record("example.com", "_chat._a2a._agents") is not None
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
 
         # Unpublish
         result = await unpublish(
@@ -257,7 +423,7 @@ class TestUnpublish:
         )
 
         assert result is True
-        assert mock_backend.get_svcb_record("example.com", "_chat._a2a._agents") is None
+        assert mock_backend.get_svcb_record("example.com", "chat") is None
 
     @pytest.mark.asyncio
     async def test_unpublish_nonexistent(self, mock_backend: MockBackend):
@@ -426,3 +592,121 @@ class TestPublishEdgeCases:
             )
             assert result.success is False
             assert "boom" in result.message
+
+
+class TestPublishWalkableAlias:
+    """Tests for the draft-02 walkable AliasMode write."""
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_off_by_default(self, mock_backend: MockBackend):
+        """The walkable record is opt-in under -02 to avoid an
+        enumeration handle (crawlers walking _agents.<zone>).
+        Operators who want DNS-SD-style enumeration explicitly enable it."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+        )
+
+        walkable = mock_backend.get_svcb_record("example.com", "chat._agents")
+        assert walkable is None, "default must be off to avoid enumeration handle"
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_written_when_opted_in(self, mock_backend: MockBackend):
+        """publish_walkable_alias=True emits the walkable record."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+            publish_walkable_alias=True,
+        )
+
+        walkable = mock_backend.get_svcb_record("example.com", "chat._agents")
+        assert walkable is not None
+        assert walkable["priority"] == 0  # AliasMode
+        assert walkable["target"] == "chat.example.com."
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_can_be_suppressed(self, mock_backend: MockBackend):
+        """Setting publish_walkable_alias=False on the AgentRecord skips the walkable write."""
+        from dns_aid.core.models import AgentRecord
+
+        agent = AgentRecord(
+            name="chat",
+            domain="example.com",
+            protocol=Protocol.A2A,
+            target_host="chat.example.com",
+            publish_walkable_alias=False,
+        )
+        records = await mock_backend.publish_agent(agent)
+
+        # Only SVCB primary + TXT (no walkable).
+        assert len(records) == 2
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is None
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
+
+    @pytest.mark.asyncio
+    async def test_unpublish_removes_walkable(self, mock_backend: MockBackend):
+        """unpublish() removes both the flat owner and the walkable alias."""
+        await publish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            endpoint="chat.example.com",
+            backend=mock_backend,
+            publish_walkable_alias=True,
+        )
+        assert mock_backend.get_svcb_record("example.com", "chat") is not None
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is not None
+
+        result = await unpublish(
+            name="chat",
+            domain="example.com",
+            protocol="a2a",
+            backend=mock_backend,
+        )
+        assert result is True
+        assert mock_backend.get_svcb_record("example.com", "chat") is None
+        assert mock_backend.get_svcb_record("example.com", "chat._agents") is None
+
+    @pytest.mark.asyncio
+    async def test_unpublish_also_clears_legacy_01_shape(self, mock_backend: MockBackend):
+        """Migration path: unpublish() cleans up draft-01 records too.
+
+        Operators who published under -01 and then upgraded to a -02
+        dns-aid-core should be able to call unpublish() once and have
+        the SVCB + TXT records at `_{name}._{protocol}._agents.{domain}`
+        deleted alongside the new flat / walkable forms.
+        """
+        # Simulate a pre-existing draft-01 publication by writing records
+        # directly at the legacy name.
+        await mock_backend.create_svcb_record(
+            zone="example.com",
+            name="_legacy._mcp._agents",
+            priority=1,
+            target="legacy.example.com.",
+            params={"alpn": "mcp", "port": "443"},
+            ttl=3600,
+        )
+        await mock_backend.create_txt_record(
+            zone="example.com",
+            name="_legacy._mcp._agents",
+            values=["capabilities=test"],
+            ttl=3600,
+        )
+        assert mock_backend.get_svcb_record("example.com", "_legacy._mcp._agents") is not None
+
+        # unpublish() finds and deletes the legacy records even though
+        # nothing was published at the flat/walkable names.
+        result = await unpublish(
+            name="legacy",
+            domain="example.com",
+            protocol="mcp",
+            backend=mock_backend,
+        )
+        assert result is True
+        assert mock_backend.get_svcb_record("example.com", "_legacy._mcp._agents") is None

--- a/tests/unit/test_route53_backend.py
+++ b/tests/unit/test_route53_backend.py
@@ -608,6 +608,7 @@ class TestRoute53PublishAgentParamDemotion:
             port=443,
             capabilities=["testing"],
             realm="demo",
+            publish_walkable_alias=True,
         )
 
         backend = Route53Backend(zone_id="Z123")
@@ -617,10 +618,12 @@ class TestRoute53PublishAgentParamDemotion:
         with patch.object(backend, "_get_client", return_value=mock_client):
             records = await backend.publish_agent(agent)
 
-        # Should create both SVCB and TXT
-        assert len(records) == 2
+        # Should create SVCB primary, TXT companion, and the walkable
+        # AliasMode (default-on per draft-02).
+        assert len(records) == 3
         assert records[0].startswith("SVCB")
         assert records[1].startswith("TXT")
+        assert records[2].startswith("SVCB(AliasMode)")
 
         # Inspect the SVCB call — must NOT contain key65404
         svcb_call = mock_client.change_resource_record_sets.call_args_list[0]
@@ -651,6 +654,7 @@ class TestRoute53PublishAgentParamDemotion:
             target_host="simple.example.com",
             port=443,
             capabilities=["chat"],
+            publish_walkable_alias=True,
         )
 
         backend = Route53Backend(zone_id="Z123")
@@ -660,7 +664,8 @@ class TestRoute53PublishAgentParamDemotion:
         with patch.object(backend, "_get_client", return_value=mock_client):
             records = await backend.publish_agent(agent)
 
-        assert len(records) == 2
+        # SVCB + TXT + walkable AliasMode (default-on per draft-02)
+        assert len(records) == 3
         # No dnsaid_ entries in TXT
         txt_call = mock_client.change_resource_record_sets.call_args_list[1]
         txt_values = txt_call[1]["ChangeBatch"]["Changes"][0]["ResourceRecordSet"][
@@ -683,7 +688,7 @@ class TestRoute53PublishAgentParamDemotion:
             capabilities=["dns"],
             realm="production",
             policy_uri="urn:policy:strict",
-            bap=["mcp/1", "a2a/1"],
+            bap="mcp=2.1",
         )
 
         backend = Route53Backend(zone_id="Z123")

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -185,9 +185,11 @@ class TestCapSha256Verification:
                 assert doc.capabilities == ["test"]
 
     @pytest.mark.asyncio
-    async def test_hash_mismatch_returns_none(self):
-        """Wrong hash should cause fetch to return None."""
-        from dns_aid.core.cap_fetcher import fetch_cap_document
+    async def test_hash_mismatch_raises_digest_error(self):
+        """Wrong hash MUST raise CapDigestMismatchError so the discoverer
+        can distinguish digest mismatch (refuse the record) from network
+        failures (fall back to a lower-priority capability source)."""
+        from dns_aid.core.cap_fetcher import CapDigestMismatchError, fetch_cap_document
 
         content = b'{"capabilities": ["test"]}'
 
@@ -196,11 +198,13 @@ class TestCapSha256Verification:
 
         with patch("dns_aid.utils.url_safety.validate_fetch_url", return_value="https://ok.com"):
             with patch("dns_aid.utils.url_safety.safe_fetch_bytes", side_effect=mock_fetch):
-                doc = await fetch_cap_document(
-                    "https://ok.com/cap.json",
-                    expected_sha256="WRONG_HASH",
-                )
-                assert doc is None
+                with pytest.raises(CapDigestMismatchError) as excinfo:
+                    await fetch_cap_document(
+                        "https://ok.com/cap.json",
+                        expected_sha256="WRONG_HASH",
+                    )
+                assert excinfo.value.expected == "WRONG_HASH"
+                assert excinfo.value.cap_uri == "https://ok.com/cap.json"
 
     @pytest.mark.asyncio
     async def test_no_hash_skips_verification(self):

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -14,10 +14,12 @@ from dns_aid.utils.validation import (
     validate_domain,
     validate_endpoint,
     validate_fqdn,
+    validate_no_underscore_in_target,
     validate_port,
     validate_protocol,
     validate_ttl,
     validate_version,
+    validate_well_known_path,
 )
 
 
@@ -294,10 +296,25 @@ class TestValidateFqdn:
             validate_fqdn("")
         assert exc.value.field == "fqdn"
 
-    def test_missing_agents_raises(self):
+    def test_flat_fqdn_valid(self):
+        # draft-02 flat primary owner: {name}.{domain}, no _agents label.
+        assert validate_fqdn("chat.example.com") == "chat.example.com"
+
+    def test_walkable_fqdn_valid(self):
+        assert validate_fqdn("chat._agents.example.com") == "chat._agents.example.com"
+
+    def test_index_fqdn_valid(self):
+        assert validate_fqdn("_index._agents.example.com") == "_index._agents.example.com"
+
+    def test_single_label_raises(self):
         with pytest.raises(ValidationError) as exc:
-            validate_fqdn("example.com")
-        assert "_agents" in exc.value.message
+            validate_fqdn("localhost")
+        assert exc.value.field == "fqdn"
+
+    def test_empty_label_raises(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_fqdn("chat..example.com")
+        assert exc.value.field == "fqdn"
 
 
 class TestValidateBackend:
@@ -336,3 +353,198 @@ class TestValidateBackend:
         with pytest.raises(ValidationError) as exc:
             validate_backend("")
         assert exc.value.field == "backend"
+
+
+class TestValidateNoUnderscoreInTarget:
+    """Tests for the SVCB TargetName no-underscore rule (draft-02 §Known Organization)."""
+
+    def test_clean_target_passes(self):
+        assert (
+            validate_no_underscore_in_target("agent-index.example.com") == "agent-index.example.com"
+        )
+
+    def test_trailing_dot_tolerated(self):
+        assert (
+            validate_no_underscore_in_target("agent-index.example.com.")
+            == "agent-index.example.com."
+        )
+
+    def test_label_starting_with_underscore_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("_index.example.com")
+        assert exc.value.field == "target"
+        assert "_index" in str(exc.value)
+
+    def test_label_containing_underscore_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("agent_index.example.com")
+        assert exc.value.field == "target"
+        assert "agent_index" in str(exc.value)
+
+    def test_multiple_underscored_labels_all_reported(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("_a._b.example.com")
+        msg = str(exc.value)
+        assert "_a" in msg
+        assert "_b" in msg
+
+    def test_allow_underscore_requires_env_gate(self, monkeypatch):
+        """The bypass is operator-gated. ``allow_underscore=True`` alone
+        is insufficient — ``DNS_AID_ALLOW_UNDERSCORE_TARGET`` must also
+        be set in the environment so a calling LLM or MCP client can't
+        unilaterally downgrade the draft §Known Organization MUST."""
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+
+        with pytest.raises(ValidationError):
+            validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+
+    def test_allow_underscore_with_env_gate_allows(self, monkeypatch):
+        """With env gate set, allow_underscore=True is honoured and
+        emits a structured WARN for log aggregation."""
+        from unittest.mock import patch
+
+        from dns_aid.utils import validation as validation_module
+
+        monkeypatch.setenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", "1")
+        with patch.object(validation_module, "logger") as mock_logger:
+            result = validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        assert result == "_index.example.com"
+        mock_logger.warning.assert_called_once()
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert kwargs["target"] == "_index.example.com"
+        assert kwargs["warning_class"] == "dns_aid.underscore_bypass"
+        assert kwargs["env_gate"] == "DNS_AID_ALLOW_UNDERSCORE_TARGET"
+
+    def test_allow_underscore_without_env_logs_distinct_warning(self, monkeypatch):
+        """When the caller asks for the bypass but the env gate is
+        unset, surface that with a distinct warning_class so operators
+        can distinguish 'I forgot to set the env' from 'genuine
+        validation error'."""
+        from unittest.mock import patch
+
+        from dns_aid.utils import validation as validation_module
+
+        monkeypatch.delenv("DNS_AID_ALLOW_UNDERSCORE_TARGET", raising=False)
+        with patch.object(validation_module, "logger") as mock_logger:
+            with pytest.raises(ValidationError):
+                validate_no_underscore_in_target("_index.example.com", allow_underscore=True)
+        mock_logger.warning.assert_called_once()
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert kwargs["warning_class"] == "dns_aid.underscore_bypass_env_missing"
+
+    def test_allow_underscore_on_clean_target_is_silent(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = validate_no_underscore_in_target("clean.example.com", allow_underscore=True)
+        assert result == "clean.example.com"
+        assert not caplog.records
+
+    def test_empty_target_raises_regardless_of_flag(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_no_underscore_in_target("", allow_underscore=True)
+        assert exc.value.field == "target"
+
+
+class TestValidateWellKnownPath:
+    """Tests for validate_well_known_path.
+
+    The well-known SvcParamKey value flows from DNS into a URL the
+    discoverer fetches. Untrusted input must not be able to slip path
+    traversal, query strings, fragments, or embedded slashes through to
+    the URL — even though validate_fetch_url pins the host, the path is
+    still attacker-influenceable without this check.
+    """
+
+    def test_accepts_iana_registered_examples(self):
+        # Pull from IANA RFC 8615 examples to show the validator
+        # accepts the actual shape of real well-known names.
+        for name in (
+            "agent-card.json",
+            "oauth-authorization-server",
+            "did-configuration",
+            "change-password",
+            "openid-credential-issuer",
+            "openid-federation",
+            "matrix",
+        ):
+            assert validate_well_known_path(name) == name
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            validate_well_known_path("")
+
+    def test_rejects_path_traversal(self):
+        for evil in (
+            "..",
+            "../etc/passwd",
+            "..%2Fetc",
+            "agent-card.json/..",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_query_or_fragment(self):
+        for evil in (
+            "agent-card.json?token=x",
+            "agent-card.json#section",
+            "agent-card.json?",
+            "agent-card.json#",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_embedded_slash_in_bare_suffix(self):
+        """Bare suffixes can't contain slashes — that's the single-segment
+        constraint. Absolute paths starting with '/' are a separate, supported
+        shape (see test_accepts_absolute_paths)."""
+        for evil in (
+            "agent/card.json",
+            "agent-card.json/extra",  # trailing junk
+            "//double-leading-slash",  # absolute but with empty first segment
+            "/seg//empty",  # empty segment in absolute path
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_accepts_absolute_paths_per_draft_figure_3(self):
+        """Per draft Figure 3, well-known values may be absolute paths —
+        not just bare suffixes under /.well-known/. Examples from the
+        draft itself: `/.well-known/agent-card.json`, `/not-well-known/
+        other-card.json`."""
+        for ok in (
+            "/.well-known/agent-card.json",
+            "/not-well-known/other-card.json",
+            "/agent-card.json",
+            "/openid-credential-issuer",
+            "/v1/agents/card.json",
+        ):
+            assert validate_well_known_path(ok) == ok
+
+    def test_rejects_absolute_path_with_traversal(self):
+        """`..` segments must still be refused in absolute form."""
+        for evil in (
+            "/.well-known/../etc/passwd",
+            "/..",
+            "/../../etc",
+            "/segment/../escape",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_percent_encoded(self):
+        for evil in (
+            "agent%2Fcard.json",
+            "%2E%2E",
+            "agent-card%00.json",
+        ):
+            with pytest.raises(ValidationError):
+                validate_well_known_path(evil)
+
+    def test_rejects_oversize(self):
+        with pytest.raises(ValidationError):
+            validate_well_known_path("a" * 129)
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValidationError):
+            validate_well_known_path(None)  # type: ignore[arg-type]

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -504,6 +504,46 @@ class TestVerify:
             assert result.dnssec_valid is False
 
     @pytest.mark.asyncio
+    async def test_verify_dane_without_dnssec_demotes_to_unknown(self):
+        """A TLSA record served without DNSSEC has no integrity guarantee.
+
+        Even though ``_check_dane`` would return ``True`` (TLSA found),
+        the absence of a DNSSEC validation means we cannot trust the
+        TLSA record itself. The validator demotes ``dane_valid`` to
+        ``None`` (unknown), and the security_score's gated +15 does
+        not fire.
+        """
+        from dns_aid.core.models import DNSSECDetail, TLSDetail
+
+        with (
+            patch("dns_aid.core.validator._check_svcb_record") as mock_svcb,
+            patch("dns_aid.core.validator._check_dnssec_detail") as mock_dnssec_detail,
+            patch("dns_aid.core.validator._check_dane") as mock_dane,
+            patch("dns_aid.core.validator._check_endpoint") as mock_endpoint,
+            patch("dns_aid.core.validator._check_tls") as mock_tls,
+        ):
+            mock_svcb.return_value = {
+                "target": "agent.example.com",
+                "port": 443,
+                "valid": True,
+            }
+            mock_dnssec_detail.return_value = DNSSECDetail(validated=False)
+            mock_dane.return_value = True  # TLSA record present
+            mock_endpoint.return_value = {"reachable": True, "latency_ms": 50.0}
+            mock_tls.return_value = TLSDetail()
+
+            result = await verify("chat.example.com")
+
+            assert result.dnssec_valid is False
+            assert result.dane_valid is None, (
+                "DANE without DNSSEC must be demoted to unknown, not True"
+            )
+            assert result.dane_note is not None
+            assert "DNSSEC" in result.dane_note
+            # 20 (record) + 20 (svcb) + 0 (dnssec) + 0 (DANE gated) + 15 (endpoint)
+            assert result.security_score == 55
+
+    @pytest.mark.asyncio
     async def test_verify_endpoint_unreachable(self):
         """Test verify when endpoint is unreachable."""
         from dns_aid.core.models import DNSSECDetail, TLSDetail

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
@@ -740,8 +740,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pygments", marker = "extra == 'all'", specifier = ">=2.20.0" },
     { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.20.0" },
-    { name = "pyjwt", marker = "extra == 'all'", specifier = ">=2.12.0" },
-    { name = "pyjwt", marker = "extra == 'mcp'", specifier = ">=2.12.0" },
+    { name = "pyjwt", marker = "extra == 'all'", specifier = ">=2.13.0" },
+    { name = "pyjwt", marker = "extra == 'mcp'", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'all'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'all'", specifier = ">=0.23.0" },
@@ -1792,11 +1792,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
# feat(core): complete draft-02 flat-FQDN migration across all surfaces

## Summary

This PR consolidates the full **draft-mozleywilliams-dnsop-dnsaid-02** wire-format migration into a single `0.24.0` release.

The bulk of this work was authored by **@nicknacnic** across his draft-02 stack (#153, #154, #155, #156, #158): flat primary-owner records, the optional walkable AliasMode, the `well-known` SvcParamKey, the TargetName underscore validator, and the scalar `bap` shape. This PR lands all of it together with the completion fixes needed to make the flat FQDN consistent end to end, so we ship the migration as one reviewable, releasable unit instead of merging a five-deep stack incrementally.

Closing #153–#158 in favour of this consolidated PR — full credit to Nick for the underlying work.

## What ships in 0.24.0

**From Nick's stack:**
- Flat primary owner `{name}.{domain}` (valid x.509 SAN dNSName) — the agent protocol moves out of the FQDN into the `bap` SvcParamKey (or `alpn` when single-protocol)
- Optional walkable AliasMode at `{name}._agents.{domain}` pointing at the flat owner — off by default (enumeration trade-off, see `docs/privacy-considerations.md`)
- Per-call `allow_legacy` -01 fallback, result stamped `legacy_resolved`
- `well-known` SvcParamKey (interim `key65409`) + `validate_well_known_path` (RFC 8615, traversal/injection-safe)
- TargetName underscore validator (CA/Browser-Forum BR + RFC 5280 SAN conformance) with operator-only env+flag bypass
- Scalar `bap` per draft §5.1 (bare or `=`-versioned) + injection-safe field validator closing a SvcParam quoting break-out
- JWS record-binding, `cap-sha256` refuse-on-mismatch, DANE-gates-on-DNSSEC

**Completion fixes (this consolidation):**
- `validate_fqdn` accepts the flat owner — it previously required a literal `_agents` label, so MCP `verify_agent_dns` rejected every draft-02 agent
- **Discovery reconciles the agent protocol from the SVCB record** (`bap`, or `alpn`) on every path (`discover_at_fqdn`, zone-walk, HTTP index) — a default-published `a2a`/`https` agent (which carries `alpn`, no `bap`) was previously mislabeled `mcp`, failing the JWS binding check and selecting the wrong handler. Zone-walk now dedups by `(fqdn, protocol)`
- JWS signature binding DNS-normalized (case-insensitive, trailing-dot-insensitive on `fqdn`/`target`)
- CLI/MCP emit the flat owner name (`delete`/`search` output, MCP unpublish result, `list_agent_index`); `index sync` enumerates flat-only owners via their companion TXT
- `parse_dnsaid_fqdn` accepts two-label / internal zones and normalizes case + trailing dot
- Docs, CHANGELOG, CITATION, version `0.23.0 → 0.24.0`

## Production hardening

- **SVCB SvcParam injection closed on every free-form field.** The `bap` validator already blocked quote break-out injection; the same guard now covers `cap`/`cap-sha256`/`policy`/`realm`/`sig`/`connect-meta`/`enroll-uri` on both models, so a forged value can't inject a sibling SvcParamKey through the presentation-format backends
- **JWKS fetch SSRF-guarded + size-capped (64 KB) + redirect-free + bounded cache;** JWS verification pins `alg=ES256` and a P-256 EC key (32-byte coords) — closes algorithm/curve confusion on the attacker-influenceable JWKS path
- **HTTP agent index bounded** in body size (1 MB) and agent count (500) against OOM / fan-out amplification

## Verification

- Full local gate run green: `ruff`, `ruff format`, `mypy` (83 files), `bandit` (0 issues), **1890** unit/integration tests
- Live end-to-end across CLI + MCP + SDK against **Route53** and a local **BIND9/DDNS** backend: publish → discover → verify → delete round-trips, flat owner resolvable, **protocol reconciliation for `a2a`/`mcp`/`https`**, signature binding holds, index round-trip. NIOS WAPI lifecycle validated on the same code paths
- **JWKS hardening validated live over real TLS sockets + real ES256 crypto:** SSRF guard blocks a loopback JWKS, the full sign → fetch → verify chain succeeds, the streaming size cap rejects an oversized document, and alg/curve confusion is refused

## Breaking changes

Documented in CHANGELOG `[0.24.0]` with migration notes: strict underscore TargetName validator, scalar `bap` (was `list[str] | None`), and the -01 → -02 default flip.
