### PR TITLE
feat: add unpublish_catalog_pointer across library, CLI, MCP (0.26.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-07-06
+
+### Added
+
+- **`unpublish_catalog_pointer` — remove an ARD catalog DNS pointer.** The
+  inverse of `publish_catalog_pointer`, available across all three interfaces:
+  the library `unpublish_catalog_pointer(domain, ...)`, the CLI
+  `dns-aid index unpublish-catalog <domain>`, and the MCP
+  `unpublish_catalog_pointer` tool. Deletes the SVCB records under
+  `_catalog._agents.{domain}` and `_index._agents.{domain}` (`--catalog-only`
+  to leave the latter). Only the SVCB pointer is removed — any TXT at
+  `_index._agents` (org-index listing) is left intact. Idempotent: missing
+  records are a no-op.
+
 ## [0.26.0] - 2026-07-06
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.26.0"
+version: "0.26.1"
 date-released: "2026-07-06"
 
 keywords:

--- a/docs/ard-catalog.md
+++ b/docs/ard-catalog.md
@@ -74,6 +74,24 @@ catalog over HTTPS at `/.well-known/ai-catalog.json`.
 Library and MCP equivalents: `dns_aid.core.catalog_pointer.publish_catalog_pointer(...)`
 and the MCP `publish_catalog_pointer` tool.
 
+#### Removing a catalog pointer
+
+The inverse operation removes the pointer SVCB records — available on all three
+interfaces, and idempotent (missing records are a no-op):
+
+```bash
+# Remove both _catalog._agents and _index._agents SVCB records
+dns-aid index unpublish-catalog example.com
+
+# Remove only the ARD _catalog._agents label (leave _index._agents in place)
+dns-aid index unpublish-catalog example.com --catalog-only
+```
+
+Only the SVCB pointer is deleted — any TXT at `_index._agents` (a DNS-AID
+org-index listing) is left intact. Library and MCP equivalents:
+`dns_aid.core.catalog_pointer.unpublish_catalog_pointer(...)` and the MCP
+`unpublish_catalog_pointer` tool.
+
 ### Compatibility
 
 - **Pure-DNS discovery is untouched.** Publishing a pointer only affects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.26.0"
+version = "0.26.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -1397,6 +1397,55 @@ def index_publish_catalog(
     console.print(f"\n[dim]Catalog: https://{catalog_host}/.well-known/{filename}[/dim]")
 
 
+@index_app.command("unpublish-catalog")
+def index_unpublish_catalog(
+    domain: Annotated[str, typer.Argument(help="Domain to remove the catalog pointer from")],
+    backend: Annotated[
+        str | None,
+        typer.Option("--backend", "-b", help="DNS backend, or set DNS_AID_BACKEND env var"),
+    ] = None,
+    catalog_only: Annotated[
+        bool,
+        typer.Option(
+            "--catalog-only",
+            help="Remove only _catalog._agents (leave _index._agents in place)",
+        ),
+    ] = False,
+):
+    """
+    Remove ARD catalog DNS pointer records for a domain.
+
+    Deletes the SVCB records under _catalog._agents.{domain} and
+    _index._agents.{domain}. Any TXT at _index._agents (org-index listing)
+    is left intact. Idempotent — missing records are a no-op.
+
+    Example:
+        dns-aid index unpublish-catalog example.com
+    """
+    from dns_aid.core.catalog_pointer import (
+        CATALOG_POINTER_LABELS,
+        unpublish_catalog_pointer,
+    )
+
+    dns_backend = _get_backend(backend)
+    labels = ("_catalog._agents",) if catalog_only else CATALOG_POINTER_LABELS
+
+    console.print(f"\n[bold]Removing ARD catalog pointer for {domain}...[/bold]\n")
+
+    try:
+        removed = run_async(unpublish_catalog_pointer(domain, labels=labels, backend=dns_backend))
+    except Exception as e:
+        error_console.print(f"[red]✗ Failed to remove catalog pointer: {e}[/red]")
+        raise typer.Exit(1) from None
+
+    if removed:
+        console.print("[green]✓ Catalog pointer removed![/green]\n")
+        for fqdn in removed:
+            console.print(f"  [dim]deleted SVCB[/dim] {fqdn}")
+    else:
+        console.print("[yellow]No catalog pointer records found to remove.[/yellow]")
+
+
 # ============================================================================
 # KEYS COMMANDS (JWS Signing)
 # ============================================================================

--- a/src/dns_aid/core/catalog_pointer.py
+++ b/src/dns_aid/core/catalog_pointer.py
@@ -322,3 +322,40 @@ async def publish_catalog_pointer(
             filename=filename,
         )
     return written
+
+
+async def unpublish_catalog_pointer(
+    domain: str,
+    *,
+    labels: tuple[str, ...] = CATALOG_POINTER_LABELS,
+    backend: DNSBackend | None = None,
+) -> list[str]:
+    """Remove ARD catalog pointer SVCB records for a domain.
+
+    The inverse of :func:`publish_catalog_pointer`: deletes the SVCB record
+    under each label in ``labels`` (default both ``_catalog._agents`` and
+    ``_index._agents``). Only the SVCB pointer is removed — any TXT at
+    ``_index._agents`` (e.g. a DNS-AID org-index listing) is left intact.
+
+    Best-effort and idempotent: a label with no existing SVCB record — or a
+    per-label backend error — is skipped, and the other labels are still
+    removed. Returns the list of FQDNs actually removed.
+    """
+    domain = domain.lower().rstrip(".")
+    dns_backend = backend or get_default_backend()
+
+    removed: list[str] = []
+    for label in labels:
+        try:
+            deleted = await dns_backend.delete_record(domain, label, "SVCB")
+        except Exception as e:  # noqa: BLE001 — one label's failure must not block the others
+            logger.warning(
+                "catalog_pointer.unpublish_error", domain=domain, label=label, error=str(e)
+            )
+            continue
+        if deleted:
+            removed.append(f"{label}.{domain}")
+            logger.info("catalog_pointer.unpublished", domain=domain, label=label)
+        else:
+            logger.debug("catalog_pointer.unpublish_noop", domain=domain, label=label)
+    return removed

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -500,6 +500,51 @@ def publish_catalog_pointer(
 
 
 @mcp.tool(
+    title="Unpublish ARD Catalog Pointer",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def unpublish_catalog_pointer(
+    domain: str,
+    catalog_only: bool = False,
+    backend: Literal[
+        "route53", "cloudflare", "ns1", "infoblox", "nios", "ddns", "mock"
+    ] = "route53",
+) -> dict:
+    """Remove ARD catalog DNS pointer records for a domain.
+
+    Deletes the SVCB records under ``_catalog._agents.{domain}`` and, unless
+    ``catalog_only`` is set, ``_index._agents.{domain}``. Any TXT at
+    ``_index._agents`` (org-index listing) is left intact. Idempotent —
+    missing records are a no-op.
+    """
+    from dns_aid.core.catalog_pointer import (
+        CATALOG_POINTER_LABELS,
+        unpublish_catalog_pointer,
+    )
+
+    try:
+        dns_backend = _get_dns_backend(backend)
+        labels = ("_catalog._agents",) if catalog_only else CATALOG_POINTER_LABELS
+        removed = _run_async(unpublish_catalog_pointer(domain, labels=labels, backend=dns_backend))
+        return {
+            "success": True,
+            "domain": domain,
+            "removed": removed,
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": "unpublish_catalog_error",
+            "message": str(e),
+        }
+
+
+@mcp.tool(
     title="Discover Agents via DNS",
     annotations=ToolAnnotations(
         readOnlyHint=True,

--- a/tests/unit/test_catalog_pointer.py
+++ b/tests/unit/test_catalog_pointer.py
@@ -14,6 +14,7 @@ from dns_aid.core.catalog_pointer import (
     DEFAULT_CATALOG_FILENAME,
     publish_catalog_pointer,
     resolve_catalog_pointer,
+    unpublish_catalog_pointer,
 )
 
 
@@ -342,6 +343,71 @@ class TestPublishCatalogPointer:
         backend.zone_exists = AsyncMock(return_value=False)
         with pytest.raises(ValueError, match="does not exist"):
             await publish_catalog_pointer("acme.com", "ard.acme.com", backend=backend)
+
+
+class TestUnpublishCatalogPointer:
+    def _mock_backend(self, deleted: bool = True):
+        backend = MagicMock()
+        backend.delete_record = AsyncMock(return_value=deleted)
+        return backend
+
+    @pytest.mark.asyncio
+    async def test_dual_label_unpublish(self):
+        backend = self._mock_backend(deleted=True)
+        removed = await unpublish_catalog_pointer("acme.com", backend=backend)
+        assert removed == ["_catalog._agents.acme.com", "_index._agents.acme.com"]
+        # both deletes were SVCB deletes at the right owner names in the zone
+        names = set()
+        for c in backend.delete_record.await_args_list:
+            args = (
+                c.args if c.args else (c.kwargs["zone"], c.kwargs["name"], c.kwargs["record_type"])
+            )
+            assert args[0] == "acme.com" and args[2] == "SVCB"
+            names.add(args[1])
+        assert names == set(CATALOG_POINTER_LABELS)
+
+    @pytest.mark.asyncio
+    async def test_catalog_only_unpublish(self):
+        backend = self._mock_backend(deleted=True)
+        removed = await unpublish_catalog_pointer(
+            "acme.com", labels=("_catalog._agents",), backend=backend
+        )
+        assert removed == ["_catalog._agents.acme.com"]
+        assert backend.delete_record.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_no_records(self):
+        # delete_record returns False when nothing was there → empty result, no error
+        backend = self._mock_backend(deleted=False)
+        removed = await unpublish_catalog_pointer("acme.com", backend=backend)
+        assert removed == []
+
+    @pytest.mark.asyncio
+    async def test_per_label_error_tolerated(self):
+        # _catalog delete raises; _index still removed.
+        backend = MagicMock()
+
+        async def _delete(zone, name, record_type):
+            if name == "_catalog._agents":
+                raise RuntimeError("backend hiccup")
+            return True
+
+        backend.delete_record = AsyncMock(side_effect=_delete)
+        removed = await unpublish_catalog_pointer("acme.com", backend=backend)
+        assert removed == ["_index._agents.acme.com"]
+
+    @pytest.mark.asyncio
+    async def test_round_trip_with_mock_backend(self):
+        # Real stateful mock backend: publish then unpublish leaves nothing.
+        from dns_aid.backends import create_backend
+
+        backend = create_backend("mock")
+        written = await publish_catalog_pointer("acme.com", "catalogue.acme.com", backend=backend)
+        assert len(written) == 2
+        removed = await unpublish_catalog_pointer("acme.com", backend=backend)
+        assert set(removed) == set(written)
+        # unpublishing again is a no-op
+        assert await unpublish_catalog_pointer("acme.com", backend=backend) == []
 
 
 class TestPointerDrivenDiscovery:

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Publishing an ARD catalog pointer (0.26.0) had no inverse — removing one meant hand-editing DNS. This adds `unpublish_catalog_pointer` as the symmetric operation on **all three interfaces**, restoring publish/unpublish parity for the catalog-pointer lifecycle.

- **Library** — `dns_aid.core.catalog_pointer.unpublish_catalog_pointer(domain, labels=…, backend=…)`
- **CLI** — `dns-aid index unpublish-catalog <domain> [--catalog-only]`
- **MCP** — `unpublish_catalog_pointer` tool (`destructiveHint=True`, `idempotentHint=True`)

Deletes the SVCB record under `_catalog._agents` and `_index._agents`. **Only the SVCB pointer is removed** — a TXT org-index at `_index._agents` is preserved. Best-effort and idempotent: a missing record or per-label backend error is skipped and the other labels still process.

## Changes

- `src/dns_aid/core/catalog_pointer.py` — `unpublish_catalog_pointer()`
- `src/dns_aid/cli/main.py` — `index unpublish-catalog` command
- `src/dns_aid/mcp/server.py` — `unpublish_catalog_pointer` tool
- `tests/unit/test_catalog_pointer.py` — `TestUnpublishCatalogPointer` (dual-label, catalog-only, idempotent no-op, per-label-error tolerance, stateful round-trip)
- `docs/ard-catalog.md` — removal section
- version bump 0.26.0 → 0.26.1 (`pyproject.toml`, `CITATION.cff`, `CHANGELOG.md`, `uv.lock`)

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/dns_aid` clean
- [x] `pytest tests/unit/` — 1937 passing
- [x] `pytest tests/integration/ -m "not live"` — 30 passing
- [x] Secrets scan clean; commit DCO signed-off
- [x] **Live-verified on Route53 across all three interfaces** — publish → API-confirmed present → unpublish → API-confirmed zero, via library, CLI (`✓ removed`), and MCP (`removed:[both]`). Throwaway zone; no production impact.

Note: dependency-security patch and CodeQL fixes already landed in 0.26.0 (#183), so CI starts from a green baseline.