### PR TITLE
feat(infoblox): full ServiceMode SVCB + safe in-place upsert on UDDI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-06-10
+
+### Added
+
+- **Full RFC 9460 ServiceMode SVCB support for the Infoblox UDDI backend.** The
+  backend now declares `supports_private_svcb_keys = True`, so the DNS-AID
+  custom SvcParams (`cap` / `cap-sha256` / `bap` / `policy` / `realm` / `sig` /
+  `connect-*` / `enroll-uri`, encoded as the private-use keys
+  `key65400`–`key65405`) are written natively on the SVCB record itself via the
+  UDDI DNS Data API's `svc_params` list rather than demoted to a TXT companion.
+  Verified against the live UDDI DNS Data API across the library, CLI, and MCP
+  interfaces, including idempotent upsert, concurrent publish, adversarial
+  values, and the SvcParam quote-breakout injection guard.
+
+### Changed
+
+- **The Infoblox UDDI backend emits true ServiceMode SVCB rdata.** SVCB records
+  now carry their real `priority` (ServiceMode when `> 0`) and a structured
+  `svc_params` list of `{"key", "value"}` objects. Previously the backend
+  hardcoded `priority` to `0` (AliasMode) and dropped all SvcParams, mirroring
+  a now-removed assumption that UDDI could not store them. Record listing and
+  lookup render through a single shared presentation helper so `list_records`
+  and `get_record` stay consistent. Records published by earlier versions
+  continue to resolve; re-publishing upgrades them to ServiceMode in place.
+
+### Fixed
+
+- **Infoblox UDDI writes are now a safe in-place upsert (no data-loss window).**
+  `create_svcb_record` / `create_txt_record` previously deleted the existing
+  record before creating the replacement, so a rejected or transient failure on
+  the follow-up create (throttle, 5xx, oversize payload during a re-publish)
+  could leave the name with no record — for SVCB, an agent silently dropping out
+  of DNS. The backend now reads the existing record and updates it in place with
+  `PATCH` (creating with `POST` only when none exists), so a failed write leaves
+  the previous record intact. This also resolves the repeated-index-update `409`
+  the delete-then-create was working around, and heals duplicate records left by
+  older non-idempotent writes. The expanded ServiceMode SvcParam payload made the
+  previous window materially larger, so it is closed here alongside that change.
+
 ## [0.24.4] - 2026-06-10
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.24.4"
+version: "0.25.0"
 date-released: "2026-06-10"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -859,26 +859,22 @@ Infoblox UDDI (Universal DDI) is Infoblox's cloud-native DDI platform. DNS-AID s
    )
    ```
 
-#### Infoblox UDDI Limitations & DNS-AID Compliance
+#### Infoblox UDDI SVCB Support
 
-> **⚠️ Important**: Infoblox UDDI SVCB records only support "alias mode" (priority 0) and do not
-> support SVC parameters (`alpn`, `port`, `mandatory`). This means **Infoblox UDDI is not fully
-> compliant with the [DNS-AID draft](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)**.
->
-> The draft requires ServiceMode SVCB records (priority > 0) with mandatory `alpn` and `port`
-> parameters. Infoblox UDDI's limitation is a platform constraint, not a DNS-AID limitation.
+Infoblox UDDI supports **full ServiceMode SVCB** (RFC 9460): `priority > 0` with `svc_params`,
+including the standard keys (`alpn`, `port`, `mandatory`, `ipv4hint`, `ipv6hint`, ...) and the
+private-use range `key65280`–`key65534`. DNS-AID's custom parameters (`cap`, `cap-sha256`,
+`bap`, `policy`, `realm`, `sig`, `connect-class`, `connect-meta`, `enroll-uri` — encoded as
+`key65400`–`key65405`) are written **natively on the SVCB record**, not demoted to a TXT
+companion.
 
 | DNS-AID Requirement | Route 53 | Infoblox UDDI |
 |---------------------|----------|---------------|
-| ServiceMode (priority > 0) | ✅ | ❌ |
-| `alpn` parameter | ✅ | ❌ |
-| `port` parameter | ✅ | ❌ |
-| `mandatory` key | ✅ | ❌ |
+| ServiceMode (priority > 0) | ✅ | ✅ |
+| `alpn` / `port` / `mandatory` | ✅ | ✅ |
+| Private-use keys (cap/bap/policy/realm/sig/...) | ✅ | ✅ |
 
-**For full DNS-AID compliance, use Route 53 or another RFC 9460-compliant DNS provider.**
-
-DNS-AID stores `alpn` and `port` in TXT records as a fallback for Infoblox UDDI, but this is
-a workaround and not standard-compliant for agent discovery.
+Infoblox UDDI is a **fully DNS-AID-compliant** ServiceMode SVCB backend.
 
 #### Verify Records via API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.24.4"
+version = "0.25.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/backends/infoblox/bloxone.py
+++ b/src/dns_aid/backends/infoblox/bloxone.py
@@ -19,6 +19,7 @@ import httpx
 import structlog
 
 from dns_aid.backends.base import DNSBackend
+from dns_aid.core.models import SVCB_ALIAS_MODE
 
 logger = structlog.get_logger(__name__)
 
@@ -93,6 +94,18 @@ class InfobloxBloxOneBackend(DNSBackend):
     def dns_view(self) -> str:
         """Get the configured DNS view name."""
         return self._dns_view
+
+    @property
+    def supports_private_svcb_keys(self) -> bool:
+        """Infoblox UDDI accepts private-use SVCB keys (key65280-key65534).
+
+        UDDI's DNS Data API takes the DNS-AID custom SvcParams
+        (cap / cap-sha256 / bap / policy / realm / sig / connect-* / enroll-uri,
+        encoded as key65400-key65405) natively in ServiceMode ``svc_params``,
+        so they are written on the SVCB record itself rather than demoted to a
+        TXT companion. Confirmed against the live UDDI DNS Data API.
+        """
+        return True
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client.
@@ -272,77 +285,115 @@ class InfobloxBloxOneBackend(DNSBackend):
         target: str,
         params: dict[str, str],
     ) -> dict:
-        """
-        Format SVCB rdata for BloxOne API.
+        """Format SVCB rdata for the Infoblox UDDI DNS Data API.
 
-        BloxOne SVCB rdata format uses only target_name.
-        Priority defaults to 0 (alias mode) in BloxOne.
-
-        Note: BloxOne currently supports basic SVCB without SVC params.
-        For full SVCB with alpn/port params, use the TXT record for metadata.
+        UDDI accepts full ServiceMode SVCB. The rdata is an integer
+        ``priority`` (0 = AliasMode, >0 = ServiceMode), a ``target_name``, and,
+        in ServiceMode, ``svc_params`` as a list of ``{"key", "value"}``
+        objects. Standard keys (alpn, port, ipv4hint, ipv6hint, mandatory, ...)
+        and the DNS-AID private-use keys (key65400-key65405) are all accepted
+        natively, so params are written on the SVCB record rather than demoted
+        to a TXT companion.
         """
-        # Ensure target has trailing dot
         if not target.endswith("."):
             target = f"{target}."
 
-        # BloxOne only accepts target_name for SVCB
-        # Priority and svc_params are not supported in current API
-        return {
-            "target_name": target,
-        }
+        rdata: dict = {"priority": priority, "target_name": target}
+        # AliasMode (priority 0) carries no SvcParams; ServiceMode puts the
+        # SvcParams on the SVCB record itself.
+        if priority != SVCB_ALIAS_MODE and params:
+            rdata["svc_params"] = [{"key": k, "value": str(v)} for k, v in params.items()]
+        return rdata
 
-    async def _delete_existing_records(
-        self, zone_id: str, name_in_zone: str, record_type: str
-    ) -> int:
-        """Delete every record at ``(name_in_zone, record_type)`` in the zone.
+    @staticmethod
+    def _svcb_presentation(rdata: dict) -> str:
+        """Render UDDI SVCB rdata as an RFC 9460 presentation-format value.
+
+        Handles ServiceMode (``priority`` > 0 with a ``svc_params`` list) as
+        well as AliasMode (``priority`` 0). Tolerates an empty/absent
+        ``svc_params`` and value-less keys (e.g. ``no-default-alpn``).
+        """
+        priority = rdata.get("priority", 0)
+        target = rdata.get("target_name", "")
+        svc_params = rdata.get("svc_params") or []
+        if isinstance(svc_params, list):
+            rendered = " ".join(
+                f"{p['key']}={p['value']}" if p.get("value") else p.get("key", "")
+                for p in svc_params
+                if p.get("key")
+            )
+        else:
+            rendered = str(svc_params)
+        return f"{priority} {target} {rendered}".strip()
+
+    async def _upsert_record(
+        self,
+        zone_id: str,
+        name_in_zone: str,
+        record_type: str,
+        rdata: dict,
+        ttl: int,
+        comment: str,
+    ) -> str:
+        """Idempotently write exactly one record at ``(name_in_zone, type)``.
+
+        Read-modify-write upsert: when a record already exists it is updated in
+        place with ``PATCH``; otherwise a new record is created with ``POST``.
+
+        PATCH never removes the live record before the replacement is committed,
+        so a rejected or failed write leaves the previous record intact. The
+        earlier delete-then-create ordering could drop the record entirely if
+        the follow-up create was rejected (a transient API error, throttle, or
+        oversize payload during a re-publish), which for SVCB meant an agent
+        silently disappearing from DNS. PATCH closes that window: the worst case
+        is the record keeping its previous value.
 
         DNS-AID owns the names it writes (agent owners and ``_index._agents``)
-        and publishes exactly one record per ``(name, type)``. Removing any
-        existing record(s) before a create makes the write idempotent (an
-        upsert) and self-heals accidental duplicates left by earlier
-        non-idempotent writes — matching the UPSERT contract other backends
-        (e.g. Route53) already provide, and avoiding BloxOne ``409 Conflict``
-        on repeated index updates and re-publishes.
+        and keeps exactly one record per ``(name, type)``, so re-publishing and
+        repeated index updates converge on a single record without the BloxOne
+        ``409 Conflict`` that non-idempotent POST-only writes hit. Any duplicate
+        records left by an earlier non-idempotent write are healed best-effort:
+        the first is updated and the extras removed.
 
-        Returns the number of records deleted.
+        Returns the id of the surviving record.
         """
-        deleted = 0
-        # Bounded loop: re-query from the top after each batch (deletions shift
-        # pagination). The cap is a safety stop, far above any real fan-out.
-        for _ in range(50):
-            response = await self._request(
-                "GET",
-                "/dns/record",
-                params={
-                    "_filter": (
-                        f'zone=="{zone_id}" and name_in_zone=="{name_in_zone}" '
-                        f'and type=="{record_type}"'
-                    ),
-                    "_limit": "100",
-                },
-            )
-            results = response.get("results", [])
-            if not results:
-                break
-            for record in results:
-                record_id = record.get("id")
-                if record_id:
-                    await self._request("DELETE", f"/{record_id}")
-                    deleted += 1
-            # A partial page means we have just deleted the last of them, so
-            # there is nothing left to re-query. Only loop again if the page
-            # was full (which a real DNS-AID name never reaches).
-            if len(results) < 100:
-                break
-        if deleted:
-            logger.debug(
-                "Replaced existing record(s) before write",
-                zone_id=zone_id,
-                name=name_in_zone,
-                type=record_type,
-                deleted=deleted,
-            )
-        return deleted
+        import contextlib
+
+        response = await self._request(
+            "GET",
+            "/dns/record",
+            params={
+                "_filter": (
+                    f'zone=="{zone_id}" and name_in_zone=="{name_in_zone}" '
+                    f'and type=="{record_type}"'
+                ),
+                "_limit": "100",
+            },
+        )
+        existing = [r.get("id") for r in response.get("results", []) if r.get("id")]
+        body = {"rdata": rdata, "ttl": ttl, "comment": comment}
+
+        if existing:
+            primary = existing[0]
+            # Update the live record in place — its previous rdata survives a
+            # failed PATCH, so a write error never leaves the name empty.
+            patched = await self._request("PATCH", f"/{primary}", json=body)
+            # Heal duplicates from an earlier non-idempotent write. Best-effort:
+            # a leftover duplicate is reconciled on the next write rather than
+            # failing the upsert.
+            for dup in existing[1:]:
+                with contextlib.suppress(Exception):
+                    await self._request("DELETE", f"/{dup}")
+            return patched.get("result", {}).get("id", primary)
+
+        payload = {
+            "name_in_zone": name_in_zone,
+            "zone": zone_id,
+            "type": record_type,
+            **body,
+        }
+        created = await self._request("POST", "/dns/record", json=payload)
+        return created.get("result", {}).get("id", "")
 
     async def create_svcb_record(
         self,
@@ -361,11 +412,6 @@ class InfobloxBloxOneBackend(DNSBackend):
         # name comes as "_agent._mcp._agents"
         name_in_zone = name
 
-        # Idempotent write (upsert): replace any existing SVCB at this name so
-        # re-publishing an agent updates in place instead of accumulating
-        # duplicate records (see _delete_existing_records).
-        await self._delete_existing_records(zone_id, name_in_zone, "SVCB")
-
         # Build FQDN for logging
         fqdn = f"{name}.{zone}"
 
@@ -373,7 +419,7 @@ class InfobloxBloxOneBackend(DNSBackend):
         rdata = self._format_svcb_rdata(priority, target, params)
 
         logger.info(
-            "Creating SVCB record in BloxOne",
+            "Writing SVCB record in BloxOne",
             zone=zone,
             name=name_in_zone,
             fqdn=fqdn,
@@ -381,21 +427,18 @@ class InfobloxBloxOneBackend(DNSBackend):
             ttl=ttl,
         )
 
-        # Create record via API
-        payload = {
-            "name_in_zone": name_in_zone,
-            "zone": zone_id,
-            "type": "SVCB",
-            "rdata": rdata,
-            "ttl": ttl,
-            "comment": f"DNS-AID: SVCB record for {name}",
-        }
-
-        response = await self._request("POST", "/dns/record", json=payload)
-
-        record_id = response.get("result", {}).get("id")
+        # Idempotent in-place upsert (PATCH existing / POST new): re-publishing
+        # an agent updates the record without dropping it on a failed write.
+        record_id = await self._upsert_record(
+            zone_id,
+            name_in_zone,
+            "SVCB",
+            rdata,
+            ttl,
+            f"DNS-AID: SVCB record for {name}",
+        )
         logger.info(
-            "SVCB record created in BloxOne",
+            "SVCB record written in BloxOne",
             fqdn=fqdn,
             record_id=record_id,
         )
@@ -413,11 +456,6 @@ class InfobloxBloxOneBackend(DNSBackend):
         zone_info = await self._get_zone_info(zone)
         zone_id = zone_info["id"]
 
-        # Idempotent write (upsert): replace any existing TXT at this name.
-        # Without this, repeated index updates (_index._agents) POST-create
-        # duplicate TXT records and eventually 409 on BloxOne.
-        await self._delete_existing_records(zone_id, name, "TXT")
-
         # Build FQDN
         fqdn = f"{name}.{zone}"
 
@@ -427,7 +465,7 @@ class InfobloxBloxOneBackend(DNSBackend):
         rdata = {"text": " ".join(f'"{v}"' for v in values)}
 
         logger.info(
-            "Creating TXT record in BloxOne",
+            "Writing TXT record in BloxOne",
             zone=zone,
             name=name,
             fqdn=fqdn,
@@ -435,20 +473,19 @@ class InfobloxBloxOneBackend(DNSBackend):
             ttl=ttl,
         )
 
-        payload = {
-            "name_in_zone": name,
-            "zone": zone_id,
-            "type": "TXT",
-            "rdata": rdata,
-            "ttl": ttl,
-            "comment": f"DNS-AID: TXT record for {name}",
-        }
-
-        response = await self._request("POST", "/dns/record", json=payload)
-
-        record_id = response.get("result", {}).get("id")
+        # Idempotent in-place upsert (PATCH existing / POST new): repeated index
+        # updates (_index._agents) and re-publishes converge on one record
+        # without duplicate accumulation or 409 conflicts.
+        record_id = await self._upsert_record(
+            zone_id,
+            name,
+            "TXT",
+            rdata,
+            ttl,
+            f"DNS-AID: TXT record for {name}",
+        )
         logger.info(
-            "TXT record created in BloxOne",
+            "TXT record written in BloxOne",
             fqdn=fqdn,
             record_id=record_id,
         )
@@ -572,11 +609,7 @@ class InfobloxBloxOneBackend(DNSBackend):
                 if rtype == "TXT":
                     values = [rdata.get("text", "")]
                 elif rtype == "SVCB":
-                    target = rdata.get("target_name", "")
-                    # BloxOne SVCB only supports alias mode (priority 0)
-                    # The API doesn't return priority in rdata, but always uses 0
-                    svc_params = rdata.get("svc_params", "")
-                    values = [f"0 {target} {svc_params}".strip()]
+                    values = [self._svcb_presentation(rdata)]
                 else:
                     # Generic handling
                     values = [str(rdata)]
@@ -650,9 +683,7 @@ class InfobloxBloxOneBackend(DNSBackend):
             if record_type == "TXT":
                 values = [rdata.get("text", "")]
             elif record_type == "SVCB":
-                target = rdata.get("target_name", "")
-                svc_params = rdata.get("svc_params", "")
-                values = [f"0 {target} {svc_params}".strip()]
+                values = [self._svcb_presentation(rdata)]
             else:
                 values = [str(rdata)]
 

--- a/tests/unit/test_infoblox_backend.py
+++ b/tests/unit/test_infoblox_backend.py
@@ -10,6 +10,7 @@ requiring real Infoblox credentials.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from dns_aid.backends.infoblox.bloxone import InfobloxBloxOneBackend
@@ -49,18 +50,50 @@ class TestInfobloxBloxOneBackend:
         backend = InfobloxBloxOneBackend(api_key="test-key")
         assert backend.name == "bloxone"
 
-    def test_format_svcb_rdata(self):
-        """Test SVCB rdata formatting."""
+    def test_format_svcb_rdata_service_mode(self):
+        """ServiceMode SVCB rdata carries priority + svc_params as {key,value} objects."""
         backend = InfobloxBloxOneBackend(api_key="test-key")
 
         rdata = backend._format_svcb_rdata(
-            priority=1, target="target.example.com", params={"alpn": "mcp", "port": "443"}
+            priority=1,
+            target="target.example.com",
+            params={"alpn": "mcp", "port": "443", "key65400": "https://x/cap.json"},
         )
 
-        # BloxOne only supports target_name in SVCB rdata
         assert rdata["target_name"] == "target.example.com."
-        assert "priority" not in rdata  # Not supported by BloxOne API
-        assert "svc_params" not in rdata  # Not supported by BloxOne API
+        assert rdata["priority"] == 1
+        # svc_params is a list of {"key","value"} (UDDI DNS Data schema), and
+        # DNS-AID private-use keys (key65400-key65405) are carried natively.
+        assert {"key": "alpn", "value": "mcp"} in rdata["svc_params"]
+        assert {"key": "port", "value": "443"} in rdata["svc_params"]
+        assert {"key": "key65400", "value": "https://x/cap.json"} in rdata["svc_params"]
+
+    def test_format_svcb_rdata_alias_mode(self):
+        """AliasMode (priority 0) carries no svc_params (used for walkable aliases)."""
+        backend = InfobloxBloxOneBackend(api_key="test-key")
+
+        rdata = backend._format_svcb_rdata(priority=0, target="flat.example.com.", params={})
+
+        assert rdata == {"priority": 0, "target_name": "flat.example.com."}
+
+    def test_supports_private_svcb_keys(self):
+        """UDDI declares private-key support, so customs are not demoted to TXT."""
+        backend = InfobloxBloxOneBackend(api_key="test-key")
+        assert backend.supports_private_svcb_keys is True
+
+    def test_svcb_presentation_service_mode(self):
+        """SVCB readback renders real priority + params (not a hardcoded 0)."""
+        value = InfobloxBloxOneBackend._svcb_presentation(
+            {
+                "priority": 1,
+                "target_name": "mcp.example.com.",
+                "svc_params": [
+                    {"key": "alpn", "value": "mcp"},
+                    {"key": "no-default-alpn", "value": ""},
+                ],
+            }
+        )
+        assert value == "1 mcp.example.com. alpn=mcp no-default-alpn"
 
     def test_format_svcb_rdata_with_trailing_dot(self):
         """Test SVCB rdata doesn't double trailing dot."""
@@ -211,23 +244,24 @@ class TestInfobloxBloxOneBackendAsync:
             assert payload["type"] == "TXT"
             assert "capabilities" in payload["rdata"]["text"]
 
-    async def test_create_is_idempotent_replaces_existing(
+    async def test_create_is_idempotent_patches_existing_in_place(
         self, backend, mock_view_response, mock_zone_response
     ):
-        """A create with an existing record at the same (name, type) deletes it
-        first, then creates — an upsert that prevents duplicate/409 accumulation
-        (regression for the BloxOne _index._agents duplication bug)."""
+        """A create with an existing record at the same (name, type) updates it
+        in place with PATCH — an upsert that never deletes the live record
+        before the replacement is committed, so a failed write can't drop it
+        (regression for the BloxOne _index._agents duplication bug, hardened so
+        a rejected re-publish keeps the previous record)."""
         existing = {"results": [{"id": "dns/record/old-index-1"}]}
-        create_resp = {"result": {"id": "dns/record/new-index", "type": "TXT"}}
+        patch_resp = {"result": {"id": "dns/record/old-index-1", "type": "TXT"}}
 
         with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
-            # view, zone, upsert-existing lookup (one present), DELETE, POST
+            # view, zone, upsert-existing lookup (one present), PATCH
             mock_req.side_effect = [
                 mock_view_response,
                 mock_zone_response,
                 existing,
-                {},  # DELETE response
-                create_resp,
+                patch_resp,
             ]
 
             await backend.create_txt_record(
@@ -238,13 +272,77 @@ class TestInfobloxBloxOneBackendAsync:
             )
 
             methods_paths = [(c[0][0], c[0][1]) for c in mock_req.call_args_list]
-            # The existing record is deleted before the new one is created.
-            assert ("DELETE", "/dns/record/old-index-1") in methods_paths
-            delete_idx = methods_paths.index(("DELETE", "/dns/record/old-index-1"))
-            post_idx = next(
-                i for i, (m, p) in enumerate(methods_paths) if m == "POST" and p == "/dns/record"
+            # The live record is updated in place — no delete, no create.
+            assert ("PATCH", "/dns/record/old-index-1") in methods_paths
+            assert not any(m == "DELETE" for m, _ in methods_paths), (
+                "in-place upsert must not delete the live record"
             )
-            assert delete_idx < post_idx, "must delete the stale record before creating the new one"
+            assert not any(m == "POST" and p == "/dns/record" for m, p in methods_paths), (
+                "an existing record is patched, not re-created"
+            )
+            # PATCH carries the new rdata.
+            patch_call = next(c for c in mock_req.call_args_list if c[0][0] == "PATCH")
+            assert "agents=chat:mcp" in patch_call[1]["json"]["rdata"]["text"]
+
+    async def test_upsert_heals_duplicates(self, backend, mock_view_response, mock_zone_response):
+        """When earlier non-idempotent writes left duplicates, the upsert patches
+        the first and removes the extras so the name converges on one record."""
+        existing = {"results": [{"id": "dns/record/dup-1"}, {"id": "dns/record/dup-2"}]}
+        patch_resp = {"result": {"id": "dns/record/dup-1", "type": "TXT"}}
+
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            # view, zone, existing lookup (two present), PATCH first, DELETE extra
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                existing,
+                patch_resp,
+                {},  # DELETE of the duplicate
+            ]
+
+            await backend.create_txt_record(
+                zone="example.com",
+                name="_index._agents",
+                values=["agents=chat:mcp"],
+                ttl=3600,
+            )
+
+            methods_paths = [(c[0][0], c[0][1]) for c in mock_req.call_args_list]
+            assert ("PATCH", "/dns/record/dup-1") in methods_paths
+            assert ("DELETE", "/dns/record/dup-2") in methods_paths
+            patch_idx = methods_paths.index(("PATCH", "/dns/record/dup-1"))
+            delete_idx = methods_paths.index(("DELETE", "/dns/record/dup-2"))
+            assert patch_idx < delete_idx, "patch the survivor before pruning duplicates"
+
+    async def test_upsert_failed_patch_preserves_record(
+        self, backend, mock_view_response, mock_zone_response
+    ):
+        """A failed in-place update must not have deleted the live record first —
+        the previous record keeps serving (no silent agent disappearance)."""
+        existing = {"results": [{"id": "dns/record/live-1"}]}
+
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                existing,
+                httpx.HTTPStatusError(
+                    "boom", request=MagicMock(), response=MagicMock(status_code=400)
+                ),
+            ]
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await backend.create_svcb_record(
+                    zone="example.com",
+                    name="_test._mcp._agents",
+                    priority=1,
+                    target="mcp.example.com",
+                    params={"alpn": "mcp", "port": "443"},
+                )
+
+            methods = [c[0][0] for c in mock_req.call_args_list]
+            # Critical: no DELETE was issued, so the existing record still exists.
+            assert "DELETE" not in methods, "a failed upsert must never delete the live record"
 
     async def test_delete_record_success(self, backend, mock_view_response, mock_zone_response):
         """Test successful record deletion."""

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.24.4"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

The Infoblox UDDI DNS Data API accepts native **ServiceMode SVCB** with a structured `svc_params` list, including the DNS-AID private-use SvcParamKeys `key65400`–`key65409`. The backend previously hardcoded `priority` to `0` (AliasMode) and dropped every SvcParam, demoting the custom params to a TXT companion under a now-incorrect assumption that UDDI could not store them.

This PR makes the UDDI backend emit true ServiceMode SVCB with native custom params, and replaces the delete-then-create write with a **safe in-place PATCH upsert** that closes a data-loss window the expanded SvcParam payload would otherwise widen.

Release **0.25.0**.

## Changes

- `src/dns_aid/backends/infoblox/bloxone.py`
  - `supports_private_svcb_keys = True` — custom params are written natively on the SVCB record, not demoted to TXT.
  - `_format_svcb_rdata` emits the real `priority` plus a `svc_params` list of `{"key","value"}` objects; AliasMode (priority 0) still carries no params.
  - New shared `_svcb_presentation` helper renders both `list_records` and `get_record` (no more duplicated hardcoded `0`).
  - **New `_upsert_record`** (read-modify-write): updates an existing record in place with `PATCH`, creates with `POST` only when absent. A rejected/transient write no longer drops the live record (an SVCB agent silently leaving DNS). Also resolves the repeated-index-update `409` the delete-first ordering worked around, and heals duplicates from older non-idempotent writes.
- `tests/unit/test_infoblox_backend.py` — ServiceMode/AliasMode/`supports_private_svcb_keys`/presentation tests; idempotency test rewritten for in-place PATCH; new tests for duplicate-healing and **no-DELETE-on-failed-upsert** (data-loss guard).
- `README.md` — UDDI section reflects full ServiceMode compliance.
- Version bump to `0.25.0` (`pyproject.toml`, `CITATION.cff`, `uv.lock`) + CHANGELOG.

## Test plan

Verified **live against the UDDI DNS Data API** (zone `infolab.com`) across all three publish surfaces — Python library, CLI (`--backend infoblox`), and MCP tools:

- [x] Stress suite **26/26**: ServiceMode round-trip, all custom params on SVCB, **no TXT demotion**, idempotent re-publish (one record, last-write-wins), concurrent publish (6, per-record isolation), SvcParam quote-breakout injection rejected, unicode/special-char fidelity, churn leaves no leftovers.
- [x] Hardening probe **9/9**: all ten custom params (`key65400`–`key65409`) round-trip; 2048-char and ~10KB records accepted; UDDI tolerates 60KB single values; **a rejected re-publish leaves the previous record intact** (data-loss window closed); UDDI rejections surface as exceptions.
- [x] Unit: `tests/unit/test_infoblox_backend.py` 24/24; full suite green (pre-existing unrelated `test_mesh_invoke.py` failures are an untracked file).
- [x] `ruff check` / `ruff format --check` / `mypy src/dns_aid/` clean.
- [x] All four interfaces import cleanly (lib, SDK, CLI, MCP); the SDK `AgentClient` is caller-side and has no DNS-write path.