### PR TITLE
docs(positioning): correct ANS characterization per feedback from the ANS team

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -4,9 +4,9 @@
 
 ## vs Competing Proposals
 
-| Approach | Problem | DNS-AID Advantage |
-|----------|---------|-------------------|
-| **ANS (GoDaddy)** | Centralized registry, KYC required, single gatekeeper | Federated — you control your domain, publish instantly |
+| Approach | Trade-off | DNS-AID Advantage |
+|----------|-----------|-------------------|
+| **ANS (GoDaddy)** | Adjacent registration/identity layer: RA-issued identity certificates, registration via ACME domain-control validation (DNS-01/HTTP-01); organizational verification is an optional higher trust tier. RA federation is specified; one RA operational today | No registration step at all — publish SVCB records in the zone you already control |
 | **Google (A2A + UCP)** | Discovery via Gemini/Search, payments via UCP | Neutral discovery — no platform lock-in or transaction fees |
 | **.agent gTLD** | Requires ICANN approval, ongoing domain fees | Works NOW with domains you already own |
 | **AgentDNS (China Telecom)** | Requires 6G infrastructure, carrier control | Works NOW on existing DNS infrastructure |
@@ -26,8 +26,8 @@
 
 ## The Sovereignty Question
 
-> **Who controls agent discovery?**
-> - ANS: GoDaddy (US company as gatekeeper)
+> **Who sits in the trust path?**
+> - ANS: a Registration Authority validates domain control and issues identity certificates — names anchor to domains the operator already owns; RA federation is specified, one RA operational today
 > - AgentDNS: China Telecom (state-owned carrier)
 > - Web3: Ethereum Foundation
 > - **DNS-AID: You control your own domain**


### PR DESCRIPTION
## Summary

Fixes #39, filed by @scourtney-godaddy (ANS team) in February and unanswered since.

`docs/positioning.md` described ANS as *"Centralized registry, KYC required, single gatekeeper"* (comparison table) and *"GoDaddy (US company as gatekeeper)"* (Sovereignty section). The ANS team disputed this with specifics, and the claims aren't supported by the ANS spec:

- Registration uses **ACME domain-control validation** (DNS-01/HTTP-01 — the Let's Encrypt mechanism), not KYC; organizational verification is an **optional** higher trust tier, not an entry gate.
- Names anchor to **domains the operator already owns**; the Registration Authority confirms domain control, it doesn't grant or withhold names. **RA federation is specified** (`registrar_id` + federation protocol); one RA operational today.

The README's equivalent language was already removed in #133; this doc is where that content was relocated, and the README still links to it — so the correction needs to land here too.

## Changes (5 lines, one non-normative doc)

- **ANS table row** → accurate description of the registration/identity layer, keeping the genuine contrast: DNS-AID has *no registration step at all* — you publish SVCB records in the zone you already control.
- **Sovereignty bullet** → *"a Registration Authority validates domain control and issues identity certificates — names anchor to domains the operator already owns"*, and the block's question softened from "Who controls agent discovery?" to "Who sits in the trust path?" (an RA in the trust path is a fair, verifiable statement; "gatekeeper" was not).
- **Column header** `Problem` → `Trade-off` — same de-antagonism already applied to the README in #133.

Deliberately narrow: the AgentDNS/Web3 lines carry similar unverified characterizations, but no one has disputed them on the record; happy to do a broader scrub in a follow-up if wanted.

## Test plan
- [ ] CI green (docs-only)
- Merging auto-closes #39; a reply to @scourtney-godaddy is drafted separately.