### PR TITLE
ci: pin cosign to v2.6.3 (fix release signing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,13 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin the cosign binary to the 2.x line. cosign 3.x changed
+          # `sign-blob` bundle handling ("create bundle file: open : no such
+          # file or directory") and broke the --output-signature /
+          # --output-certificate invocation below. v2.x matches the signing
+          # behavior the workflow was written for (and that shipped 0.23.0).
+          cosign-release: "v2.6.3"
 
       - name: Sign release artifacts
         run: |


### PR DESCRIPTION
The 0.24.0 release run failed at the Cosign signing step:

```
signing dist/dns_aid-0.24.0-py3-none-any.whl: create bundle file: open : no such file or directory
```

Root cause: `cosign-installer` was bumped 3.9.1 → 4.1.2 (commit ac60005), which pulls **cosign 3.x**. cosign 3.0 changed `sign-blob` bundle handling and broke the existing `--output-signature` / `--output-certificate` invocation. `v0.23.0` signed fine on cosign 2.x.

Fix: pin the cosign **binary** to `v2.6.3` (latest 2.x) via the installer's `cosign-release` input. Keeps the updated, SHA-pinned installer action; restores the proven signing behavior. No publish occurred on the failed run (PyPI/MCP skipped), so re-tagging `v0.24.0` after this merges will cut the release cleanly.