### PR TITLE
fix: resolve ARD entries via their card, not a synthesized DNS name (0.26.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2] - 2026-07-06
+
+### Fixed
+
+- **ARD entry resolution now follows the spec's identity/location separation.**
+  Per ARD §4.2.1 an entry's `identifier` (`urn:air:…`) is an abstract, stable
+  name — *not* a network locator — and per §3.4 the agent's card is carried by
+  exactly one of `url` (fetch) or `data` (inline). Discovery previously
+  synthesized `{name}.{domain}` from the identifier and preferred a DNS SVCB
+  lookup for it, which (a) conflated identity with location against §4.2.1 and
+  (b) could overwrite a real endpoint with the card-locator URL when a domain
+  published both flat DNS records and an ARD catalog. ARD entries are now
+  resolved purely from their card: inline `data` (`endpoint_source="ard_inline"`)
+  or a dereferenced `url` (`endpoint_source="ard_card"`). The identifier is never
+  turned into a DNS query. DNS-AID's authoritative per-agent DNS discovery is
+  unchanged and remains the separate pure-DNS plane (`discover(domain)` over
+  SVCB records).
+
+### Added
+
+- Inline agent cards (ARD `data`) are now dereferenced (previously dropped);
+  new `endpoint_source="ard_inline"`.
+
 ## [0.26.1] - 2026-07-06
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.26.1"
+version: "0.26.2"
 date-released: "2026-07-06"
 
 keywords:

--- a/docs/ard-catalog.md
+++ b/docs/ard-catalog.md
@@ -25,18 +25,21 @@ flowchart TD
     C --> E["parse catalog → entries"]
     D --> E
     E --> F["for each agent entry"]
-    F --> G{"authoritative DNS<br/>SVCB record?"}
-    G -- "yes" --> H["DNS record WINS<br/>catalog enriches it"]
-    G -- "no" --> I["fetch the entry's card<br/>(A2A / MCP, SSRF-checked, no redirects)"]
-    I --> J["apply REAL endpoint + skills/tools + auth<br/>endpoint_source = ard_card"]
-    H --> K["AgentRecord"]
-    J --> K
+    F --> G{"card carried inline (data)<br/>or referenced by url?"}
+    G -- "data" --> H["read the inline card<br/>endpoint_source = ard_inline"]
+    G -- "url" --> I["fetch the card<br/>(A2A / MCP, SSRF-checked, no redirects)<br/>endpoint_source = ard_card"]
+    H --> J["apply REAL endpoint + skills/tools + auth"]
+    I --> J
+    J --> K["AgentRecord"]
 ```
 
 Key invariants:
 
-- **DNS is authoritative per agent.** If a catalog agent also has a real DNS
-  SVCB record, that record wins and the catalog only enriches it (Step G→H).
+- **The identifier is a name, not a locator (ARD §4.2.1).** A catalog agent's
+  endpoint comes from its card — read inline (`data`) or dereferenced (`url`) —
+  never by turning the `urn:air:…` identifier into a DNS hostname. DNS-AID's
+  authoritative per-agent DNS discovery is the *separate* pure-DNS plane
+  (`discover(domain)` over SVCB records).
 - **The pointer is authoritative for *location*.** Publishing a `_catalog._agents`
   / `_index._agents` SVCB tells discovery where the catalog is; without one,
   discovery falls back to the well-known path on the domain itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.26.1"
+version = "0.26.2"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -1159,40 +1159,48 @@ _MAX_ARD_CARD_CAPABILITIES = 256
 
 
 async def _apply_ard_card(record: AgentRecord, http_agent: HttpIndexAgent) -> None:
-    """Dereference an ARD entry's referenced card into the discovered record.
+    """Resolve an ARD entry's artifact (its card) into the discovered record.
 
-    An ARD catalog entry's ``url`` points at the agent's CARD (an A2A agent
-    card or MCP server card), not its service endpoint — so the catalog-only
-    record currently carries the card URL as its endpoint. Fetch that card
-    (SSRF-guarded + size-capped via ``fetch_cap_document``; redirects refused
-    since the URL is catalog-controlled) and dereference it: set the real
-    service endpoint, skills/tools → capabilities, and auth.
+    Per ARD §3.4 an entry carries its agent's card by exactly one of ``data``
+    (the card inline) or ``url`` (a locator to fetch it). Per §4.2.1 the entry's
+    ``identifier`` is an abstract, stable name — NOT a network locator — so the
+    real service endpoint comes from the card, never from the identifier. This
+    reads the inline card directly, or dereferences the card URL (SSRF-guarded +
+    size-capped via ``fetch_cap_document``; redirects refused since the URL is
+    catalog-controlled), then sets the real endpoint, skills/tools →
+    capabilities, and auth.
 
-    Best-effort: on any failure the record keeps its catalog-level data (the
-    card URL stays as the endpoint fallback). Runs under the shared per-agent
-    Semaphore, so N card fetches are already bounded.
+    Best-effort: on any failure the record keeps its catalog-level data. Runs
+    under the shared per-agent Semaphore, so N card fetches are already bounded.
     """
-    card_url = http_agent.endpoint
-    if not card_url:
+    source: Literal["ard_card", "ard_inline"]
+    if http_agent.card_data is not None:
+        raw = http_agent.card_data
+        source = "ard_inline"
+    elif http_agent.card_url:
+        try:
+            cap_doc = await asyncio.wait_for(
+                fetch_cap_document(http_agent.card_url, follow_redirects=False),
+                timeout=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
+            )
+        except Exception as e:  # noqa: BLE001 — a bad card must not drop the agent
+            logger.debug(
+                "ard_card.fetch_error", agent=record.name, url=http_agent.card_url, error=str(e)
+            )
+            return
+        if not cap_doc or not cap_doc.raw_data:
+            return
+        raw = cap_doc.raw_data
+        source = "ard_card"
+    else:
         return
-    try:
-        cap_doc = await asyncio.wait_for(
-            fetch_cap_document(card_url, follow_redirects=False),
-            timeout=_DESCRIPTOR_FETCH_BUDGET_SECONDS,
-        )
-    except Exception as e:  # noqa: BLE001 — a bad card must not drop the agent
-        logger.debug("ard_card.fetch_error", agent=record.name, url=card_url, error=str(e))
-        return
-    if not cap_doc or not cap_doc.raw_data:
-        return
-    raw = cap_doc.raw_data
 
     def _set_endpoint(url: str) -> None:
         parsed = urlparse(url)
         if not parsed.hostname:
             return
         record.endpoint_override = url
-        record.endpoint_source = "ard_card"
+        record.endpoint_source = source
         record.target_host = parsed.hostname
         record.port = parsed.port or 443
 
@@ -1210,7 +1218,7 @@ async def _apply_ard_card(record: AgentRecord, http_agent: HttpIndexAgent) -> No
         if card.authentication and card.authentication.schemes:
             record.auth_type = card.authentication.schemes[0]
             record.auth_config = {"schemes": list(card.authentication.schemes)}
-        logger.debug("ard_card.applied", agent=record.name, protocol="a2a")
+        logger.debug("ard_card.applied", agent=record.name, protocol="a2a", source=source)
     else:  # MCP server card — no typed parser exists; extract minimally
         endpoint = raw.get("endpoint") or raw.get("url")
         if isinstance(endpoint, str) and endpoint.startswith("https://"):
@@ -1222,7 +1230,7 @@ async def _apply_ard_card(record: AgentRecord, http_agent: HttpIndexAgent) -> No
             if names:
                 record.capabilities = names
                 record.capability_source = "agent_card"
-        logger.debug("ard_card.applied", agent=record.name, protocol="mcp")
+        logger.debug("ard_card.applied", agent=record.name, protocol="mcp", source=source)
 
 
 async def _process_ard_agent(
@@ -1230,13 +1238,18 @@ async def _process_ard_agent(
     domain: str,
     protocol: Protocol | None,
 ) -> AgentRecord | None:
-    """Process an ARD ai-catalog entry: filter, DNS-first resolve, fallback.
+    """Resolve an ARD ai-catalog entry via its artifact (the card).
 
-    ARD entries name agents by URN and locate artifacts by URL, so the
-    legacy FQDN-parsing path doesn't apply. The authoritative DNS answer
-    still wins: try a SVCB lookup for the ARD agent name under the queried
-    domain first, and enrich it from the catalog; otherwise surface the
-    catalog data directly (``endpoint_source="http_index_fallback"``).
+    Per ARD §4.2.1 the entry's ``identifier`` is an abstract, stable name — not
+    a network locator — so we do NOT synthesize ``{name}.{domain}`` and prefer a
+    DNS SVCB lookup for it (that re-conflates identity with location, the exact
+    anti-pattern §4.2.1 warns against). The endpoint/skills/auth come from the
+    entry's card (§3.4): inline ``data`` or a dereferenced ``url``.
+
+    DNS-AID's authoritative-DNS discovery stays a separate plane — the pure-DNS
+    ``discover(domain)`` path (SVCB records) and the DNSSEC-signed
+    ``_catalog._agents`` pointer — never reached by guessing a hostname from a
+    catalog identifier.
     """
     proto_str = http_agent.primary_protocol
     if not proto_str:
@@ -1254,20 +1267,11 @@ async def _process_ard_agent(
     if protocol and ard_protocol != protocol:
         return None
 
-    agent = await _query_single_agent(domain, http_agent.name, ard_protocol)
-    if agent:
-        _enrich_from_http_index(agent, http_agent)
-        return agent
-
-    logger.debug(
-        "DNS lookup failed for ARD catalog agent, dereferencing catalog card",
-        agent=http_agent.name,
-        identifier=http_agent.identifier,
-    )
     record = _http_agent_to_record(http_agent, domain, http_agent.name, ard_protocol)
-    if record is not None:
-        # Dereference the ARD entry's card URL to the real endpoint/skills/auth.
-        await _apply_ard_card(record, http_agent)
+    if record is None:
+        return None
+    # Resolve the real endpoint/skills/auth from the entry's card artifact.
+    await _apply_ard_card(record, http_agent)
     return record
 
 

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -189,6 +189,11 @@ class HttpIndexAgent:
     identifier: str | None = None  # full ARD URN (urn:air:...) for diagnostics
     source_format: str = "legacy"  # "legacy" | "ard"
     use_cases: list[str] = field(default_factory=list)  # ARD representativeQueries
+    # ARD entry artifact locator (§3.4 Value-or-Reference). Per §4.2.1 the
+    # identifier is an abstract name, NOT a network locator — the agent's real
+    # endpoint lives in the referenced/inline card, resolved from exactly one of:
+    card_url: str | None = None  # `url`: dereference to fetch the card
+    card_data: dict[str, Any] | None = None  # `data`: the card given inline
 
     @classmethod
     def from_dict(cls, name: str, data: dict[str, Any]) -> HttpIndexAgent:
@@ -414,7 +419,9 @@ def _ard_entry_to_agent(entry: dict[str, Any]) -> tuple[HttpIndexAgent | None, s
         HttpIndexAgent(
             name=name,
             fqdn=fqdn,
-            endpoint=url,
+            # ARD entries never declare a service endpoint directly; the real
+            # endpoint is resolved from the card (card_url / card_data).
+            endpoint=None,
             description=description,
             protocols=[protocol],
             model_card=model_card,
@@ -423,6 +430,8 @@ def _ard_entry_to_agent(entry: dict[str, Any]) -> tuple[HttpIndexAgent | None, s
             identifier=identifier,
             source_format="ard",
             use_cases=use_cases,
+            card_url=url if isinstance(url, str) else None,
+            card_data=inline_data if isinstance(inline_data, dict) else None,
         ),
         None,
     )

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -707,6 +707,7 @@ class AgentRecord(BaseModel):
             "http_index",
             "http_index_fallback",
             "ard_card",
+            "ard_inline",
             "direct",
             "directory",
         ]
@@ -717,7 +718,8 @@ class AgentRecord(BaseModel):
         "'dns_svcb_enriched' (DNS + .well-known/agent-card.json path), "
         "'http_index' (DNS + HTTP index endpoint), "
         "'http_index_fallback' (HTTP index without DNS), "
-        "'ard_card' (real endpoint from the fetched ARD agent/server card), "
+        "'ard_card' (real endpoint from a dereferenced ARD agent/server card URL), "
+        "'ard_inline' (real endpoint from an ARD entry's inline card `data`), "
         "'direct' (explicitly provided), "
         "'directory' (from directory API search, Phase 5.7)",
     )

--- a/tests/unit/test_http_index.py
+++ b/tests/unit/test_http_index.py
@@ -529,7 +529,9 @@ class TestArdEntryMapping:
         assert by_name["assistant"].primary_protocol == "a2a"
         assert by_name["weather"].primary_protocol == "mcp"
         assert by_name["weather"].fqdn == "api.acme.com"
-        assert by_name["weather"].endpoint == "https://api.acme.com/mcp/weather.json"
+        # ARD `url` is a card locator (§3.4), captured as card_url — NOT endpoint.
+        assert by_name["weather"].card_url == "https://api.acme.com/mcp/weather.json"
+        assert by_name["weather"].endpoint is None
         assert by_name["weather"].capability.capabilities == ["WeatherTool", "ForecastTool"]
         assert by_name["weather"].identifier == "urn:air:acme.com:server:weather"
         assert len(by_name["weather"].use_cases) == 2
@@ -555,6 +557,9 @@ class TestArdEntryMapping:
         # Inline artifact → fqdn from URN publisher domain
         assert agents[0].fqdn == "acme.com"
         assert agents[0].endpoint is None
+        # Inline card captured as card_data (no url locator).
+        assert agents[0].card_data == {"some": "card"}
+        assert agents[0].card_url is None
 
     def test_version_maps_to_model_card(self):
         agents = parse_http_index(_ard_catalog([_ard_agent_entry(version="2.1.0")]))
@@ -979,38 +984,44 @@ class TestArdFetchEndToEnd:
         assert record.capability_source == "ard_catalog"
         assert record.capabilities == ["WeatherTool"]
         assert record.endpoint_source == "http_index_fallback"
-        assert record.endpoint_override == "https://api.acme.com/mcp/weather.json"
+        # Card unreachable → no fabricated endpoint (pre-0.26.2 stuffed the card URL here).
+        assert record.endpoint_override is None
         assert record.trust_manifest is not None
         assert record.trust_manifest.identity == "spiffe://acme.com/agents/weather"
 
     @pytest.mark.asyncio
-    async def test_discoverer_dns_answer_wins_and_is_enriched(self):
-        """DNS hit → authoritative record enriched with ARD trust data."""
+    async def test_dns_record_present_but_ard_uses_card(self):
+        """Even when a DNS SVCB record exists for the ARD agent's name, ARD
+        resolution ignores it (no identifier→hostname synthesis, §4.2.1) and
+        resolves the endpoint from the card; catalog trust still attaches."""
         from dns_aid.core import discoverer as disc
+        from dns_aid.core.cap_fetcher import CapabilityDocument
         from dns_aid.core.models import AgentRecord, Protocol
 
         dns_record = AgentRecord(
-            name="weather",
-            domain="acme.com",
-            protocol=Protocol.MCP,
-            target_host="mcp.acme.com",
+            name="weather", domain="acme.com", protocol=Protocol.MCP, target_host="mcp.acme.com"
         )
         entry = _ard_agent_entry(
             capabilities=["WeatherTool"],
             trustManifest=TestArdTrustManifest.SPIFFE_MANIFEST,
         )
         http_agents = parse_http_index(_ard_catalog([entry]))
+        card_doc = CapabilityDocument(
+            raw_data={"endpoint": "https://weather.acme.com/mcp", "tools": [{"name": "forecast"}]}
+        )
         with (
             patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
-            patch.object(disc, "_query_single_agent", AsyncMock(return_value=dns_record)),
             patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "fetch_cap_document", AsyncMock(return_value=card_doc)),
+            patch.object(disc, "_query_single_agent", AsyncMock(return_value=dns_record)) as qsa,
         ):
             records = await disc._discover_via_http_index("acme.com")
-        assert len(records) == 1
         record = records[0]
-        assert record.target_host == "mcp.acme.com"  # DNS answer preserved
-        assert record.capability_source == "ard_catalog"
+        qsa.assert_not_called()  # DNS never consulted for an ARD entry
+        assert record.target_host == "weather.acme.com"  # endpoint from the card
+        assert record.endpoint_source == "ard_card"
         assert record.trust_manifest is not None
+        assert record.trust_manifest.identity == "spiffe://acme.com/agents/weather"
 
     @pytest.mark.asyncio
     async def test_protocol_filter_applies_to_ard_agents(self):
@@ -1113,8 +1124,74 @@ class TestArdCardDereference:
         ):
             records = await disc._discover_via_http_index("acme.com")
         r = records[0]
-        # Falls back to catalog-level data: card URL stays as the endpoint.
-        assert r.endpoint_override == "https://api.acme.com/mcp/weather.json"
+        # Card unreachable → NO fabricated endpoint. The record keeps its
+        # catalog-level data (caps, trust) but must not masquerade the card
+        # URL as the service endpoint (the pre-0.26.2 bug).
+        assert r.endpoint_override is None
         assert r.endpoint_source == "http_index_fallback"
         assert r.capability_source == "ard_catalog"
         assert r.capabilities == ["invoicing"]
+
+    @pytest.mark.asyncio
+    async def test_inline_data_card_resolved_without_fetch(self):
+        # §3.4: an entry may carry its card INLINE via `data` — resolve it
+        # directly, no network fetch, endpoint_source="ard_inline".
+        from dns_aid.core import discoverer as disc
+
+        entry = {
+            "identifier": "urn:air:acme.com:agents:inline-bot",
+            "displayName": "Inline Bot",
+            "type": "application/a2a-agent-card+json",
+            "data": {
+                "name": "Inline Bot",
+                "url": "https://inline-bot.acme.com/a2a",
+                "skills": [{"id": "greet", "name": "Greet"}],
+            },
+        }
+        http_agents = parse_http_index(_ard_catalog([entry]))
+        with (
+            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "fetch_cap_document", AsyncMock()) as fc,
+        ):
+            records = await disc._discover_via_http_index("acme.com")
+        r = records[0]
+        assert r.endpoint_override == "https://inline-bot.acme.com/a2a"
+        assert r.endpoint_source == "ard_inline"
+        assert r.target_host == "inline-bot.acme.com"
+        assert r.capabilities == ["greet"]
+        assert r.capability_source == "agent_card"
+        fc.assert_not_awaited()  # inline data → zero network fetches
+
+    @pytest.mark.asyncio
+    async def test_identifier_never_synthesizes_dns_lookup(self):
+        # ARD §4.2.1: the identifier is an abstract name, NOT a locator. Even
+        # when a DNS SVCB record EXISTS for {name}.{domain}, ARD resolution must
+        # NOT query it or prefer it — the endpoint comes from the entry's card.
+        from dns_aid.core import discoverer as disc
+        from dns_aid.core.cap_fetcher import CapabilityDocument
+
+        entry = {
+            "identifier": "urn:air:acme.com:agents:billing",
+            "displayName": "Billing",
+            "type": "application/mcp-server-card+json",
+            "url": "https://cards.acme.com/billing.json",
+        }
+        http_agents = parse_http_index(_ard_catalog([entry]))
+        card_doc = CapabilityDocument(
+            raw_data={"endpoint": "https://billing.acme.com/mcp", "tools": [{"name": "invoice"}]}
+        )
+        decoy = object()  # what a DNS lookup would return — must never be used
+        with (
+            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "fetch_cap_document", AsyncMock(return_value=card_doc)),
+            patch.object(disc, "_query_single_agent", AsyncMock(return_value=decoy)) as qsa,
+        ):
+            records = await disc._discover_via_http_index("acme.com")
+        r = records[0]
+        assert r is not decoy  # resolved from the card, not a DNS record
+        assert r.endpoint_override == "https://billing.acme.com/mcp"
+        assert r.endpoint_source == "ard_card"
+        qsa.assert_not_called()  # the identifier was never turned into a DNS query

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.26.1"
+version = "0.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Aligns ARD ai-catalog resolution with the spec's identity/location separation.

Per **ARD §4.2.1** an entry's `identifier` (`urn:air:…`) is an abstract, stable **name — not a network locator**, and per **§3.4** the agent's card is carried by exactly one of `url` (fetch) or `data` (inline). Discovery was synthesizing `{name}.{domain}` from the identifier and preferring a DNS SVCB lookup for it. That:

1. **conflated identity with location** — the exact anti-pattern §4.2.1 warns against; and
2. when a domain published **both** flat DNS records **and** an ARD catalog for the same names, **overwrote the real endpoint with the card-locator URL** (`endpoint_source=http_index`, endpoint = `…/agents/foo.json`).

ARD entries are now resolved **purely from their card**: inline `data` (`endpoint_source="ard_inline"`) or a dereferenced `url` (`endpoint_source="ard_card"`). The identifier is never turned into a DNS query. Inline cards (`data`), previously dropped, are now resolved.

DNS-AID's authoritative per-agent DNS discovery is **unchanged** and remains the separate pure-DNS plane (`discover(domain)` over SVCB records).

## Changes

- `core/http_index.py` — `HttpIndexAgent.card_url` / `card_data`; ARD parser stops stuffing `url` into `endpoint` and captures inline `data`
- `core/discoverer.py` — `_process_ard_agent` drops the identifier→hostname synthesis and the enrich-clobber; `_apply_ard_card` resolves from inline `data` or a dereferenced `url`, source-aware
- `core/models.py` — new `endpoint_source="ard_inline"`
- `docs/ard-catalog.md` — flow diagram + invariants updated to the spec model
- version bump 0.26.1 → 0.26.2 (`pyproject.toml`, `CITATION.cff`, `CHANGELOG.md`, `uv.lock`)

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [x] `pytest tests/unit/` — **1939 passing** (new: inline-data→`ard_inline`, **identifier-never-synthesizes-DNS**, dns-record-present-but-ard-uses-card, fetch-failure-no-fabricated-endpoint)
- [x] `pytest tests/integration/ -m "not live"` — 30 passing
- [x] Gated live ARD test — 3 passing
- [x] **Live stress across all 3 interfaces** — 45 discovers (library seq + 12-way concurrent, MCP, CLI), 100% pass, single result signature (perfectly consistent); dual-publish pointer case → 5 `ard_card` via library/CLI/MCP; pure-DNS regression intact (12 `dns_svcb`). No production impact.