### PR TITLE
chore: rename repo URLs to dns-aid org + release 0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-06-04
+
+### Changed
+
+- **Repository URLs point to the `dns-aid` GitHub organization.** All
+  `github.com/...` links and the `io.github.*` MCP server name now use
+  `dns-aid/dns-aid-core` (was `infobloxopen/dns-aid-core`) across the
+  README, `pyproject.toml` project URLs, `CITATION.cff`, docs, and
+  packaging metadata, so the PyPI project-page links resolve to the
+  current organization. (Reimplements the intent of #152 on top of
+  current `main`.)
+
+### Fixed
+
+- **Restored the README IETF/LF positioning sections** ("Relationship to
+  IETF", "Scope of this Repository", "Background and Comparison", and the
+  Linux Foundation hosting note) that the 0.24.0 consolidation
+  inadvertently dropped.
+- **Repaired the CHANGELOG compare-link footer**, which had been frozen at
+  `v0.13.4` — backfilled every release since and pointed `[Unreleased]` at
+  the current version.
+
+### Added
+
+- **CI guard for the MCP Registry `mcp-name` tag.** A `readme-mcp-name` job
+  fails any PR whose README lacks `mcp-name: io.github.dns-aid/dns-aid`, so
+  the tag the MCP Registry validates against the published PyPI README
+  cannot be silently dropped again (it regressed in 0.24.0 and broke the
+  registry publish; restored in 0.24.1).
+
 ## [0.24.1] - 2026-06-04
 
 ### Fixed
@@ -572,7 +602,7 @@ quickstart.md, contracts/, tasks.md.
 
 ### Fixed
 
-- **DDNS backend `list_records()` yield shape ([#137](https://github.com/infobloxopen/dns-aid-core/issues/137))**:
+- **DDNS backend `list_records()` yield shape ([#137](https://github.com/dns-aid/dns-aid-core/issues/137))**:
   `DDNSBackend.list_records()` previously yielded one dict per rdata with a
   singular `data: str(rdata)` key, diverging from every other backend
   (Route53, Cloudflare, NS1, Cloud DNS, BloxOne, NIOS, Mock) which yield
@@ -711,7 +741,7 @@ quickstart.md, contracts/, tasks.md.
   pattern with a per-CVE rationale comment; publicly acknowledged in
   `SECURITY.md` "Accepted dependency vulnerabilities" section with the
   full dispute context. Re-evaluation tracked at
-  [#141](https://github.com/infobloxopen/dns-aid-core/issues/141).
+  [#141](https://github.com/dns-aid/dns-aid-core/issues/141).
 
 ### Tests
 
@@ -1098,7 +1128,7 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 ## [0.17.3] - 2026-04-14
 
 ### Added
-- **MCP Registry listing** — added `mcp-name: io.github.infobloxopen/dns-aid` tag to README for MCP Registry ownership verification.
+- **MCP Registry listing** — added `mcp-name: io.github.dns-aid/dns-aid` tag to README for MCP Registry ownership verification.
 - **MCP bundle files** — `manifest.json`, `server.json`, `.mcpbignore` for `.mcpb` packaging and registry publishing.
 
 ## [0.17.2] - 2026-04-14
@@ -1852,39 +1882,70 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/infobloxopen/dns-aid-core/compare/v0.13.4...HEAD
-[0.13.4]: https://github.com/infobloxopen/dns-aid-core/compare/v0.13.3...v0.13.4
-[0.13.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.13.2...v0.13.3
-[0.13.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.13.1...v0.13.2
-[0.13.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.13.0...v0.13.1
-[0.13.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.12.1...v0.13.0
-[0.12.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.12.0...v0.12.1
-[0.12.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.11.0...v0.12.0
-[0.11.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.10.1...v0.11.0
-[0.10.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.3...v0.8.0
-[0.7.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.2...v0.7.3
-[0.7.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.1...v0.7.2
-[0.7.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.9...v0.7.0
-[0.6.9]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.8...v0.6.9
-[0.6.8]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.7...v0.6.8
-[0.6.7]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.6...v0.6.7
-[0.6.6]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.5...v0.6.6
-[0.6.5]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.4...v0.6.5
-[0.6.4]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.3...v0.6.4
-[0.6.3]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.5.1...v0.6.0
-[0.5.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.5.0...v0.5.1
-[0.5.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.9...v0.5.0
-[0.4.9]: https://github.com/infobloxopen/dns-aid-core/compare/v0.4.8...v0.4.9
-[0.4.8]: https://github.com/infobloxopen/dns-aid-core/compare/v0.3.1...v0.4.8
-[0.3.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.3.1...v0.3.1
-[0.3.0]: https://github.com/infobloxopen/dns-aid-core/releases/tag/v0.3.1
-[0.2.1]: https://github.com/infobloxopen/dns-aid-core/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/infobloxopen/dns-aid-core/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/infobloxopen/dns-aid-core/releases/tag/v0.1.0
+[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.2...HEAD
+[0.24.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.1...v0.24.2
+[0.24.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.0...v0.24.1
+[0.24.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.23.0...v0.24.0
+[0.23.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.21.3...v0.23.0
+[0.21.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.21.2...v0.21.3
+[0.21.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.21.1...v0.21.2
+[0.21.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.21.0...v0.21.1
+[0.21.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.19.0...v0.20.0
+[0.19.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.6...v0.19.0
+[0.18.6]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.5...v0.18.6
+[0.18.5]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.4...v0.18.5
+[0.18.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.3...v0.18.4
+[0.18.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.2...v0.18.3
+[0.18.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.1...v0.18.2
+[0.18.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.17.3...v0.18.0
+[0.17.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.17.2...v0.17.3
+[0.17.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.17.1...v0.17.2
+[0.17.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.17.0...v0.17.1
+[0.17.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.14.5...v0.15.0
+[0.14.5]: https://github.com/dns-aid/dns-aid-core/compare/v0.14.4...v0.14.5
+[0.14.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.14.3...v0.14.4
+[0.14.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.14.2...v0.14.3
+[0.14.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.14.1...v0.14.2
+[0.14.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.14.0...v0.14.1
+[0.14.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.6...v0.14.0
+[0.13.6]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.5...v0.13.6
+[0.13.5]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.4...v0.13.5
+[0.13.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.3...v0.13.4
+[0.13.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.2...v0.13.3
+[0.13.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.12.1...v0.13.0
+[0.12.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.7.3...v0.8.0
+[0.7.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.9...v0.7.0
+[0.6.9]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.8...v0.6.9
+[0.6.8]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.7...v0.6.8
+[0.6.7]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.6...v0.6.7
+[0.6.6]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.5...v0.6.6
+[0.6.5]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.4...v0.6.5
+[0.6.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.4.9...v0.5.0
+[0.4.9]: https://github.com/dns-aid/dns-aid-core/compare/v0.4.8...v0.4.9
+[0.4.8]: https://github.com/dns-aid/dns-aid-core/compare/v0.3.1...v0.4.8
+[0.3.1]: https://github.com/dns-aid/dns-aid-core/releases/tag/v0.3.1
+[0.3.0]: https://github.com/dns-aid/dns-aid-core/releases/tag/v0.3.1
+[0.2.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/dns-aid/dns-aid-core/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "DNS-AID: DNS-based Agent Identification and Discovery"
 message: "If you use this software, please cite both the software and the IETF draft."
 type: software
 license: Apache-2.0
-repository-code: "https://github.com/infobloxopen/dns-aid-core"
+repository-code: "https://github.com/dns-aid/dns-aid-core"
 
 authors:
   - family-names: Racic
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.24.1"
+version: "0.24.2"
 date-released: "2026-06-04"
 
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ The `-s` flag automatically appends `Signed-off-by: Your Name <your@email.com>` 
 git push origin feat/your-feature-name
 ```
 
-Then open a Pull Request against the `main` branch on [infobloxopen/dns-aid-core](https://github.com/infobloxopen/dns-aid-core).
+Then open a Pull Request against the `main` branch on [dns-aid/dns-aid-core](https://github.com/dns-aid/dns-aid-core).
 
 ## Commit Message Guidelines
 
@@ -276,7 +276,7 @@ Releases are handled by maintainers:
 
 ## Reporting Issues
 
-Use the [issue templates](https://github.com/infobloxopen/dns-aid-core/issues/new/choose):
+Use the [issue templates](https://github.com/dns-aid/dns-aid-core/issues/new/choose):
 - **Bug Report** — include Python version, OS, dns-aid version, backend, and `dns-aid doctor` output
 - **Feature Request** — describe the motivation and proposed solution
 
@@ -304,5 +304,5 @@ By contributing, you agree that your contributions will be licensed under the Ap
 
 ## Questions?
 
-- Open a [GitHub Discussion](https://github.com/infobloxopen/dns-aid-core/discussions) for general questions
-- Open an [Issue](https://github.com/infobloxopen/dns-aid-core/issues) for bugs or feature requests
+- Open a [GitHub Discussion](https://github.com/dns-aid/dns-aid-core/discussions) for general questions
+- Open an [Issue](https://github.com/dns-aid/dns-aid-core/issues) for bugs or feature requests

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM python:3.11-slim@sha256:6ed5bff4d7396e3244b0f3c2fe578c87862efedd3e5e8cebd14
 
 LABEL org.opencontainers.image.title="DNS-AID MCP Server"
 LABEL org.opencontainers.image.description="DNS-based Agent Identification and Discovery"
-LABEL org.opencontainers.image.source="https://github.com/infobloxopen/dns-aid-core"
+LABEL org.opencontainers.image.source="https://github.com/dns-aid/dns-aid-core"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.sbom="cyclonedx"
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -94,7 +94,7 @@ DNS-AID does not select or default to any third-party service. You choose your D
 ## Open Source
 
 DNS-AID is open source under the Apache License 2.0. You can inspect all code at:
-https://github.com/infobloxopen/dns-aid-core
+https://github.com/dns-aid/dns-aid-core
 
 ## Changes to This Policy
 
@@ -102,6 +102,6 @@ Material changes to this policy will be documented in the project's release note
 
 ## Contact
 
-- **GitHub Issues:** https://github.com/infobloxopen/dns-aid-core/issues
+- **GitHub Issues:** https://github.com/dns-aid/dns-aid-core/issues
 - **Email:** iracic@infoblox.com
 - **IETF Draft:** draft-mozleywilliams-dnsop-dnsaid

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <!-- mcp-name: io.github.dns-aid/dns-aid -->
 
-[![CI](https://github.com/infobloxopen/dns-aid-core/actions/workflows/ci.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/ci.yml)
-[![Security](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/security.yml)
-[![CodeQL](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/infobloxopen/dns-aid-core/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/infobloxopen/dns-aid-core/badge)](https://scorecard.dev/viewer/?uri=github.com/infobloxopen/dns-aid-core)
+[![CI](https://github.com/dns-aid/dns-aid-core/actions/workflows/ci.yml/badge.svg)](https://github.com/dns-aid/dns-aid-core/actions/workflows/ci.yml)
+[![Security](https://github.com/dns-aid/dns-aid-core/actions/workflows/security.yml/badge.svg)](https://github.com/dns-aid/dns-aid-core/actions/workflows/security.yml)
+[![CodeQL](https://github.com/dns-aid/dns-aid-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/dns-aid/dns-aid-core/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/dns-aid/dns-aid-core/badge)](https://scorecard.dev/viewer/?uri=github.com/dns-aid/dns-aid-core)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12651/badge)](https://www.bestpractices.dev/projects/12651)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/)
@@ -59,7 +59,7 @@ You are encouraged to run your own directory or telemetry backend — the indexe
 pip install "dns-aid[cli,mcp]"
 
 # Or install the latest unreleased main from GitHub
-pip install "dns-aid[cli,mcp] @ git+https://github.com/infobloxopen/dns-aid-core.git"
+pip install "dns-aid[cli,mcp] @ git+https://github.com/dns-aid/dns-aid-core.git"
 ```
 
 For backend-specific extras (`route53`, `cloudflare`, `ns1`, `cloud_dns`, `infoblox`, `ddns`), see the [Getting Started Guide](docs/getting-started.md#install).
@@ -1122,7 +1122,7 @@ python examples/demo_full.py
 
 ```bash
 # Clone the repo
-git clone https://github.com/infobloxopen/dns-aid-core.git
+git clone https://github.com/dns-aid/dns-aid-core.git
 cd DNS-AID
 
 # Install all workspace packages (requires uv)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -163,7 +163,7 @@ We publish accepted (documented, risk-assessed) dependency CVEs here so reviewer
   includes pyjwt for OAuth-protected MCP servers, which use
   operator-issued tokens with operator-chosen key lengths.
 - **Mitigation**: None required at the SDK layer.
-- **Re-evaluation criteria**: Close [tracking issue #141](https://github.com/infobloxopen/dns-aid-core/issues/141)
+- **Re-evaluation criteria**: Close [tracking issue #141](https://github.com/dns-aid/dns-aid-core/issues/141)
   when ANY of the following changes:
   - NVD status changes away from "Analyzed / Disputed".
   - Snyk adds this CVE to their database.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,8 +11,8 @@
 
 ## Asking Questions
 
-- **GitHub Discussions** — for questions, ideas, and general conversation: [Discussions](https://github.com/infobloxopen/dns-aid-core/discussions)
-- **GitHub Issues** — for bug reports and feature requests: [Issues](https://github.com/infobloxopen/dns-aid-core/issues)
+- **GitHub Discussions** — for questions, ideas, and general conversation: [Discussions](https://github.com/dns-aid/dns-aid-core/discussions)
+- **GitHub Issues** — for bug reports and feature requests: [Issues](https://github.com/dns-aid/dns-aid-core/issues)
 
 ## Reporting Bugs
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -28,7 +28,7 @@ If DNS-AID is accepted into a Linux Foundation foundation, this trademark policy
 
 ## Contact
 
-Questions about trademark usage: open a [GitHub Discussion](https://github.com/infobloxopen/dns-aid-core/discussions) or contact the project lead listed in [MAINTAINERS.md](MAINTAINERS.md).
+Questions about trademark usage: open a [GitHub Discussion](https://github.com/dns-aid/dns-aid-core/discussions) or contact the project lead listed in [MAINTAINERS.md](MAINTAINERS.md).
 
 ## Other marks referenced in this project
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -8,7 +8,7 @@ All notable changes to DNS-AID are documented here.\n
 """
 body = """
 {%- macro remote_url() -%}
-  https://github.com/infobloxopen/dns-aid-core
+  https://github.com/dns-aid/dns-aid-core
 {%- endmacro -%}
 
 {% if version -%}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1848,4 +1848,4 @@ print(dns_aid.__version__)  # "0.6.0"
 - [Getting Started Guide](getting-started.md)
 - [IETF Draft: DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid-02/)
 - [RFC 9460: SVCB Records](https://www.rfc-editor.org/rfc/rfc9460.html)
-- [GitHub Repository](https://github.com/infobloxopen/dns-aid-core)
+- [GitHub Repository](https://github.com/dns-aid/dns-aid-core)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ The DNS-AID specification is defined in the IETF draft: https://datatracker.ietf
 
 ```bash
 # Clone the repository
-git clone https://github.com/infobloxopen/dns-aid-core.git
+git clone https://github.com/dns-aid/dns-aid-core.git
 cd dns-aid-core
 
 # Create virtual environment

--- a/docs/mcp-directory-listing.md
+++ b/docs/mcp-directory-listing.md
@@ -47,4 +47,4 @@ dns, agent-discovery, mcp, a2a, svcb, dnssec, ai-agents, infrastructure
 
 ## Privacy Policy URL
 
-https://github.com/infobloxopen/dns-aid-core/blob/main/PRIVACY.md
+https://github.com/dns-aid/dns-aid-core/blob/main/PRIVACY.md

--- a/manifest.json
+++ b/manifest.json
@@ -5,12 +5,12 @@
   "description": "DNS-based AI agent discovery. Publish, discover, and verify AI agents via DNS using SVCB records (RFC 9460). No central registry needed.",
   "license": "Apache-2.0",
   "privacy_policies": [
-    "https://github.com/infobloxopen/dns-aid-core/blob/main/PRIVACY.md"
+    "https://github.com/dns-aid/dns-aid-core/blob/main/PRIVACY.md"
   ],
   "author": {
     "name": "Infoblox",
     "email": "iracic@infoblox.com",
-    "url": "https://github.com/infobloxopen/dns-aid-core"
+    "url": "https://github.com/dns-aid/dns-aid-core"
   },
   "user_config": {
     "dns_aid_backend": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.24.1"
+version = "0.24.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -160,12 +160,12 @@ dns-aid = "dns_aid.cli.main:app"
 dns-aid-mcp = "dns_aid.mcp.server:main"
 
 [project.urls]
-Homepage = "https://github.com/infobloxopen/dns-aid-core"
-Documentation = "https://github.com/infobloxopen/dns-aid-core#readme"
-Repository = "https://github.com/infobloxopen/dns-aid-core"
-Changelog = "https://github.com/infobloxopen/dns-aid-core/blob/main/CHANGELOG.md"
-Issues = "https://github.com/infobloxopen/dns-aid-core/issues"
-Security = "https://github.com/infobloxopen/dns-aid-core/security/policy"
+Homepage = "https://github.com/dns-aid/dns-aid-core"
+Documentation = "https://github.com/dns-aid/dns-aid-core#readme"
+Repository = "https://github.com/dns-aid/dns-aid-core"
+Changelog = "https://github.com/dns-aid/dns-aid-core/blob/main/CHANGELOG.md"
+Issues = "https://github.com/dns-aid/dns-aid-core/issues"
+Security = "https://github.com/dns-aid/dns-aid-core/security/policy"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dns_aid"]

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,7 +12,7 @@ click==8.3.1
 colorama==0.4.6
 coverage==7.13.3
 cryptography==46.0.4
--e git+https://github.com/infobloxopen/dns-aid-core.git#egg=dns_aid
+-e git+https://github.com/dns-aid/dns-aid-core.git#egg=dns_aid
 dnspython==2.8.0
 h11==0.16.0
 httpcore==1.0.9

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1962,7 +1962,7 @@ try:
                     "/health": "Health check (GET)",
                     "/ready": "Readiness check (GET)",
                 },
-                "documentation": "https://github.com/infobloxopen/dns-aid-core",
+                "documentation": "https://github.com/dns-aid/dns-aid-core",
                 "specification": "IETF draft-mozleywilliams-dnsop-dnsaid-02",
             }
         )

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
Reimplements the org-migration URL sweep — the intent of #152 (@IngmarVG-IB) — rebuilt on **current main** so it doesn't re-drop the README `mcp-name` tag or the IETF/LF positioning sections that #152's stale base would revert (and which the new `readme-mcp-name` guard would now block).

### Org rename
- `github.com/infobloxopen/dns-aid-core` → `github.com/dns-aid/dns-aid-core` and `io.github.infobloxopen/dns-aid` → `io.github.dns-aid/dns-aid` across README, `pyproject` `[project.urls]` (fixes the **PyPI page links**), CITATION, docs, Dockerfile, packaging metadata.
- **Preserved**: "Infoblox" the company (NIOS backend, trademarks, "operated by Infoblox") and the deliberate "formerly `infobloxopen`" note.

### Release 0.24.2
- Version bump 0.24.1 → 0.24.2.
- CHANGELOG `[0.24.2]` covering the org-rename + the restored README sections (#170) + the CI guard.
- **Repaired the compare-link footer** — it had been frozen at `v0.13.4`; backfilled every release since and pointed `[Unreleased]` at `v0.24.2`.

Closing #152 in favour of this (rebuilt on current main). Full credit to @IngmarVG-IB for the rename.