### PR TITLE
chore(ci): bump github/codeql-action to v4.37.0 (init/autobuild/analyze/upload-sarif)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,15 +30,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Dependabot's own consolidated PR for this bump (#178, which bumped `init`/`autobuild`/`upload-sarif` together) was auto-closed by dependabot itself when rebased just now, with the message "Looks like github/codeql-action is no longer a dependency, so this is no longer needed."
- That left only #181 open, which bumps *only* `github/codeql-action/analyze`. Merging #181 alone reproduces the exact CI failure it already showed: `init`/`autobuild` stay pinned to the old SHA (v4.36.0) while `analyze` moves to a newer one, and CodeQL refuses to run with `Loaded a configuration file for version '4.36.0', but running version '...'`.
- This PR bumps all four `github/codeql-action/*` references (`init`, `autobuild`, `analyze` in codeql.yml; `upload-sarif` in scorecard.yml) together to the same SHA — the v4.37.0 release that #181 already rebased onto — so they stay consistent. Once this merges, #181 becomes redundant and will be closed.

## Test plan
- [ ] CI green on this PR (in particular CodeQL Analysis, which is what the previous mismatch broke)