### PR TITLE
chore: bump draft pin to -02 (#194) and retire the pyjwt CVE suppression (#141)

### DIFF
--- a/.github/draft-tracking.json
+++ b/.github/draft-tracking.json
@@ -1,6 +1,6 @@
 {
   "slug": "draft-mozleywilliams-dnsop-dnsaid",
-  "known_rev": "01",
+  "known_rev": "02",
   "author_person_id": 137653,
   "watched_keywords": [
     "dnsaid",

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,8 +92,7 @@ jobs:
             --ignore-vuln CVE-2026-1703 \
             --ignore-vuln CVE-2026-34073 \
             --ignore-vuln CVE-2026-25645 \
-            --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln CVE-2025-45768
+            --ignore-vuln CVE-2026-3219
         # CVE-2026-4539  pygments 2.19.2   — ReDoS in AdlLexer, local-only, no fix released
         # CVE-2025-8869  pip 25.2          — tar symlink traversal, mitigated by Python >=3.12 PEP 706
         # CVE-2026-1703  pip 25.2          — wheel path traversal, limited to install dir prefixes
@@ -102,10 +101,6 @@ jobs:
         # CVE-2026-3219  pip 26.0.1        — runner-image pip; affects the package manager only,
         #                                    not the dns-aid runtime; no user-supplied input flows
         #                                    through pip in CI; awaiting upstream pip fix
-        # CVE-2025-45768 pyjwt 2.12.1      — DISPUTED by maintainer (NVD: "Analyzed", note
-        #                                    that "key length is chosen by the application").
-        #                                    Snyk does not list this CVE; pyjwt's own GHSA
-        #                                    advisories do not list it. Third-party-filed
-        #                                    "weak encryption" claim; actually a usage concern.
-        #                                    DNS-AID does not generate JWTs in the SDK path.
-        #                                    See SECURITY.md + tracking issue #141.
+        # (CVE-2025-45768 pyjwt suppression removed 2026-07-14: OSV bounded the
+        #  affected range to <=2.10.1 on 2026-05-21; we ship 2.13.0, so pip-audit
+        #  no longer reports it. History: SECURITY.md + closed issue #141.)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,40 +134,23 @@ When using DNS-AID in production:
 
 We publish accepted (documented, risk-assessed) dependency CVEs here so reviewers and downstream users can verify the rationale. Each entry is also suppressed in `.github/workflows/security.yml` with a per-CVE comment and tracked via a GitHub issue.
 
-### CVE-2025-45768 — pyjwt (disputed; "weak encryption" claim)
+*(none currently)*
 
-- **Package**: `pyjwt 2.12.1` (transitive via the `mcp` extra; also in `all`).
-- **Status — DISPUTED**: This CVE is **disputed by the pyjwt maintainer**.
-  Per the [NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2025-45768)
-  (status: Analyzed), the maintainer's published note states:
-  *"this is disputed by the Supplier because the key length is chosen
-  by the application that uses the library."* The maintainer's own
-  [pyjwt Security Advisories](https://github.com/jpadilla/pyjwt/security/advisories)
-  list does NOT include CVE-2025-45768 — only three substantive,
-  fixed CVEs are listed there (CVE-2026-32597, CVE-2024-53861,
-  CVE-2022-29217). The [Snyk vulnerability database](https://security.snyk.io/package/pip/PyJWT/2.12.1)
-  does not list this CVE either ("No direct vulnerabilities have been
-  found for this package in Snyk's vulnerability database"). The CVE
-  was filed by a third party with a gist as the supporting evidence
-  and no fix commit. CVSS 3.1 `AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H`
-  per NVD, but the underlying claim is contested.
-- **Why we suppress in CI rather than re-prioritise as resolved**:
-  `pip-audit` mirrors OSV/PYSEC entries which retain the CVE without
-  the dispute annotation. The `--ignore-vuln` suppression keeps CI
-  green; this document carries the substantive context.
-- **DNS-AID exposure**: **Definitionally zero**. The disputed claim is
-  about applications that pick short keys; DNS-AID does not generate
-  JWTs in the SDK path. The `credential_provider` callback returns
-  tokens for transport (the application's IdP client generates them);
-  decoding is the receiving server's responsibility. The `mcp` extra
-  includes pyjwt for OAuth-protected MCP servers, which use
-  operator-issued tokens with operator-chosen key lengths.
-- **Mitigation**: None required at the SDK layer.
-- **Re-evaluation criteria**: Close [tracking issue #141](https://github.com/dns-aid/dns-aid-core/issues/141)
-  when ANY of the following changes:
-  - NVD status changes away from "Analyzed / Disputed".
-  - Snyk adds this CVE to their database.
-  - The pyjwt maintainer accepts the report and ships a fix.
+### Previously accepted, since resolved
+
+- **CVE-2025-45768 — pyjwt** (disputed "weak encryption" claim; tracked
+  in [#141](https://github.com/dns-aid/dns-aid-core/issues/141)):
+  suppressed 2026-05 → 2026-07 while the OSV/PYSEC entry listed all
+  pyjwt versions as affected. On 2026-05-21 OSV bounded the affected
+  range to `<= 2.10.1`
+  ([PYSEC-2025-183](https://osv.dev/vulnerability/PYSEC-2025-183));
+  this project ships pyjwt ≥ 2.13.0, so `pip-audit` no longer reports
+  it and the suppression was removed. The dispute itself was never
+  resolved — the maintainer's position ("key length is chosen by the
+  application") stands, pyjwt's own GHSA list and Snyk never carried
+  the CVE, and DNS-AID's exposure was definitionally zero throughout
+  (the SDK does not generate JWTs; tokens come from the application's
+  IdP with operator-chosen key lengths).
 
 ## Security Updates
 


### PR DESCRIPTION
## Summary

Two housekeeping items from open-issue triage. Merging auto-closes both issues.

**#194 — draft-watch pin (1 line).** The watcher (merged in #139) correctly detected that Datatracker is at rev **02** while `.github/draft-tracking.json` pins **01**. The codebase already implements draft-02 — `docs/architecture.md` states it outright, and the flat-owner-name / scalar-`bap` semantics are in `src/` — so this is purely a stale pin, not an unsynchronized migration. The keyword-fallback hit in #194 (`draft-mozley-aidiscovery`) is a Problem Statement draft by the same author — parallel work, not an unfiled successor; no action needed.

**#141 — pyjwt CVE-2025-45768 suppression retired.** The issue's own resolution criteria (NVD flip / Snyk listing / GHSA acceptance / fix release) were never met — instead the trigger disappeared: **OSV bounded the affected range to `<= 2.10.1` on 2026-05-21** ([PYSEC-2025-183](https://osv.dev/vulnerability/PYSEC-2025-183); it was unbounded before, which is the only reason pip-audit flagged our 2.12.1). Main ships **pyjwt 2.13.0**, outside the range. Verified locally: pip-audit **without** the suppression reports "No known vulnerabilities found." The `--ignore-vuln` flag is removed and the SECURITY.md entry moves to a "previously accepted, since resolved" note preserving the dispute history.

## Test plan
- [x] `pip-audit` run locally with the exact CI flag set minus CVE-2025-45768 → clean
- [ ] Dependency Audit check green on this PR (the authoritative validation)
- [ ] draft-watch check green (pin now matches Datatracker state)

Fixes #194
Fixes #141