### PR TITLE
fix: offload blocking getaddrinfo off the event loop in SSRF validation (0.26.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.6] - 2026-07-08
+
+### Fixed
+
+- **A blocking `socket.getaddrinfo` in `validate_fetch_url` froze the event loop,
+  silently serializing concurrent SSRF-validated fetches.** The SSRF IP check is a
+  synchronous, un-timed `getaddrinfo`; called directly from the async fetch paths it
+  stalled the single-threaded event loop for each resolution, turning `asyncio.gather`
+  fan-outs (ARD capability-document dereference, agent-card / JWKS / policy-document /
+  OAuth-discovery fetches) into an accidental serial queue — e.g. an 8-agent ARD
+  catalog spent ~16s resolving one host after another that a real concurrent fan-out
+  finishes in ~3s. The seven direct async callers now offload validation through a new
+  `validate_fetch_url_async` (worker thread + bounded timeout); `catalog_pointer` —
+  which already offloaded inline — is refactored onto the same helper. SSRF policy is
+  unchanged (public passes; private / loopback / link-local / reserved / timeout fail
+  closed). The synchronous `validate_fetch_url` is retained unchanged for sync callers.
+
 ## [0.26.5] - 2026-07-08
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.26.5"
+version: "0.26.6"
 date-released: "2026-07-08"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.26.5"
+version = "0.26.6"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -258,9 +258,9 @@ async def fetch_agent_card(
 
     # SSRF protection: validate URL before fetching
     try:
-        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
 
-        validate_fetch_url(card_url)
+        await validate_fetch_url_async(card_url)
     except UnsafeURLError as e:
         logger.warning("Agent Card URL blocked by SSRF protection", url=card_url, error=str(e))
         return None

--- a/src/dns_aid/core/cap_fetcher.py
+++ b/src/dns_aid/core/cap_fetcher.py
@@ -165,9 +165,9 @@ async def fetch_cap_document(
 
     # SSRF protection: validate URL before fetching
     try:
-        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
 
-        validate_fetch_url(cap_uri)
+        await validate_fetch_url_async(cap_uri)
     except UnsafeURLError as e:
         logger.warning("Cap URI blocked by SSRF protection", cap_uri=cap_uri, error=str(e))
         return None

--- a/src/dns_aid/core/catalog_pointer.py
+++ b/src/dns_aid/core/catalog_pointer.py
@@ -32,7 +32,6 @@ auto-detects the ARD format). No catalog content is trusted here.
 
 from __future__ import annotations
 
-import asyncio
 import ipaddress
 from dataclasses import dataclass
 
@@ -43,7 +42,7 @@ import structlog
 from dns_aid.backends.base import DNSBackend
 from dns_aid.core.models import SVCB_SERVICE_MODE
 from dns_aid.core.publisher import get_default_backend
-from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
 from dns_aid.utils.validation import (
     validate_no_underscore_in_target,
     validate_svcparam_value,
@@ -199,9 +198,7 @@ async def resolve_catalog_pointer_detail(
             # time — a limitation shared with all validate_fetch_url callers, to
             # be closed globally by a pinned-IP transport.
             try:
-                await asyncio.wait_for(
-                    asyncio.to_thread(validate_fetch_url, url), timeout=_VALIDATE_TIMEOUT
-                )
+                await validate_fetch_url_async(url, timeout=_VALIDATE_TIMEOUT)
             except UnsafeURLError as e:
                 logger.warning(
                     "catalog_pointer.unsafe_target",

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -1771,9 +1771,9 @@ async def _fetch_agent_json_auth(host: str, timeout: float = 5.0) -> dict | None
     url = f"https://{host}/.well-known/agent.json"
 
     try:
-        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+        from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
 
-        validate_fetch_url(url)
+        await validate_fetch_url_async(url)
     except UnsafeURLError:
         return None
 

--- a/src/dns_aid/core/jwks.py
+++ b/src/dns_aid/core/jwks.py
@@ -365,11 +365,11 @@ async def fetch_jwks(domain: str) -> dict[str, Any] | None:
         ResponseTooLargeError,
         UnsafeURLError,
         safe_fetch_bytes,
-        validate_fetch_url,
+        validate_fetch_url_async,
     )
 
     try:
-        validate_fetch_url(url)
+        await validate_fetch_url_async(url)
     except UnsafeURLError as e:
         logger.warning("JWKS URL blocked by SSRF protection", domain=domain, error=str(e))
         return None

--- a/src/dns_aid/sdk/auth/oauth2.py
+++ b/src/dns_aid/sdk/auth/oauth2.py
@@ -86,9 +86,9 @@ class OAuth2AuthHandler(AuthHandler):
             # SSRF protection: validate token URL before sending credentials.
             # token_url may come from untrusted agent metadata (oauth_discovery).
             try:
-                from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+                from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
 
-                validate_fetch_url(token_url)
+                await validate_fetch_url_async(token_url)
             except UnsafeURLError as e:
                 raise OAuth2TokenError(f"Token URL blocked by SSRF protection: {e}") from e
 
@@ -137,9 +137,9 @@ class OAuth2AuthHandler(AuthHandler):
 
         # SSRF protection: discovery_url may come from untrusted agent metadata.
         try:
-            from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url
+            from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
 
-            validate_fetch_url(self._discovery_url)
+            await validate_fetch_url_async(self._discovery_url)
         except UnsafeURLError as e:
             raise OAuth2TokenError(f"Discovery URL blocked by SSRF protection: {e}") from e
 
@@ -157,7 +157,7 @@ class OAuth2AuthHandler(AuthHandler):
         # response — a malicious discovery server could redirect credentials
         # to an internal host (e.g., cloud metadata at 169.254.169.254).
         try:
-            validate_fetch_url(token_endpoint)
+            await validate_fetch_url_async(token_endpoint)
         except UnsafeURLError as e:
             raise OAuth2TokenError(
                 f"Discovered token_endpoint blocked by SSRF protection: {e}"

--- a/src/dns_aid/sdk/client.py
+++ b/src/dns_aid/sdk/client.py
@@ -43,7 +43,7 @@ from dns_aid.sdk.protocols.mcp import MCPProtocolHandler
 from dns_aid.sdk.search import SearchResponse
 from dns_aid.sdk.signals.collector import SignalCollector
 from dns_aid.sdk.telemetry.otel import TelemetryManager
-from dns_aid.utils.url_safety import UnsafeURLError, redact_url_for_log, validate_fetch_url
+from dns_aid.utils.url_safety import UnsafeURLError, redact_url_for_log, validate_fetch_url_async
 
 
 class _OTELInvocationContext:
@@ -891,7 +891,7 @@ class AgentClient:
             )
 
         try:
-            validated_base = validate_fetch_url(directory_base)
+            validated_base = await validate_fetch_url_async(directory_base)
         except UnsafeURLError as exc:
             # The URL failed validation — it might be ``https://user:pass@host``,
             # malformed scheme, or pointing at a private IP. Whatever the reason,

--- a/src/dns_aid/sdk/policy/evaluator.py
+++ b/src/dns_aid/sdk/policy/evaluator.py
@@ -27,7 +27,7 @@ from dns_aid.sdk.policy.schema import (
     PolicyEnforcementLayer,
     PolicyRules,
 )
-from dns_aid.utils.url_safety import validate_fetch_url
+from dns_aid.utils.url_safety import validate_fetch_url_async
 
 if TYPE_CHECKING:
     from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
@@ -93,7 +93,7 @@ class PolicyEvaluator:
                 return entry.doc
 
             # Validate URL is safe (blocks SSRF)
-            validate_fetch_url(policy_uri)
+            await validate_fetch_url_async(policy_uri)
 
             # Fetch with size + timeout + content-type guards
             async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT) as client:

--- a/src/dns_aid/utils/url_safety.py
+++ b/src/dns_aid/utils/url_safety.py
@@ -10,6 +10,7 @@ requests to private/loopback/link-local IP addresses.
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import os
 import socket
@@ -109,6 +110,32 @@ def validate_fetch_url(url: str) -> str:
             )
 
     return url
+
+
+# Per-URL SSRF-validation time budget for the async wrapper. ``validate_fetch_url``
+# does a blocking ``socket.getaddrinfo`` with no timeout of its own; bound it so a
+# slow/blackholed authoritative server for the target host can't stall a caller.
+_DEFAULT_VALIDATE_TIMEOUT = 3.0
+
+
+async def validate_fetch_url_async(url: str, *, timeout: float = _DEFAULT_VALIDATE_TIMEOUT) -> str:
+    """Async, non-loop-blocking wrapper around :func:`validate_fetch_url`.
+
+    ``validate_fetch_url`` performs a blocking ``socket.getaddrinfo`` (the SSRF IP
+    check) with no timeout of its own. Called directly from a coroutine it freezes
+    the whole event loop for the resolution's duration, serializing any concurrent
+    ``asyncio.gather`` fan-out. This offloads the full validation to a worker thread
+    under a bounded timeout so concurrent fetches stay concurrent.
+
+    Raises:
+        UnsafeURLError: the URL failed SSRF validation, or resolution exceeded
+            ``timeout`` (fail-closed — a slow/blackholed host is treated as unsafe
+            rather than fetched).
+    """
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(validate_fetch_url, url), timeout)
+    except TimeoutError as exc:
+        raise UnsafeURLError(f"SSRF validation timed out after {timeout}s: {url}") from exc
 
 
 class ResponseTooLargeError(ValueError):

--- a/tests/integration/test_policy_e2e.py
+++ b/tests/integration/test_policy_e2e.py
@@ -60,7 +60,7 @@ def _allow_localhost_http():
         return original(url) if original else url
 
     with (
-        patch("dns_aid.sdk.policy.evaluator.validate_fetch_url", side_effect=_test_validate),
+        patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=_test_validate),
         patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=_test_validate),
     ):
         yield

--- a/tests/unit/sdk/policy/test_evaluator.py
+++ b/tests/unit/sdk/policy/test_evaluator.py
@@ -80,7 +80,7 @@ class TestFetch:
 
         evaluator = PolicyEvaluator(cache_ttl=300)
         with patch(
-            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            "dns_aid.utils.url_safety.validate_fetch_url",
             return_value="https://example.com/policy.json",
         ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
@@ -102,7 +102,7 @@ class TestFetch:
     async def test_fetch_ssrf_blocked(self) -> None:
         evaluator = PolicyEvaluator()
         with patch(
-            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            "dns_aid.utils.url_safety.validate_fetch_url",
             side_effect=ValueError("SSRF blocked"),
         ):
             with pytest.raises(ValueError, match="SSRF blocked"):
@@ -114,7 +114,7 @@ class TestFetch:
 
         evaluator = PolicyEvaluator()
         with patch(
-            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            "dns_aid.utils.url_safety.validate_fetch_url",
             return_value="https://example.com/policy.json",
         ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
@@ -135,7 +135,7 @@ class TestFetch:
     async def test_fetch_wrong_content_type(self) -> None:
         evaluator = PolicyEvaluator()
         with patch(
-            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            "dns_aid.utils.url_safety.validate_fetch_url",
             return_value="https://example.com/policy.json",
         ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
@@ -173,7 +173,7 @@ class TestFetch:
         body = new_doc.model_dump_json()
 
         with patch(
-            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            "dns_aid.utils.url_safety.validate_fetch_url",
             return_value="https://example.com/p.json",
         ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:
@@ -211,7 +211,7 @@ class TestFetch:
 
         evaluator = PolicyEvaluator(cache_ttl=300)
         with patch(
-            "dns_aid.sdk.policy.evaluator.validate_fetch_url",
+            "dns_aid.utils.url_safety.validate_fetch_url",
             return_value="https://example.com/p.json",
         ):
             with patch("dns_aid.sdk.policy.evaluator.httpx.AsyncClient") as mock_client_cls:

--- a/tests/unit/test_catalog_pointer.py
+++ b/tests/unit/test_catalog_pointer.py
@@ -55,7 +55,7 @@ class TestResolveCatalogPointer:
     def _bypass_ssrf(self):
         # These tests exercise resolution logic with unresolvable mock hosts;
         # bypass the SSRF/DNS guard here (its own behavior is tested below).
-        with patch("dns_aid.core.catalog_pointer.validate_fetch_url", side_effect=lambda u: u):
+        with patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=lambda u: u):
             yield
 
     @pytest.mark.asyncio
@@ -157,7 +157,7 @@ class TestResolveSsrf:
                 return_value=_resolver_returning(mapping),
             ),
             patch(
-                "dns_aid.core.catalog_pointer.validate_fetch_url",
+                "dns_aid.utils.url_safety.validate_fetch_url",
                 side_effect=UnsafeURLError("resolves to non-public IP 169.254.169.254"),
             ),
         ):
@@ -184,7 +184,7 @@ class TestResolveSsrf:
                 "dns_aid.core.catalog_pointer.dns.asyncresolver.Resolver",
                 return_value=_resolver_returning(mapping),
             ),
-            patch("dns_aid.core.catalog_pointer.validate_fetch_url", side_effect=_count),
+            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=_count),
         ):
             assert await resolve_catalog_pointer("evil.com") is None
         assert calls["n"] <= _MAX_POINTER_RECORDS
@@ -208,7 +208,7 @@ class TestResolveSsrf:
                 "dns_aid.core.catalog_pointer.dns.asyncresolver.Resolver",
                 return_value=_resolver_returning(mapping),
             ),
-            patch("dns_aid.core.catalog_pointer.validate_fetch_url", side_effect=_guard),
+            patch("dns_aid.utils.url_safety.validate_fetch_url", side_effect=_guard),
         ):
             url = await resolve_catalog_pointer("acme.com")
         assert url == "https://idx.acme.com/.well-known/ai-catalog.json"

--- a/tests/unit/test_url_safety_async.py
+++ b/tests/unit/test_url_safety_async.py
@@ -1,0 +1,63 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async SSRF-validation wrapper (``validate_fetch_url_async``).
+
+The sync ``validate_fetch_url`` does a blocking ``socket.getaddrinfo``; called
+directly from a coroutine it freezes the event loop and serializes concurrent
+fetches. ``validate_fetch_url_async`` offloads it to a worker thread under a
+bounded timeout. These tests lock in the SSRF policy (public passes; private and
+timeout fail closed) and the concurrency property (a fan-out is not serialized).
+"""
+
+import asyncio
+import socket
+import time
+
+import pytest
+
+from dns_aid.utils import url_safety
+from dns_aid.utils.url_safety import UnsafeURLError, validate_fetch_url_async
+
+_PUBLIC = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+_PRIVATE = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
+
+
+@pytest.mark.asyncio
+async def test_async_returns_url_on_public_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", lambda *a, **k: _PUBLIC)
+    assert await validate_fetch_url_async("https://example.com/x") == "https://example.com/x"
+
+
+@pytest.mark.asyncio
+async def test_async_raises_on_private_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", lambda *a, **k: _PRIVATE)
+    with pytest.raises(UnsafeURLError):
+        await validate_fetch_url_async("https://example.com/x")
+
+
+@pytest.mark.asyncio
+async def test_async_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def slow(*a: object, **k: object) -> list:
+        time.sleep(0.5)
+        return _PUBLIC
+
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", slow)
+    with pytest.raises(UnsafeURLError, match="timed out"):
+        await validate_fetch_url_async("https://example.com/x", timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_concurrency_not_serialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Each resolution "costs" 0.3s. Six offloaded validations run concurrently, so
+    # wall-time stays well under the serial sum (6 x 0.3 = 1.8s). Pre-fix — a direct
+    # blocking getaddrinfo on the single-threaded event loop — this serialized to ~1.8s.
+    def slow(*a: object, **k: object) -> list:
+        time.sleep(0.3)
+        return _PUBLIC
+
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", slow)
+    start = time.perf_counter()
+    await asyncio.gather(*[validate_fetch_url_async(f"https://example.com/{i}") for i in range(6)])
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"fan-out serialized ({elapsed:.2f}s); expected concurrent (<1s)"

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.26.5"
+version = "0.26.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
`validate_fetch_url()` (SSRF guard) does a **synchronous, un-timed `socket.getaddrinfo`**. Called directly from the async fetch paths it froze the single-threaded event loop for each resolution, silently **serializing concurrent `asyncio.gather` fan-outs** — the ARD capability-document dereference, agent-card, JWKS, policy-document, and OAuth-discovery fetches all queued behind one another instead of running in parallel. Ships as 0.26.6.

Root cause was library-wide: **all 8 `validate_fetch_url` call sites are inside `async def`**, but only `catalog_pointer.py` offloaded via `to_thread`; the other 7 blocked the loop.

## Fix
- New `validate_fetch_url_async(url, *, timeout=3.0)` in `utils/url_safety.py` — offloads the full validation to a worker thread (`asyncio.to_thread`) under a bounded timeout, mapping `TimeoutError → UnsafeURLError` (fail-closed). The **synchronous `validate_fetch_url` is retained unchanged**.
- Route the 7 direct async callers through it (`cap_fetcher`, `discoverer`, `a2a_card`, `jwks`, `sdk/client.search`, `sdk/auth/oauth2` ×3, `sdk/policy/evaluator`).
- Refactor `catalog_pointer` — which already offloaded inline — onto the same helper so the pattern can't drift again.
- **SSRF policy unchanged**: public passes; private / loopback / link-local / reserved / timeout fail closed.

## Test plan
- [x] Unit: **2015 passed, 2 skipped** (+4). New `test_url_safety_async.py`: public-passes, private-fails, timeout-fails, and a **concurrency regression** (6×0.3s fan-out completes <1.0s; pre-fix ~1.8s). 3 test files repointed to patch the sync source the wrapper still calls (mocks stay effective + exercise the real async wrapper). Policy-e2e integration: 12 passed.
- [x] ruff / ruff format / mypy (85 files) / bandit (`-c pyproject.toml`, no issues) clean
- [x] Reproduction: an 8-way fan-out with a 0.5s getaddrinfo drops from **4.03s serialized → 0.51s concurrent** (8×)
- [x] Live correctness: `discover(ard.hvn, use_http_index=True)` still returns 5 agents

## Note on magnitude
Real-world speedup is **per-network**, bound by the resolver's `AF_UNSPEC` (A+AAAA) latency. On a fast resolver the impact is small; on a resolver slow on the AAAA/IPv6 leg (~2s/call, as in the reporter's environment) it removes a multi-second serialized DNS phase. The fix is a strict improvement — DNS resolution never blocks the event loop again — regardless of magnitude.