### PR TITLE
feat: ARD catalog-pointer trust (DNSSEC/JWS off-domain, catalog_trust)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.3] - 2026-07-07
+
+### Security
+
+- **Off-domain ARD catalog pointers are no longer followed unauthenticated.**
+  A `_catalog._agents` / `_index._agents` DNS pointer whose target is on a
+  *different* domain than the one queried is now trusted only when the catalog's
+  records are JWS-signed against the queried domain's JWKS (`verify_signatures=True`)
+  — the default, resolver-independent off-domain anchor — or, opt-in via
+  `trust_dnssec_pointers=True`, when the pointer record is DNSSEC-validated (the
+  library's canonical `_check_dnssec`; trustworthy only with a validating resolver
+  over a secure path).
+  Otherwise the off-domain target is ignored and discovery falls back to the
+  queried domain's own TLS-bound `/.well-known/ai-catalog.json`. This prevents a
+  spoofed or injected pointer from redirecting discovery to a forged off-domain
+  catalog. **Catalogs served on the queried domain (or a subdomain) are
+  unaffected** — TLS already binds them to the domain, and DNSSEC is never
+  required. An off-domain catalog followed under `verify_signatures` has its JWS
+  signature as its *only* trust anchor, so records that do not verify are dropped
+  automatically (regardless of `require_signed`).
+- The ARD `ard_trust_foreign_publisher` warning now anchors on the host that
+  actually served the catalog over TLS (not the queried domain), so it fires
+  correctly on the DNS-pointer path — where it was previously a no-op.
+
+### Fixed
+
+- **A valid-but-empty catalog source no longer shadows a real catalog.** The
+  HTTP-index fallback cascade stopped on the first source that returned HTTP 200
+  even when it parsed to zero agents (`[] is not None`), so a stale/empty pointer
+  or an empty legacy index silently suppressed a good `ai-catalog.json` further
+  down the cascade. The cascade now returns the first *non-empty* source and
+  yields an empty result only when every responding source is empty.
+
+### Added
+
+- `AgentRecord.catalog_trust` surfaces the trust basis by which an ARD /
+  HTTP-index catalog was served: `tls_domain`, `dnssec`, or `jws`.
+- `discover(..., trust_dnssec_pointers=False)` — opt-in to following an off-domain
+  ARD catalog pointer that is DNSSEC-validated. Off by default; JWS
+  (`verify_signatures`) is the default resolver-independent off-domain anchor.
+
 ## [0.26.2] - 2026-07-06
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.26.2"
-date-released: "2026-07-06"
+version: "0.26.3"
+date-released: "2026-07-07"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ for agent in agents:
 # Discover via HTTP index (ANS-compatible, richer metadata) — also auto-detects
 # and dereferences ARD ai-catalogs (see docs/ard-catalog.md)
 agents = await dns_aid.discover("example.com", use_http_index=True)
+# (0.26.3+) A catalog on your own domain needs nothing. An off-domain catalog
+# pointer is trusted only via per-record JWS (verify_signatures=True) or, opt-in,
+# a DNSSEC-validated pointer (trust_dnssec_pointers=True) — otherwise it is ignored
+# and discovery falls back to the on-domain catalog. The trust basis is surfaced as
+# AgentRecord.catalog_trust (tls_domain | dnssec | jws). See docs/ard-catalog.md.
 
 # Filtered discovery — pure-Python predicates over the in-memory result (v0.19.0+)
 result = await dns_aid.discover(

--- a/docs/ard-catalog.md
+++ b/docs/ard-catalog.md
@@ -20,7 +20,7 @@ the catalog entirely.
 ```mermaid
 flowchart TD
     A["discover(domain, use_http_index=True)"] --> B{"DNS pointer?<br/>_catalog._agents / _index._agents SVCB"}
-    B -- "resolves (host-anywhere)" --> C["fetch catalog at the pointer's host<br/>(SSRF-checked, redirects refused)"]
+    B -- "resolves & trusted<br/>(on-domain, or off-domain via JWS / DNSSEC — see Trust)" --> C["fetch catalog at the pointer's host<br/>(SSRF-checked, redirects refused)"]
     B -- "no pointer" --> D["probe well-known patterns in order:<br/>legacy index endpoints, then<br/>/.well-known/ai-catalog.json"]
     C --> E["parse catalog → entries"]
     D --> E
@@ -121,6 +121,7 @@ dns-aid discover example.com --use-http-index --json
   "endpoint_source": "ard_card",
   "capabilities": ["create_invoice", "list_payments"],
   "capability_source": "agent_card",
+  "catalog_trust": "tls_domain",               // how the catalog was trusted: tls_domain | dnssec | jws
   "trust_manifest": { "identity": "spiffe://example.com/agents/billing", "...": "..." }
 }
 ```
@@ -132,6 +133,46 @@ attestations, provenance, signature) is preserved on `AgentRecord.trust_manifest
 as **pass-through published claims** — DNS-AID does not verify signatures,
 digests, or identity in this release. Two warning-only signals flag possible
 impersonation: `ard_trust_identity_mismatch` (identity domain ≠ URN publisher)
-and `ard_trust_foreign_publisher` (URN publisher ≠ the domain that served the
-catalog over TLS). Cryptographic verification anchored in DNSSEC/DANE is future
-work.
+and `ard_trust_foreign_publisher` (URN publisher ≠ the host that actually served
+the catalog over TLS).
+
+### Catalog-pointer trust
+
+The catalog's *location* is trusted by one of three anchors — **you only ever
+need one, and DNSSEC is never required**. The basis is surfaced on every ARD
+record as `catalog_trust` (SDK/CLI/MCP):
+
+```mermaid
+flowchart TD
+    P{"catalog pointer target"} -->|"queried domain<br/>or a subdomain"| T["<b>follow</b> — TLS binds it<br/>catalog_trust = tls_domain"]
+    P -->|"off-domain<br/>(different registrable domain)"| O{"authenticated?"}
+    O -->|"records JWS-verify vs the domain's<br/>/.well-known/dns-aid-jwks.json<br/>(verify_signatures=True)"| J["<b>follow</b> — catalog_trust = jws<br/>(unverified records dropped)"]
+    O -->|"pointer DNSSEC-validated<br/>AND trust_dnssec_pointers=True"| DS["<b>follow</b> — catalog_trust = dnssec"]
+    O -->|"neither"| F["<b>ignore the pointer</b> →<br/>fall back to the on-domain<br/>/.well-known catalog (tls_domain)"]
+```
+
+- **TLS-to-own-domain (default).** A catalog served on the queried domain (or a
+  subdomain) — via the well-known path or an on-domain `_catalog._agents` /
+  `_index._agents` pointer target — is bound to the domain by TLS.
+  → `catalog_trust: "tls_domain"`.
+- **DNSSEC (opt-in via `trust_dnssec_pointers=True`).** An off-domain pointer is
+  followed when its pointer record is DNSSEC-validated. Off by default — the AD
+  flag is only trustworthy with a validating resolver over a secure path
+  (localhost / DoT / DoH), so enable it only when you run one. →
+  `catalog_trust: "dnssec"`.
+- **JWS (optional).** With `verify_signatures=True`, an off-domain catalog whose
+  records are JWS-signed against the queried domain's
+  `/.well-known/dns-aid-jwks.json` is followed. → `catalog_trust: "jws"`.
+  Records that fail verification are dropped automatically — an off-domain
+  catalog has no other trust anchor.
+
+An off-domain pointer that is **neither** DNSSEC-authenticated nor JWS-signed is
+**ignored** — discovery falls back to the queried domain's own well-known
+catalog. This prevents a spoofed or injected pointer from redirecting discovery
+to a forged off-domain catalog.
+
+Two fail-safe tradeoffs to know: an off-domain catalog that is authenticated but
+*legitimately empty* can be shadowed by a stale on-domain well-known catalog (an
+empty source never wins the fallback cascade); and a record listed inside an
+off-domain JWS catalog that carries no signature of its own is dropped. Both are
+stricter, never looser — they fail closed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.26.2"
+version = "0.26.3"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/cli/main.py
+++ b/src/dns_aid/cli/main.py
@@ -470,8 +470,9 @@ def discover(
                     "policy_uri": a.policy_uri,
                     "realm": a.realm,
                     "description": a.description,
-                    # ARD-sourced agents only — key omitted otherwise so
+                    # ARD-sourced agents only — keys omitted otherwise so
                     # legacy output stays byte-identical.
+                    **({"catalog_trust": a.catalog_trust} if a.catalog_trust is not None else {}),
                     **(
                         {"trust_manifest": a.trust_manifest.model_dump()}
                         if a.trust_manifest is not None

--- a/src/dns_aid/core/catalog_pointer.py
+++ b/src/dns_aid/core/catalog_pointer.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+from dataclasses import dataclass
 
 import dns.asyncresolver
 import dns.resolver
@@ -73,6 +74,29 @@ _MAX_POINTER_RECORDS = 4
 # getaddrinfo with no timeout of its own; bound it so a slow/blackholed
 # authoritative server for the target host can't stall discovery.
 _VALIDATE_TIMEOUT = 3.0
+
+
+@dataclass(frozen=True)
+class PointerResolution:
+    """Resolved catalog pointer: catalog URL, SVCB target host, pointer FQDN.
+
+    ``url`` is the catalog URL to fetch; ``target_host`` is the SVCB target
+    (the host that will serve the catalog), compared against the queried domain
+    to decide on-domain vs off-domain; ``pointer_fqdn`` is the DNS name that
+    carried the pointer (``_catalog._agents.{domain}`` or
+    ``_index._agents.{domain}``), which the caller DNSSEC-validates (via the
+    library's canonical ``validator._check_dnssec``) before trusting an
+    off-domain redirection.
+
+    DNSSEC authentication of the pointer inherits the library-wide model: the AD
+    flag is trustworthy only with a validating resolver over a secured path
+    (localhost / DoT / DoH). This resolution step performs NO trust decision — it
+    only reports the location; the caller decides.
+    """
+
+    url: str
+    target_host: str
+    pointer_fqdn: str
 
 
 async def _resolve_svcb(
@@ -117,18 +141,19 @@ def _read_wellknown_filename(rdata: object) -> str | None:
         return None
 
 
-async def resolve_catalog_pointer(
+async def resolve_catalog_pointer_detail(
     domain: str, *, timeout: float = DEFAULT_RESOLVE_TIMEOUT
-) -> str | None:
-    """Resolve a domain's ARD catalog URL from its DNS pointer records.
+) -> PointerResolution | None:
+    """Resolve a domain's ARD catalog pointer to a URL + SVCB target host.
 
     Tries ``_catalog._agents.{domain}`` then ``_index._agents.{domain}``
-    SVCB and, on the first ServiceMode answer with a usable target, returns
-    ``https://{target}/.well-known/{filename}``. Returns ``None`` when no
-    pointer is published (the caller then falls back to well-known probing).
+    SVCB and, on the first ServiceMode answer with a usable target, returns a
+    :class:`PointerResolution` (catalog URL + target host). Returns ``None`` when
+    no pointer is published (the caller then falls back to well-known probing).
 
-    Location discovery only — the returned URL is fetched and format-detected
-    by the caller; nothing about the catalog's contents is trusted here.
+    Location discovery only — nothing about the catalog's *contents* or its DNS
+    authentication is trusted here (a bare stub-resolver AD flag is forgeable);
+    trusted off-domain hosting is gated on per-record JWS by the caller.
     """
     domain = domain.lower().rstrip(".")
     resolver = dns.asyncresolver.Resolver()
@@ -195,9 +220,28 @@ async def resolve_catalog_pointer(
                     error=str(e),
                 )
                 continue
-            logger.info("catalog_pointer.resolved", domain=domain, label=label, url=url)
-            return url
+            logger.info(
+                "catalog_pointer.resolved",
+                domain=domain,
+                label=label,
+                url=url,
+            )
+            return PointerResolution(url=url, target_host=target, pointer_fqdn=fqdn)
     return None
+
+
+async def resolve_catalog_pointer(
+    domain: str, *, timeout: float = DEFAULT_RESOLVE_TIMEOUT
+) -> str | None:
+    """Resolve a domain's ARD catalog URL from its DNS pointer records.
+
+    Back-compatible location-only wrapper over
+    :func:`resolve_catalog_pointer_detail`: returns just the catalog URL (or
+    ``None``). Callers that need the trust signals (target host, DNSSEC AD)
+    should use the detail form.
+    """
+    detail = await resolve_catalog_pointer_detail(domain, timeout=timeout)
+    return detail.url if detail else None
 
 
 async def _existing_svcb_target(backend: DNSBackend, zone: str, name: str) -> str | None:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -27,14 +27,15 @@ import structlog
 
 from dns_aid.core.a2a_card import A2AAgentCard, fetch_agent_card
 from dns_aid.core.cap_fetcher import fetch_cap_document
-from dns_aid.core.catalog_pointer import resolve_catalog_pointer
+from dns_aid.core.catalog_pointer import PointerResolution, resolve_catalog_pointer_detail
 from dns_aid.core.filters import apply_filters
 from dns_aid.core.http_index import (
     HttpIndexAgent,
     _ard_domains_aligned,
     _ard_identity_domain,
     _name_from_urn,
-    fetch_http_index_or_empty,
+    fetch_http_index_result_or_empty,
+    is_on_domain,
 )
 from dns_aid.core.models import (
     AgentRecord,
@@ -70,11 +71,19 @@ async def _execute_discovery(
     query: str,
     *,
     allow_legacy: bool | None = None,
+    verify_signatures: bool = False,
+    trust_dnssec_pointers: bool = False,
 ) -> list[AgentRecord]:
     """Execute the appropriate discovery strategy and handle DNS errors."""
     try:
         if use_http_index:
-            return await _discover_via_http_index(domain, protocol, name)
+            return await _discover_via_http_index(
+                domain,
+                protocol,
+                name,
+                verify_signatures=verify_signatures,
+                trust_dnssec_pointers=trust_dnssec_pointers,
+            )
         elif name and protocol:
             agent = await _query_single_agent(domain, name, protocol, allow_legacy=allow_legacy)
             return [agent] if agent else []
@@ -140,6 +149,26 @@ async def _apply_post_discovery(
     return bool(per_agent_dnssec) and all(per_agent_dnssec.values())
 
 
+def _drop_unverified_off_domain(agents: list[AgentRecord], domain: str) -> list[AgentRecord]:
+    """Drop off-domain (JWS-trust) records whose signature did not verify.
+
+    An off-domain catalog is followed only because the caller opted into
+    ``verify_signatures``; unlike a DNS-plane record it has NO authoritative-DNS
+    trust basis, so its per-record JWS signature is the sole anchor. Records that
+    did not verify are dropped regardless of ``require_signed`` — enabling
+    ``verify_signatures`` alone must never surface an unverified off-domain
+    record. On-domain / DNSSEC / pure-DNS records (``catalog_trust`` in
+    {``tls_domain``, ``dnssec``, ``None``}) are unaffected.
+    """
+    kept = [
+        a for a in agents if not (a.catalog_trust == "jws" and a.signature_verified is not True)
+    ]
+    dropped = len(agents) - len(kept)
+    if dropped:
+        logger.info("sdk.dropped_unverified_off_domain", domain=domain, dropped=dropped)
+    return kept
+
+
 async def discover(
     domain: str,
     protocol: str | Protocol | None = None,
@@ -152,6 +181,7 @@ async def discover(
     use_http_index: bool = False,
     enrich_endpoints: bool = True,
     verify_signatures: bool = False,
+    trust_dnssec_pointers: bool = False,
     *,
     # Path A in-memory filter kwargs (FR-002, FR-021..FR-023). All optional; default
     # behavior is unchanged when none are passed.
@@ -187,7 +217,18 @@ async def discover(
         enrich_endpoints: If True (default), fetch ``.well-known/agent-card.json``
             from each discovered agent's host to resolve protocol-specific endpoint paths.
         verify_signatures: If True, verify JWS signatures. Implicit when ``require_signed``
-            is set so the trust filter has data to act on.
+            is set so the trust filter has data to act on. This is also the default
+            trust anchor for an *off-domain* ARD catalog pointer: a pointer to a
+            different registrable domain is followed when its catalog's records
+            JWS-verify against the queried domain's JWKS (resolver-independent).
+        trust_dnssec_pointers: Opt-in (default False). When True, an off-domain ARD
+            catalog pointer (``_catalog._agents`` / ``_index._agents`` whose target
+            is a different registrable domain) is also followed when the pointer
+            record is DNSSEC-validated. Off by default because the AD flag is only
+            trustworthy with a validating resolver over a secure path (localhost /
+            DoT / DoH) and following it redirects discovery to a foreign host —
+            enable only when you run such a resolver. On-domain pointers and JWS do
+            not require this.
         capabilities: All-of capability match. Empty list explicitly matches no records.
         capabilities_any: Any-of capability match. Empty list explicitly matches no records.
         auth_type: Case-insensitive exact match against ``agent.auth_type``.
@@ -261,7 +302,14 @@ async def discover(
     )
 
     agents = await _execute_discovery(
-        domain, protocol, name, use_http_index, query, allow_legacy=allow_legacy
+        domain,
+        protocol,
+        name,
+        use_http_index,
+        query,
+        allow_legacy=allow_legacy,
+        verify_signatures=verify_signatures,
+        trust_dnssec_pointers=trust_dnssec_pointers,
     )
 
     # Path A name filter — applied here, *before* enrichment, so we don't fetch
@@ -280,6 +328,12 @@ async def discover(
     )
     # Per-agent `dnssec_validated` is set inside _apply_post_discovery
     # when require_dnssec=True; no need to re-stamp at this level.
+
+    # Off-domain catalogs (catalog_trust=="jws") have their JWS signature as the
+    # sole trust anchor — drop any that did not verify even when require_signed
+    # is off, so verify_signatures alone can't surface an unverified off-domain
+    # record.
+    agents = _drop_unverified_off_domain(agents, domain)
 
     # Apply Path A in-memory filters (FR-002, FR-021..FR-023). When no filter kwargs are
     # set, ``apply_filters`` short-circuits and returns the input list unchanged.
@@ -1069,7 +1123,9 @@ def _enrich_from_http_index(agent: AgentRecord, http_agent: HttpIndexAgent) -> N
     # Preserve ARD trust manifest on DNS-discovered agents too — the
     # catalog is enriching an authoritative DNS answer.
     if http_agent.trust_manifest is not None and agent.trust_manifest is None:
-        agent.trust_manifest = _validated_trust_manifest(http_agent, agent.domain)
+        agent.trust_manifest = _validated_trust_manifest(
+            http_agent, http_agent.served_host or agent.domain
+        )
 
     if http_agent.endpoint and not agent.endpoint_override:
         parsed = urlparse(http_agent.endpoint)
@@ -1275,48 +1331,128 @@ async def _process_ard_agent(
     return record
 
 
+async def _pointer_dnssec_validated(pointer: PointerResolution) -> bool:
+    """True when the catalog pointer record is DNSSEC-authenticated.
+
+    Validates the pointer's OWN DNS name (``_catalog._agents`` /
+    ``_index._agents``) with the library's canonical AD-flag check
+    (``validator._check_dnssec``) — the same mechanism the pure-DNS
+    ``require_dnssec`` path uses. Trust model + precondition are identical: the
+    AD flag is trustworthy only with a validating resolver over a secured path
+    (localhost / DoT / DoH); otherwise this returns False and the off-domain
+    pointer is not trusted via DNSSEC (it may still be followed via JWS).
+    """
+    from dns_aid.core.validator import _check_dnssec
+
+    return await _check_dnssec(pointer.pointer_fqdn)
+
+
 async def _discover_via_http_index(
     domain: str,
     protocol: Protocol | None = None,
     name: str | None = None,
+    verify_signatures: bool = False,
+    trust_dnssec_pointers: bool = False,
 ) -> list[AgentRecord]:
     """
-    Discover agents using HTTP index endpoint.
+    Discover agents via an ARD catalog / HTTP index endpoint.
 
-    Fetches agent list from HTTP and resolves each via DNS SVCB.
-    Protocol and agent name are extracted from the FQDN in the HTTP index,
-    not from separate fields — the FQDN is the single source of truth.
+    Resolves the catalog location, applies the pointer trust decision, fetches
+    the catalog, and processes each entry (legacy entries resolve via their
+    FQDN; ARD entries via their card).
 
-    Args:
-        domain: Domain to fetch HTTP index from
-        protocol: Filter by protocol (or None for all)
-        name: Filter by specific agent name (or None for all)
-
-    Returns:
-        List of AgentRecord objects
+    Trust: a ``_catalog._agents`` / ``_index._agents`` DNS pointer whose target
+    is the queried domain (or a subdomain) is followed — TLS binds it to the
+    domain. A pointer to a *different* domain is followed only when
+    (``verify_signatures``) the catalog's records JWS-verify against the queried
+    domain's JWKS (unverified records are then dropped), or (``trust_dnssec_pointers``,
+    opt-in) the pointer record is DNSSEC-validated; otherwise it is ignored and
+    discovery falls back to the queried domain's own well-known catalog. JWS is
+    the default off-domain anchor (resolver-independent); DNSSEC-pointer trust is
+    opt-in because the AD flag is only trustworthy with a validating resolver over
+    a secure path. DNSSEC is never required for on-domain hosting.
     """
-    # DNS pointer first: if the domain publishes a _catalog._agents /
-    # _index._agents SVCB pointer, it authoritatively declares where its
-    # catalog lives — resolve it and fetch there before the well-known paths.
-    catalog_url = await resolve_catalog_pointer(domain)
-    http_agents = await fetch_http_index_or_empty(domain, catalog_url=catalog_url)
+    # Resolve the pointer (location + trust signals), then decide whether the
+    # declared catalog location may be trusted.
+    pointer = await resolve_catalog_pointer_detail(domain)
+    catalog_url: str | None = None
+    off_domain_trust: str | None = None
+    if pointer is not None:
+        if is_on_domain(pointer.target_host, domain):
+            catalog_url = pointer.url  # on-domain: TLS binds it to the queried domain
+        elif trust_dnssec_pointers and await _pointer_dnssec_validated(pointer):
+            # Off-domain, the caller opted into DNSSEC-pointer trust, AND the
+            # pointer record is DNSSEC-validated (validator._check_dnssec on the
+            # pointer's own name). Opt-in (default off): the AD flag is only
+            # trustworthy with a validating resolver over a secure path, and this
+            # follows an attacker-influenceable redirect to a foreign host.
+            catalog_url = pointer.url
+            off_domain_trust = "dnssec"
+            logger.info(
+                "catalog_pointer.off_domain_followed",
+                domain=domain,
+                target_host=pointer.target_host,
+                basis="dnssec",
+            )
+        elif verify_signatures:
+            # Off-domain: fetch it, but its records must JWS-verify against the
+            # queried domain's JWKS (checked in _apply_post_discovery); any that
+            # do not verify are dropped (_drop_unverified_off_domain).
+            catalog_url = pointer.url
+            off_domain_trust = "jws"
+            logger.info(
+                "catalog_pointer.off_domain_followed",
+                domain=domain,
+                target_host=pointer.target_host,
+                basis="jws",
+            )
+        else:
+            logger.info(
+                "catalog_pointer.off_domain_untrusted",
+                domain=domain,
+                target_host=pointer.target_host,
+                message=(
+                    "off-domain catalog pointer is not JWS-authenticated (and "
+                    "DNSSEC-pointer trust is not enabled); ignoring it and falling "
+                    "back to the on-domain well-known catalog"
+                ),
+            )
+
+    result = await fetch_http_index_result_or_empty(domain, catalog_url=catalog_url)
+    http_agents = result.agents
+    served_host = result.served_host or domain
+
+    # Trust basis. An off-domain follow (dnssec/jws) holds only if a genuine
+    # off-domain host actually served. If the fetch fell through to the
+    # on-domain well-known path (served host is the domain or a subdomain), the
+    # served catalog is TLS-bound to the queried domain. An unknown/empty served
+    # host under an off-domain follow is treated as off-domain — fail closed, so
+    # an unverified off-domain record can never surface as tls_domain.
+    sh = result.served_host
+    if off_domain_trust and (not sh or not is_on_domain(sh, domain)):
+        catalog_trust = off_domain_trust
+    else:
+        catalog_trust = "tls_domain"
 
     if not http_agents:
         logger.debug("No agents found in HTTP index", domain=domain)
         return []
 
+    # Anchor the foreign-publisher trust check on the host that actually served
+    # the catalog over TLS (not the query domain) by stamping it on each entry.
+    for ha in http_agents:
+        ha.served_host = served_host
+
     logger.debug(
         "HTTP index fetched",
         domain=domain,
         agent_count=len(http_agents),
+        served_host=served_host,
+        catalog_trust=catalog_trust,
     )
 
     # Mirror the DNS-index path's concurrency pattern: cap fan-out with a
-    # Semaphore and dispatch via asyncio.gather. Per-agent processing is
-    # independent (each call does its own SVCB+cap+TXT chain), so the
-    # sequential for-loop here was a real performance asymmetry vs
-    # _discover_agents_in_zone — for N agents on cold DNS/HTTPS caches it
-    # multiplied latency by ~N. Same Semaphore(20) cap as the DNS path.
+    # Semaphore and dispatch via asyncio.gather.
     sem = asyncio.Semaphore(20)
 
     async def _process_with_sem(ha: HttpIndexAgent) -> AgentRecord | None:
@@ -1325,7 +1461,11 @@ async def _discover_via_http_index(
 
     tasks = [_process_with_sem(ha) for ha in http_agents]
     results = await asyncio.gather(*tasks, return_exceptions=True)
-    return _collect_agent_results(results)
+    records = _collect_agent_results(results)
+    # Surface the trust basis by which the catalog was served (FR-009).
+    for rec in records:
+        rec.catalog_trust = catalog_trust
+    return records
 
 
 def _http_agent_to_record(
@@ -1396,7 +1536,12 @@ def _http_agent_to_record(
         use_cases=list(http_agent.use_cases),
         endpoint_override=http_agent.endpoint,
         endpoint_source="http_index_fallback",
-        trust_manifest=_validated_trust_manifest(http_agent, domain) if is_ard else None,
+        sig=http_agent.sig,
+        trust_manifest=(
+            _validated_trust_manifest(http_agent, http_agent.served_host or domain)
+            if is_ard
+            else None
+        ),
     )
 
 

--- a/src/dns_aid/core/http_index.py
+++ b/src/dns_aid/core/http_index.py
@@ -194,6 +194,14 @@ class HttpIndexAgent:
     # endpoint lives in the referenced/inline card, resolved from exactly one of:
     card_url: str | None = None  # `url`: dereference to fetch the card
     card_data: dict[str, Any] | None = None  # `data`: the card given inline
+    # Optional DNS-AID JWS over the (identifier→endpoint) binding, carried on an
+    # ARD entry. When present it authenticates an off-domain catalog without
+    # DNSSEC: the discoverer verifies it against the publisher domain's JWKS.
+    sig: str | None = None
+    # Populated by the discoverer (not the wire): the host that actually served
+    # this agent's catalog over TLS — the trust anchor for the foreign-publisher
+    # check. None on legacy/direct call sites (which fall back to the domain).
+    served_host: str | None = None
 
     @classmethod
     def from_dict(cls, name: str, data: dict[str, Any]) -> HttpIndexAgent:
@@ -409,6 +417,9 @@ def _ard_entry_to_agent(entry: dict[str, Any]) -> tuple[HttpIndexAgent | None, s
     use_cases = _ard_str_list(entry.get("representativeQueries"))
     version = entry.get("version")
     trust_manifest = entry.get("trustManifest")
+    # Optional DNS-AID JWS over the record binding (authenticates an off-domain
+    # catalog without DNSSEC). Verified against the queried domain's JWKS.
+    sig = entry.get("sig")
 
     capability = Capability(protocols=[protocol], capabilities=capabilities)
     model_card = ModelCard(
@@ -432,6 +443,7 @@ def _ard_entry_to_agent(entry: dict[str, Any]) -> tuple[HttpIndexAgent | None, s
             use_cases=use_cases,
             card_url=url if isinstance(url, str) else None,
             card_data=inline_data if isinstance(inline_data, dict) else None,
+            sig=sig if isinstance(sig, str) else None,
         ),
         None,
     )
@@ -618,6 +630,116 @@ async def _fetch_and_parse(
     return None
 
 
+@dataclass
+class HttpIndexResult:
+    """Outcome of an HTTP-index / ARD catalog fetch.
+
+    ``served_host`` is the host that actually returned the catalog over TLS
+    (the DNS-pointer target or the well-known host) — the discoverer uses it as
+    the trust anchor for the foreign-publisher check. ``catalog_trust`` records
+    why the served catalog is trusted; it defaults to ``"tls_domain"`` (an
+    on-domain / well-known fetch is bound to the domain by TLS) and is refined
+    by the discoverer to ``"dnssec"`` / ``"jws"`` when it followed an
+    authenticated off-domain pointer.
+    """
+
+    agents: list[HttpIndexAgent]
+    served_host: str | None = None
+    catalog_trust: str = "tls_domain"
+
+
+def is_on_domain(host: str, domain: str) -> bool:
+    """True when ``host`` is the queried ``domain`` or a subdomain of it.
+
+    Label-boundary match (``host == domain`` or ``host`` ends with
+    ``"." + domain``) — no public-suffix list needed. A TLS connection to such
+    a host authenticates control within the queried domain's own namespace, so
+    an on-domain catalog is trusted without DNSSEC or signatures. A host on any
+    other registrable domain is off-domain.
+    """
+    host = host.lower().rstrip(".")
+    domain = domain.lower().rstrip(".")
+    return host == domain or host.endswith("." + domain)
+
+
+def _host_of(url: str) -> str:
+    """Best-effort host of a URL (lowercased, no port)."""
+    return (urlparse(url).hostname or "").lower()
+
+
+async def _fetch_index_cascade(
+    domain: str,
+    timeout: float,
+    verify_ssl: bool,
+    catalog_url: str | None,
+) -> HttpIndexResult:
+    """Fetch the first usable HTTP index / ARD catalog across the source cascade.
+
+    Source order: the DNS-pointer ``catalog_url`` (if supplied) first, then the
+    well-known ``HTTP_INDEX_PATTERNS``. The first source that returns a
+    **non-empty** agent list wins. A source that returns HTTP 200 but zero
+    usable agents (a valid-but-empty catalog) does NOT terminate the cascade —
+    it is remembered and the search continues, so a stale/empty pointer or an
+    empty legacy index can never shadow a real catalog further down. When every
+    responding source is empty, that empty result is returned; when no source
+    responds at all, ``HttpIndexError`` is raised.
+    """
+    domain = domain.lower().rstrip(".")
+    errors: list[str] = []
+
+    # TLS verification defaults on; the verify_ssl=False opt-out (dev/self-signed)
+    # is audited with a structured warning.
+    if not verify_ssl:
+        logger.warning(
+            "http_index.tls_verification_disabled",
+            domain=domain,
+            message=(
+                "HTTP index fetched with TLS certificate verification DISABLED — "
+                "only safe for test/development environments; do NOT use in production."
+            ),
+        )
+
+    # Source cascade as (url, follow_redirects) pairs. The DNS-pointer catalog
+    # host is attacker-influenceable and SSRF-validated pre-redirect only, so it
+    # forbids redirects; the well-known patterns allow them.
+    sources: list[tuple[str, bool]] = []
+    if catalog_url:
+        sources.append((catalog_url, False))
+    for pattern in HTTP_INDEX_PATTERNS:
+        host = pattern["host"].format(domain=domain)
+        sources.append((f"https://{host}{pattern['path']}", True))
+
+    empty_served_host: str | None = None
+
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        verify=verify_ssl,  # noqa: S501 — opt-out is gated by explicit caller-supplied kwarg; warning logged above
+        follow_redirects=True,
+        max_redirects=3,
+    ) as client:
+        for url, follow in sources:
+            logger.debug("Trying HTTP index endpoint", url=url, follow_redirects=follow)
+            agents = await _fetch_and_parse(client, url, errors, follow_redirects=follow)
+            if agents is None:
+                continue  # nothing served here — keep trying
+            if agents:
+                # First non-empty source wins.
+                return HttpIndexResult(agents=agents, served_host=_host_of(url))
+            # Valid HTTP 200 but zero usable agents: remember and keep searching
+            # so an empty source cannot shadow a real catalog downstream (the
+            # `[] is not None` fallback-shadowing bug).
+            if empty_served_host is None:
+                empty_served_host = _host_of(url)
+
+    if empty_served_host is not None:
+        logger.debug("HTTP index sources all empty", domain=domain)
+        return HttpIndexResult(agents=[], served_host=empty_served_host)
+
+    # No source responded at all.
+    logger.warning("All HTTP index endpoints failed", domain=domain, errors=errors)
+    raise HttpIndexError(f"No HTTP index found at {domain}. Tried: {', '.join(errors)}")
+
+
 async def fetch_http_index(
     domain: str,
     timeout: float = DEFAULT_TIMEOUT,
@@ -634,65 +756,23 @@ async def fetch_http_index(
     on pointer-fetch failure, the well-known ``HTTP_INDEX_PATTERNS`` are
     tried in order (legacy index locations, then the ARD well-known path).
 
-    Args:
-        domain: Domain to fetch index from (e.g., "example.com")
-        timeout: HTTP request timeout in seconds
-        verify_ssl: Whether to verify SSL certificates
-        catalog_url: Optional pre-resolved catalog URL to try before the
-            well-known patterns.
-
-    Returns:
-        List of HttpIndexAgent objects
-
-    Raises:
-        HttpIndexError: If all endpoints fail
+    Returns the parsed ``HttpIndexAgent`` list. See
+    :func:`fetch_http_index_result` for the richer form that also reports the
+    served host. Raises ``HttpIndexError`` if no endpoint responds.
     """
-    domain = domain.lower().rstrip(".")
-    errors: list[str] = []
+    result = await _fetch_index_cascade(domain, timeout, verify_ssl, catalog_url)
+    return result.agents
 
-    # Configure TLS verification.
-    # Default is verify=True (system trust store). The opt-out path is gated
-    # by the explicit verify_ssl=False kwarg (a documented public API surface
-    # for testing against self-signed certs in dev environments). Whenever
-    # the opt-out is taken at runtime, log a structured warning so operators
-    # can audit insecure usage.
-    if not verify_ssl:
-        logger.warning(
-            "http_index.tls_verification_disabled",
-            domain=domain,
-            message=(
-                "HTTP index fetched with TLS certificate verification DISABLED — "
-                "only safe for test/development environments; do NOT use in production."
-            ),
-        )
 
-    async with httpx.AsyncClient(
-        timeout=timeout,
-        verify=verify_ssl,  # noqa: S501 — opt-out is gated by explicit caller-supplied kwarg; warning logged above
-        follow_redirects=True,
-        max_redirects=3,
-    ) as client:
-        # DNS pointer first: the domain owner authoritatively declared where
-        # the catalog lives, which overrides the well-known path convention.
-        if catalog_url:
-            logger.debug("Trying DNS-pointer catalog URL", url=catalog_url)
-            # No redirects: the catalog host came from an (attacker-influenceable)
-            # SVCB target and was SSRF-validated pre-redirect only.
-            agents = await _fetch_and_parse(client, catalog_url, errors, follow_redirects=False)
-            if agents is not None:
-                return agents
-
-        for pattern in HTTP_INDEX_PATTERNS:
-            host = pattern["host"].format(domain=domain)
-            url = f"https://{host}{pattern['path']}"
-            logger.debug("Trying HTTP index endpoint", url=url, pattern_type=pattern["type"])
-            agents = await _fetch_and_parse(client, url, errors)
-            if agents is not None:
-                return agents
-
-    # All endpoints failed
-    logger.warning("All HTTP index endpoints failed", domain=domain, errors=errors)
-    raise HttpIndexError(f"No HTTP index found at {domain}. Tried: {', '.join(errors)}")
+async def fetch_http_index_result(
+    domain: str,
+    timeout: float = DEFAULT_TIMEOUT,
+    verify_ssl: bool = True,
+    *,
+    catalog_url: str | None = None,
+) -> HttpIndexResult:
+    """Like :func:`fetch_http_index` but also reports the served host + trust basis."""
+    return await _fetch_index_cascade(domain, timeout, verify_ssl, catalog_url)
 
 
 def parse_http_index(data: dict[str, Any]) -> list[HttpIndexAgent]:
@@ -789,3 +869,28 @@ async def fetch_http_index_or_empty(
             error=str(e),
         )
         return []
+
+
+async def fetch_http_index_result_or_empty(
+    domain: str,
+    timeout: float = DEFAULT_TIMEOUT,
+    verify_ssl: bool = True,
+    *,
+    catalog_url: str | None = None,
+) -> HttpIndexResult:
+    """Like :func:`fetch_http_index_result` but returns an empty result on failure.
+
+    Never raises — the fallback-friendly form used by the discoverer, which
+    needs the served host alongside the agents.
+    """
+    try:
+        return await fetch_http_index_result(domain, timeout, verify_ssl, catalog_url=catalog_url)
+    except HttpIndexError:
+        return HttpIndexResult(agents=[], served_host=None)
+    except Exception as e:  # noqa: BLE001 — one bad index must not abort discovery
+        logger.warning(
+            "Unexpected error fetching HTTP index",
+            domain=domain,
+            error=str(e),
+        )
+        return HttpIndexResult(agents=[], served_host=None)

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -666,6 +666,16 @@ class AgentRecord(BaseModel):
         description="JWS compact signature for record verification when DNSSEC unavailable. "
         "Contains signed payload with fqdn, target, port, alpn, iat, exp.",
     )
+    catalog_trust: str | None = Field(
+        default=None,
+        description=(
+            "For ARD / HTTP-index-discovered agents: the trust basis by which the "
+            "catalog was served — 'tls_domain' (served on the queried domain or a "
+            "subdomain, bound by TLS), 'dnssec' (DNSSEC-authenticated off-domain "
+            "pointer), or 'jws' (off-domain catalog followed under signature "
+            "verification). None for pure-DNS agents."
+        ),
+    )
 
     # Capability source tracking
     capability_source: CapabilitySource | None = Field(

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -684,8 +684,13 @@ def discover_agents_via_dns(
                     "realm": agent.realm,
                     "description": agent.description,
                     "fqdn": agent.fqdn,
-                    # ARD-sourced agents only — key omitted otherwise so
+                    # ARD-sourced agents only — keys omitted otherwise so
                     # legacy output stays byte-identical.
+                    **(
+                        {"catalog_trust": agent.catalog_trust}
+                        if agent.catalog_trust is not None
+                        else {}
+                    ),
                     **(
                         {"trust_manifest": agent.trust_manifest.model_dump()}
                         if agent.trust_manifest is not None

--- a/tests/integration/test_ard_live.py
+++ b/tests/integration/test_ard_live.py
@@ -66,6 +66,12 @@ async def test_live_discover_via_library():
     assert all(a.endpoint_source == "ard_card" for a in result.agents), (
         "every ARD agent's card should be dereferenced to its real endpoint"
     )
+
+    # spec 008: the catalog is served on the queried domain, so the trust basis
+    # is TLS-to-domain (no off-domain pointer, no regression to the DNS plane).
+    assert all(a.catalog_trust == "tls_domain" for a in result.agents), (
+        "on-domain catalog must surface catalog_trust=tls_domain"
+    )
     billing = by_name["billing"]
     assert urlparse(billing.endpoint_url).hostname == "billing.highvelocitynetworking.com"
     assert "create_invoice" in billing.capabilities  # tools from the fetched card

--- a/tests/unit/test_ard_pointer_trust.py
+++ b/tests/unit/test_ard_pointer_trust.py
@@ -1,0 +1,286 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ARD catalog-pointer trust (spec 008).
+
+Covers the layered pointer trust decision (on-domain / DNSSEC / JWS / fallback),
+the foreign-publisher anchor fix (② — anchored on the served host, not the query
+domain), and the surfaced ``catalog_trust`` basis.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import structlog
+
+from dns_aid.core.catalog_pointer import PointerResolution
+from dns_aid.core.discoverer import (
+    _discover_via_http_index,
+    _drop_unverified_off_domain,
+    _http_agent_to_record,
+    _validated_trust_manifest,
+)
+from dns_aid.core.http_index import (
+    HttpIndexAgent,
+    HttpIndexResult,
+    is_on_domain,
+    parse_http_index,
+)
+from dns_aid.core.models import AgentRecord, Protocol
+
+DOMAIN = "acme.com"
+ON_DOMAIN = PointerResolution(
+    url="https://ard.acme.com/.well-known/ai-catalog.json",
+    target_host="ard.acme.com",
+    pointer_fqdn="_catalog._agents.acme.com",
+)
+# An off-domain pointer target (a different registrable domain) — the shape an
+# injected/spoofed pointer takes, and also a legitimate third-party CDN host.
+OFF_DOMAIN = PointerResolution(
+    url="https://catalog.partner.com/.well-known/ai-catalog.json",
+    target_host="catalog.partner.com",
+    pointer_fqdn="_catalog._agents.acme.com",
+)
+
+
+def _ard_agent(name: str = "chat") -> HttpIndexAgent:
+    return HttpIndexAgent(
+        name=name,
+        fqdn=f"{name}.acme.com",
+        source_format="ard",
+        protocols=["a2a"],
+        identifier=f"urn:air:acme.com:agents:{name}",
+        card_url="https://acme.com/agents/chat.json",
+    )
+
+
+async def _run_decision(
+    pointer,
+    *,
+    verify_signatures: bool = False,
+    dnssec_validated: bool = False,
+    trust_dnssec_pointers: bool = False,
+):
+    """Drive _discover_via_http_index with the pointer resolution mocked.
+
+    Returns (captured_catalog_url, records). ``fake_fetch`` reports the
+    off-domain host as the server only when the pointer URL was actually
+    followed, mirroring the real fetch-vs-fallback behaviour.
+    """
+    captured: dict = {}
+
+    async def fake_fetch(domain, *, catalog_url=None):
+        captured["catalog_url"] = catalog_url
+        served = pointer.target_host if (catalog_url and pointer) else domain
+        return HttpIndexResult(agents=[_ard_agent()], served_host=served)
+
+    async def fake_process(ha, domain, protocol, name):
+        return AgentRecord(
+            name=ha.name,
+            domain=domain,
+            protocol=Protocol.A2A,
+            target_host="chat.acme.com",
+            port=443,
+        )
+
+    with (
+        patch(
+            "dns_aid.core.discoverer.resolve_catalog_pointer_detail",
+            AsyncMock(return_value=pointer),
+        ),
+        patch(
+            "dns_aid.core.discoverer._pointer_dnssec_validated",
+            AsyncMock(return_value=dnssec_validated),
+        ),
+        patch(
+            "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
+            side_effect=fake_fetch,
+        ),
+        patch("dns_aid.core.discoverer._process_http_agent", side_effect=fake_process),
+    ):
+        records = await _discover_via_http_index(
+            DOMAIN,
+            verify_signatures=verify_signatures,
+            trust_dnssec_pointers=trust_dnssec_pointers,
+        )
+    return captured.get("catalog_url"), records
+
+
+class TestOnDomainCheck:
+    @pytest.mark.parametrize(
+        ("host", "domain", "expected"),
+        [
+            ("acme.com", "acme.com", True),
+            ("ard.acme.com", "acme.com", True),
+            ("a.b.acme.com", "acme.com", True),
+            ("ARD.ACME.COM", "acme.com", True),  # case-insensitive
+            ("ard.acme.com.", "acme.com", True),  # trailing dot
+            ("catalog.evil.com", "acme.com", False),
+            ("evil-acme.com", "acme.com", False),  # label-boundary, not substring
+            ("acme.com.evil.com", "acme.com", False),  # suffix spoof
+        ],
+    )
+    def test_is_on_domain(self, host, domain, expected):
+        assert is_on_domain(host, domain) is expected
+
+
+class TestPointerTrustDecision:
+    """US1/US3 — which pointer targets are followed vs. fall back to well-known."""
+
+    @pytest.mark.asyncio
+    async def test_no_pointer_uses_wellknown(self):
+        catalog_url, records = await _run_decision(None)
+        assert catalog_url is None  # well-known cascade on the queried domain
+        assert records[0].catalog_trust == "tls_domain"
+
+    @pytest.mark.asyncio
+    async def test_on_domain_pointer_followed(self):
+        catalog_url, records = await _run_decision(ON_DOMAIN)
+        assert catalog_url == ON_DOMAIN.url  # subdomain of the queried domain — TLS-bound
+        assert records[0].catalog_trust == "tls_domain"
+
+    @pytest.mark.asyncio
+    async def test_off_domain_unauthenticated_falls_back(self):
+        # THE security property: a spoofed/injected off-domain pointer is NOT
+        # followed — discovery falls back to the on-domain well-known catalog.
+        catalog_url, records = await _run_decision(OFF_DOMAIN)
+        assert catalog_url is None
+        assert records[0].catalog_trust == "tls_domain"
+
+    @pytest.mark.asyncio
+    async def test_off_domain_dnssec_followed_when_opted_in(self):
+        # Opt-in trust_dnssec_pointers=True + DNSSEC-validated pointer → followed.
+        catalog_url, records = await _run_decision(
+            OFF_DOMAIN, dnssec_validated=True, trust_dnssec_pointers=True
+        )
+        assert catalog_url == OFF_DOMAIN.url
+        assert records[0].catalog_trust == "dnssec"
+
+    @pytest.mark.asyncio
+    async def test_off_domain_dnssec_ignored_without_optin(self):
+        # DNSSEC-validated pointer but the caller did NOT opt in → NOT followed;
+        # falls back to the on-domain well-known catalog (JWS is the default anchor).
+        catalog_url, records = await _run_decision(OFF_DOMAIN, dnssec_validated=True)
+        assert catalog_url is None
+        assert records[0].catalog_trust == "tls_domain"
+
+    @pytest.mark.asyncio
+    async def test_off_domain_jws_followed_under_verify_signatures(self):
+        catalog_url, records = await _run_decision(OFF_DOMAIN, verify_signatures=True)
+        assert catalog_url == OFF_DOMAIN.url
+        assert records[0].catalog_trust == "jws"
+
+    @pytest.mark.asyncio
+    async def test_off_domain_without_verify_signatures_still_falls_back(self):
+        catalog_url, _ = await _run_decision(OFF_DOMAIN, verify_signatures=False)
+        assert catalog_url is None
+
+
+class TestForeignPublisherAnchor:
+    """② — the foreign-publisher warning anchors on the served host, not the query domain."""
+
+    def _agent(self) -> HttpIndexAgent:
+        return HttpIndexAgent(
+            name="chat",
+            fqdn="chat.acme.com",
+            source_format="ard",
+            identifier="urn:air:acme.com:agents:chat",
+            trust_manifest={
+                "identity": "spiffe://acme.com/agents/chat",
+                "identityType": "spiffe",
+                "attestations": [{"type": "SOC2-Type2", "uri": "https://acme.com/soc2.pdf"}],
+            },
+        )
+
+    def test_off_domain_served_host_trips_warning(self):
+        with structlog.testing.capture_logs() as logs:
+            manifest = _validated_trust_manifest(self._agent(), "catalog.evil.com")
+        events = {e.get("event") for e in logs}
+        assert "http_index.ard_trust_foreign_publisher" in events
+        # The manifest is still returned (advisory-only), now with the true anchor.
+        assert manifest is not None
+
+    def test_on_domain_served_host_does_not_trip_warning(self):
+        with structlog.testing.capture_logs() as logs:
+            _validated_trust_manifest(self._agent(), "acme.com")
+        events = {e.get("event") for e in logs}
+        assert "http_index.ard_trust_foreign_publisher" not in events
+
+    def test_query_domain_would_have_masked_it(self):
+        # Regression guard: passing the *query* domain (the old behaviour) hides
+        # the foreign publisher; the served host must be used instead.
+        with structlog.testing.capture_logs() as logs:
+            _validated_trust_manifest(self._agent(), "acme.com")  # query domain
+        assert not any(e.get("event") == "http_index.ard_trust_foreign_publisher" for e in logs)
+
+
+class TestOffDomainSignatureEnforcement:
+    """③ safe-by-default — off-domain (jws) records that did not verify are dropped."""
+
+    def _rec(self, catalog_trust, sig_verified):
+        r = AgentRecord(
+            name="x",
+            domain="acme.com",
+            protocol=Protocol.MCP,
+            target_host="x.acme.com",
+            port=443,
+        )
+        r.catalog_trust = catalog_trust
+        r.signature_verified = sig_verified
+        return r
+
+    def test_drops_unverified_off_domain_records(self):
+        agents = [
+            self._rec("jws", True),  # verified off-domain — keep
+            self._rec("jws", False),  # failed verification — drop
+            self._rec("jws", None),  # not verified (e.g. no sig) — drop
+            self._rec("tls_domain", None),  # on-domain — keep
+            self._rec("dnssec", None),  # DNSSEC-authenticated off-domain — keep
+            self._rec(None, None),  # pure-DNS — keep
+        ]
+        kept = _drop_unverified_off_domain(agents, "acme.com")
+        assert [(a.catalog_trust, a.signature_verified) for a in kept] == [
+            ("jws", True),
+            ("tls_domain", None),
+            ("dnssec", None),
+            (None, None),
+        ]
+
+    def test_empty_input_ok(self):
+        assert _drop_unverified_off_domain([], "acme.com") == []
+
+
+class TestArdSigWiring:
+    """Adversarial-review fix — the per-entry `sig` is actually read + carried,
+    so the JWS off-domain arm is not dead code (it was previously never parsed)."""
+
+    def test_ard_entry_sig_is_extracted_from_wire(self):
+        catalog = {
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:air:acme.com:agents:billing",
+                    "displayName": "Billing",
+                    "type": "application/mcp-server-card+json",
+                    "url": "https://cards.acme.com/billing.json",
+                    "sig": "eyJhbGciOiJFUzI1NiJ9.payload.signature",
+                }
+            ],
+        }
+        agents = parse_http_index(catalog)
+        assert len(agents) == 1
+        assert agents[0].sig == "eyJhbGciOiJFUzI1NiJ9.payload.signature"
+
+    def test_ard_sig_flows_into_record(self):
+        ha = HttpIndexAgent(
+            name="billing",
+            fqdn="billing.acme.com",
+            source_format="ard",
+            protocols=["mcp"],
+            identifier="urn:air:acme.com:agents:billing",
+            card_url="https://cards.acme.com/billing.json",
+            sig="eyJ.a.b",
+        )
+        rec = _http_agent_to_record(ha, "acme.com", "billing", Protocol.MCP)
+        assert rec is not None
+        assert rec.sig == "eyJ.a.b"

--- a/tests/unit/test_catalog_pointer.py
+++ b/tests/unit/test_catalog_pointer.py
@@ -12,6 +12,7 @@ import pytest
 from dns_aid.core.catalog_pointer import (
     CATALOG_POINTER_LABELS,
     DEFAULT_CATALOG_FILENAME,
+    PointerResolution,
     publish_catalog_pointer,
     resolve_catalog_pointer,
     unpublish_catalog_pointer,
@@ -501,8 +502,14 @@ class TestPointerDrivenDiscovery:
         with (
             patch.object(
                 disc,
-                "resolve_catalog_pointer",
-                AsyncMock(return_value="https://cat.acme.com/.well-known/ai-catalog.json"),
+                "resolve_catalog_pointer_detail",
+                AsyncMock(
+                    return_value=PointerResolution(
+                        url="https://cat.acme.com/.well-known/ai-catalog.json",
+                        target_host="cat.acme.com",
+                        pointer_fqdn="_catalog._agents.acme.com",
+                    )
+                ),
             ),
             patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=client),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -24,7 +24,7 @@ from dns_aid.core.discoverer import (
     discover,
     discover_at_fqdn,
 )
-from dns_aid.core.http_index import HttpIndexAgent
+from dns_aid.core.http_index import HttpIndexAgent, HttpIndexResult
 from dns_aid.core.models import AgentRecord, Protocol
 
 
@@ -127,7 +127,9 @@ class TestDiscover:
             return_value=[],
         ) as mock_http:
             result = await discover("example.com", use_http_index=True)
-            mock_http.assert_called_once_with("example.com", None, None)
+            mock_http.assert_called_once_with(
+                "example.com", None, None, verify_signatures=False, trust_dnssec_pointers=False
+            )
             assert result.domain == "example.com"
 
     @pytest.mark.asyncio
@@ -462,9 +464,9 @@ class TestDiscoverViaHttpIndex:
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_http_agents(self):
         with patch(
-            "dns_aid.core.discoverer.fetch_http_index_or_empty",
+            "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
             new_callable=AsyncMock,
-            return_value=[],
+            return_value=HttpIndexResult(agents=[], served_host=None),
         ):
             agents = await _discover_via_http_index("example.com")
             assert agents == []
@@ -484,9 +486,9 @@ class TestDiscoverViaHttpIndex:
 
         with (
             patch(
-                "dns_aid.core.discoverer.fetch_http_index_or_empty",
+                "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
                 new_callable=AsyncMock,
-                return_value=http_agents,
+                return_value=HttpIndexResult(agents=http_agents, served_host="example.com"),
             ),
             patch(
                 "dns_aid.core.discoverer._query_single_agent",
@@ -513,9 +515,9 @@ class TestDiscoverViaHttpIndex:
 
         with (
             patch(
-                "dns_aid.core.discoverer.fetch_http_index_or_empty",
+                "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
                 new_callable=AsyncMock,
-                return_value=http_agents,
+                return_value=HttpIndexResult(agents=http_agents, served_host="example.com"),
             ),
             patch(
                 "dns_aid.core.discoverer._query_single_agent",
@@ -538,9 +540,9 @@ class TestDiscoverViaHttpIndex:
         ]
 
         with patch(
-            "dns_aid.core.discoverer.fetch_http_index_or_empty",
+            "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
             new_callable=AsyncMock,
-            return_value=http_agents,
+            return_value=HttpIndexResult(agents=http_agents, served_host="example.com"),
         ):
             agents = await _discover_via_http_index("example.com")
             assert agents == []
@@ -555,9 +557,9 @@ class TestDiscoverViaHttpIndex:
         ]
 
         with patch(
-            "dns_aid.core.discoverer.fetch_http_index_or_empty",
+            "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
             new_callable=AsyncMock,
-            return_value=http_agents,
+            return_value=HttpIndexResult(agents=http_agents, served_host="example.com"),
         ):
             agents = await _discover_via_http_index("example.com")
             assert agents == []
@@ -574,9 +576,9 @@ class TestDiscoverViaHttpIndex:
 
         with (
             patch(
-                "dns_aid.core.discoverer.fetch_http_index_or_empty",
+                "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
                 new_callable=AsyncMock,
-                return_value=http_agents,
+                return_value=HttpIndexResult(agents=http_agents, served_host="example.com"),
             ),
             patch(
                 "dns_aid.core.discoverer._query_single_agent",
@@ -600,9 +602,9 @@ class TestDiscoverViaHttpIndex:
 
         with (
             patch(
-                "dns_aid.core.discoverer.fetch_http_index_or_empty",
+                "dns_aid.core.discoverer.fetch_http_index_result_or_empty",
                 new_callable=AsyncMock,
-                return_value=http_agents,
+                return_value=HttpIndexResult(agents=http_agents, served_host="example.com"),
             ),
             patch(
                 "dns_aid.core.discoverer._query_single_agent",

--- a/tests/unit/test_http_index.py
+++ b/tests/unit/test_http_index.py
@@ -13,9 +13,11 @@ from dns_aid.core.http_index import (
     Capability,
     HttpIndexAgent,
     HttpIndexError,
+    HttpIndexResult,
     ModelCard,
     fetch_http_index,
     fetch_http_index_or_empty,
+    fetch_http_index_result,
     parse_http_index,
 )
 
@@ -327,6 +329,33 @@ class TestFetchHttpIndex:
         with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
             with pytest.raises(HttpIndexError):
                 await fetch_http_index("example.com")
+
+
+class TestFetchIndexResultCascade:
+    """spec 008 (①) — the fallback cascade must not stop on a valid-but-empty source."""
+
+    @pytest.mark.asyncio
+    async def test_empty_source_does_not_shadow_later_nonempty(self):
+        # First source returns HTTP 200 with zero agents; a later source has one.
+        # Under the old `[] is not None` logic the empty source shadowed the rest.
+        mock_client = _streaming_client(
+            _stream_response({}),  # 200, parses to zero agents
+            _stream_response({"booking": {"location": {"fqdn": "booking.example.com"}}}),
+        )
+        with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
+            result = await fetch_http_index_result("example.com")
+        assert [a.name for a in result.agents] == ["booking"]
+        assert mock_client.stream.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_all_sources_empty_returns_empty_result(self):
+        # Every source responds but is empty → an empty result, not a hard error
+        # (and not a shadowed non-existent catalog).
+        mock_client = _streaming_client(*[_stream_response({}) for _ in range(5)])
+        with patch("dns_aid.core.http_index.httpx.AsyncClient", return_value=mock_client):
+            result = await fetch_http_index_result("example.com")
+        assert result.agents == []
+        assert result.served_host is not None
 
 
 class TestFetchHttpIndexOrEmpty:
@@ -969,9 +998,13 @@ class TestArdFetchEndToEnd:
         )
         http_agents = parse_http_index(_ard_catalog([entry]))
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(
                 disc, "fetch_cap_document", AsyncMock(return_value=None)
             ),  # card unfetchable
@@ -1010,8 +1043,12 @@ class TestArdFetchEndToEnd:
             raw_data={"endpoint": "https://weather.acme.com/mcp", "tools": [{"name": "forecast"}]}
         )
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(disc, "fetch_cap_document", AsyncMock(return_value=card_doc)),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=dns_record)) as qsa,
         ):
@@ -1030,9 +1067,13 @@ class TestArdFetchEndToEnd:
 
         http_agents = parse_http_index(_ard_catalog([_ard_agent_entry()]))  # mcp agent
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
         ):
             records = await disc._discover_via_http_index("acme.com", protocol=Protocol.A2A)
         assert records == []
@@ -1062,9 +1103,13 @@ class TestArdCardDereference:
             }
         )
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(disc, "fetch_cap_document", AsyncMock(return_value=card_doc)) as fc,
         ):
             records = await disc._discover_via_http_index("acme.com")
@@ -1099,9 +1144,13 @@ class TestArdCardDereference:
             }
         )
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(disc, "fetch_cap_document", AsyncMock(return_value=card_doc)),
         ):
             records = await disc._discover_via_http_index("acme.com")
@@ -1117,9 +1166,13 @@ class TestArdCardDereference:
         entry = _ard_agent_entry(capabilities=["invoicing"])
         http_agents = parse_http_index(_ard_catalog([entry]))
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(disc, "fetch_cap_document", AsyncMock(return_value=None)),  # fetch fails
         ):
             records = await disc._discover_via_http_index("acme.com")
@@ -1150,9 +1203,13 @@ class TestArdCardDereference:
         }
         http_agents = parse_http_index(_ard_catalog([entry]))
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=None)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(disc, "fetch_cap_document", AsyncMock()) as fc,
         ):
             records = await disc._discover_via_http_index("acme.com")
@@ -1184,8 +1241,12 @@ class TestArdCardDereference:
         )
         decoy = object()  # what a DNS lookup would return — must never be used
         with (
-            patch.object(disc, "fetch_http_index_or_empty", AsyncMock(return_value=http_agents)),
-            patch.object(disc, "resolve_catalog_pointer", AsyncMock(return_value=None)),
+            patch.object(
+                disc,
+                "fetch_http_index_result_or_empty",
+                AsyncMock(return_value=HttpIndexResult(agents=http_agents, served_host=None)),
+            ),
+            patch.object(disc, "resolve_catalog_pointer_detail", AsyncMock(return_value=None)),
             patch.object(disc, "fetch_cap_document", AsyncMock(return_value=card_doc)),
             patch.object(disc, "_query_single_agent", AsyncMock(return_value=decoy)) as qsa,
         ):

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary
Secure the ARD catalog-pointer discovery path and add a layered off-domain trust model. Ships as **0.26.3**. On-domain, legacy-index, and pure-DNS discovery are unchanged (backward-compatible; legacy/pure-DNS JSON is byte-identical).

## What changed
- **Fallback cascade fix** — a valid-but-empty source (`[] is not None`) no longer shadows a real catalog further down; the cascade returns the first *non-empty* source.
- **Foreign-publisher anchor fix** — `ard_trust_foreign_publisher` now compares the URN publisher against the host that actually served the catalog over TLS, not the queried domain (previously a no-op on the DNS-pointer path).
- **Layered off-domain pointer trust** — a pointer target on the queried domain (or a subdomain) is followed (TLS-bound → `catalog_trust=tls_domain`). An off-domain pointer is followed only when:
  - its records JWS-verify against the queried domain's `/.well-known/dns-aid-jwks.json` (`verify_signatures=True`) → `jws` (default, resolver-independent anchor; unverified records dropped automatically), or
  - opt-in `trust_dnssec_pointers=True` **and** the pointer record is DNSSEC-validated (`validator._check_dnssec`) → `dnssec`.
  Otherwise the pointer is ignored and discovery falls back to the on-domain well-known catalog — preventing a spoofed/injected pointer from redirecting to a forged off-domain catalog.
- **`AgentRecord.catalog_trust`** (`tls_domain | dnssec | jws`) surfaced on SDK/CLI/MCP.

## Security review
Two independent adversarial review passes. Initial findings — a forgeable stub-resolver-AD DNSSEC trust and a dead (never-parsed) JWS arm — were both fixed: JWS `sig` is now wired end-to-end, and off-domain DNSSEC-pointer trust is gated behind the explicit `trust_dnssec_pointers` opt-in (JWS is the default off-domain anchor, resolver-independent). Fail-closed reconciliation independently confirmed: no path surfaces an unverified off-domain record as `tls_domain`.

## Live verification
- **JWKS/JWS** — live against a real published JWKS + a signed catalog entry: `signature_verified=True, alg=ES256`.
- **DNSSEC** — live via a DNSSEC-signed BIND zone + validating resolver: pointer record validated -> follow as `dnssec`.
- On-domain ARD (5 agents), legacy HTTP index (13), pure-DNS (12) — all unchanged.

## Test plan
- [x] `ruff check src/` + `ruff format --check src/` clean
- [x] `mypy src/dns_aid/` clean (85 files)
- [x] 1963 unit tests pass (incl. new `test_ard_pointer_trust.py` — trust matrix, sig-wiring, foreign-publisher anchor, off-domain enforcement)
- [x] Gated live integration (3/3)
- [x] Secrets scan clean