### PR TITLE
fix: run SSRF resolution on a dedicated thread pool to stop spurious blocks (0.26.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.7] - 2026-07-08
+
+### Fixed
+
+- **Concurrent SSRF validations to the same host could be spuriously blocked under
+  load** — a regression surfaced by the 0.26.6 concurrency fix. `validate_fetch_url_async`
+  offloaded the blocking `getaddrinfo` via `asyncio.to_thread`, which shares the event
+  loop's default thread pool (`min(32, cpu+4)` workers) with all other offloaded work.
+  On a low-core host a wide discovery fan-out (e.g. 8 ARD capability-document fetches)
+  queued the excess validations, and the queue wait counted against the 3s timeout —
+  so the last-queued URLs timed out and surfaced as `UnsafeURLError` ("blocked by SSRF
+  protection"), even though they resolve to the same public host as their siblings.
+  Failed safe (the affected agents fell back to catalog-level data), but noisy and
+  wrong. SSRF resolution now runs on a **dedicated, generously-sized thread pool**
+  (32 workers, override with `DNS_AID_SSRF_RESOLVER_THREADS`) so concurrent validations
+  don't queue behind each other, and the per-call timeout is raised to 5s for headroom
+  against a slow-but-legitimate resolver (e.g. an AF_UNSPEC A+AAAA lookup with a slow
+  IPv6 leg). SSRF policy is unchanged.
+
 ## [0.26.6] - 2026-07-08
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.26.6"
+version: "0.26.7"
 date-released: "2026-07-08"
 
 keywords:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.26.6"
+version = "0.26.7"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/utils/url_safety.py
+++ b/src/dns_aid/utils/url_safety.py
@@ -11,6 +11,7 @@ requests to private/loopback/link-local IP addresses.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import ipaddress
 import os
 import socket
@@ -115,7 +116,31 @@ def validate_fetch_url(url: str) -> str:
 # Per-URL SSRF-validation time budget for the async wrapper. ``validate_fetch_url``
 # does a blocking ``socket.getaddrinfo`` with no timeout of its own; bound it so a
 # slow/blackholed authoritative server for the target host can't stall a caller.
-_DEFAULT_VALIDATE_TIMEOUT = 3.0
+# Sized with headroom for a resolver that is slow-but-legitimate under concurrent
+# load (e.g. an AF_UNSPEC A+AAAA lookup with a slow IPv6 leg).
+_DEFAULT_VALIDATE_TIMEOUT = 5.0
+
+# Dedicated thread pool for the (blocking) SSRF DNS resolution. ``asyncio.to_thread``
+# shares the event loop's default executor (``min(32, cpu+4)`` workers) with every
+# other offloaded call; on a low-core host a wide discovery fan-out queues
+# validations behind each other, and that queue wait counts against the timeout
+# above — so the last-queued URLs spuriously time out (surfacing as an SSRF block)
+# even though they resolve to the same public host as their siblings. A dedicated,
+# generously-sized pool removes that cross-call queueing, so the timeout bounds only
+# the actual resolution. getaddrinfo is I/O-bound (the thread just waits), so a wide
+# pool is cheap. Override the width with ``DNS_AID_SSRF_RESOLVER_THREADS``.
+_SSRF_RESOLVER_THREADS = max(1, int(os.environ.get("DNS_AID_SSRF_RESOLVER_THREADS", "32")))
+_resolver_pool: concurrent.futures.ThreadPoolExecutor | None = None
+
+
+def _get_resolver_pool() -> concurrent.futures.ThreadPoolExecutor:
+    """Lazily create the process-wide SSRF-resolution thread pool."""
+    global _resolver_pool
+    if _resolver_pool is None:
+        _resolver_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=_SSRF_RESOLVER_THREADS, thread_name_prefix="dns-aid-ssrf"
+        )
+    return _resolver_pool
 
 
 async def validate_fetch_url_async(url: str, *, timeout: float = _DEFAULT_VALIDATE_TIMEOUT) -> str:
@@ -124,16 +149,22 @@ async def validate_fetch_url_async(url: str, *, timeout: float = _DEFAULT_VALIDA
     ``validate_fetch_url`` performs a blocking ``socket.getaddrinfo`` (the SSRF IP
     check) with no timeout of its own. Called directly from a coroutine it freezes
     the whole event loop for the resolution's duration, serializing any concurrent
-    ``asyncio.gather`` fan-out. This offloads the full validation to a worker thread
-    under a bounded timeout so concurrent fetches stay concurrent.
+    ``asyncio.gather`` fan-out. This offloads the validation to a **dedicated** thread
+    pool (not the shared default executor, which would re-serialize a wide fan-out on
+    a low-core host) under a bounded timeout, so concurrent validations — to the same
+    or different hosts — stay independent and none is spuriously blocked for losing a
+    thread-pool slot.
 
     Raises:
         UnsafeURLError: the URL failed SSRF validation, or resolution exceeded
             ``timeout`` (fail-closed — a slow/blackholed host is treated as unsafe
             rather than fetched).
     """
+    loop = asyncio.get_running_loop()
     try:
-        return await asyncio.wait_for(asyncio.to_thread(validate_fetch_url, url), timeout)
+        return await asyncio.wait_for(
+            loop.run_in_executor(_get_resolver_pool(), validate_fetch_url, url), timeout
+        )
     except TimeoutError as exc:
         raise UnsafeURLError(f"SSRF validation timed out after {timeout}s: {url}") from exc
 

--- a/tests/unit/test_url_safety_async.py
+++ b/tests/unit/test_url_safety_async.py
@@ -61,3 +61,28 @@ async def test_concurrency_not_serialized(monkeypatch: pytest.MonkeyPatch) -> No
     await asyncio.gather(*[validate_fetch_url_async(f"https://example.com/{i}") for i in range(6)])
     elapsed = time.perf_counter() - start
     assert elapsed < 1.0, f"fan-out serialized ({elapsed:.2f}s); expected concurrent (<1s)"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_host_all_consistent(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: under the previous wrapper, concurrent validations shared the event
+    # loop's default thread pool (min(32, cpu+4)); a wide fan-out on a slow resolver
+    # queued the excess, and the queue wait counted against the per-call timeout — so
+    # the last-queued URLs for the SAME host spuriously "timed out" (surfacing as an
+    # SSRF block) while their siblings passed. The dedicated resolver pool must run
+    # them independently: fire more validations than a low-core default pool would
+    # admit at once and assert every one resolves identically — none blocked purely
+    # for losing a thread-pool slot.
+    def slow(*a: object, **k: object) -> list:
+        time.sleep(0.3)
+        return _PUBLIC
+
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", slow)
+    n = 24
+    urls = [f"https://same-host.example.com/{i}" for i in range(n)]
+    results = await asyncio.gather(
+        *(validate_fetch_url_async(u) for u in urls), return_exceptions=True
+    )
+    blocked = [r for r in results if isinstance(r, BaseException)]
+    assert not blocked, f"{len(blocked)}/{n} spuriously blocked under concurrency: {blocked[:2]}"
+    assert results == urls

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.26.6"
+version = "0.26.7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
Regression surfaced by the 0.26.6 concurrency fix. `validate_fetch_url_async` offloaded the blocking `getaddrinfo` via `asyncio.to_thread`, which shares the event loop's **default** thread pool (`min(32, cpu+4)` workers) with all other offloaded work. On a low-core host a wide discovery fan-out **queued** the excess validations, and the queue wait counted against the 3s timeout — so the last-queued URLs timed out and surfaced as `UnsafeURLError` ("blocked by SSRF protection"), even though they resolve to the **same public host** as their siblings. Ships as 0.26.7.

## Root cause (not a shared-state race)
`validate_fetch_url` is stateless (no cache; `_get_allowlist()` re-reads an env var into a fresh set). The reporter's "2 of 8 blocked, same host" was **thread-pool contention + the per-call timeout**, not a race: `8 concurrent − ~6 free workers = 2 queued`, and the queued ones (the last two submitted) exceeded 3s. Reproduced deterministically — a 6-worker pool + 2s getaddrinfo blocks exactly the last 2 URLs.

## Fix
- SSRF resolution runs on a **dedicated `ThreadPoolExecutor`** (32 workers, override via `DNS_AID_SSRF_RESOLVER_THREADS`) so concurrent validations don't queue behind each other or behind unrelated `to_thread` work — the timeout then bounds only the actual resolution.
- Per-call timeout raised 3s → **5s** for headroom against a slow-but-legitimate resolver (AF_UNSPEC A+AAAA with a slow IPv6 leg).
- **SSRF policy unchanged** (public passes; private/loopback/link-local/reserved/timeout fail closed).

## Test plan
- [x] Reproduction: 8 concurrent same-host validations, 2s getaddrinfo — **pre-fix** 2/8 blocked on a constrained pool; **post-fix 0/8** regardless of the default pool size.
- [x] New regression test (`test_concurrent_same_host_all_consistent`): 24 concurrent same-host validations, assert none is treated differently.
- [x] Unit: **2016 passed, 2 skipped**; ruff / format / mypy (85 files) / bandit (`-c pyproject.toml`, EXIT 0) clean.

## Note
Failed safe already (affected agents fell back to catalog-level `capability_source=ard_catalog` data rather than being dropped), so this is a correctness/noise fix, not a functional break.