### PR TITLE
release: 0.24.1 — restore mcp-name README tag (MCP Registry publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-06-04
+
+### Fixed
+
+- **Restore the `mcp-name` README tag** dropped during the 0.24.0
+  consolidation, so the MCP Registry ownership validation against the
+  published PyPI package succeeds. No functional change from 0.24.0 —
+  the flat-FQDN migration and hardening shipped in 0.24.0.
+
 ## [0.24.0] - 2026-06-04
 
 ### Fixed — flat-FQDN completion

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.24.0"
+version: "0.24.1"
 date-released: "2026-06-04"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DNS-AID
 
+<!-- mcp-name: io.github.dns-aid/dns-aid -->
+
 [![CI](https://github.com/infobloxopen/dns-aid-core/actions/workflows/ci.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/ci.yml)
 [![Security](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml)
 [![CodeQL](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.24.0"
+version = "0.24.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
0.24.0 shipped to PyPI + GitHub Release, but the **MCP Registry** publish failed: it validates ownership against the published PyPI README's `mcp-name: io.github.dns-aid/dns-aid` tag, which PR #167 inadvertently dropped (it was added in #160). PyPI 0.24.0 is immutable, so the registry can't validate it.

This restores the tag and bumps to **0.24.1** (docs/version only — no functional change from 0.24.0). Tagging `v0.24.1` will re-publish to PyPI + MCP Registry + GitHub Release with the now-working cosign v2.6.3 pin (#168).