### PR TITLE
fix(deps): bump click to 8.4.2 to resolve PYSEC-2026-2132

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -323,14 +323,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `pip-audit` flags `click==8.3.1` for PYSEC-2026-2132 (fix version 8.3.3+). This is the sole current failure in the required **Dependency Audit** check on `main`, blocking merges on every open PR (verified against PR #182 and the latest `main` run).
- `click` is a transitive dependency (not declared directly in `pyproject.toml`); bumped via `uv lock --upgrade-package click`, which resolved to 8.4.2.
- Confirmed locally: `uv sync --frozen ...` + `pip-audit` (same invocation as CI) now reports "No known vulnerabilities found". Full unit test suite passes (2043 passed); the 4 failures seen locally are pre-existing `tests/integration/test_sdk_auth_live.py` live-AWS tests requiring a local `okta-sso` profile, unrelated to this change.

## Test plan
- [x] `uv sync --frozen --extra dev --extra cli --extra mcp --extra route53`
- [x] `pip-audit` (mirroring the Dependency Audit CI step) — no known vulnerabilities
- [x] `pytest` — 2043 passed, 99 skipped (pre-existing live-AWS integration failures unrelated to this diff)
- [ ] CI green on this PR