### PR TITLE
docs+ci: restore README IETF/LF positioning sections + guard mcp-name tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,21 @@ jobs:
 
       - name: Mypy
         run: uv run mypy src/dns_aid
+
+  readme-mcp-name:
+    name: README mcp-name tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Verify README carries the MCP Registry mcp-name tag
+        run: |
+          # The MCP Registry validates package ownership against this tag in
+          # the PUBLISHED PyPI README. Dropping it silently breaks the release
+          # MCP Registry publish (it regressed in 0.24.0, fixed in 0.24.1).
+          # Fail loudly here so no PR can drop it again unnoticed.
+          if ! grep -qF 'mcp-name: io.github.dns-aid/dns-aid' README.md; then
+            echo "::error file=README.md::README is missing the required MCP Registry ownership tag '<!-- mcp-name: io.github.dns-aid/dns-aid -->' — the release MCP Registry publish will fail without it."
+            exit 1
+          fi
+          echo "OK: README carries the mcp-name tag."

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Reference implementation for [IETF draft-mozleywilliams-dnsop-dnsaid-02](https:/
 
 DNS-AID enables AI agents to discover each other via DNS, using the internet's existing naming infrastructure instead of centralized registries or hardcoded URLs.
 
+## Relationship to IETF
+
+The DNS-AID specification is being developed within the IETF: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/.
+
+This repository provides a reference implementation.
+
+This project does not define the specification. The IETF draft is authoritative.
+
+## Scope of this Repository
+
+This project focuses on implementation, tooling, and ecosystem activities.
+
+Changes to protocol behavior should be discussed within the IETF.
+
 > **New to DNS-AID?** Start with the [Getting Started Guide](docs/getting-started.md) for install, first agent publication, and backend setup.
 
 ## Documentation
@@ -1087,6 +1101,10 @@ DNS-AID doesn't require waiting for ICANN approval or paying for new domains—i
 
 *Fun fact: When `.agent` domains become available, DNS-AID records will work on them too! The approaches are complementary.*
 
+## Background and Comparison
+
+For background on how DNS-AID compares to other agent-discovery approaches (ANS, Google A2A+UCP, `.agent` gTLD, AgentDNS, NANDA, Web3, `ai.txt`) and "The Sovereignty Question", see [docs/positioning.md](docs/positioning.md). That content is non-normative — protocol positioning is determined at the IETF.
+
 ## Examples
 
 See the `examples/` directory:
@@ -1134,6 +1152,6 @@ Apache 2.0
 
 ## Contributing
 
-Contributions welcome! This project is intended for contribution to the Linux Foundation Agent AI Foundation.
+Contributions welcome! This project supports an implementation ecosystem with planned hosting in the Linux Foundation. The DNS-AID specification is developed in the IETF.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## What
Restores README content that PR #167 silently reverted (post-0.23.0 main additions, never released), and adds a CI guard so the MCP-Registry ownership tag can't be dropped again.

### Restored (authored by @nicknacnic/Chris Herbst via a084529 + Igor via 216bad3)
- `## Relationship to IETF`
- `## Scope of this Repository`
- `## Background and Comparison` (positioning.md pointer)
- Contributing: "planned hosting in the Linux Foundation" wording

### New CI guard
`readme-mcp-name` job fails any PR whose README lacks `mcp-name: io.github.dns-aid/dns-aid`. The MCP Registry validates package ownership against this tag in the **published PyPI README**; #167 dropped it and broke the 0.24.0 MCP Registry publish (fixed by 0.24.1). This makes the regression impossible to repeat unnoticed.

### Note for other open README PRs (#152, #133, #135, #132, #123)
All are based on a stale README and will hit this guard (missing tag) + would re-drop these sections — they should rebase onto this.