### PR TITLE
feat(core): TXT-record fallback for SVCB-less DNS deployments (draft-02 rebase of #135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ await dns_aid.publish(
     capabilities=["chat", "code-review"]
 )
 
-# Discover agents at a domain (Path A: DNS substrate)
+# Discover agents at a domain (Path A: DNS substrate).
+# Falls back to a v=1 TXT record automatically for zones whose authoritative
+# DNS doesn't expose SVCB — see docs/architecture.md for the resolution ladder.
 agents = await dns_aid.discover("example.com")
 for agent in agents:
     print(f"{agent.name}: {agent.endpoint_url}")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -255,6 +255,13 @@ nested catalogs recurse (depth ≤ 3); registry entries and non-agent artifacts 
 entry's `trustManifest` is preserved on `AgentRecord.trust_manifest` (pass-through — dns-aid does
 not verify signatures, attestation digests, or identity↔publisher alignment).
 
+For zones whose authoritative DNS server does not expose SVCB, per-agent
+resolution falls back to a `v=1` TXT record at the same FQDN. The returned
+`AgentRecord` carries `endpoint_source="dns_txt_fallback"`. See
+[architecture.md](architecture.md#svcb--https--txt-fallback-ladder) for
+the resolution ladder and [`docs/rfc/wire-format.abnf`](rfc/wire-format.abnf)
+for the wire grammar.
+
 #### Returns
 
 `DiscoveryResult` - Contains list of discovered agents and query metadata.
@@ -588,7 +595,7 @@ agent = AgentRecord(
 | `policy_uri` | `str` | No | `None` | URI to agent policy document |
 | `realm` | `str` | No | `None` | Multi-tenant scope identifier |
 | `capability_source` | `str` | No | `None` | Where capabilities came from: `cap_uri`, `well_known`, `agent_card`, `http_index`, `ard_catalog`, `txt_fallback`, `none` |
-| `endpoint_source` | `str` | No | `None` | Where endpoint came from: `dns_svcb`, `dns_svcb_enriched`, `http_index`, `http_index_fallback`, `ard_card` (real endpoint from a fetched ARD agent/server card), `ard_inline`, `direct`, `directory` |
+| `endpoint_source` | `str` | No | `None` | Where endpoint came from: `dns_svcb`, `dns_svcb_enriched`, `dns_txt_fallback` (TXT-encoded fallback for SVCB-less zones), `http_index`, `http_index_fallback`, `ard_card` (real endpoint from a fetched ARD agent/server card), `ard_inline`, `direct`, `directory` |
 | `trust_manifest` | `TrustManifest` | No | `None` | Publisher trust claims from an ARD ai-catalog entry (identity, attestations, provenance, signature) — pass-through, not verified |
 | `catalog_trust` | `str \| None` | No | `None` | ARD-sourced records only — how the catalog was trusted: `tls_domain` (on-domain), `dnssec` (DNSSEC-validated off-domain pointer), or `jws` (JWS-signed off-domain). `None` for pure-DNS records. |
 | `dnssec_validated` | `bool` | No | `False` | `True` when this agent's DNS response carried the resolver **AD flag**. Set for DNS-plane agents when `require_dnssec` / `min_dnssec` / `verify_dane` is used; ARD / HTTP-catalog agents are exempt and stay `False`. AD-flag based — not independent DNSKEY→DS→RRSIG chain validation. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,6 +172,8 @@ that round-trip the same inputs through every surface.
 2. For each agent: Query SVCB {name}.{domain} (draft-02 flat primary owner)
    → extract endpoint, port, ALPN + DNS-AID custom params (cap, bap,
    policy, realm, well-known)
+   On SVCB NoAnswer → try HTTPS RR (RFC 9460 type 65)
+   On HTTPS miss → try TXT v=1 fallback at the same owner name (see below)
 3. For each agent: If cap URI present → fetch capability document (primary).
    Otherwise, if well-known is set, construct
    https://<svcb-target>/.well-known/<well-known-value> and fetch
@@ -187,6 +189,47 @@ publishers MAY additionally publish a walkable AliasMode record at
 Consumers MUST try the flat form first. Older publishers using the
 legacy `-01` form `_{name}._{protocol}._agents.{domain}` are
 resolvable when consumers set `DNS_AID_LEGACY_01_FALLBACK=1`.
+
+#### SVCB → HTTPS → TXT fallback ladder
+
+For DNS deployments that don't expose SVCB records (older managed-DNS
+appliances, smaller hosted providers, self-hosted DNS that hasn't adopted
+SVCB yet), the discoverer falls back to a TXT-encoded representation of the
+same agent endpoint information. The TXT body mirrors the SVCB SvcParam
+names as `key=value` pairs and is distinguished from the existing
+capabilities/metadata TXT by a leading `v=1` discriminator:
+
+```
+chat.example.com. 3600 IN TXT (
+    "v=1 target=mcp.example.com port=443 alpn=mcp "
+    "cap=https://example.com/cap/chat-v1.json cap-sha256=..."
+)
+```
+
+Resolution order inside `_query_single_agent` — the full ladder runs at
+each owner name before the next owner name is tried:
+
+1. SVCB at the flat FQDN `{name}.{domain}` — primary, preserves existing
+   behaviour
+2. HTTPS RR (type 65, same SVCB family) at the flat FQDN
+3. **TXT `v=1` fallback** at the flat FQDN — for SVCB-less zones; produces
+   a complete `AgentRecord` with `endpoint_source="dns_txt_fallback"`.
+   Coexists with metadata TXT (`capabilities=...`) on the same owner name
+4. Only when legacy fallback is active (`allow_legacy=True` or
+   `DNS_AID_LEGACY_01_FALLBACK=1`): the same SVCB → HTTPS → TXT ladder at
+   the legacy `-01` owner name, with `legacy_resolved=True` stamped on the
+   result
+
+A flat TXT `v=1` record therefore takes precedence over a leftover legacy
+SVCB record: a publisher who deliberately placed a draft-02 flat TXT
+record has migrated, and stale `-01` records must not shadow it.
+
+The publisher side is opt-in: a backend declaring `supports_svcb=False`
+combined with `DNS_AID_EXPERIMENTAL_TXT_FALLBACK=1` writes the fallback
+TXT instead of SVCB. Backends that do support SVCB (every bundled
+backend today) are unaffected. Full grammar in
+[`docs/rfc/wire-format.abnf`](rfc/wire-format.abnf) under
+`dns-aid-txt-fallback`.
 
 ### HTTP Index Discovery
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1675,6 +1675,60 @@ python examples/demo_full.py
 | `NIOS_WAPI_VERSION` | nios | WAPI version (default: `2.13.7`) |
 | `NIOS_VERIFY_SSL` | nios | Verify TLS certificate (default: `false`) |
 
+## TXT-Fallback Discovery (For SVCB-less DNS)
+
+Every backend bundled with dns-aid-core (Route53, Cloudflare, Google Cloud
+DNS, NS1, NIOS, UDDI) exposes SVCB through its API. If you operate against a
+DNS system that doesn't — an older managed-DNS appliance, a smaller hosted
+provider, or self-hosted DNS that hasn't adopted SVCB yet — the SDK can still
+discover agents at your zone via a TXT-encoded fallback record.
+
+### Consuming TXT-fallback zones (no opt-in needed)
+
+`discover()` automatically falls back to a `v=1` TXT record when SVCB and
+HTTPS RR both return NoAnswer. The returned `AgentRecord` carries
+`endpoint_source="dns_txt_fallback"`; otherwise the API is identical:
+
+```python
+import dns_aid
+
+# Works against SVCB-publishing zones AND against TXT-fallback-publishing zones.
+result = await dns_aid.discover("legacy.example.com", protocol="mcp", name="chat")
+for agent in result.agents:
+    print(agent.name, agent.endpoint_url, agent.endpoint_source)
+```
+
+### Publishing TXT-fallback records (experimental, opt-in)
+
+If you write your own backend for a DNS system that can't write SVCB,
+override `supports_svcb` to return `False`:
+
+```python
+from dns_aid.backends.base import DNSBackend
+
+class MyLegacyBackend(DNSBackend):
+    @property
+    def supports_svcb(self) -> bool:
+        return False
+    # ... rest of the backend ...
+```
+
+Then publish with the env flag set:
+
+```bash
+export DNS_AID_EXPERIMENTAL_TXT_FALLBACK=1
+dns-aid publish --name chat --domain example.com --protocol mcp \
+    --endpoint mcp.example.com --backend my-legacy
+```
+
+The publisher emits a single TXT RR with a `v=1` body carrying the same
+target / port / cap / policy / realm information SVCB would carry, plus the
+companion metadata TXT (`capabilities=...`, `version=...`) so downstream
+readers and `dig` debugging still work. SVCB is not attempted.
+
+Wire-format grammar: [`docs/rfc/wire-format.abnf`](rfc/wire-format.abnf)
+under `dns-aid-txt-fallback`.
+
 ## Experimental Models
 
 The following modules define forward-looking data models for `.well-known/agent-card.json`

--- a/docs/rfc/wire-format.abnf
+++ b/docs/rfc/wire-format.abnf
@@ -271,6 +271,11 @@ txt-value      = 1*255(VCHAR / SP)
 ; The leading "v=1" discriminator distinguishes this endpoint TXT
 ; from the capabilities/metadata TXT defined above; both may
 ; coexist as distinct TXT RRs on the same FQDN.
+;
+; Acknowledgment: the TXT-based agent identification approach this
+; rule encodes was surfaced by the Agent Community
+; (https://agentcommunity.org/, maintainer Balazs Nemethi). The wire
+; format here mirrors SVCB SvcParam names for parser symmetry.
 
 dns-aid-txt-fallback = version-marker SP target-kv *(SP fallback-kv)
 

--- a/docs/rfc/wire-format.abnf
+++ b/docs/rfc/wire-format.abnf
@@ -265,8 +265,10 @@ txt-value      = 1*255(VCHAR / SP)
 ; ==================================================================
 
 ; Optional TXT-encoded agent record for DNS deployments that don't
-; expose SVCB. Published at the same FQDN as the SVCB ServiceMode
-; record would otherwise be: _{name}._{protocol}._agents.{domain}.
+; expose SVCB. Published at the same owner name the SVCB ServiceMode
+; record would otherwise use: the draft-02 flat FQDN {name}.{domain}
+; (consumers reached via the opt-in legacy fallback also accept it at
+; the legacy -01 shape _{name}._{protocol}._agents.{domain}).
 ;
 ; The leading "v=1" discriminator distinguishes this endpoint TXT
 ; from the capabilities/metadata TXT defined above; both may
@@ -299,13 +301,30 @@ ipv4hint-kv      = "ipv4hint=" IPv4-address
 ipv6hint-kv      = "ipv6hint=" IPv6-address
 cap-kv           = "cap=" URI
 cap-sha256-kv    = "cap-sha256=" base64url
-bap-kv           = "bap=" bap-list
+bap-kv           = "bap=" protocol
+                 ; draft-02 §5.1 scalar form (``mcp`` / ``mcp=1.0``) — one
+                 ; identifier per record, mirroring the SVCB bap SvcParam.
+                 ; Consumers MUST accept a legacy comma-separated list by
+                 ; collapsing it to the first token (with a warning).
 policy-kv        = "policy=" URI
-realm-kv         = "realm=" 1*64(ALPHA / DIGIT / "-" / "_" / SP)
+realm-kv         = "realm=" quotable-value
 sig-kv           = "sig=" jws-compact
 connect-class-kv = "connect-class=" 1*32(ALPHA / DIGIT / "-")
-connect-meta-kv  = "connect-meta=" 1*255(VCHAR)
+connect-meta-kv  = "connect-meta=" quotable-value
 enroll-uri-kv    = "enroll-uri=" URI
+
+quotable-value   = 1*255(vchar-no-sp)
+                 / DQUOTE 1*255(%x20-21 / %x23-5B / %x5D-7E / escaped) DQUOTE
+vchar-no-sp      = %x21-7E              ; VCHAR, no space — bare form
+escaped          = "\" (DQUOTE / "\")   ; inside quotes: \" and \\ only
+
+; ; Tokenization rule: the joined body is split on unquoted spaces.
+; ; A value containing SP MUST be double-quoted; inside quotes the
+; ; only escapes are \" and \\. This matches the POSIX-shell-style
+; ; tokenizer (shlex) used by the reference parser; publishers SHOULD
+; ; emit bare (unquoted) values whenever the value contains no SP,
+; ; and MUST NOT rely on single-quote or other shell-ism forms even
+; ; where the reference parser tolerates them.
 
 ; ; Concatenation rule (RFC 1035 character-string): when a TXT RR
 ; ; carries multiple <character-string>s, the parser joins them with

--- a/docs/rfc/wire-format.abnf
+++ b/docs/rfc/wire-format.abnf
@@ -261,6 +261,59 @@ txt-value      = 1*255(VCHAR / SP)
                  ; Max 255 characters per TXT string chunk
 
 ; ==================================================================
+; DNS-AID TXT Fallback Record Format (SVCB-less DNS deployments)
+; ==================================================================
+
+; Optional TXT-encoded agent record for DNS deployments that don't
+; expose SVCB. Published at the same FQDN as the SVCB ServiceMode
+; record would otherwise be: _{name}._{protocol}._agents.{domain}.
+;
+; The leading "v=1" discriminator distinguishes this endpoint TXT
+; from the capabilities/metadata TXT defined above; both may
+; coexist as distinct TXT RRs on the same FQDN.
+
+dns-aid-txt-fallback = version-marker SP target-kv *(SP fallback-kv)
+
+; REQUIRED — version marker, currently fixed at 1
+version-marker = "v=1"
+
+; REQUIRED — endpoint hostname
+target-kv      = "target=" hostname
+
+; OPTIONAL — mirror of SVCB SvcParam set. Field names are identical
+; to the SVCB parameters they represent so the parser is symmetric
+; with the SVCB consumer.
+fallback-kv    = port-kv / alpn-kv / ipv4hint-kv / ipv6hint-kv /
+                 cap-kv / cap-sha256-kv / bap-kv / policy-kv /
+                 realm-kv / sig-kv / connect-class-kv /
+                 connect-meta-kv / enroll-uri-kv
+
+port-kv          = "port=" 1*5DIGIT          ; default 443 if omitted
+alpn-kv          = "alpn=" 1*32(ALPHA / DIGIT / "-")
+ipv4hint-kv      = "ipv4hint=" IPv4-address
+ipv6hint-kv      = "ipv6hint=" IPv6-address
+cap-kv           = "cap=" URI
+cap-sha256-kv    = "cap-sha256=" base64url
+bap-kv           = "bap=" bap-list
+policy-kv        = "policy=" URI
+realm-kv         = "realm=" 1*64(ALPHA / DIGIT / "-" / "_" / SP)
+sig-kv           = "sig=" jws-compact
+connect-class-kv = "connect-class=" 1*32(ALPHA / DIGIT / "-")
+connect-meta-kv  = "connect-meta=" 1*255(VCHAR)
+enroll-uri-kv    = "enroll-uri=" URI
+
+; ; Concatenation rule (RFC 1035 character-string): when a TXT RR
+; ; carries multiple <character-string>s, the parser joins them with
+; ; a single space before key=value tokenization.
+; ;
+; ; Multiple TXT RRs with v=1 at the same FQDN are not permitted in
+; ; this version; consumers that observe more than one SHOULD log a
+; ; warning and use the first.
+; ;
+; ; Unknown fields are silently ignored by v=1 parsers (forward-
+; ; compatibility with future field additions).
+
+; ==================================================================
 ; DNS-AID Error Codes
 ; ==================================================================
 

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -10,6 +10,7 @@ implement this interface.
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
@@ -88,6 +89,83 @@ class DNSBackend(ABC):
         Override in subclasses to indicate support level.
         """
         return False
+
+    def _txt_fallback_enabled(self) -> bool:
+        """Return True iff this backend should write TXT-fallback instead of SVCB.
+
+        Requires both:
+        - ``self.supports_svcb`` is ``False`` (backend wraps a DNS system that
+          can't write SVCB)
+        - ``DNS_AID_EXPERIMENTAL_TXT_FALLBACK`` is truthy in the environment
+          (operator opt-in)
+
+        Used by :meth:`publish_agent` to decide whether to take the
+        TXT-fallback write path. Backends that override ``publish_agent``
+        should also consult this helper at the top of their override so the
+        feature behaves consistently across backend implementations.
+        """
+        if self.supports_svcb:
+            return False
+        return os.environ.get("DNS_AID_EXPERIMENTAL_TXT_FALLBACK", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    async def _publish_via_txt_fallback(
+        self, agent: AgentRecord, zone: str, name: str
+    ) -> list[str]:
+        """Write a TXT-encoded agent record for SVCB-less DNS deployments.
+
+        Emits a single TXT RR containing the ``v=1 target=... port=...``
+        body produced by :func:`dns_aid.core._txt_fallback.build_txt_fallback`,
+        followed by the companion metadata values from
+        :meth:`AgentRecord.to_txt_values` so downstream readers and ``dig``
+        debuggers still see capability / version / description.
+        """
+        from dns_aid.core._txt_fallback import build_txt_fallback
+
+        logger.info(
+            "Publishing agent via TXT fallback (backend does not support SVCB)",
+            backend=self.name,
+            agent_fqdn=f"{name}.{zone}",
+        )
+        txt_values: list[str] = [build_txt_fallback(agent)]
+        txt_values.extend(agent.to_txt_values())
+        txt_fqdn = await self.create_txt_record(
+            zone=zone,
+            name=name,
+            values=txt_values,
+            ttl=agent.ttl,
+        )
+        records = [f"TXT {txt_fqdn} (fallback v=1)"]
+        logger.info(
+            "Agent published via TXT fallback",
+            backend=self.name,
+            records=records,
+        )
+        return records
+
+    @property
+    def supports_svcb(self) -> bool:
+        """Whether this backend's underlying DNS system supports SVCB records at all.
+
+        This is distinct from :attr:`supports_private_svcb_keys`, which is
+        about *key encoding* inside a SVCB record. ``supports_svcb`` is about
+        whether the backend can write SVCB records of any kind.
+
+        Returns:
+            ``True``  — backend writes SVCB records (default; all currently
+                        bundled backends — Route53, Cloudflare, Google Cloud
+                        DNS, NS1, NIOS, UDDI — return True).
+            ``False`` — backend cannot write SVCB. The publisher will fall
+                        back to a TXT-encoded agent record when the
+                        ``DNS_AID_EXPERIMENTAL_TXT_FALLBACK`` env flag is set.
+
+        Override in subclasses wrapping older DNS appliances, smaller hosted
+        providers, or self-hosted DNS that hasn't adopted SVCB yet.
+        """
+        return True
 
     @abstractmethod
     async def create_svcb_record(
@@ -245,6 +323,16 @@ class DNSBackend(ABC):
         # just the agent name (no leading underscore, no protocol label).
         name = agent.name
         walkable_name = f"{agent.name}._agents"
+
+        # ── TXT-fallback gate (experimental) ─────────────────────────────
+        # When the underlying DNS system can't write SVCB at all, fall back
+        # to a TXT-encoded agent record so SDK consumers can still discover
+        # this agent. Off by default — operators must opt in via env flag
+        # AND the backend must explicitly signal SVCB-unsupported, both to
+        # avoid surprising publisher behaviour and to keep the experimental
+        # path quiescent for the typical case.
+        if self._txt_fallback_enabled():
+            return await self._publish_via_txt_fallback(agent, zone, name)
 
         all_params = agent.to_svcb_params()
         support = self.supports_private_svcb_keys

--- a/src/dns_aid/backends/mock.py
+++ b/src/dns_aid/backends/mock.py
@@ -221,13 +221,20 @@ class MockBackend(DNSBackend):
 
         MockBackend accepts all params (like NIOS) to enable full protocol
         testing without private-use key restrictions.
+
+        Consults the shared TXT-fallback gate first so the experimental
+        fallback path is exercised consistently across backend
+        implementations.
         """
-        records: list[str] = []
         zone = agent.domain
         # draft-02: flat primary owner — relative record name is just the agent name.
         name = agent.name
         walkable_name = f"{agent.name}._agents"
 
+        if self._txt_fallback_enabled():
+            return await self._publish_via_txt_fallback(agent, zone, name)
+
+        records: list[str] = []
         svcb_fqdn = await self.create_svcb_record(
             zone=zone,
             name=name,

--- a/src/dns_aid/core/_txt_fallback.py
+++ b/src/dns_aid/core/_txt_fallback.py
@@ -1,0 +1,234 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TXT-record fallback parser and builder.
+
+For DNS deployments that don't expose SVCB records (older managed-DNS
+appliances, smaller hosted providers, self-hosted DNS that hasn't adopted
+SVCB yet), the SDK falls back to a TXT-encoded representation of the same
+agent endpoint information. The wire format mirrors the SVCB SvcParam
+names as key=value pairs so the consumer parser is symmetric with the
+SVCB parser already used by ``core.discoverer``.
+
+Wire format (single TXT RR; ``v=1`` discriminator distinguishes endpoint
+TXT from the metadata TXT that ``AgentRecord.to_txt_values()`` writes
+alongside):
+
+    _chat._mcp._agents.example.com. 3600 IN TXT (
+        "v=1 target=mcp.example.com port=443 alpn=mcp "
+        "cap=https://example.com/cap/chat-v1.json "
+        "cap-sha256=DEADBEEF... policy=https://example.com/policy/strict"
+    )
+
+Required fields: ``v`` (must equal ``"1"``), ``target``.
+Defaults: ``port=443``.
+Optional: ``alpn``, ``ipv4hint``, ``ipv6hint``, ``cap``, ``cap-sha256``,
+``bap``, ``policy``, ``realm``, ``sig``, ``connect-class``,
+``connect-meta``, ``enroll-uri``.
+
+Unknown fields are silently ignored on parse (forward compatibility).
+
+Multiple TXT strings inside a single RR are concatenated with a single
+space before key=value parsing, per RFC 1035 ``<character-string>``
+semantics. Multiple TXT *RRs* at the same FQDN are not supported as
+fallback containers in v1 — callers that see more than one ``v=1`` RR
+should log a warning and use the first.
+"""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from dns_aid.core.models import AgentRecord
+
+logger = structlog.get_logger(__name__)
+
+# Current wire-format version. Bump only on a wire-incompatible change.
+TXT_FALLBACK_VERSION: str = "1"
+
+# Field-name constants — kept in module scope so tests and downstream code can
+# reference them without string duplication.
+KEY_VERSION = "v"
+KEY_TARGET = "target"
+KEY_PORT = "port"
+KEY_ALPN = "alpn"
+KEY_IPV4HINT = "ipv4hint"
+KEY_IPV6HINT = "ipv6hint"
+KEY_CAP = "cap"
+KEY_CAP_SHA256 = "cap-sha256"
+KEY_BAP = "bap"
+KEY_POLICY = "policy"
+KEY_REALM = "realm"
+KEY_SIG = "sig"
+KEY_CONNECT_CLASS = "connect-class"
+KEY_CONNECT_META = "connect-meta"
+KEY_ENROLL_URI = "enroll-uri"
+
+
+@dataclass
+class TxtFallbackRecord:
+    """Parsed agent record from a TXT-fallback wire format.
+
+    All optional fields are ``None`` (or empty list for ``bap``) when the
+    publisher omitted them. The discoverer maps a populated record onto an
+    ``AgentRecord`` using the same field correspondences SVCB uses.
+    """
+
+    target: str
+    port: int = 443
+    alpn: str | None = None
+    ipv4hint: str | None = None
+    ipv6hint: str | None = None
+    cap: str | None = None
+    cap_sha256: str | None = None
+    bap: list[str] = field(default_factory=list)
+    policy: str | None = None
+    realm: str | None = None
+    sig: str | None = None
+    connect_class: str | None = None
+    connect_meta: str | None = None
+    enroll_uri: str | None = None
+
+
+def parse_txt_fallback(strings: Iterable[bytes]) -> TxtFallbackRecord | None:
+    """Parse a TXT RR's per-string segments into a :class:`TxtFallbackRecord`.
+
+    ``strings`` is the ``rdata.strings`` sequence dnspython exposes — each
+    element is a ``<character-string>`` of at most 255 bytes. They are joined
+    on a single space before parsing, which is the format
+    :func:`build_txt_fallback` emits.
+
+    Returns ``None`` when the body cannot be interpreted as a v1 fallback
+    record:
+
+    - Any string is not valid UTF-8
+    - ``shlex`` fails to tokenise the body (e.g., unclosed quotes)
+    - No ``v=`` field is present
+    - ``v`` is anything other than ``"1"``
+    - The required ``target=`` field is missing or empty
+
+    A malformed ``port=`` value falls back to the default (443) rather than
+    failing the whole parse — this matches the publisher behaviour of
+    omitting the port when it's the default.
+
+    Unknown fields are silently dropped; the dataclass only exposes the
+    fields this SDK understands.
+    """
+    try:
+        body = " ".join(s.decode("utf-8") for s in strings)
+    except UnicodeDecodeError:
+        logger.debug("txt_fallback.invalid_utf8")
+        return None
+
+    try:
+        tokens = shlex.split(body)
+    except ValueError as exc:
+        logger.debug("txt_fallback.shlex_failed", error=str(exc))
+        return None
+
+    kv: dict[str, str] = {}
+    for tok in tokens:
+        if "=" not in tok:
+            continue
+        key, _, value = tok.partition("=")
+        kv[key.strip().lower()] = value
+
+    version = kv.get(KEY_VERSION)
+    if version is None:
+        # No version marker → this is not a fallback record. Not an error
+        # condition; the caller may be looking at a metadata TXT.
+        return None
+    if version != TXT_FALLBACK_VERSION:
+        logger.debug("txt_fallback.unsupported_version", version=version)
+        return None
+
+    target = kv.get(KEY_TARGET)
+    if not target:
+        logger.debug("txt_fallback.missing_target")
+        return None
+
+    port_raw = kv.get(KEY_PORT)
+    port = 443
+    if port_raw is not None:
+        try:
+            port = int(port_raw)
+        except ValueError:
+            logger.debug("txt_fallback.invalid_port", value=port_raw)
+            # Continue with default; malformed port is recoverable.
+
+    bap_raw = kv.get(KEY_BAP, "")
+    bap = [b.strip() for b in bap_raw.split(",") if b.strip()] if bap_raw else []
+
+    return TxtFallbackRecord(
+        target=target,
+        port=port,
+        alpn=kv.get(KEY_ALPN),
+        ipv4hint=kv.get(KEY_IPV4HINT),
+        ipv6hint=kv.get(KEY_IPV6HINT),
+        cap=kv.get(KEY_CAP),
+        cap_sha256=kv.get(KEY_CAP_SHA256),
+        bap=bap,
+        policy=kv.get(KEY_POLICY),
+        realm=kv.get(KEY_REALM),
+        sig=kv.get(KEY_SIG),
+        connect_class=kv.get(KEY_CONNECT_CLASS),
+        connect_meta=kv.get(KEY_CONNECT_META),
+        enroll_uri=kv.get(KEY_ENROLL_URI),
+    )
+
+
+def build_txt_fallback(agent: AgentRecord) -> str:
+    """Serialize an :class:`AgentRecord` into a single TXT body string.
+
+    Returned string is the concatenated body that the publisher should pass
+    to its backend as a TXT value. Backends typically chunk into 255-byte
+    ``<character-string>`` segments transparently; this builder does not
+    perform the chunking itself, so callers retain control of how the
+    backend's TXT-write API expects the input.
+
+    Fields that are unset on the AgentRecord are omitted from the output.
+    The protocol enum is encoded as ``alpn=`` so the wire shape mirrors a
+    SVCB ServiceMode record with ``alpn=`` set.
+    """
+    parts: list[str] = [
+        f"{KEY_VERSION}={TXT_FALLBACK_VERSION}",
+        f"{KEY_TARGET}={agent.target_host}",
+    ]
+    if agent.port != 443:
+        parts.append(f"{KEY_PORT}={agent.port}")
+
+    proto = getattr(agent.protocol, "value", None) or str(agent.protocol)
+    if proto:
+        parts.append(f"{KEY_ALPN}={proto}")
+
+    if agent.ipv4_hint:
+        parts.append(f"{KEY_IPV4HINT}={agent.ipv4_hint}")
+    if agent.ipv6_hint:
+        parts.append(f"{KEY_IPV6HINT}={agent.ipv6_hint}")
+    if agent.cap_uri:
+        parts.append(f"{KEY_CAP}={agent.cap_uri}")
+    if agent.cap_sha256:
+        parts.append(f"{KEY_CAP_SHA256}={agent.cap_sha256}")
+    if agent.bap:
+        parts.append(f"{KEY_BAP}={','.join(agent.bap)}")
+    if agent.policy_uri:
+        parts.append(f"{KEY_POLICY}={agent.policy_uri}")
+    if agent.realm:
+        parts.append(f"{KEY_REALM}={agent.realm}")
+    if agent.sig:
+        parts.append(f"{KEY_SIG}={agent.sig}")
+    if agent.connect_class:
+        parts.append(f"{KEY_CONNECT_CLASS}={agent.connect_class}")
+    if agent.connect_meta:
+        parts.append(f"{KEY_CONNECT_META}={agent.connect_meta}")
+    if agent.enroll_uri:
+        parts.append(f"{KEY_ENROLL_URI}={agent.enroll_uri}")
+
+    return " ".join(parts)

--- a/src/dns_aid/core/_txt_fallback.py
+++ b/src/dns_aid/core/_txt_fallback.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import shlex
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import structlog
@@ -76,9 +76,15 @@ KEY_ENROLL_URI = "enroll-uri"
 class TxtFallbackRecord:
     """Parsed agent record from a TXT-fallback wire format.
 
-    All optional fields are ``None`` (or empty list for ``bap``) when the
-    publisher omitted them. The discoverer maps a populated record onto an
-    ``AgentRecord`` using the same field correspondences SVCB uses.
+    All optional fields are ``None`` when the publisher omitted them. The
+    discoverer maps a populated record onto an ``AgentRecord`` using the
+    same field correspondences SVCB uses.
+
+    ``bap`` is kept as the raw wire value (draft-02 §5.1 scalar form,
+    ``mcp`` / ``mcp=1.0``) exactly like the SVCB path's
+    ``custom_params.get("bap")`` — the consumer boundary normalizes it via
+    :func:`dns_aid.core.bap.normalize_bap`, which also collapses legacy
+    comma-separated lists with a warning.
     """
 
     target: str
@@ -88,7 +94,7 @@ class TxtFallbackRecord:
     ipv6hint: str | None = None
     cap: str | None = None
     cap_sha256: str | None = None
-    bap: list[str] = field(default_factory=list)
+    bap: str | None = None
     policy: str | None = None
     realm: str | None = None
     sig: str | None = None
@@ -163,8 +169,10 @@ def parse_txt_fallback(strings: Iterable[bytes]) -> TxtFallbackRecord | None:
             logger.debug("txt_fallback.invalid_port", value=port_raw)
             # Continue with default; malformed port is recoverable.
 
-    bap_raw = kv.get(KEY_BAP, "")
-    bap = [b.strip() for b in bap_raw.split(",") if b.strip()] if bap_raw else []
+    # Raw pass-through, like the SVCB path's ``custom_params.get("bap")``.
+    # The consumer boundary runs ``normalize_bap`` (scalar draft-02 form;
+    # legacy comma lists collapse there with a warning).
+    bap = kv.get(KEY_BAP) or None
 
     return TxtFallbackRecord(
         target=target,
@@ -217,7 +225,9 @@ def build_txt_fallback(agent: AgentRecord) -> str:
     if agent.cap_sha256:
         parts.append(f"{KEY_CAP_SHA256}={agent.cap_sha256}")
     if agent.bap:
-        parts.append(f"{KEY_BAP}={','.join(agent.bap)}")
+        # draft-02 scalar form (``mcp`` / ``mcp=1.0``) — AgentRecord.bap is
+        # a single identifier, not a list.
+        parts.append(f"{KEY_BAP}={agent.bap}")
     if agent.policy_uri:
         parts.append(f"{KEY_POLICY}={agent.policy_uri}")
     if agent.realm:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -975,6 +975,23 @@ async def _try_txt_fallback(
         )
     fallback = matches[0]
 
+    # Cross-validate the parsed ``alpn=`` against the protocol the caller
+    # derived from the FQDN. They should match — the publisher wrote the
+    # record at ``_{name}._{protocol}._agents.{domain}`` AND emitted
+    # ``alpn={protocol}`` in the TXT body. A mismatch indicates a publisher
+    # error (record published at the wrong FQDN, or hand-edited alpn that
+    # diverged). The FQDN-derived protocol is authoritative — the record
+    # location is what the SDK dispatched on — but the discrepancy is
+    # worth surfacing so the deployment can fix it.
+    if fallback.alpn is not None and fallback.alpn != protocol.value:
+        logger.warning(
+            "txt_fallback.alpn_mismatch",
+            fqdn=fqdn,
+            fqdn_protocol=protocol.value,
+            txt_alpn=fallback.alpn,
+            note="using FQDN protocol; publisher should align alpn= with the record's _{protocol} label",
+        )
+
     # Tier 1: cap URI (mirrors the SVCB-success path's tier 1)
     capabilities: list[str] = []
     capability_source: Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] = (

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -975,22 +975,29 @@ async def _try_txt_fallback(
         )
     fallback = matches[0]
 
-    # Cross-validate the parsed ``alpn=`` against the protocol the caller
-    # derived from the FQDN. They should match — the publisher wrote the
-    # record at ``_{name}._{protocol}._agents.{domain}`` AND emitted
-    # ``alpn={protocol}`` in the TXT body. A mismatch indicates a publisher
-    # error (record published at the wrong FQDN, or hand-edited alpn that
-    # diverged). The FQDN-derived protocol is authoritative — the record
-    # location is what the SDK dispatched on — but the discrepancy is
-    # worth surfacing so the deployment can fix it.
+    # Cross-validate the parsed ``alpn=`` against the protocol probe the
+    # caller queried with. Under draft-02 the flat owner name carries no
+    # protocol, so the probe is only a placeholder — but a disagreement is
+    # still worth surfacing (hand-edited alpn, or a record reached via the
+    # legacy -01 shape whose ``_{protocol}`` label diverged from the body).
     if fallback.alpn is not None and fallback.alpn != protocol.value:
         logger.warning(
             "txt_fallback.alpn_mismatch",
             fqdn=fqdn,
-            fqdn_protocol=protocol.value,
+            probe_protocol=protocol.value,
             txt_alpn=fallback.alpn,
-            note="using FQDN protocol; publisher should align alpn= with the record's _{protocol} label",
+            note="record signal wins after reconciliation (draft-02: protocol lives in the record)",
         )
+
+    # Mirror the SVCB path exactly: normalize the raw bap value (scalar
+    # draft-02 form; legacy comma lists collapse with a warning) and stamp
+    # the record's true protocol (bap, then alpn) over the query probe so
+    # TXT-sourced records label identically to SVCB-sourced ones and the
+    # JWS binding check (payload.alpn == agent.protocol.value) holds.
+    from dns_aid.core.bap import normalize_bap
+
+    bap = normalize_bap(fallback.bap)
+    protocol = _reconcile_protocol(protocol, bap, fallback.alpn)
 
     # Tier 1: cap URI (mirrors the SVCB-success path's tier 1)
     capabilities: list[str] = []
@@ -1025,29 +1032,48 @@ async def _try_txt_fallback(
         port=fallback.port,
     )
 
-    return AgentRecord(
-        name=name,
-        domain=domain,
-        protocol=protocol,
-        target_host=fallback.target,
-        port=fallback.port,
-        ipv4_hint=fallback.ipv4hint,
-        ipv6_hint=fallback.ipv6hint,
-        capabilities=capabilities,
-        legacy_resolved=legacy_resolved,
-        cap_uri=fallback.cap,
-        cap_sha256=fallback.cap_sha256,
-        bap=fallback.bap,
-        policy_uri=fallback.policy,
-        realm=fallback.realm,
-        sig=fallback.sig,
-        connect_class=fallback.connect_class,
-        connect_meta=fallback.connect_meta,
-        enroll_uri=fallback.enroll_uri,
-        capability_source=capability_source,
-        endpoint_source="dns_txt_fallback",
-        agent_card=agent_card,
-    )
+    # TXT bodies are attacker-shapable free text: a record can pass the
+    # wire-format parser yet still trip an AgentRecord field validator
+    # (underscore target, oversized connect-meta, ...). Catch that case
+    # HERE with a specific event so operators can tell "TXT present but
+    # model-invalid" apart from a plain DNS miss — the outer
+    # _query_single_agent handler would otherwise swallow it at debug as
+    # a generic query failure.
+    from pydantic import ValidationError as PydanticValidationError
+
+    try:
+        return AgentRecord(
+            name=name,
+            domain=domain,
+            protocol=protocol,
+            target_host=fallback.target,
+            port=fallback.port,
+            ipv4_hint=fallback.ipv4hint,
+            ipv6_hint=fallback.ipv6hint,
+            capabilities=capabilities,
+            legacy_resolved=legacy_resolved,
+            cap_uri=fallback.cap,
+            cap_sha256=fallback.cap_sha256,
+            bap=bap,
+            policy_uri=fallback.policy,
+            realm=fallback.realm,
+            sig=fallback.sig,
+            connect_class=fallback.connect_class,
+            connect_meta=fallback.connect_meta,
+            enroll_uri=fallback.enroll_uri,
+            capability_source=capability_source,
+            endpoint_source="dns_txt_fallback",
+            agent_card=agent_card,
+        )
+    except PydanticValidationError as exc:
+        logger.warning(
+            "txt_fallback.model_rejected",
+            fqdn=fqdn,
+            target=fallback.target,
+            error=str(exc),
+            note="TXT v=1 record parsed but failed AgentRecord validation; skipping",
+        )
+        return None
 
 
 async def _query_capabilities(fqdn: str) -> list[str]:

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -506,6 +506,16 @@ async def _query_single_agent(
         try:
             answers = await _try(fqdn)
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            # Last-resort tier at the flat owner name: TXT-encoded fallback
+            # for DNS providers that can't serve SVCB. Returns a complete
+            # AgentRecord when a v=1 fallback record is present; None when
+            # only metadata TXT (or nothing) lives there. Deliberately tried
+            # BEFORE the legacy -01 shape: a publisher who placed a draft-02
+            # flat TXT record has migrated, and a leftover legacy SVCB
+            # record must not shadow it.
+            txt_agent = await _try_txt_fallback(resolver, fqdn, name, domain, protocol)
+            if txt_agent is not None:
+                return txt_agent
             if legacy_fqdn is None:
                 return None
             try:
@@ -520,7 +530,11 @@ async def _query_single_agent(
                 fqdn = legacy_fqdn
                 resolved_via_legacy = True
             except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-                return None
+                # Same last-resort TXT tier at the legacy owner name, only
+                # reachable when legacy fallback is active for this call.
+                return await _try_txt_fallback(
+                    resolver, legacy_fqdn, name, domain, protocol, legacy_resolved=True
+                )
 
         for rdata in answers:
             # AliasMode (priority 0): follow alias to canonical name
@@ -896,6 +910,127 @@ def _parse_svcb_custom_params(svcb_text: str) -> dict[str, str]:
             custom_params[key] = value
 
     return custom_params
+
+
+async def _try_txt_fallback(
+    resolver: dns.asyncresolver.Resolver,
+    fqdn: str,
+    name: str,
+    domain: str,
+    protocol: Protocol,
+    *,
+    legacy_resolved: bool = False,
+) -> AgentRecord | None:
+    """Last-resort TXT-encoded fallback when SVCB / HTTPS RR aren't available.
+
+    Used by ``_query_single_agent`` when the authoritative DNS server doesn't
+    expose SVCB (older DNS appliances, smaller hosted providers, self-hosted
+    DNS that hasn't adopted SVCB yet). Looks for a ``v=1`` agent record
+    encoded inside a TXT RR at the same FQDN the SVCB lookup targeted —
+    the draft-02 flat owner name, or the legacy -01 shape when the caller
+    reached this tier via the opt-in legacy fallback (``legacy_resolved=True``
+    is then stamped on the returned record, mirroring the SVCB path).
+
+    Returns a complete :class:`AgentRecord` when a v=1 fallback record is
+    present and parses cleanly. Returns ``None`` when:
+
+    - No TXT records exist at the FQDN
+    - TXT records exist but none carry a v=1 marker (the publisher only
+      writes metadata TXT, no endpoint fallback)
+    - Parsing fails (malformed body, missing required field)
+
+    Coexists with metadata TXT (``capabilities=`` and friends) on the same
+    FQDN: parser ignores RRs that lack ``v=`` so they fall through. When
+    multiple v=1 RRs are present (out-of-spec), the first parses-able one
+    wins and a warning is logged.
+
+    Mitigates the SVCB-less-DNS reach gap; mirrors the SVCB SvcParam set
+    in TXT key=value form so the consumer parser stays symmetric with
+    :func:`_parse_svcb_custom_params`.
+    """
+    from dns_aid.core._txt_fallback import parse_txt_fallback
+
+    try:
+        answers = await resolver.resolve(fqdn, "TXT")
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        return None
+    except Exception as exc:  # noqa: BLE001 — fallback is best-effort
+        logger.debug("txt_fallback.resolve_failed", fqdn=fqdn, error=str(exc))
+        return None
+
+    matches: list[Any] = []
+    for rdata in answers:
+        parsed = parse_txt_fallback(rdata.strings)
+        if parsed is not None:
+            matches.append(parsed)
+
+    if not matches:
+        return None
+    if len(matches) > 1:
+        logger.warning(
+            "txt_fallback.multiple_records",
+            fqdn=fqdn,
+            count=len(matches),
+            note="using first; spec does not permit multiple v=1 records at one FQDN",
+        )
+    fallback = matches[0]
+
+    # Tier 1: cap URI (mirrors the SVCB-success path's tier 1)
+    capabilities: list[str] = []
+    capability_source: Literal["cap_uri", "agent_card", "http_index", "txt_fallback", "none"] = (
+        "none"
+    )
+    agent_card = None
+    if fallback.cap:
+        cap_doc = await fetch_cap_document(fallback.cap, expected_sha256=fallback.cap_sha256)
+        if cap_doc and cap_doc.capabilities:
+            capabilities = cap_doc.capabilities
+            capability_source = "cap_uri"
+        if cap_doc and cap_doc.raw_data:
+            try:
+                agent_card = A2AAgentCard.from_dict(cap_doc.raw_data)
+            except Exception:  # nosec B110 — not an agent card; that's fine
+                agent_card = None
+
+    # Tier 4: TXT capabilities — same TXT records may carry both the v=1
+    # fallback record and a separate ``capabilities=`` metadata string.
+    # _query_capabilities already filters for ``capabilities=`` so it
+    # ignores the v=1 record itself.
+    if not capabilities:
+        capabilities = await _query_capabilities(fqdn)
+        if capabilities:
+            capability_source = "txt_fallback"
+
+    logger.info(
+        "Resolved agent via TXT fallback (SVCB unavailable)",
+        fqdn=fqdn,
+        target=fallback.target,
+        port=fallback.port,
+    )
+
+    return AgentRecord(
+        name=name,
+        domain=domain,
+        protocol=protocol,
+        target_host=fallback.target,
+        port=fallback.port,
+        ipv4_hint=fallback.ipv4hint,
+        ipv6_hint=fallback.ipv6hint,
+        capabilities=capabilities,
+        legacy_resolved=legacy_resolved,
+        cap_uri=fallback.cap,
+        cap_sha256=fallback.cap_sha256,
+        bap=fallback.bap,
+        policy_uri=fallback.policy,
+        realm=fallback.realm,
+        sig=fallback.sig,
+        connect_class=fallback.connect_class,
+        connect_meta=fallback.connect_meta,
+        enroll_uri=fallback.enroll_uri,
+        capability_source=capability_source,
+        endpoint_source="dns_txt_fallback",
+        agent_card=agent_card,
+    )
 
 
 async def _query_capabilities(fqdn: str) -> list[str]:

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -727,6 +727,7 @@ class AgentRecord(BaseModel):
         Literal[
             "dns_svcb",
             "dns_svcb_enriched",
+            "dns_txt_fallback",
             "http_index",
             "http_index_fallback",
             "ard_card",
@@ -739,6 +740,7 @@ class AgentRecord(BaseModel):
         default=None,
         description="Source of endpoint: 'dns_svcb' (from DNS SVCB record), "
         "'dns_svcb_enriched' (DNS + .well-known/agent-card.json path), "
+        "'dns_txt_fallback' (DNS TXT-encoded fallback for SVCB-less zones), "
         "'http_index' (DNS + HTTP index endpoint), "
         "'http_index_fallback' (HTTP index without DNS), "
         "'ard_card' (real endpoint from a dereferenced ARD agent/server card URL), "

--- a/tests/unit/test_discoverer_txt_fallback.py
+++ b/tests/unit/test_discoverer_txt_fallback.py
@@ -1,0 +1,233 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discoverer integration tests for the TXT-record fallback path.
+
+Mirrors the structure of ``tests/unit/test_discoverer.py``: mocks
+``dns.asyncresolver.Resolver`` and dispatches per rdtype so each test can
+declare independently whether SVCB / HTTPS / TXT yield records.
+
+Covers the SVCB → HTTPS → TXT ladder added to ``_query_single_agent``:
+
+- SVCB present  → SVCB used, fallback skipped
+- SVCB+HTTPS NoAnswer, TXT v=1 present → fallback used (full record returned)
+- SVCB+HTTPS NoAnswer, TXT metadata only → None
+- SVCB+HTTPS NoAnswer, TXT malformed → None
+- SVCB+HTTPS NoAnswer, no TXT → None
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import dns.resolver
+import pytest
+
+from dns_aid.core.discoverer import _query_single_agent
+from dns_aid.core.models import Protocol
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_txt_answer(strings_list: list[list[bytes]]) -> MagicMock:
+    """Build a mock TXT answer with one rdata per inner-list of strings.
+
+    Each element of ``strings_list`` is the list of ``<character-string>``
+    bytes that one TXT RR exposes via ``rdata.strings``.
+    """
+    rdatas = []
+    for strings in strings_list:
+        rdata = MagicMock()
+        rdata.strings = strings
+        rdatas.append(rdata)
+    answer = MagicMock()
+    answer.__iter__ = lambda self: iter(rdatas)
+    return answer
+
+
+def _make_svcb_answer(target: str, port: int = 443) -> MagicMock:
+    """Minimal SVCB answer used when SVCB is present and the test wants it used."""
+    rdata = MagicMock()
+    rdata.priority = 1
+    rdata.target = MagicMock()
+    rdata.target.__str__ = lambda self: target  # type: ignore[misc]
+    rdata.params = {}
+    rdata.__str__ = lambda self: f"1 {target}. alpn=mcp port={port}"  # type: ignore[misc]
+    answer = MagicMock()
+    answer.__iter__ = lambda self: iter([rdata])
+    return answer
+
+
+def _dispatching_resolver(
+    *,
+    svcb: MagicMock | Exception | None = None,
+    https: MagicMock | Exception | None = None,
+    txt: MagicMock | Exception | None = None,
+) -> MagicMock:
+    """Build a resolver mock that returns / raises per rdtype.
+
+    ``None`` for any of the three means "raise NoAnswer for that type."
+    Pass an Exception instance to raise it; pass a MagicMock answer to
+    return it.
+    """
+
+    async def fake_resolve(qname: str, rdtype: str) -> MagicMock:
+        cfg = {"SVCB": svcb, "HTTPS": https, "TXT": txt}.get(rdtype)
+        if cfg is None:
+            raise dns.resolver.NoAnswer()
+        if isinstance(cfg, Exception):
+            raise cfg
+        return cfg
+
+    resolver = MagicMock()
+    resolver.resolve = AsyncMock(side_effect=fake_resolve)
+    return resolver
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_svcb_present_skips_txt_fallback() -> None:
+    """SVCB returns a usable record → endpoint_source remains dns_svcb.
+
+    (TXT may still be queried by the post-SVCB capability-enrichment tier,
+    but that's a separate concern from the new endpoint-TXT fallback. The
+    important property is that endpoint_source did not flip to
+    ``dns_txt_fallback``.)
+    """
+    svcb = _make_svcb_answer(target="mcp.example.com")
+    resolver = _dispatching_resolver(svcb=svcb)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is not None
+    assert result.target_host == "mcp.example.com"
+    assert result.endpoint_source == "dns_svcb"
+
+
+@pytest.mark.asyncio
+async def test_svcb_and_https_noanswer_txt_fallback_used() -> None:
+    """SVCB+HTTPS NoAnswer, TXT carries a v=1 record → fallback path returns it."""
+    txt = _make_txt_answer(
+        [
+            [b"v=1 target=mcp.example.com port=8443 alpn=mcp cap=https://example.com/cap"],
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is not None
+    assert result.target_host == "mcp.example.com"
+    assert result.port == 8443
+    assert result.endpoint_source == "dns_txt_fallback"
+    assert result.cap_uri == "https://example.com/cap"
+
+
+@pytest.mark.asyncio
+async def test_svcb_and_https_noanswer_txt_only_metadata_returns_none() -> None:
+    """TXT exists but only carries capability/version metadata — no v=1 → None."""
+    txt = _make_txt_answer(
+        [
+            [b"capabilities=chat,code-review", b"version=1.0.0"],
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_svcb_and_https_noanswer_txt_malformed_returns_none() -> None:
+    """TXT has a v= marker but missing target=. parse_txt_fallback returns None."""
+    txt = _make_txt_answer(
+        [
+            [b"v=1 port=443"],  # missing target
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_no_records_anywhere_returns_none() -> None:
+    """SVCB+HTTPS+TXT all NoAnswer → None (today's behaviour preserved when no fallback)."""
+    resolver = _dispatching_resolver()  # all three default to NoAnswer
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_txt_multiple_v1_records_uses_first_logs_warning() -> None:
+    """Two v=1 records at the same FQDN — out of spec; use the first, warn."""
+    txt = _make_txt_answer(
+        [
+            [b"v=1 target=first.example.com"],
+            [b"v=1 target=second.example.com"],
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with (
+        patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver),
+        patch("dns_aid.core.discoverer.logger") as mock_logger,
+    ):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is not None
+    assert result.target_host == "first.example.com"
+    # Confirm the warning fired
+    warning_calls = [c for c in mock_logger.warning.call_args_list if c.args]
+    assert any("txt_fallback.multiple_records" in c.args[0] for c in warning_calls)
+
+
+@pytest.mark.asyncio
+async def test_txt_fallback_with_metadata_alongside() -> None:
+    """Real-world shape: v=1 endpoint TXT + capabilities= metadata TXT at same FQDN.
+
+    Both come back in one TXT answer. The v=1 record drives the endpoint;
+    capabilities= TXT is consumed by the existing _query_capabilities tier.
+    """
+    txt = _make_txt_answer(
+        [
+            [b"v=1 target=mcp.example.com port=443 alpn=mcp"],
+            [b"capabilities=chat,code-review", b"version=1.0.0"],
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is not None
+    assert result.target_host == "mcp.example.com"
+    assert result.endpoint_source == "dns_txt_fallback"
+    # Capabilities should have been picked up by _query_capabilities from the
+    # adjacent metadata TXT RR.
+    assert "chat" in result.capabilities
+    assert "code-review" in result.capabilities
+    assert result.capability_source == "txt_fallback"
+
+
+@pytest.mark.asyncio
+async def test_txt_fallback_nxdomain_returns_none() -> None:
+    """TXT NXDOMAIN (no records at all) returns None gracefully — no crash."""
+    resolver = _dispatching_resolver(txt=dns.resolver.NXDOMAIN())
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+    assert result is None

--- a/tests/unit/test_discoverer_txt_fallback.py
+++ b/tests/unit/test_discoverer_txt_fallback.py
@@ -224,6 +224,57 @@ async def test_txt_fallback_with_metadata_alongside() -> None:
 
 
 @pytest.mark.asyncio
+async def test_txt_fallback_alpn_mismatch_warns_and_proceeds() -> None:
+    """Parsed alpn= disagrees with the FQDN-derived protocol → warn but proceed.
+
+    Closes the alpn round-trip asymmetry: the parser captures alpn and the
+    discoverer now uses it to cross-validate against the protocol the caller
+    derived from the FQDN. FQDN remains authoritative; mismatch is a
+    publisher-side bug worth surfacing.
+    """
+    txt = _make_txt_answer(
+        [
+            [b"v=1 target=mcp.example.com alpn=a2a"],  # alpn says a2a, FQDN says mcp
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with (
+        patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver),
+        patch("dns_aid.core.discoverer.logger") as mock_logger,
+    ):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is not None
+    assert result.target_host == "mcp.example.com"
+    assert result.protocol == Protocol.MCP  # FQDN protocol wins
+    # Warning fired with the mismatch event
+    warning_events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+    assert "txt_fallback.alpn_mismatch" in warning_events
+
+
+@pytest.mark.asyncio
+async def test_txt_fallback_alpn_matches_no_warning() -> None:
+    """Round-trip happy path: parsed alpn= matches FQDN-derived protocol, no warning."""
+    txt = _make_txt_answer(
+        [
+            [b"v=1 target=mcp.example.com alpn=mcp"],
+        ]
+    )
+    resolver = _dispatching_resolver(txt=txt)
+
+    with (
+        patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver),
+        patch("dns_aid.core.discoverer.logger") as mock_logger,
+    ):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is not None
+    warning_events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+    assert "txt_fallback.alpn_mismatch" not in warning_events
+
+
+@pytest.mark.asyncio
 async def test_txt_fallback_nxdomain_returns_none() -> None:
     """TXT NXDOMAIN (no records at all) returns None gracefully — no crash."""
     resolver = _dispatching_resolver(txt=dns.resolver.NXDOMAIN())

--- a/tests/unit/test_discoverer_txt_fallback.py
+++ b/tests/unit/test_discoverer_txt_fallback.py
@@ -224,17 +224,17 @@ async def test_txt_fallback_with_metadata_alongside() -> None:
 
 
 @pytest.mark.asyncio
-async def test_txt_fallback_alpn_mismatch_warns_and_proceeds() -> None:
-    """Parsed alpn= disagrees with the FQDN-derived protocol → warn but proceed.
+async def test_txt_fallback_alpn_mismatch_warns_and_reconciles() -> None:
+    """Parsed alpn= disagrees with the query probe → warn AND reconcile.
 
-    Closes the alpn round-trip asymmetry: the parser captures alpn and the
-    discoverer now uses it to cross-validate against the protocol the caller
-    derived from the FQDN. FQDN remains authoritative; mismatch is a
-    publisher-side bug worth surfacing.
+    draft-02: the flat owner name carries no protocol, so the probe is only
+    a placeholder — the record's own signal (bap, then alpn) is stamped onto
+    the result via _reconcile_protocol, exactly like the SVCB path. The
+    disagreement is still surfaced as a warning for observability.
     """
     txt = _make_txt_answer(
         [
-            [b"v=1 target=mcp.example.com alpn=a2a"],  # alpn says a2a, FQDN says mcp
+            [b"v=1 target=mcp.example.com alpn=a2a"],  # alpn says a2a, probe says mcp
         ]
     )
     resolver = _dispatching_resolver(txt=txt)
@@ -247,7 +247,9 @@ async def test_txt_fallback_alpn_mismatch_warns_and_proceeds() -> None:
 
     assert result is not None
     assert result.target_host == "mcp.example.com"
-    assert result.protocol == Protocol.MCP  # FQDN protocol wins
+    # Record signal wins (mirrors the SVCB path's _reconcile_protocol so the
+    # JWS binding check payload.alpn == agent.protocol.value holds).
+    assert result.protocol == Protocol.A2A
     # Warning fired with the mismatch event
     warning_events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
     assert "txt_fallback.alpn_mismatch" in warning_events
@@ -282,3 +284,91 @@ async def test_txt_fallback_nxdomain_returns_none() -> None:
     with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
         result = await _query_single_agent("example.com", "chat", Protocol.MCP)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_txt_fallback_at_legacy_fqdn_sets_legacy_resolved() -> None:
+    """Flat ladder dry, legacy ladder reaches TXT → legacy_resolved=True.
+
+    The full SVCB → HTTPS → TXT ladder runs at the flat owner name first;
+    only when it comes up completely dry AND legacy fallback is active does
+    the same ladder run at the legacy -01 shape. A TXT hit there must stamp
+    ``legacy_resolved=True`` exactly like a legacy SVCB hit would.
+    """
+    legacy_fqdn = "_chat._mcp._agents.example.com"
+    txt = _make_txt_answer([[b"v=1 target=mcp.example.com port=8443 alpn=mcp"]])
+
+    async def fake_resolve(qname: str, rdtype: str) -> MagicMock:
+        # TXT only exists at the legacy owner name; everything else is dry.
+        if rdtype == "TXT" and str(qname).rstrip(".") == legacy_fqdn:
+            return txt
+        raise dns.resolver.NoAnswer()
+
+    resolver = MagicMock()
+    resolver.resolve = AsyncMock(side_effect=fake_resolve)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP, allow_legacy=True)
+
+    assert result is not None
+    assert result.target_host == "mcp.example.com"
+    assert result.port == 8443
+    assert result.legacy_resolved is True
+    assert result.endpoint_source == "dns_txt_fallback"
+
+
+@pytest.mark.asyncio
+async def test_txt_fallback_flat_txt_beats_legacy_svcb() -> None:
+    """A flat TXT v=1 record wins over a leftover legacy SVCB record.
+
+    The flat owner name is draft-02's canonical location: a publisher who
+    deliberately placed a flat TXT record has migrated, and a stale legacy
+    SVCB record must not shadow it.
+    """
+    flat_fqdn = "chat.example.com"
+    legacy_fqdn = "_chat._mcp._agents.example.com"
+    txt = _make_txt_answer([[b"v=1 target=new.example.com alpn=mcp"]])
+    legacy_svcb = _make_svcb_answer(target="stale.example.com")
+
+    async def fake_resolve(qname: str, rdtype: str) -> MagicMock:
+        q = str(qname).rstrip(".")
+        if q == flat_fqdn and rdtype == "TXT":
+            return txt
+        if q == legacy_fqdn and rdtype == "SVCB":
+            return legacy_svcb
+        raise dns.resolver.NoAnswer()
+
+    resolver = MagicMock()
+    resolver.resolve = AsyncMock(side_effect=fake_resolve)
+
+    with patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP, allow_legacy=True)
+
+    assert result is not None
+    assert result.target_host == "new.example.com"
+    assert result.endpoint_source == "dns_txt_fallback"
+    assert result.legacy_resolved is False
+
+
+@pytest.mark.asyncio
+async def test_txt_fallback_model_invalid_logs_and_returns_none() -> None:
+    """Wire-valid but model-invalid TXT → specific warning, graceful None.
+
+    TXT bodies are attacker-shapable: a record can pass the wire-format
+    parser yet trip an AgentRecord field validator (here: underscored
+    target_host). That boundary must not crash discovery, and must emit
+    ``txt_fallback.model_rejected`` so operators can tell it apart from a
+    plain DNS miss.
+    """
+    txt = _make_txt_answer([[b"v=1 target=_evil.example.com alpn=mcp"]])
+    resolver = _dispatching_resolver(txt=txt)
+
+    with (
+        patch("dns_aid.core.discoverer.dns.asyncresolver.Resolver", return_value=resolver),
+        patch("dns_aid.core.discoverer.logger") as mock_logger,
+    ):
+        result = await _query_single_agent("example.com", "chat", Protocol.MCP)
+
+    assert result is None
+    warning_events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+    assert "txt_fallback.model_rejected" in warning_events

--- a/tests/unit/test_publisher_txt_fallback.py
+++ b/tests/unit/test_publisher_txt_fallback.py
@@ -1,0 +1,161 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publisher tests for the flag-gated TXT-fallback write path.
+
+The gate has two preconditions, both required:
+
+1. The backend declares ``supports_svcb=False`` (it wraps a DNS system
+   that can't write SVCB).
+2. The operator sets ``DNS_AID_EXPERIMENTAL_TXT_FALLBACK=1`` in the
+   environment.
+
+When both are true the publisher emits a single TXT RR with a ``v=1``
+endpoint body alongside the companion metadata TXT. When either is false
+the publisher behaves exactly as it does today (SVCB + companion TXT).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dns_aid.backends.mock import MockBackend
+from dns_aid.core.models import AgentRecord, Protocol
+
+
+def _make_agent() -> AgentRecord:
+    return AgentRecord(
+        name="chat",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="mcp.example.com",
+        port=443,
+        capabilities=["chat", "code-review"],
+        version="1.0.0",
+        cap_uri="https://example.com/cap/chat-v1.json",
+        cap_sha256="DEADBEEF",
+    )
+
+
+class _SvcbLessBackend(MockBackend):
+    """Test double: a backend whose underlying DNS system can't write SVCB."""
+
+    @property
+    def supports_svcb(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Default path (SVCB-capable backend) — no TXT fallback regardless of env flag
+# ---------------------------------------------------------------------------
+
+
+async def test_svcb_capable_backend_writes_svcb_not_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with env flag on, a backend reporting supports_svcb=True writes SVCB."""
+    monkeypatch.setenv("DNS_AID_EXPERIMENTAL_TXT_FALLBACK", "1")
+    backend = MockBackend()  # supports_svcb defaults to True
+    agent = _make_agent()
+
+    records = await backend.publish_agent(agent)
+
+    # Expect a normal SVCB + metadata TXT publication
+    assert any("SVCB" in r for r in records)
+    assert any("TXT" in r for r in records)
+    assert not any("fallback v=1" in r for r in records)
+
+    # The TXT record should NOT contain a v=1 body — backend wrote SVCB
+    zone = backend.records.get("example.com", {})
+    txt_rrs = zone.get("_chat._mcp._agents", {}).get("TXT", [])
+    txt_bodies = " ".join(
+        v for rec in txt_rrs for v in (rec.get("values", []) if isinstance(rec, dict) else [])
+    )
+    assert "v=1 target=" not in txt_bodies
+
+
+# ---------------------------------------------------------------------------
+# Backend signals SVCB-less, env flag OFF → no fallback (today's behavior)
+# ---------------------------------------------------------------------------
+
+
+async def test_svcb_less_backend_no_env_flag_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backend says no-SVCB but operator hasn't opted in — base path runs as today.
+
+    For a real legacy-DNS backend without env opt-in the SVCB write would
+    typically fail downstream; we don't change that behaviour here. The
+    important property is that the TXT-fallback path is NOT silently taken
+    without explicit operator consent.
+    """
+    monkeypatch.delenv("DNS_AID_EXPERIMENTAL_TXT_FALLBACK", raising=False)
+    backend = _SvcbLessBackend()
+    agent = _make_agent()
+
+    records = await backend.publish_agent(agent)
+
+    # No fallback marker — the gate did NOT fire
+    assert not any("fallback v=1" in r for r in records)
+
+
+# ---------------------------------------------------------------------------
+# Backend signals SVCB-less, env flag ON → TXT fallback path
+# ---------------------------------------------------------------------------
+
+
+async def test_fallback_path_when_both_preconditions_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DNS_AID_EXPERIMENTAL_TXT_FALLBACK", "1")
+    backend = _SvcbLessBackend()
+    agent = _make_agent()
+
+    records = await backend.publish_agent(agent)
+
+    # Only TXT records; no SVCB attempted
+    assert all("SVCB" not in r for r in records)
+    assert any("fallback v=1" in r for r in records)
+
+    # The single TXT RR should carry: (1) the v=1 endpoint body, AND
+    # (2) the companion metadata values (capabilities=, version=, etc.)
+    zone = backend.records["example.com"]
+    txt_rrs = zone["_chat._mcp._agents"]["TXT"]
+    assert len(txt_rrs) >= 1
+    first = txt_rrs[0]
+    values = first["values"] if isinstance(first, dict) else first.values  # type: ignore[attr-defined]
+    joined = " | ".join(values)
+    # Endpoint body
+    assert "v=1" in joined
+    assert "target=mcp.example.com" in joined
+    assert "alpn=mcp" in joined
+    assert "cap=https://example.com/cap/chat-v1.json" in joined
+    assert "cap-sha256=DEADBEEF" in joined
+    # Companion metadata (must coexist on the same FQDN)
+    assert any("capabilities=" in v for v in values)
+    assert any("version=" in v for v in values)
+
+
+# ---------------------------------------------------------------------------
+# Env flag accepts the same truthy values as the rest of the codebase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag_value", ["1", "true", "yes", "TRUE", "Yes"])
+async def test_env_flag_truthy_variants(monkeypatch: pytest.MonkeyPatch, flag_value: str) -> None:
+    monkeypatch.setenv("DNS_AID_EXPERIMENTAL_TXT_FALLBACK", flag_value)
+    backend = _SvcbLessBackend()
+    agent = _make_agent()
+    records = await backend.publish_agent(agent)
+    assert any("fallback v=1" in r for r in records)
+
+
+@pytest.mark.parametrize("flag_value", ["0", "false", "no", "off", ""])
+async def test_env_flag_falsy_variants_keep_default_path(
+    monkeypatch: pytest.MonkeyPatch, flag_value: str
+) -> None:
+    monkeypatch.setenv("DNS_AID_EXPERIMENTAL_TXT_FALLBACK", flag_value)
+    backend = _SvcbLessBackend()
+    agent = _make_agent()
+    records = await backend.publish_agent(agent)
+    assert not any("fallback v=1" in r for r in records)

--- a/tests/unit/test_publisher_txt_fallback.py
+++ b/tests/unit/test_publisher_txt_fallback.py
@@ -120,7 +120,9 @@ async def test_fallback_path_when_both_preconditions_set(
     # The single TXT RR should carry: (1) the v=1 endpoint body, AND
     # (2) the companion metadata values (capabilities=, version=, etc.)
     zone = backend.records["example.com"]
-    txt_rrs = zone["_chat._mcp._agents"]["TXT"]
+    # draft-02 flat owner name — publish_agent writes at {name}, not the
+    # legacy _{name}._{protocol}._agents shape.
+    txt_rrs = zone["chat"]["TXT"]
     assert len(txt_rrs) >= 1
     first = txt_rrs[0]
     values = first["values"] if isinstance(first, dict) else first.values  # type: ignore[attr-defined]

--- a/tests/unit/test_txt_fallback.py
+++ b/tests/unit/test_txt_fallback.py
@@ -1,0 +1,271 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``dns_aid.core._txt_fallback`` — TXT-fallback parser + builder.
+
+Wire-format reference: ``docs/rfc/wire-format.abnf`` (dns-aid-txt-fallback).
+"""
+
+from __future__ import annotations
+
+from dns_aid.core._txt_fallback import (
+    KEY_TARGET,
+    KEY_VERSION,
+    TXT_FALLBACK_VERSION,
+    TxtFallbackRecord,
+    build_txt_fallback,
+    parse_txt_fallback,
+)
+from dns_aid.core.models import AgentRecord, Protocol
+
+# ---------------------------------------------------------------------------
+# Constants smoke check
+# ---------------------------------------------------------------------------
+
+
+def test_version_constant() -> None:
+    assert TXT_FALLBACK_VERSION == "1"
+    assert KEY_VERSION == "v"
+    assert KEY_TARGET == "target"
+
+
+# ---------------------------------------------------------------------------
+# parse_txt_fallback — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_parse_minimal_record() -> None:
+    """v=1 + target= is the smallest legal record."""
+    result = parse_txt_fallback([b"v=1 target=mcp.example.com"])
+    assert isinstance(result, TxtFallbackRecord)
+    assert result.target == "mcp.example.com"
+    assert result.port == 443  # default
+    assert result.alpn is None
+    assert result.bap == []
+
+
+def test_parse_full_record() -> None:
+    body = (
+        b"v=1 target=mcp.example.com port=8443 alpn=mcp "
+        b"ipv4hint=192.0.2.5 ipv6hint=2001:db8::5 "
+        b"cap=https://example.com/cap/chat-v1.json "
+        b"cap-sha256=DEADBEEF bap=mcp/1,a2a/1 "
+        b"policy=https://example.com/policy/strict realm=prod "
+        b"sig=eyJhbGc connect-class=direct connect-meta=arn:example "
+        b"enroll-uri=https://example.com/enroll"
+    )
+    result = parse_txt_fallback([body])
+    assert result is not None
+    assert result.target == "mcp.example.com"
+    assert result.port == 8443
+    assert result.alpn == "mcp"
+    assert result.ipv4hint == "192.0.2.5"
+    assert result.ipv6hint == "2001:db8::5"
+    assert result.cap == "https://example.com/cap/chat-v1.json"
+    assert result.cap_sha256 == "DEADBEEF"
+    assert result.bap == ["mcp/1", "a2a/1"]
+    assert result.policy == "https://example.com/policy/strict"
+    assert result.realm == "prod"
+    assert result.sig == "eyJhbGc"
+    assert result.connect_class == "direct"
+    assert result.connect_meta == "arn:example"
+    assert result.enroll_uri == "https://example.com/enroll"
+
+
+def test_parse_multi_string_concatenation() -> None:
+    """RFC 1035 multi-string TXT — strings join on a single space before parse."""
+    result = parse_txt_fallback(
+        [
+            b"v=1 target=mcp.example.com",
+            b"port=8443 alpn=mcp",
+            b"cap=https://example.com/cap/v1",
+        ]
+    )
+    assert result is not None
+    assert result.target == "mcp.example.com"
+    assert result.port == 8443
+    assert result.alpn == "mcp"
+    assert result.cap == "https://example.com/cap/v1"
+
+
+def test_parse_quoted_value_with_space() -> None:
+    """shlex respects double-quoted values so a description-style field with a space works."""
+    result = parse_txt_fallback([b'v=1 target=mcp.example.com realm="prod east"'])
+    assert result is not None
+    assert result.realm == "prod east"
+
+
+# ---------------------------------------------------------------------------
+# parse_txt_fallback — rejection paths
+# ---------------------------------------------------------------------------
+
+
+def test_parse_missing_version_returns_none() -> None:
+    """No v= field → not a fallback record. Returns None silently."""
+    result = parse_txt_fallback([b"target=mcp.example.com port=443"])
+    assert result is None
+
+
+def test_parse_wrong_version_returns_none() -> None:
+    result = parse_txt_fallback([b"v=99 target=mcp.example.com"])
+    assert result is None
+
+
+def test_parse_missing_target_returns_none() -> None:
+    result = parse_txt_fallback([b"v=1 port=443"])
+    assert result is None
+
+
+def test_parse_empty_target_returns_none() -> None:
+    result = parse_txt_fallback([b"v=1 target="])
+    assert result is None
+
+
+def test_parse_invalid_utf8_returns_none() -> None:
+    result = parse_txt_fallback([b"v=1 target=\xff\xfe"])
+    assert result is None
+
+
+def test_parse_unclosed_quote_returns_none() -> None:
+    result = parse_txt_fallback([b'v=1 target=mcp.example.com realm="oops'])
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# parse_txt_fallback — recoverable malformations
+# ---------------------------------------------------------------------------
+
+
+def test_parse_invalid_port_falls_back_to_default() -> None:
+    """Malformed port= is not a fatal parse error — record is still usable."""
+    result = parse_txt_fallback([b"v=1 target=mcp.example.com port=not-a-number"])
+    assert result is not None
+    assert result.port == 443
+
+
+def test_parse_unknown_field_is_ignored() -> None:
+    """Forward-compat: a future field the SDK doesn't know about is skipped silently."""
+    result = parse_txt_fallback([b"v=1 target=mcp.example.com future-thing=hello"])
+    assert result is not None
+    assert result.target == "mcp.example.com"
+
+
+def test_parse_tokens_without_equals_are_ignored() -> None:
+    """A stray bareword in the body doesn't break the parse."""
+    result = parse_txt_fallback([b"v=1 stray-word target=mcp.example.com"])
+    assert result is not None
+    assert result.target == "mcp.example.com"
+
+
+def test_parse_key_case_insensitive() -> None:
+    """Keys are normalized to lowercase so backend casing differences don't bite."""
+    result = parse_txt_fallback([b"V=1 TARGET=mcp.example.com PORT=8443"])
+    assert result is not None
+    assert result.target == "mcp.example.com"
+    assert result.port == 8443
+
+
+# ---------------------------------------------------------------------------
+# build_txt_fallback
+# ---------------------------------------------------------------------------
+
+
+def _agent(**overrides: object) -> AgentRecord:
+    """Build a minimal AgentRecord with optional field overrides."""
+    base: dict[str, object] = {
+        "name": "chat",
+        "domain": "example.com",
+        "protocol": Protocol.MCP,
+        "target_host": "mcp.example.com",
+        "port": 443,
+        "capabilities": ["chat"],
+        "version": "1.0.0",
+    }
+    base.update(overrides)
+    return AgentRecord(**base)  # type: ignore[arg-type]
+
+
+def test_build_minimal() -> None:
+    """Default port + no optional params → just v=1 target= alpn=."""
+    body = build_txt_fallback(_agent())
+    assert body == "v=1 target=mcp.example.com alpn=mcp"
+
+
+def test_build_omits_default_port() -> None:
+    """port=443 is the default; don't emit it."""
+    body = build_txt_fallback(_agent(port=443))
+    assert "port=" not in body
+
+
+def test_build_includes_non_default_port() -> None:
+    body = build_txt_fallback(_agent(port=8443))
+    assert "port=8443" in body
+
+
+def test_build_includes_optional_fields() -> None:
+    agent = _agent(
+        cap_uri="https://example.com/cap",
+        cap_sha256="DEADBEEF",
+        policy_uri="https://example.com/policy/strict",
+        realm="prod",
+        bap=["mcp/1", "a2a/1"],
+        ipv4_hint="192.0.2.5",
+        sig="eyJhbGc",
+    )
+    body = build_txt_fallback(agent)
+    assert "cap=https://example.com/cap" in body
+    assert "cap-sha256=DEADBEEF" in body
+    assert "policy=https://example.com/policy/strict" in body
+    assert "realm=prod" in body
+    assert "bap=mcp/1,a2a/1" in body
+    assert "ipv4hint=192.0.2.5" in body
+    assert "sig=eyJhbGc" in body
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_minimal() -> None:
+    original = _agent()
+    body = build_txt_fallback(original)
+    parsed = parse_txt_fallback([body.encode("utf-8")])
+    assert parsed is not None
+    assert parsed.target == original.target_host
+    assert parsed.port == original.port
+    assert parsed.alpn == original.protocol.value
+
+
+def test_round_trip_full() -> None:
+    original = _agent(
+        port=8443,
+        cap_uri="https://example.com/cap",
+        cap_sha256="DEADBEEF",
+        policy_uri="https://example.com/policy/strict",
+        realm="prod",
+        bap=["mcp/1", "a2a/1"],
+        ipv4_hint="192.0.2.5",
+        ipv6_hint="2001:db8::5",
+        sig="eyJhbGc",
+        connect_class="direct",
+        connect_meta="arn:example",
+        enroll_uri="https://example.com/enroll",
+    )
+    body = build_txt_fallback(original)
+    parsed = parse_txt_fallback([body.encode("utf-8")])
+    assert parsed is not None
+    assert parsed.target == original.target_host
+    assert parsed.port == original.port
+    assert parsed.alpn == original.protocol.value
+    assert parsed.cap == original.cap_uri
+    assert parsed.cap_sha256 == original.cap_sha256
+    assert parsed.policy == original.policy_uri
+    assert parsed.realm == original.realm
+    assert parsed.bap == original.bap
+    assert parsed.ipv4hint == original.ipv4_hint
+    assert parsed.ipv6hint == original.ipv6_hint
+    assert parsed.sig == original.sig
+    assert parsed.connect_class == original.connect_class
+    assert parsed.connect_meta == original.connect_meta
+    assert parsed.enroll_uri == original.enroll_uri

--- a/tests/unit/test_txt_fallback.py
+++ b/tests/unit/test_txt_fallback.py
@@ -41,7 +41,7 @@ def test_parse_minimal_record() -> None:
     assert result.target == "mcp.example.com"
     assert result.port == 443  # default
     assert result.alpn is None
-    assert result.bap == []
+    assert result.bap is None
 
 
 def test_parse_full_record() -> None:
@@ -63,7 +63,9 @@ def test_parse_full_record() -> None:
     assert result.ipv6hint == "2001:db8::5"
     assert result.cap == "https://example.com/cap/chat-v1.json"
     assert result.cap_sha256 == "DEADBEEF"
-    assert result.bap == ["mcp/1", "a2a/1"]
+    # Raw pass-through — the consumer boundary (normalize_bap) collapses
+    # legacy comma lists; the parser itself does not interpret the value.
+    assert result.bap == "mcp/1,a2a/1"
     assert result.policy == "https://example.com/policy/strict"
     assert result.realm == "prod"
     assert result.sig == "eyJhbGc"
@@ -208,7 +210,7 @@ def test_build_includes_optional_fields() -> None:
         cap_sha256="DEADBEEF",
         policy_uri="https://example.com/policy/strict",
         realm="prod",
-        bap=["mcp/1", "a2a/1"],
+        bap="mcp=1.0",
         ipv4_hint="192.0.2.5",
         sig="eyJhbGc",
     )
@@ -217,7 +219,7 @@ def test_build_includes_optional_fields() -> None:
     assert "cap-sha256=DEADBEEF" in body
     assert "policy=https://example.com/policy/strict" in body
     assert "realm=prod" in body
-    assert "bap=mcp/1,a2a/1" in body
+    assert "bap=mcp=1.0" in body
     assert "ipv4hint=192.0.2.5" in body
     assert "sig=eyJhbGc" in body
 
@@ -244,7 +246,7 @@ def test_round_trip_full() -> None:
         cap_sha256="DEADBEEF",
         policy_uri="https://example.com/policy/strict",
         realm="prod",
-        bap=["mcp/1", "a2a/1"],
+        bap="mcp=1.0",
         ipv4_hint="192.0.2.5",
         ipv6_hint="2001:db8::5",
         sig="eyJhbGc",


### PR DESCRIPTION
## Summary

Rebase-with-rework of #135 onto current `main`. **All feature work is @nicknacnic's** — their six commits are cherry-picked with authorship and DCO sign-off intact; the final commit is the reconciliation needed because `main`'s discovery layer was rewritten for draft-02 (flat naming, ARD catalog pointers, DANE) while the PR was open.

Adds a third discovery tier for DNS providers that can't serve SVCB: **SVCB → HTTPS RR → TXT `v=1` fallback**, with a symmetric publisher path gated behind `supports_svcb=False` **and** `DNS_AID_EXPERIMENTAL_TXT_FALLBACK=1` (off for every bundled backend; consumer side is always-on, best-effort).

## What the reconciliation commit changes vs. #135 as-written

- **bap type drift (real runtime bug):** draft-02 made `AgentRecord.bap` a scalar; the PR's parser produced `list[str]`, so *every* TXT record failed model validation and was silently dropped. Now mirrors the SVCB path — raw wire value through the parser, `normalize_bap` at the consumer boundary (legacy comma lists collapse with a warning), scalar emission in the builder.
- **Ladder placement:** the full SVCB → HTTPS → TXT ladder runs per owner name — flat FQDN `{name}.{domain}` first; only when it's completely dry *and* legacy fallback is active does the same ladder run at the legacy `-01` shape, stamping `legacy_resolved=True`. Deliberate consequence (tested): a flat TXT `v=1` record beats a leftover legacy SVCB record — a publisher who placed a draft-02 flat TXT record has migrated.
- **Protocol semantics:** TXT-sourced records now run `_reconcile_protocol` (record signal — bap, then alpn — wins over the query probe), matching SVCB so the JWS binding check holds. The alpn-mismatch warning from #135 is kept for observability; its "FQDN protocol wins" rule is gone (under draft-02 the flat owner name carries no protocol).
- **Model-rejection boundary:** TXT bodies are attacker-shapable; a wire-valid/model-invalid record (e.g. underscored target) now logs a specific `txt_fallback.model_rejected` warning instead of being swallowed as a generic debug-level query failure.
- **ABNF ↔ parser reconciliation:** the grammar now defines the quoting/tokenization the shlex-based parser implements (bare values, or double-quoted with `\"` / `\` only), and `bap-kv` is the draft-02 scalar.
- **Tests:** updated to flat naming + scalar bap; new coverage for the legacy-TXT path, flat-TXT-vs-stale-legacy-SVCB precedence, and the model-rejection boundary.

## Test plan

- [x] `ruff check` + `ruff format --check` clean (one pre-existing `test_lister.py` format drift on main excluded)
- [x] `mypy` clean on all touched modules
- [x] Full suite: **2109 passed** locally (2 failures are live `httpbin.org` 503s — external service, not run in CI)
- [x] 47/47 TXT-fallback tests, including the 6 new/updated ones
- [ ] CI green on this PR

Supersedes #135 (left open for discussion/reference).

Co-authored-by: Layer8 <NWillAU900@gmail.com>