### PR TITLE
release: 0.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.4] - 2026-06-10
+
 ### Fixed
 
 - **`dns-aid[cli]` imports without the `mcp` extra.** The MCP telemetry seam
@@ -1918,7 +1920,8 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.3...HEAD
+[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.4...HEAD
+[0.24.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.3...v0.24.4
 [0.24.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.2...v0.24.3
 [0.24.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.0...v0.24.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.24.3"
-date-released: "2026-06-04"
+version: "0.24.4"
+date-released: "2026-06-10"
 
 keywords:
   - dns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.24.3"
+version = "0.24.4"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.24.3"
+version = "0.24.4"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Patch release bundling the three fixes merged in #175:

- **`dns-aid[cli]` imports without the `mcp` extra** — MCP telemetry type import moved under `TYPE_CHECKING`.
- **`list` / `list_published_agents` surface flat-FQDN agents** — new structure-based `dns_aid.core.lister`.
- **Idempotent Infoblox BloxOne writes** — `create_*` now upsert (delete-before-create), fixing duplicate `_index._agents` and `409 Conflict`.

## Changes

- `pyproject.toml` — version 0.24.3 → 0.24.4
- `CITATION.cff` — version 0.24.4, date-released 2026-06-10
- `CHANGELOG.md` — promote `[Unreleased]` fixes to `[0.24.4]` + footer compare link
- `uv.lock` — self-version bump

No code changes beyond version metadata (the fixes landed in #175). Tagging `v0.24.4` after merge triggers the PyPI + MCP Registry publish.