### PR TITLE
fix: optional-mcp import, flat-FQDN listing, and BloxOne idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`dns-aid[cli]` imports without the `mcp` extra.** The MCP telemetry seam
+  imported `mcp.shared._httpx_utils.McpHttpClientFactory` at module load for a
+  single return-type annotation, so `import dns_aid` (and therefore the CLI)
+  failed with `ModuleNotFoundError: No module named 'mcp'` whenever the `mcp`
+  extra was not installed. The import now lives under `TYPE_CHECKING`
+  (`from __future__ import annotations` already keeps the annotation lazy), so
+  the package and CLI import with the core dependencies alone.
+- **`list` and `list_published_agents` surface flat-FQDN agents.** Listing
+  filtered records by the `_agents` substring, which under draft-02 matched
+  only the organization index and walkable aliases and silently missed every
+  flat agent owner (`{name}.{domain}`). A new `dns_aid.core.lister` identifies
+  DNS-AID records by structure (SVCB owners + companion TXT + `_agents`
+  bookkeeping); the CLI `list` command and the `list_published_agents` MCP tool
+  now report the same, complete set.
+- **Idempotent Infoblox BloxOne writes.** `create_svcb_record` and
+  `create_txt_record` POST-created records unconditionally, so repeated index
+  updates and re-publishes accumulated duplicate records and eventually failed
+  with `409 Conflict` on the `_index._agents` TXT. They now replace any
+  existing record at the same `(name, type)` before writing — an upsert that
+  matches the Route 53 backend's `UPSERT` contract and self-heals pre-existing
+  duplicates.
+
 ## [0.24.3] - 2026-06-04
 
 ### Fixed

--- a/src/dns_aid/backends/infoblox/bloxone.py
+++ b/src/dns_aid/backends/infoblox/bloxone.py
@@ -291,6 +291,59 @@ class InfobloxBloxOneBackend(DNSBackend):
             "target_name": target,
         }
 
+    async def _delete_existing_records(
+        self, zone_id: str, name_in_zone: str, record_type: str
+    ) -> int:
+        """Delete every record at ``(name_in_zone, record_type)`` in the zone.
+
+        DNS-AID owns the names it writes (agent owners and ``_index._agents``)
+        and publishes exactly one record per ``(name, type)``. Removing any
+        existing record(s) before a create makes the write idempotent (an
+        upsert) and self-heals accidental duplicates left by earlier
+        non-idempotent writes — matching the UPSERT contract other backends
+        (e.g. Route53) already provide, and avoiding BloxOne ``409 Conflict``
+        on repeated index updates and re-publishes.
+
+        Returns the number of records deleted.
+        """
+        deleted = 0
+        # Bounded loop: re-query from the top after each batch (deletions shift
+        # pagination). The cap is a safety stop, far above any real fan-out.
+        for _ in range(50):
+            response = await self._request(
+                "GET",
+                "/dns/record",
+                params={
+                    "_filter": (
+                        f'zone=="{zone_id}" and name_in_zone=="{name_in_zone}" '
+                        f'and type=="{record_type}"'
+                    ),
+                    "_limit": "100",
+                },
+            )
+            results = response.get("results", [])
+            if not results:
+                break
+            for record in results:
+                record_id = record.get("id")
+                if record_id:
+                    await self._request("DELETE", f"/{record_id}")
+                    deleted += 1
+            # A partial page means we have just deleted the last of them, so
+            # there is nothing left to re-query. Only loop again if the page
+            # was full (which a real DNS-AID name never reaches).
+            if len(results) < 100:
+                break
+        if deleted:
+            logger.debug(
+                "Replaced existing record(s) before write",
+                zone_id=zone_id,
+                name=name_in_zone,
+                type=record_type,
+                deleted=deleted,
+            )
+        return deleted
+
     async def create_svcb_record(
         self,
         zone: str,
@@ -307,6 +360,11 @@ class InfobloxBloxOneBackend(DNSBackend):
         # Build record name (without zone suffix)
         # name comes as "_agent._mcp._agents"
         name_in_zone = name
+
+        # Idempotent write (upsert): replace any existing SVCB at this name so
+        # re-publishing an agent updates in place instead of accumulating
+        # duplicate records (see _delete_existing_records).
+        await self._delete_existing_records(zone_id, name_in_zone, "SVCB")
 
         # Build FQDN for logging
         fqdn = f"{name}.{zone}"
@@ -354,6 +412,11 @@ class InfobloxBloxOneBackend(DNSBackend):
         """Create TXT record in BloxOne."""
         zone_info = await self._get_zone_info(zone)
         zone_id = zone_info["id"]
+
+        # Idempotent write (upsert): replace any existing TXT at this name.
+        # Without this, repeated index updates (_index._agents) POST-create
+        # duplicate TXT records and eventually 409 on BloxOne.
+        await self._delete_existing_records(zone_id, name, "TXT")
 
         # Build FQDN
         fqdn = f"{name}.{zone}"

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -787,11 +787,14 @@ def list_records(
     """
     List DNS-AID records in a domain.
 
-    Shows all _agents.* records in the specified zone.
+    Shows the flat agent owners ({name}.{domain} SVCB + TXT), the organization
+    index (_index._agents), and any walkable aliases in the specified zone.
 
     Example:
         dns-aid list example.com
     """
+    from dns_aid.core.lister import list_dns_aid_records
+
     dns_backend = _get_backend(backend)
 
     console.print(f"\n[bold]DNS-AID records in {domain}:[/bold]\n")
@@ -799,10 +802,7 @@ def list_records(
     async def list_all():
         if not await dns_backend.zone_exists(domain):
             return None  # sentinel: zone not found
-        records = []
-        async for record in dns_backend.list_records(domain, name_pattern="_agents"):
-            records.append(record)
-        return records
+        return await list_dns_aid_records(dns_backend, domain)
 
     try:
         records = run_async(list_all())

--- a/src/dns_aid/core/lister.py
+++ b/src/dns_aid/core/lister.py
@@ -1,0 +1,84 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Enumerate the DNS-AID records published in a zone, via a DNS backend.
+
+Under draft-mozleywilliams-dnsop-dnsaid-02 an agent's primary owner is the
+**flat** FQDN ``{name}.{domain}`` (SVCB + companion TXT). The pre-flat
+listing logic filtered records by the substring ``_agents`` in the owner
+label, which only ever matched the organization index (``_index._agents``)
+and walkable aliases (``{name}._agents``) — it silently missed every flat
+agent owner. This module identifies DNS-AID records by *structure* instead of
+by a name substring, so flat owners are surfaced.
+
+A record is a DNS-AID record when it is:
+
+* an **SVCB** record — every published agent (flat owner) and every walkable
+  alias has exactly one;
+* a **TXT** record sharing an owner with an SVCB record — the companion
+  capability/metadata TXT of a flat agent owner;
+* a record in the ``_agents`` bookkeeping namespace — the organization index
+  (``_index._agents``) and walkable-alias owners.
+
+System records (SOA/NS/A/AAAA/CNAME/...) are excluded. Used by ``dns-aid
+list`` (CLI) and the ``list_published_agents`` MCP tool so both interfaces
+report the same, correct set.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dns_aid.backends.base import DNSBackend
+
+# The label that marks the DNS-AID bookkeeping namespace (index + walkable
+# aliases). Agent *primary* owners are flat and do NOT contain it — that is
+# exactly why a substring filter on it is insufficient on its own.
+_AGENTS_LABEL = "_agents"
+
+
+def _owner(record: dict[str, Any]) -> str:
+    """Stable owner key for a record: name-in-zone, falling back to the FQDN."""
+    return record.get("name") or record.get("fqdn", "")
+
+
+async def list_dns_aid_records(backend: DNSBackend, domain: str) -> list[dict[str, Any]]:
+    """Return the DNS-AID records published under ``domain``.
+
+    Issues two type-filtered backend queries (SVCB, TXT) so unrelated system
+    records are never fetched. The result preserves the backend's record-dict
+    shape (``name``, ``fqdn``, ``type``, ``ttl``, ``values``, ``id``) and
+    de-duplicates by ``(fqdn, type)``.
+
+    Args:
+        backend: DNS backend to query.
+        domain: Zone to enumerate.
+
+    Returns:
+        DNS-AID records (SVCB owners + walkable aliases + companion TXT +
+        the ``_agents`` bookkeeping records), in backend order.
+    """
+    svcb_records = [r async for r in backend.list_records(domain, record_type="SVCB")]
+    txt_records = [r async for r in backend.list_records(domain, record_type="TXT")]
+
+    svcb_owners = {_owner(r) for r in svcb_records}
+
+    out: list[dict[str, Any]] = list(svcb_records)
+    for record in txt_records:
+        owner = _owner(record)
+        # Companion TXT of a flat agent owner, or an `_agents` bookkeeping TXT.
+        if owner in svcb_owners or _AGENTS_LABEL in owner:
+            out.append(record)
+
+    # De-duplicate defensively (a backend could surface a record under both
+    # queries); keep first occurrence and preserve order.
+    seen: set[tuple[str, str]] = set()
+    deduped: list[dict[str, Any]] = []
+    for record in out:
+        key = (record.get("fqdn", ""), record.get("type", ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(record)
+    return deduped

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -1009,12 +1009,11 @@ def list_published_agents(
     dns_backend = _get_dns_backend(backend)
 
     async def _list():
+        from dns_aid.core.lister import list_dns_aid_records
+
         if not await dns_backend.zone_exists(domain):
             return None  # sentinel: zone not found
-        records = []
-        async for record in dns_backend.list_records(domain, name_pattern="_agents"):
-            records.append(record)
-        return records
+        return await list_dns_aid_records(dns_backend, domain)
 
     try:
         records = _run_async(_list())

--- a/src/dns_aid/sdk/protocols/_mcp_telemetry.py
+++ b/src/dns_aid/sdk/protocols/_mcp_telemetry.py
@@ -19,11 +19,18 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import httpx
-from mcp.shared._httpx_utils import McpHttpClientFactory
 
 from dns_aid.sdk.telemetry.propagation import inject_otel_context
+
+if TYPE_CHECKING:
+    # `mcp` is an optional dependency (the `mcp` extra). It is referenced here
+    # only as a return-type annotation, which `from __future__ import
+    # annotations` keeps lazy — so importing this module (and therefore the
+    # whole `dns_aid` package and CLI) must not require `mcp` to be installed.
+    from mcp.shared._httpx_utils import McpHttpClientFactory
 
 
 @dataclass

--- a/tests/unit/sdk/test_optional_mcp_import.py
+++ b/tests/unit/sdk/test_optional_mcp_import.py
@@ -1,0 +1,63 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the package (and CLI) must import without the optional ``mcp`` extra.
+
+``mcp`` is declared in the ``mcp`` extra, not the core dependencies. A stray
+module-level ``from mcp...`` in the SDK import chain made ``import dns_aid``
+(and therefore ``dns-aid[cli]`` with no ``mcp`` extra) fail with
+``ModuleNotFoundError: No module named 'mcp'``. The MCP telemetry seam only
+references ``mcp`` as a type annotation, so the import belongs under
+``TYPE_CHECKING``. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+
+def _block_mcp(monkeypatch) -> None:
+    """Make any ``import mcp`` / ``from mcp...`` raise, simulating the absent extra."""
+    for mod in list(sys.modules):
+        if mod == "mcp" or mod.startswith("mcp."):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp" or name.startswith("mcp."):
+            raise ModuleNotFoundError("No module named 'mcp' (simulated: extra not installed)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_mcp_telemetry_module_imports_without_mcp(monkeypatch):
+    """The telemetry module references ``mcp`` only for typing — import must not need it."""
+    _block_mcp(monkeypatch)
+    monkeypatch.delitem(sys.modules, "dns_aid.sdk.protocols._mcp_telemetry", raising=False)
+
+    mod = importlib.import_module("dns_aid.sdk.protocols._mcp_telemetry")
+
+    assert hasattr(mod, "_make_telemetry_factory")
+    # The factory builds a plain httpx client factory and never touches ``mcp``.
+    assert "mcp" not in sys.modules
+
+
+async def test_factory_builds_without_mcp(monkeypatch):
+    """The telemetry factory is callable and returns an httpx client without ``mcp``."""
+    import httpx
+
+    _block_mcp(monkeypatch)
+    monkeypatch.delitem(sys.modules, "dns_aid.sdk.protocols._mcp_telemetry", raising=False)
+    mod = importlib.import_module("dns_aid.sdk.protocols._mcp_telemetry")
+
+    capture = mod._TelemetryCapture()
+    factory = mod._make_telemetry_factory(capture)
+    client = factory()
+    try:
+        assert isinstance(client, httpx.AsyncClient)
+    finally:
+        await client.aclose()

--- a/tests/unit/test_infoblox_backend.py
+++ b/tests/unit/test_infoblox_backend.py
@@ -146,8 +146,14 @@ class TestInfobloxBloxOneBackendAsync:
     ):
         """Test SVCB record creation."""
         with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
-            # Calls: view lookup, zone lookup, record creation
-            mock_req.side_effect = [mock_view_response, mock_zone_response, mock_record_response]
+            # Calls: view lookup, zone lookup, upsert-existing lookup (none
+            # present), record creation.
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                {"results": []},  # no existing SVCB at this name
+                mock_record_response,
+            ]
 
             result = await backend.create_svcb_record(
                 zone="example.com",
@@ -159,10 +165,10 @@ class TestInfobloxBloxOneBackendAsync:
             )
 
             assert result == "_test._mcp._agents.example.com"
-            assert mock_req.call_count == 3
+            assert mock_req.call_count == 4
 
             # Verify the POST call payload
-            post_call = mock_req.call_args_list[2]
+            post_call = mock_req.call_args_list[3]
             assert post_call[0][0] == "POST"
             assert post_call[0][1] == "/dns/record"
             payload = post_call[1]["json"]
@@ -181,8 +187,14 @@ class TestInfobloxBloxOneBackendAsync:
         }
 
         with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
-            # Calls: view lookup, zone lookup, record creation
-            mock_req.side_effect = [mock_view_response, mock_zone_response, mock_txt_response]
+            # Calls: view lookup, zone lookup, upsert-existing lookup (none
+            # present), record creation.
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                {"results": []},  # no existing TXT at this name
+                mock_txt_response,
+            ]
 
             result = await backend.create_txt_record(
                 zone="example.com",
@@ -194,10 +206,45 @@ class TestInfobloxBloxOneBackendAsync:
             assert result == "_test._mcp._agents.example.com"
 
             # Verify payload
-            post_call = mock_req.call_args_list[2]
+            post_call = mock_req.call_args_list[3]
             payload = post_call[1]["json"]
             assert payload["type"] == "TXT"
             assert "capabilities" in payload["rdata"]["text"]
+
+    async def test_create_is_idempotent_replaces_existing(
+        self, backend, mock_view_response, mock_zone_response
+    ):
+        """A create with an existing record at the same (name, type) deletes it
+        first, then creates — an upsert that prevents duplicate/409 accumulation
+        (regression for the BloxOne _index._agents duplication bug)."""
+        existing = {"results": [{"id": "dns/record/old-index-1"}]}
+        create_resp = {"result": {"id": "dns/record/new-index", "type": "TXT"}}
+
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            # view, zone, upsert-existing lookup (one present), DELETE, POST
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                existing,
+                {},  # DELETE response
+                create_resp,
+            ]
+
+            await backend.create_txt_record(
+                zone="example.com",
+                name="_index._agents",
+                values=["agents=chat:mcp"],
+                ttl=3600,
+            )
+
+            methods_paths = [(c[0][0], c[0][1]) for c in mock_req.call_args_list]
+            # The existing record is deleted before the new one is created.
+            assert ("DELETE", "/dns/record/old-index-1") in methods_paths
+            delete_idx = methods_paths.index(("DELETE", "/dns/record/old-index-1"))
+            post_idx = next(
+                i for i, (m, p) in enumerate(methods_paths) if m == "POST" and p == "/dns/record"
+            )
+            assert delete_idx < post_idx, "must delete the stale record before creating the new one"
 
     async def test_delete_record_success(self, backend, mock_view_response, mock_zone_response):
         """Test successful record deletion."""

--- a/tests/unit/test_lister.py
+++ b/tests/unit/test_lister.py
@@ -1,0 +1,77 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dns_aid.core.lister.list_dns_aid_records (flat-FQDN listing)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dns_aid.core.lister import list_dns_aid_records
+
+
+class _FakeBackend:
+    """Minimal backend exposing the ``list_records`` async-iterator contract."""
+
+    def __init__(self, records: list[dict[str, Any]]):
+        self._records = records
+
+    async def list_records(self, zone, name_pattern=None, record_type=None):
+        for r in self._records:
+            if record_type and r.get("type") != record_type:
+                continue
+            if name_pattern and name_pattern not in (r.get("name") or ""):
+                continue
+            yield r
+
+
+def _rec(name: str, fqdn: str, rtype: str) -> dict[str, Any]:
+    return {"name": name, "fqdn": fqdn, "type": rtype, "ttl": 3600, "values": ["x"], "id": fqdn}
+
+
+@pytest.fixture
+def zone_records() -> list[dict[str, Any]]:
+    return [
+        _rec("@", "example.com", "SOA"),
+        _rec("@", "example.com", "NS"),
+        _rec("www", "www.example.com", "A"),
+        # Flat draft-02 agent owner — the records the old `_agents` filter missed.
+        _rec("chat", "chat.example.com", "SVCB"),
+        _rec("chat", "chat.example.com", "TXT"),
+        # Organization index + a walkable alias (the `_agents` bookkeeping).
+        _rec("_index._agents", "_index._agents.example.com", "TXT"),
+        _rec("chat._agents", "chat._agents.example.com", "SVCB"),
+        # A non-DNS-AID TXT that must NOT be listed.
+        _rec("_dmarc", "_dmarc.example.com", "TXT"),
+    ]
+
+
+async def test_lists_flat_owners_and_bookkeeping(zone_records):
+    result = await list_dns_aid_records(_FakeBackend(zone_records), "example.com")
+    got = {(r["fqdn"], r["type"]) for r in result}
+
+    # The regression: flat agent owner SVCB + companion TXT are surfaced.
+    assert ("chat.example.com", "SVCB") in got
+    assert ("chat.example.com", "TXT") in got
+    # Bookkeeping records are included.
+    assert ("_index._agents.example.com", "TXT") in got
+    assert ("chat._agents.example.com", "SVCB") in got
+    # System + unrelated records are excluded.
+    assert ("example.com", "SOA") not in got
+    assert ("example.com", "NS") not in got
+    assert ("www.example.com", "A") not in got
+    assert ("_dmarc.example.com", "TXT") not in got
+
+
+async def test_empty_zone_returns_empty():
+    result = await list_dns_aid_records(_FakeBackend([_rec("@", "example.com", "SOA")]), "example.com")
+    assert result == []
+
+
+async def test_dedup_when_backend_double_yields():
+    dup = _rec("chat", "chat.example.com", "SVCB")
+    backend = _FakeBackend([dup, dict(dup)])  # same (fqdn, type) twice
+    result = await list_dns_aid_records(backend, "example.com")
+    assert len([r for r in result if r["type"] == "SVCB"]) == 1


### PR DESCRIPTION
## Summary

Three independent production bugs surfaced while integration-testing the Infoblox BloxOne backend against a live zone. Each is its own atomic commit; all are covered by unit tests and verified end-to-end with a live publish / list / delete cycle across all three interfaces (CLI, SDK, MCP).

## Fixes

### 1. `dns-aid[cli]` imports without the `mcp` extra — `fix(sdk)`
The MCP telemetry seam imported `mcp.shared._httpx_utils.McpHttpClientFactory` at module load for a single return-type annotation, so `import dns_aid` (and therefore the CLI) failed with `ModuleNotFoundError: No module named 'mcp'` whenever the `mcp` extra was not installed. The import now lives under `TYPE_CHECKING` (the annotation is already lazy via `from __future__ import annotations`).

- `src/dns_aid/sdk/protocols/_mcp_telemetry.py`

### 2. `list` / `list_published_agents` surface flat-FQDN agents — `fix(core)`
Listing filtered records by the `_agents` substring, which under draft-02 matched only the organization index and walkable aliases and silently missed every flat agent owner (`{name}.{domain}`). A new `dns_aid.core.lister` identifies DNS-AID records by structure (SVCB owners + companion TXT + `_agents` bookkeeping); the CLI `list` command and the `list_published_agents` MCP tool now report the same, complete set.

- `src/dns_aid/core/lister.py` (new), `src/dns_aid/cli/main.py`, `src/dns_aid/mcp/server.py`

### 3. Idempotent Infoblox BloxOne writes — `fix(backends)`
`create_svcb_record` and `create_txt_record` POST-created records unconditionally, so repeated index updates and re-publishes accumulated duplicate `_index._agents` TXT records and eventually returned `409 Conflict`. They now replace any existing record at the same `(name, type)` before writing — an upsert matching the Route 53 backend's `UPSERT` contract that also self-heals pre-existing duplicates.

- `src/dns_aid/backends/infoblox/bloxone.py`

## Test plan

- [x] Unit tests added/updated (`test_optional_mcp_import`, `test_lister`, `test_infoblox_backend` idempotency); full unit suite green (1849 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/dns_aid/` clean (84 files)
- [x] Live-verified against a real Infoblox BloxOne zone via CLI, SDK, and MCP: `list` now shows flat agents, re-publish is idempotent (no duplicate index, no 409), and the package imports without the `mcp` extra

No version bump in this PR; a release can be cut separately.