### PR TITLE
feat(cloudflare): write DNS-AID private-use SVCB keys natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (quoted, with escaping) instead of space-joining all values into a single string.
   The discoverer iterates character-strings individually, so the previous join
   corrupted capability parsing and any value containing a space. Read paths parse the
-  presentation-format `content` back into a list. Mirrors the Route 53 backend.
+  presentation-format `content` back into a list. Like the Route 53 backend's
+  per-value quoting, but additionally escaping embedded quotes and backslashes.
   *Migration note:* TXT records written by the previous Cloudflare backend (unquoted,
   space-joined) now read back split on whitespace. For `key=value` tokens this is the
   correct recovery, but a single legacy value that legitimately contained spaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Supports private-use SVCB keys natively (`supports_private_svcb_keys = True`),
   so all DNS-AID custom SvcParams are written directly on the SVCB record without TXT demotion.
   Install: `pip install dns-aid[akamai-edgedns]`.
+- **Cloudflare backend now writes DNS-AID private-use SVCB keys natively.** Verified
+  against the Cloudflare API v4 that SVCB `data.value` accepts RFC 9460 generic
+  private-use SvcParamKeys (`key65280`–`key65534`), so `CloudflareBackend` sets
+  `supports_private_svcb_keys = True`. DNS-AID custom params (cap, cap-sha256, bap,
+  policy, realm, … → `key65400`–`key65409`) are written directly to the SVCB record
+  instead of being demoted to TXT, matching the NS1 and NIOS backends.
+
+### Fixed
+
+- **Cloudflare TXT records now write each value as its own RFC 1035 `<character-string>`**
+  (quoted, with escaping) instead of space-joining all values into a single string.
+  The discoverer iterates character-strings individually, so the previous join
+  corrupted capability parsing and any value containing a space. Read paths parse the
+  presentation-format `content` back into a list. Mirrors the Route 53 backend.
+- **Cloudflare record writes converge under concurrent-publish races.** A shared
+  `_write_record` helper treats Cloudflare error 81058 ("identical record already
+  exists") on POST as idempotent success, and recreates via POST when a PUT 404s
+  because the record was deleted between lookup and update.
+- **`CloudflareBackend.get_record` no longer masks auth/network/server errors as
+  "record not found."** Only an empty result set means not-found; other errors
+  propagate so reconciliation cannot silently recreate or overwrite records.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corrupted capability parsing and any value containing a space. Read paths parse the
   presentation-format `content` back into a list. Like the Route 53 backend's
   per-value quoting, but additionally escaping embedded quotes and backslashes.
+  The read path uses a DNS master-file tokenizer (not `shlex`): it splits
+  quoted/bare `<character-string>` tokens, decodes `\DDD` decimal octet escapes
+  (how Cloudflare returns non-ASCII) back to UTF-8, and never raises on malformed
+  input — fixing a bare apostrophe dumping the whole value back as one string and
+  non-ASCII values reading back mangled.
   *Migration note:* TXT records written by the previous Cloudflare backend (unquoted,
   space-joined) now read back split on whitespace. For `key=value` tokens this is the
   correct recovery, but a single legacy value that legitimately contained spaces
   (e.g. a free-text description) will read back fragmented until it is re-published.
 - **Cloudflare record writes converge under concurrent-publish races.** A shared
   `_write_record` helper treats Cloudflare error 81058 ("identical record already
-  exists") on POST as idempotent success, and recreates via POST when a PUT 404s
-  because the record was deleted between lookup and update.
+  exists") as idempotent success **only on a POST**, and recreates via POST when a
+  PUT 404s because the record was deleted between lookup and update. An 81058 on a
+  PUT now raises: Cloudflare allows multiple records at one name, so a PUT colliding
+  with a *different* record there does not apply the update, and reporting success
+  would falsely claim the write took effect.
+- **Cloudflare API traffic honours rate limits.** All requests route through a shared
+  `_request` helper that retries on HTTP 429 (and on a 200 body carrying a rate-limit
+  error), honouring the `Retry-After` header when present and otherwise backing off
+  exponentially, so reads, writes, and deletes all handle throttling uniformly.
 - **`CloudflareBackend.get_record` no longer masks auth/network/server errors as
   "record not found."** Only an empty result set means not-found; other errors
   propagate so reconciliation cannot silently recreate or overwrite records.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.27.0] - 2026-07-22
-
 ### Added
 
-- **Akamai Edge DNS backend** (`akamai-edgedns`). New DNS backend using the
-  Akamai Config DNS API v2 with EdgeGrid authentication (`edgegrid-python`).
-  Supports private-use SVCB keys natively (`supports_private_svcb_keys = True`),
-  so all DNS-AID custom SvcParams are written directly on the SVCB record without TXT demotion.
-  Install: `pip install dns-aid[akamai-edgedns]`.
 - **Cloudflare backend now writes DNS-AID private-use SVCB keys natively.** Verified
   against the Cloudflare API v4 that SVCB `data.value` accepts RFC 9460 generic
   private-use SvcParamKeys (`key65280`–`key65534`), so `CloudflareBackend` sets
@@ -54,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`CloudflareBackend.get_record` no longer masks auth/network/server errors as
   "record not found."** Only an empty result set means not-found; other errors
   propagate so reconciliation cannot silently recreate or overwrite records.
+
+## [0.27.0] - 2026-07-22
+
+### Added
+
+- **Akamai Edge DNS backend** (`akamai-edgedns`). New DNS backend using the
+  Akamai Config DNS API v2 with EdgeGrid authentication (`edgegrid-python`).
+  Supports private-use SVCB keys natively (`supports_private_svcb_keys = True`),
+  so all DNS-AID custom SvcParams are written directly on the SVCB record without TXT demotion.
+  Install: `pip install dns-aid[akamai-edgedns]`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The discoverer iterates character-strings individually, so the previous join
   corrupted capability parsing and any value containing a space. Read paths parse the
   presentation-format `content` back into a list. Mirrors the Route 53 backend.
+  *Migration note:* TXT records written by the previous Cloudflare backend (unquoted,
+  space-joined) now read back split on whitespace. For `key=value` tokens this is the
+  correct recovery, but a single legacy value that legitimately contained spaces
+  (e.g. a free-text description) will read back fragmented until it is re-published.
 - **Cloudflare record writes converge under concurrent-publish races.** A shared
   `_write_record` helper treats Cloudflare error 81058 ("identical record already
   exists") on POST as idempotent success, and recreates via POST when a PUT 404s

--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ DDNS (Dynamic DNS) is a universal backend that works with any DNS server support
 
 ### Cloudflare Setup
 
-Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to its free tier and excellent API support. DNS-AID fully supports Cloudflare's SVCB record implementation.
+Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to its free tier and excellent API support. DNS-AID fully supports Cloudflare's SVCB record implementation, including **native private-use SVCB keys** — DNS-AID's custom parameters (`cap`, `cap-sha256`, `bap`, `policy`, `realm`, ...) are written directly to the SVCB record (`key65400`–`key65409`), with no TXT demotion.
 
 #### Environment Variables
 
@@ -999,6 +999,7 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 
 - **Free tier**: DNS hosting is free for unlimited domains
 - **SVCB support**: Full RFC 9460 compliance with SVCB Type 64 records
+- **Native private-use SVCB keys**: DNS-AID custom params go straight into the SVCB record (`key65400`–`key65409`) — no TXT demotion, matching NS1 and NIOS
 - **Global anycast**: Fast DNS resolution worldwide
 - **Simple API**: Well-documented REST API v4
 - **Full DNS-AID compliance**: Supports ServiceMode SVCB with all parameters

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -881,6 +881,29 @@ backend = AkamaiEdgeDNSBackend(
 
 **Concurrency**: Akamai serializes modifications per zone. The backend serializes its own writes per zone and automatically retries transient `409 concurrentZoneModification` responses with exponential backoff, so concurrent `publish_agent()` calls are safe.
 
+### CloudflareBackend
+
+Cloudflare DNS REST API v4 implementation.
+
+```python
+from dns_aid.backends.cloudflare import CloudflareBackend
+
+backend = CloudflareBackend()  # reads CLOUDFLARE_API_TOKEN from env
+
+# Or with explicit configuration
+backend = CloudflareBackend(
+    api_token="your-api-token",
+    zone_id="optional-zone-id",  # auto-discovered from domain if omitted
+)
+```
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLOUDFLARE_API_TOKEN` | Yes | - | API token with Zone → DNS → Edit (and Read) permissions |
+| `CLOUDFLARE_ZONE_ID` | No | - | Zone ID (auto-discovered by zone name if omitted) |
+
+**DNS-AID Compliance**: Cloudflare supports ServiceMode SVCB records (priority > 0) with full SVC parameters including private-use keys (`key65400`–`key65409`). Cloudflare natively accepts private-use SVCB keys via the `supports_private_svcb_keys` property — cap_uri, cap_sha256, bap, policy_uri, and realm go directly into the SVCB record without TXT demotion. TXT records are still written for human-readable metadata (capabilities, version, description), each value stored as its own RFC 1035 character-string.
+
 ### DDNSBackend
 
 RFC 2136 Dynamic DNS implementation. Works with BIND, Windows DNS, PowerDNS, Knot DNS, and any RFC 2136 compliant server.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -823,7 +823,7 @@ backend = InfobloxNIOSBackend(
 | `NIOS_WAPI_VERSION` | No | `2.13.7` | WAPI version |
 | `NIOS_VERIFY_SSL` | No | `false` | Verify TLS certificate |
 
-**DNS-AID Compliance**: NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters including custom DNS-AID keys (`key65400`–`key65408`). NIOS natively supports private-use SVCB keys via the `supports_private_svcb_keys` property.
+**DNS-AID Compliance**: NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC parameters including custom DNS-AID keys (`key65400`–`key65409`). NIOS natively supports private-use SVCB keys via the `supports_private_svcb_keys` property.
 
 ### NS1Backend
 
@@ -846,7 +846,7 @@ backend = NS1Backend(
 | `NS1_API_KEY` | Yes | - | NS1 API key with DNS read/write permissions |
 | `NS1_BASE_URL` | No | `https://api.nsone.net/v1` | API base URL (for private/dedicated deployments) |
 
-**DNS-AID Compliance**: NS1 supports ServiceMode SVCB records with full SVC parameters including private-use keys (`key65400`–`key65408`). NS1 natively accepts private-use SVCB keys — cap_uri, policy_uri, and realm go directly into the SVCB record without TXT demotion.
+**DNS-AID Compliance**: NS1 supports ServiceMode SVCB records with full SVC parameters including private-use keys (`key65400`–`key65409`). NS1 natively accepts private-use SVCB keys — cap_uri, policy_uri, and realm go directly into the SVCB record without TXT demotion.
 
 ### AkamaiEdgeDNSBackend
 

--- a/src/dns_aid/backends/base.py
+++ b/src/dns_aid/backends/base.py
@@ -24,13 +24,14 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 # Standard SVCB SvcParamKeys accepted by all known DNS providers (RFC 9460).
-# Private-use keys (key65280–key65534) are rejected by Route 53, Cloudflare,
-# and Cloud DNS. NIOS and NS1 support them natively.
+# Private-use keys (key65280–key65534) are rejected by Route 53 and Cloud DNS.
+# NIOS, NS1, and Cloudflare support them natively (Cloudflare's SVCB
+# data.value accepts key65280–key65534 verbatim, verified against the v4 API).
 # DDNS returns None (auto-detect): tries native first, falls back to demotion.
 #
 # supports_private_svcb_keys property:
-#   True  → pass all params to SVCB (NS1, NIOS)
-#   False → demote custom params to TXT (Route53, Cloudflare, CloudDNS, BloxOne)
+#   True  → pass all params to SVCB (NS1, NIOS, Cloudflare)
+#   False → demote custom params to TXT (Route53, CloudDNS, BloxOne)
 #   None  → try native, auto-fallback on server rejection (DDNS)
 _STANDARD_SVCB_KEYS = frozenset(
     {
@@ -77,9 +78,9 @@ class DNSBackend(ABC):
         """Whether this backend accepts private-use SVCB keys (key65280–key65534).
 
         Returns:
-            ``True``  — backend accepts private keys natively (NS1, NIOS).
-                        All params go directly to SVCB.
-            ``False`` — backend rejects private keys (Route53, Cloudflare).
+            ``True``  — backend accepts private keys natively (NS1, NIOS,
+                        Cloudflare). All params go directly to SVCB.
+            ``False`` — backend rejects private keys (Route53, CloudDNS).
                         Custom params demoted to TXT.
             ``None``  — unknown, try native first, auto-fallback on error (DDNS).
                         First publish attempts full SVCB; if server rejects,

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -11,6 +11,7 @@ Supports zone ID or automatic zone lookup by domain name.
 from __future__ import annotations
 
 import os
+import shlex
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -21,8 +22,39 @@ from dns_aid.backends.base import DNSBackend
 
 logger = structlog.get_logger(__name__)
 
-# Private-use SVCB key demotion is handled by the DNSBackend base class.
-# Cloudflare rejects key65280–key65534 — base class demotes them to TXT.
+# Cloudflare API error code returned when an identical record already exists.
+# Used to make create-then-update idempotent under concurrent publishes.
+_CF_ERR_IDENTICAL_RECORD = 81058
+
+
+def _quote_txt_value(value: str) -> str:
+    """Wrap a single TXT value as one RFC 1035 <character-string>.
+
+    Embedded backslashes and double quotes are escaped so the value survives
+    Cloudflare's presentation-format parser as a single string.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _parse_txt_content(content: str) -> list[str]:
+    """Parse a Cloudflare TXT ``content`` string into its character-strings.
+
+    Cloudflare returns TXT rdata in DNS presentation format: one or more
+    double-quoted (or bare) character-strings separated by whitespace, e.g.
+    ``"cap=..." "version=1.0.0"``. ``shlex`` splits on whitespace while
+    honouring quotes and backslash escapes, which matches DNS master-file
+    semantics and inverts :func:`_quote_txt_value`.
+    """
+    if not content:
+        return []
+    try:
+        return shlex.split(content)
+    except ValueError:
+        # Unbalanced quotes (shouldn't happen from Cloudflare) — fall back to
+        # returning the raw content as a single value rather than raising.
+        logger.debug("Unparseable TXT content; returning raw", content=content)
+        return [content]
 
 
 class CloudflareBackend(DNSBackend):
@@ -68,6 +100,19 @@ class CloudflareBackend(DNSBackend):
     @property
     def name(self) -> str:
         return "cloudflare"
+
+    @property
+    def supports_private_svcb_keys(self) -> bool:
+        """Cloudflare accepts private-use SVCB keys (key65280–key65534) natively.
+
+        Verified against the Cloudflare API v4: the SVCB record ``data.value``
+        field accepts RFC 9460 generic private-use SvcParamKeys in ``keyNNNNN``
+        form (e.g. the DNS-AID ``key65400``–``key65409`` set for cap, cap-sha256,
+        bap, policy, realm, ...). They are stored and served verbatim, so the
+        base class passes all params straight to the SVCB record instead of
+        demoting the DNS-AID custom keys to TXT.
+        """
+        return True
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create httpx async client.
@@ -208,6 +253,84 @@ class CloudflareBackend(DNSBackend):
             "value": value_str,
         }
 
+    async def _write_record(
+        self,
+        zone_id: str,
+        fqdn: str,
+        record_type: str,
+        request_data: dict[str, Any],
+        existing_id: str | None,
+    ) -> str:
+        """Create (POST) or update (PUT) a record; idempotent under both races.
+
+        There is an unavoidable check-then-act window between looking up an
+        existing record id (``_get_record_id``) and writing. A concurrent
+        publisher can change the world in that window in two ways, and this
+        method converges on the intended state for both:
+
+        * **Create race** — we found no existing record and POST, but a racer
+          created an identical one first. Cloudflare answers HTTP 400 with error
+          code 81058 ("An identical record already exists"). For an idempotent
+          upsert that is success, not failure, so we return the fqdn.
+        * **Delete race** — we found an existing id and PUT, but a racer deleted
+          it first, so the PUT 404s. We recreate the record with a POST.
+
+        Any other non-success response raises ``ValueError`` carrying the
+        Cloudflare error payload (more actionable than a bare ``HTTPStatusError``
+        and uniform whether the failure arrives as a 4xx/5xx or as a 200 with
+        ``success: false``).
+        """
+        client = await self._get_client()
+
+        if existing_id:
+            response = await client.put(
+                f"/zones/{zone_id}/dns_records/{existing_id}",
+                json=request_data,
+            )
+            # Delete race: the record vanished between lookup and update.
+            if response.status_code == 404:
+                logger.info(
+                    "Record vanished before update; recreating",
+                    fqdn=fqdn,
+                    type=record_type,
+                )
+                response = await client.post(
+                    f"/zones/{zone_id}/dns_records",
+                    json=request_data,
+                )
+        else:
+            response = await client.post(
+                f"/zones/{zone_id}/dns_records",
+                json=request_data,
+            )
+
+        try:
+            data = response.json()
+        except ValueError:
+            # Non-JSON body (e.g. an edge 5xx returning HTML).
+            data = {}
+
+        # Create race: an identical record already exists — idempotent success.
+        if response.status_code == 400 and any(
+            e.get("code") == _CF_ERR_IDENTICAL_RECORD for e in (data.get("errors") or [])
+        ):
+            logger.info(
+                "Record already exists; treating as idempotent success",
+                fqdn=fqdn,
+                type=record_type,
+            )
+            return fqdn
+
+        if not data.get("success", False):
+            errors = data.get("errors") or []
+            raise ValueError(
+                f"Failed to write {record_type} record (HTTP {response.status_code}): {errors}"
+            )
+
+        record_id = data["result"]["id"]
+        logger.info("Record written", fqdn=fqdn, type=record_type, record_id=record_id)
+        return fqdn
+
     async def create_svcb_record(
         self,
         zone: str,
@@ -219,7 +342,6 @@ class CloudflareBackend(DNSBackend):
     ) -> str:
         """Create SVCB record in Cloudflare."""
         zone_id = await self._get_zone_id(zone)
-        client = await self._get_client()
 
         # Build FQDN
         fqdn = f"{name}.{zone}".rstrip(".")
@@ -247,30 +369,7 @@ class CloudflareBackend(DNSBackend):
             "ttl": ttl,
         }
 
-        if existing_id:
-            # Update existing record
-            response = await client.put(
-                f"/zones/{zone_id}/dns_records/{existing_id}",
-                json=request_data,
-            )
-        else:
-            # Create new record
-            response = await client.post(
-                f"/zones/{zone_id}/dns_records",
-                json=request_data,
-            )
-
-        response.raise_for_status()
-        data = response.json()
-
-        if not data.get("success"):
-            errors = data.get("errors", [])
-            raise ValueError(f"Failed to create SVCB record: {errors}")
-
-        record_id = data["result"]["id"]
-        logger.info("SVCB record created", fqdn=fqdn, record_id=record_id)
-
-        return fqdn
+        return await self._write_record(zone_id, fqdn, "SVCB", request_data, existing_id)
 
     async def create_txt_record(
         self,
@@ -281,7 +380,6 @@ class CloudflareBackend(DNSBackend):
     ) -> str:
         """Create TXT record in Cloudflare."""
         zone_id = await self._get_zone_id(zone)
-        client = await self._get_client()
 
         # Build FQDN
         fqdn = f"{name}.{zone}".rstrip(".")
@@ -298,10 +396,14 @@ class CloudflareBackend(DNSBackend):
         # Check if record exists (for update)
         existing_id = await self._get_record_id(zone_id, fqdn, "TXT")
 
-        # Cloudflare TXT records use "content" field — raw value, no extra quoting.
-        # The API stores whatever string is provided literally; adding '"..."' wrapping
-        # causes those literal quote characters to appear in RDATA and break parsing.
-        content = " ".join(values)
+        # Each value must be its own RFC 1035 <character-string>. Cloudflare's
+        # "content" field is DNS presentation format, so we wrap each value in
+        # double quotes (escaping embedded quotes/backslashes). Space-joining
+        # unquoted would collapse all values into a SINGLE character-string on
+        # the wire, and the discoverer iterates character-strings one by one
+        # (see core/discoverer.py) — merging them corrupts capability parsing
+        # and any value containing a space. Mirrors the Route 53 backend.
+        content = " ".join(_quote_txt_value(v) for v in values)
 
         request_data = {
             "type": "TXT",
@@ -310,33 +412,11 @@ class CloudflareBackend(DNSBackend):
             "ttl": ttl,
         }
 
-        if existing_id:
-            # Update existing record
-            response = await client.put(
-                f"/zones/{zone_id}/dns_records/{existing_id}",
-                json=request_data,
-            )
-        else:
-            # Create new record
-            response = await client.post(
-                f"/zones/{zone_id}/dns_records",
-                json=request_data,
-            )
+        return await self._write_record(zone_id, fqdn, "TXT", request_data, existing_id)
 
-        response.raise_for_status()
-        data = response.json()
-
-        if not data.get("success"):
-            errors = data.get("errors", [])
-            raise ValueError(f"Failed to create TXT record: {errors}")
-
-        record_id = data["result"]["id"]
-        logger.info("TXT record created", fqdn=fqdn, record_id=record_id)
-
-        return fqdn
-
-    # publish_agent() inherited from DNSBackend base class — automatically
-    # demotes private-use SVCB keys to TXT since Cloudflare rejects them.
+    # publish_agent() is inherited from DNSBackend. Because
+    # supports_private_svcb_keys is True, the base class writes DNS-AID's
+    # private-use SVCB keys directly to the SVCB record (no TXT demotion).
 
     async def delete_record(
         self,
@@ -424,7 +504,7 @@ class CloudflareBackend(DNSBackend):
 
                 # Extract values based on record type
                 if rtype == "TXT":
-                    values = [record.get("content", "")]
+                    values = _parse_txt_content(record.get("content", ""))
                 elif rtype == "SVCB":
                     # SVCB records have structured data
                     svcb_data = record.get("data", {})
@@ -487,44 +567,43 @@ class CloudflareBackend(DNSBackend):
         # Build FQDN
         fqdn = f"{name}.{zone}".rstrip(".")
 
-        try:
-            response = await client.get(
-                f"/zones/{zone_id}/dns_records",
-                params={"name": fqdn, "type": record_type},
-            )
-            response.raise_for_status()
-            data = response.json()
+        response = await client.get(
+            f"/zones/{zone_id}/dns_records",
+            params={"name": fqdn, "type": record_type},
+        )
+        # A successful query for a non-existent record returns an empty result
+        # set, not an error. Only that means "not found" — auth, network, or
+        # server errors must propagate rather than be masked as a missing
+        # record (which would let reconciliation silently recreate/overwrite).
+        response.raise_for_status()
+        data = response.json()
 
-            records = data.get("result", [])
-            if not records:
-                return None
-
-            record = records[0]
-
-            # Extract values based on record type
-            if record_type == "TXT":
-                values = [record.get("content", "")]
-            elif record_type == "SVCB":
-                svcb_data = record.get("data", {})
-                priority = svcb_data.get("priority", 0)
-                target = svcb_data.get("target", "")
-                value = svcb_data.get("value", "")
-                values = [f"{priority} {target} {value}".strip()]
-            else:
-                values = [record.get("content", "")]
-
-            return {
-                "name": name,
-                "fqdn": fqdn,
-                "type": record_type,
-                "ttl": record.get("ttl", 0),
-                "values": values,
-                "id": record.get("id"),
-            }
-
-        except Exception as e:
-            logger.debug("Record not found", fqdn=fqdn, type=record_type, error=str(e))
+        records = data.get("result", [])
+        if not records:
             return None
+
+        record = records[0]
+
+        # Extract values based on record type
+        if record_type == "TXT":
+            values = _parse_txt_content(record.get("content", ""))
+        elif record_type == "SVCB":
+            svcb_data = record.get("data", {})
+            priority = svcb_data.get("priority", 0)
+            target = svcb_data.get("target", "")
+            value = svcb_data.get("value", "")
+            values = [f"{priority} {target} {value}".strip()]
+        else:
+            values = [record.get("content", "")]
+
+        return {
+            "name": name,
+            "fqdn": fqdn,
+            "type": record_type,
+            "ttl": record.get("ttl", 0),
+            "values": values,
+            "id": record.get("id"),
+        }
 
     async def list_zones(self) -> list[dict]:
         """

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -27,14 +27,23 @@ logger = structlog.get_logger(__name__)
 _CF_ERR_IDENTICAL_RECORD = 81058
 
 
+def _escape_dns_char_string(value: str) -> str:
+    """Escape backslashes and double quotes for a DNS presentation-format string.
+
+    Shared by the TXT and SVCB writers so a value carrying a ``"`` or ``\\``
+    survives Cloudflare's presentation-format parser as a single, intact token
+    rather than terminating the quoted string early.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _quote_txt_value(value: str) -> str:
     """Wrap a single TXT value as one RFC 1035 <character-string>.
 
     Embedded backslashes and double quotes are escaped so the value survives
     Cloudflare's presentation-format parser as a single string.
     """
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    return f'"{_escape_dns_char_string(value)}"'
 
 
 def _parse_txt_content(content: str) -> list[str]:
@@ -242,9 +251,14 @@ class CloudflareBackend(DNSBackend):
 
         # Build the value string for SVCB params
         # Format: alpn="mcp" port="443"
+        # publish_agent's params are already validated at the model boundary
+        # (validate_svcparam_value rejects embedded quotes/backslashes/control
+        # chars), but create_svcb_record is public and can be called directly
+        # with an arbitrary params dict, so escape here for defense-in-depth —
+        # symmetric with the TXT writer.
         param_parts = []
         for key, value in params.items():
-            param_parts.append(f'{key}="{value}"')
+            param_parts.append(f'{key}="{_escape_dns_char_string(value)}"')
         value_str = " ".join(param_parts) if param_parts else ""
 
         return {
@@ -327,7 +341,9 @@ class CloudflareBackend(DNSBackend):
                 f"Failed to write {record_type} record (HTTP {response.status_code}): {errors}"
             )
 
-        record_id = data["result"]["id"]
+        # A success response should always carry result.id, but guard against a
+        # null/absent result rather than raising KeyError on a surprising body.
+        record_id = (data.get("result") or {}).get("id")
         logger.info("Record written", fqdn=fqdn, type=record_type, record_id=record_id)
         return fqdn
 
@@ -402,7 +418,9 @@ class CloudflareBackend(DNSBackend):
         # unquoted would collapse all values into a SINGLE character-string on
         # the wire, and the discoverer iterates character-strings one by one
         # (see core/discoverer.py) — merging them corrupts capability parsing
-        # and any value containing a space. Mirrors the Route 53 backend.
+        # and any value containing a space. Like the Route 53 backend's
+        # per-value quoting, but additionally escaping embedded quotes and
+        # backslashes (which Route 53's writer does not).
         content = " ".join(_quote_txt_value(v) for v in values)
 
         request_data = {

--- a/src/dns_aid/backends/cloudflare.py
+++ b/src/dns_aid/backends/cloudflare.py
@@ -10,8 +10,8 @@ Supports zone ID or automatic zone lookup by domain name.
 
 from __future__ import annotations
 
+import asyncio
 import os
-import shlex
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -25,6 +25,14 @@ logger = structlog.get_logger(__name__)
 # Cloudflare API error code returned when an identical record already exists.
 # Used to make create-then-update idempotent under concurrent publishes.
 _CF_ERR_IDENTICAL_RECORD = 81058
+
+# Cloudflare rate-limiting: the documented cap is 1,200 requests per 5-minute
+# window. All API traffic routes through ``_request`` so a 429 is retried
+# uniformly — honouring ``Retry-After`` when present, otherwise backing off
+# exponentially from ``_CF_RETRY_BASE_DELAY`` up to ``_CF_MAX_RETRY_DELAY``.
+_CF_MAX_RETRIES = 3
+_CF_RETRY_BASE_DELAY = 1.0
+_CF_MAX_RETRY_DELAY = 30.0
 
 
 def _escape_dns_char_string(value: str) -> str:
@@ -49,21 +57,79 @@ def _quote_txt_value(value: str) -> str:
 def _parse_txt_content(content: str) -> list[str]:
     """Parse a Cloudflare TXT ``content`` string into its character-strings.
 
-    Cloudflare returns TXT rdata in DNS presentation format: one or more
-    double-quoted (or bare) character-strings separated by whitespace, e.g.
-    ``"cap=..." "version=1.0.0"``. ``shlex`` splits on whitespace while
-    honouring quotes and backslash escapes, which matches DNS master-file
-    semantics and inverts :func:`_quote_txt_value`.
+    Cloudflare returns TXT rdata in DNS presentation format (RFC 1035 §5.1):
+    one or more double-quoted (or bare) ``<character-string>`` tokens separated
+    by whitespace, e.g. ``"cap=..." "version=1.0.0"``. This is a DNS master-file
+    tokenizer, not a shell one — ``shlex`` was wrong for two live cases: a bare
+    apostrophe (``it's fine``) raised ``ValueError`` (dumping the whole blob back
+    as a single value), and Cloudflare returns non-ASCII octets as ``\\DDD``
+    decimal escapes that ``shlex`` left mangled. This tokenizer:
+
+    * splits on unquoted whitespace while honouring double-quoted tokens,
+    * decodes ``\\DDD`` (three decimal digits) to the corresponding octet and
+      ``\\X`` to the literal ``X`` (inverting :func:`_escape_dns_char_string`),
+    * accumulates decoded octets per token and UTF-8 decodes them together, so a
+      multi-byte character split across several ``\\DDD`` escapes round-trips,
+    * never raises — an unterminated quote simply ends the final token.
+
+    Matches the read-back behaviour of the Akamai backend and drops the shell
+    dependency entirely.
     """
     if not content:
         return []
-    try:
-        return shlex.split(content)
-    except ValueError:
-        # Unbalanced quotes (shouldn't happen from Cloudflare) — fall back to
-        # returning the raw content as a single value rather than raising.
-        logger.debug("Unparseable TXT content; returning raw", content=content)
-        return [content]
+
+    values: list[str] = []
+    buf = bytearray()
+    in_quotes = False
+    have_token = False  # a token is "open" (covers a quoted empty string)
+    i = 0
+    n = len(content)
+
+    def flush() -> None:
+        nonlocal have_token
+        if have_token:
+            values.append(buf.decode("utf-8", errors="replace"))
+            buf.clear()
+            have_token = False
+
+    while i < n:
+        c = content[i]
+
+        if c == "\\" and i + 1 < n:
+            nxt = content[i + 1]
+            # \DDD decimal octet escape: exactly three ASCII digits, value
+            # 0–255. Use isascii()+isdecimal() rather than isdigit() — the
+            # latter is True for characters int() can't parse (superscripts) and
+            # for non-ASCII/full-width digits, which would either crash or
+            # silently misdecode. RFC 1035 \DDD is strictly ASCII decimal.
+            esc = content[i + 1 : i + 4]
+            if len(esc) == 3 and esc.isascii() and esc.isdecimal() and int(esc) <= 255:
+                buf.append(int(esc))
+                i += 4
+            else:
+                # \X — emit the escaped character literally.
+                buf.extend(nxt.encode("utf-8"))
+                i += 2
+            have_token = True
+            continue
+
+        if c == '"':
+            in_quotes = not in_quotes
+            have_token = True
+            i += 1
+            continue
+
+        if c.isspace() and not in_quotes:
+            flush()
+            i += 1
+            continue
+
+        buf.extend(c.encode("utf-8"))
+        have_token = True
+        i += 1
+
+    flush()
+    return values
 
 
 class CloudflareBackend(DNSBackend):
@@ -130,8 +196,6 @@ class CloudflareBackend(DNSBackend):
         uses multiple asyncio.run() calls). This is necessary because httpx
         clients are bound to the event loop they were created in.
         """
-        import asyncio
-
         current_loop_id = id(asyncio.get_running_loop())
 
         # Check if we need to recreate the client due to loop change
@@ -161,6 +225,95 @@ class CloudflareBackend(DNSBackend):
             self._client_loop_id = current_loop_id
         return self._client
 
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float | None:
+        """Return the ``Retry-After`` delay in seconds, if the header is usable.
+
+        Cloudflare sends ``Retry-After`` as an integer number of seconds. A
+        missing or unparseable header returns ``None`` so the caller falls back
+        to exponential backoff.
+        """
+        raw = response.headers.get("Retry-After")
+        if raw is None:
+            return None
+        try:
+            return max(0.0, float(raw))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_rate_limited(response: httpx.Response) -> bool:
+        """Report whether a response signals Cloudflare rate limiting.
+
+        A genuine throttle is HTTP 429. As defence-in-depth we also treat an
+        HTTP 200 body carrying a ``success: false`` rate-limit error as
+        throttled, in case a limit ever surfaces as something other than a clean
+        429. Non-200 responses are left untouched — parsing an error body here
+        would undermine the ``get_record`` contract that only an empty result
+        set means "not found" while auth/network/server errors propagate.
+        """
+        if response.status_code == 429:
+            return True
+        if response.status_code != 200:
+            return False
+        try:
+            data = response.json()
+        except Exception:
+            return False
+        if not isinstance(data, dict) or data.get("success", True):
+            return False
+        errors = data.get("errors") or []
+        return any(
+            "rate limit" in str(e.get("message", "")).lower() for e in errors if isinstance(e, dict)
+        )
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue an HTTP request, transparently retrying on rate limiting.
+
+        All Cloudflare API traffic (reads, writes, deletes) routes through here
+        so a 429 is handled the same way everywhere. On a rate-limited response
+        we honour ``Retry-After`` when present, otherwise back off exponentially
+        — both bounded by :data:`_CF_MAX_RETRY_DELAY` so a hostile or
+        misconfigured ``Retry-After`` cannot stall the publish path — for up to
+        :data:`_CF_MAX_RETRIES` retries. If the limit still has not cleared we
+        raise, rather than hand back a throttled body: otherwise a persistent
+        200 ``success: false`` rate-limit response would parse to an empty
+        result and be misread by ``get_record``/``list_*`` as "not found" or an
+        empty zone. Other status interpretation (``raise_for_status``, the 81058
+        idempotency check, ``success`` parsing) stays at the call sites.
+        """
+        client = await self._get_client()
+        send = getattr(client, method.lower())
+        delay = _CF_RETRY_BASE_DELAY
+
+        response = await send(path, **kwargs)
+        for attempt in range(_CF_MAX_RETRIES):
+            if not self._is_rate_limited(response):
+                return response
+            header_wait = self._retry_after_seconds(response)
+            if header_wait is None:
+                wait = delay
+                delay = min(delay * 2, _CF_MAX_RETRY_DELAY)
+            else:
+                wait = min(header_wait, _CF_MAX_RETRY_DELAY)
+            logger.warning(
+                "Cloudflare rate limited; backing off before retry",
+                method=method,
+                path=path,
+                attempt=attempt + 1,
+                max_retries=_CF_MAX_RETRIES,
+                wait_seconds=wait,
+            )
+            await asyncio.sleep(wait)
+            response = await send(path, **kwargs)
+
+        if self._is_rate_limited(response):
+            raise ValueError(
+                f"Cloudflare rate limit not cleared after {_CF_MAX_RETRIES} retries "
+                f"({method} {path}); giving up rather than masking as an empty result"
+            )
+        return response
+
     async def _get_zone_id(self, zone: str) -> str:
         """
         Get Cloudflare zone ID for a domain.
@@ -183,10 +336,8 @@ class CloudflareBackend(DNSBackend):
         if domain in self._zone_cache:
             return self._zone_cache[domain]
 
-        client = await self._get_client()
-
         # List zones and find matching one
-        response = await client.get("/zones", params={"name": domain})
+        response = await self._request("GET", "/zones", params={"name": domain})
         response.raise_for_status()
         data = response.json()
 
@@ -220,9 +371,8 @@ class CloudflareBackend(DNSBackend):
         Returns:
             Record ID if found, None otherwise
         """
-        client = await self._get_client()
-
-        response = await client.get(
+        response = await self._request(
+            "GET",
             f"/zones/{zone_id}/dns_records",
             params={"name": fqdn, "type": record_type},
         )
@@ -289,18 +439,29 @@ class CloudflareBackend(DNSBackend):
         * **Delete race** — we found an existing id and PUT, but a racer deleted
           it first, so the PUT 404s. We recreate the record with a POST.
 
+        The 81058 idempotency shortcut applies **only to a POST**. Cloudflare
+        permits multiple records at one name and ``_get_record_id`` returns the
+        first, so a PUT that hits 81058 means the update collided with a
+        *different* record at the same name — the record we targeted was *not*
+        changed. Treating that as success would tell the caller we wrote when we
+        did not, so on a PUT 81058 falls through and raises.
+
         Any other non-success response raises ``ValueError`` carrying the
         Cloudflare error payload (more actionable than a bare ``HTTPStatusError``
         and uniform whether the failure arrives as a 4xx/5xx or as a 200 with
         ``success: false``).
         """
-        client = await self._get_client()
+        # Track whether the response we ultimately interpret came from a POST,
+        # since 81058 is only idempotent success for a create (see docstring).
+        wrote_via_post: bool
 
         if existing_id:
-            response = await client.put(
+            response = await self._request(
+                "PUT",
                 f"/zones/{zone_id}/dns_records/{existing_id}",
                 json=request_data,
             )
+            wrote_via_post = False
             # Delete race: the record vanished between lookup and update.
             if response.status_code == 404:
                 logger.info(
@@ -308,15 +469,19 @@ class CloudflareBackend(DNSBackend):
                     fqdn=fqdn,
                     type=record_type,
                 )
-                response = await client.post(
+                response = await self._request(
+                    "POST",
                     f"/zones/{zone_id}/dns_records",
                     json=request_data,
                 )
+                wrote_via_post = True
         else:
-            response = await client.post(
+            response = await self._request(
+                "POST",
                 f"/zones/{zone_id}/dns_records",
                 json=request_data,
             )
+            wrote_via_post = True
 
         try:
             data = response.json()
@@ -324,9 +489,13 @@ class CloudflareBackend(DNSBackend):
             # Non-JSON body (e.g. an edge 5xx returning HTML).
             data = {}
 
-        # Create race: an identical record already exists — idempotent success.
-        if response.status_code == 400 and any(
-            e.get("code") == _CF_ERR_IDENTICAL_RECORD for e in (data.get("errors") or [])
+        # Create race: an identical record already exists — idempotent success,
+        # but only for a POST. A PUT hitting 81058 collided with a different
+        # record at the same name and did not apply, so let it raise below.
+        if (
+            wrote_via_post
+            and response.status_code == 400
+            and any(e.get("code") == _CF_ERR_IDENTICAL_RECORD for e in (data.get("errors") or []))
         ):
             logger.info(
                 "Record already exists; treating as idempotent success",
@@ -444,7 +613,6 @@ class CloudflareBackend(DNSBackend):
     ) -> bool:
         """Delete a DNS record from Cloudflare."""
         zone_id = await self._get_zone_id(zone)
-        client = await self._get_client()
 
         # Build FQDN
         fqdn = f"{name}.{zone}".rstrip(".")
@@ -463,7 +631,7 @@ class CloudflareBackend(DNSBackend):
             return False
 
         # Delete the record
-        response = await client.delete(f"/zones/{zone_id}/dns_records/{record_id}")
+        response = await self._request("DELETE", f"/zones/{zone_id}/dns_records/{record_id}")
         response.raise_for_status()
         data = response.json()
 
@@ -483,7 +651,6 @@ class CloudflareBackend(DNSBackend):
     ) -> AsyncIterator[dict]:
         """List DNS records in Cloudflare zone."""
         zone_id = await self._get_zone_id(zone)
-        client = await self._get_client()
 
         logger.debug(
             "Listing records",
@@ -501,7 +668,7 @@ class CloudflareBackend(DNSBackend):
         page = 1
         while True:
             params["page"] = page
-            response = await client.get(f"/zones/{zone_id}/dns_records", params=params)
+            response = await self._request("GET", f"/zones/{zone_id}/dns_records", params=params)
             response.raise_for_status()
             data = response.json()
 
@@ -580,12 +747,12 @@ class CloudflareBackend(DNSBackend):
         More efficient than list_records for single record lookup.
         """
         zone_id = await self._get_zone_id(zone)
-        client = await self._get_client()
 
         # Build FQDN
         fqdn = f"{name}.{zone}".rstrip(".")
 
-        response = await client.get(
+        response = await self._request(
+            "GET",
             f"/zones/{zone_id}/dns_records",
             params={"name": fqdn, "type": record_type},
         )
@@ -630,12 +797,11 @@ class CloudflareBackend(DNSBackend):
         Returns:
             List of zone info dicts with id, name, status
         """
-        client = await self._get_client()
         zones = []
 
         page = 1
         while True:
-            response = await client.get("/zones", params={"page": page, "per_page": 50})
+            response = await self._request("GET", "/zones", params={"page": page, "per_page": 50})
             response.raise_for_status()
             data = response.json()
 

--- a/tests/integration/test_cloudflare.py
+++ b/tests/integration/test_cloudflare.py
@@ -1,0 +1,192 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for the Cloudflare backend against a live zone.
+
+These tests require a Cloudflare API token with DNS edit permissions and a
+real zone. Set environment variables:
+  - CLOUDFLARE_API_TOKEN   API token with Zone.DNS Edit + Read
+  - DNS_AID_TEST_ZONE      e.g. "testing.example.com"
+  - CLOUDFLARE_ZONE_ID     optional; otherwise looked up by zone name
+
+Read-only tests run with just the above. Tests that create or delete records
+are additionally gated behind:
+  - CLOUDFLARE_MUTATION_TESTS=1
+
+Run with: pytest tests/integration/test_cloudflare.py -m live -v
+"""
+
+import contextlib
+import os
+import uuid
+
+import pytest
+
+
+async def _safe_delete(backend, zone: str, name: str, record_type: str) -> None:
+    """Best-effort cleanup: never let one delete failure mask another.
+
+    delete_record can raise (its underlying API call uses raise_for_status),
+    so sequential cleanups in a finally block must be individually guarded or
+    a single failure leaks the remaining live test records.
+    """
+    with contextlib.suppress(Exception):
+        await backend.delete_record(zone, name, record_type)
+
+
+# Live backend tests — run with: pytest -m live
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.environ.get("DNS_AID_TEST_ZONE"),
+        reason="DNS_AID_TEST_ZONE not set",
+    ),
+    pytest.mark.skipif(
+        not os.environ.get("CLOUDFLARE_API_TOKEN"),
+        reason="CLOUDFLARE_API_TOKEN not set",
+    ),
+]
+
+_MUTATION = pytest.mark.skipif(
+    not os.environ.get("CLOUDFLARE_MUTATION_TESTS"),
+    reason="CLOUDFLARE_MUTATION_TESTS not set (set to 1 to enable writes)",
+)
+
+
+@pytest.fixture
+def test_zone() -> str:
+    """Get test zone from environment."""
+    return os.environ["DNS_AID_TEST_ZONE"]
+
+
+@pytest.fixture
+async def cloudflare_backend():
+    """Create a Cloudflare backend, closing its client afterwards."""
+    from dns_aid.backends.cloudflare import CloudflareBackend
+
+    backend = CloudflareBackend()
+    try:
+        yield backend
+    finally:
+        await backend.close()
+
+
+class TestCloudflareBackendReadOnly:
+    """Non-mutating live checks."""
+
+    @pytest.mark.asyncio
+    async def test_zone_exists(self, cloudflare_backend, test_zone):
+        assert await cloudflare_backend.zone_exists(test_zone) is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        bool(os.environ.get("CLOUDFLARE_ZONE_ID")),
+        reason="zone_exists short-circuits to True when a zone ID is pinned; "
+        "this negative test requires name-based lookup",
+    )
+    async def test_zone_not_exists(self, cloudflare_backend):
+        assert await cloudflare_backend.zone_exists("nonexistent-zone-12345.example") is False
+
+    @pytest.mark.asyncio
+    async def test_backend_declares_native_svcb_support(self, cloudflare_backend):
+        # The whole point of this backend revision: no TXT demotion needed.
+        assert cloudflare_backend.supports_private_svcb_keys is True
+
+
+@_MUTATION
+class TestCloudflareBackendNativeSvcb:
+    """Live create/read/delete proving native private-use SVCB keys."""
+
+    @pytest.mark.asyncio
+    async def test_svcb_private_use_keys_roundtrip(self, cloudflare_backend, test_zone):
+        """Private-use keys (key65400..key65404) are stored on the SVCB record
+        verbatim — NOT demoted to TXT."""
+        suffix = uuid.uuid4().hex[:8]
+        name = f"_it-svcb-{suffix}._mcp._agents"
+        params = {
+            "alpn": "mcp",
+            "port": "443",
+            "key65400": "https://example.com/cap.json",  # cap
+            "key65401": "cGxhY2Vob2xkZXI",  # cap-sha256
+            "key65402": "mcp=1.0",  # bap
+            "key65403": "https://example.com/policy",  # policy
+            "key65404": "production",  # realm
+        }
+        try:
+            fqdn = await cloudflare_backend.create_svcb_record(
+                zone=test_zone,
+                name=name,
+                priority=1,
+                target=".",
+                params=params,
+                ttl=300,
+            )
+            assert fqdn == f"{name}.{test_zone}"
+
+            record = await cloudflare_backend.get_record(test_zone, name, "SVCB")
+            assert record is not None, "SVCB record not found after creation"
+
+            value = record["values"][0]
+            # Every private-use key must survive on the SVCB record.
+            for key in ("key65400", "key65401", "key65402", "key65403", "key65404"):
+                assert f'{key}="' in value, f"{key} missing from SVCB rdata: {value!r}"
+        finally:
+            await _safe_delete(cloudflare_backend, test_zone, name, "SVCB")
+
+    @pytest.mark.asyncio
+    async def test_publish_agent_writes_native_svcb(self, cloudflare_backend, test_zone):
+        """Full publish path: custom params land on SVCB, TXT has no dnsaid_ demotion."""
+        from dns_aid.core.models import AgentRecord, Protocol
+
+        suffix = uuid.uuid4().hex[:8]
+        agent = AgentRecord(
+            name=f"it-agent-{suffix}",
+            domain=test_zone,
+            protocol=Protocol.MCP,
+            target_host=f"mcp.{test_zone}",
+            port=443,
+            capabilities=["test", "integration"],
+            cap_uri="https://example.com/cap.json",
+            policy_uri="https://example.com/policy",
+            realm="production",
+            ttl=300,
+        )
+        record_name = agent.name  # draft-02 flat primary owner
+        walkable_name = f"{agent.name}._agents"
+        try:
+            records = await cloudflare_backend.publish_agent(agent)
+            assert any(r.startswith("SVCB") for r in records)
+
+            svcb = await cloudflare_backend.get_record(test_zone, record_name, "SVCB")
+            assert svcb is not None
+            value = svcb["values"][0]
+            assert 'key65400="' in value  # cap
+            assert 'key65403="' in value  # policy
+            assert 'key65404="' in value  # realm
+
+            txt = await cloudflare_backend.get_record(test_zone, record_name, "TXT")
+            if txt is not None:
+                assert not any(v.startswith("dnsaid_") for v in txt["values"])
+        finally:
+            await _safe_delete(cloudflare_backend, test_zone, record_name, "SVCB")
+            await _safe_delete(cloudflare_backend, test_zone, record_name, "TXT")
+            await _safe_delete(cloudflare_backend, test_zone, walkable_name, "SVCB")
+
+    @pytest.mark.asyncio
+    async def test_txt_multistring_roundtrip(self, cloudflare_backend, test_zone):
+        """Multiple TXT values round-trip as distinct character-strings."""
+        suffix = uuid.uuid4().hex[:8]
+        name = f"_it-txt-{suffix}._mcp._agents"
+        values = ["capabilities=chat,code", "version=1.0.0", "description=has spaces here"]
+        try:
+            await cloudflare_backend.create_txt_record(
+                zone=test_zone, name=name, values=values, ttl=300
+            )
+            record = await cloudflare_backend.get_record(test_zone, name, "TXT")
+            assert record is not None
+            # Each value must come back as its own string, spaces preserved.
+            for v in values:
+                assert v in record["values"], f"{v!r} not in {record['values']!r}"
+        finally:
+            await _safe_delete(cloudflare_backend, test_zone, name, "TXT")

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -417,6 +417,96 @@ class TestCloudflareBackendCreateSvcb:
         mock_client.put.assert_called_once()
         mock_client.post.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_put_81058_raises_not_silent_success(self):
+        """A PUT hitting 81058 must RAISE, not report success.
+
+        Cloudflare allows multiple records at one name and ``_get_record_id``
+        returns the first. If our PUT would make the targeted record identical
+        to a *different* record at the same name, Cloudflare answers 400/81058
+        and the update does NOT apply — the record still resolves to its old
+        value. Treating that as idempotent success (as a POST race legitimately
+        is) would tell the caller we wrote when we did not, so it must raise.
+        """
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        # Pre-check finds an existing record, so we PUT.
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"success": True, "result": [{"id": "alpha1"}]}
+        mock_get_response.raise_for_status = MagicMock()
+
+        # The PUT collides with a different record at the same name -> 81058.
+        mock_put_response = MagicMock()
+        mock_put_response.status_code = 400
+        mock_put_response.json.return_value = {
+            "success": False,
+            "errors": [{"code": 81058, "message": "An identical record already exists."}],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_get_response)
+        mock_client.put = AsyncMock(return_value=mock_put_response)
+        mock_client.post = AsyncMock()
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with pytest.raises(ValueError, match="81058"):
+                await backend.create_svcb_record(
+                    zone="example.com",
+                    name="_chat._a2a._agents",
+                    priority=1,
+                    target="chat.example.com",
+                    params={"alpn": "a2a"},
+                )
+
+        # We must NOT have fallen back to a POST on a 400 (only a 404 recreates).
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_post_after_put_404_still_idempotent_on_81058(self):
+        """Delete-race fallback POST that itself loses a create race converges.
+
+        A PUT 404s (record deleted), we fall back to POST, and that POST races a
+        concurrent publisher into 81058. Because the write we interpret is a
+        POST, 81058 is still idempotent success — the record exists as intended.
+        """
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"success": True, "result": [{"id": "gone123"}]}
+        mock_get_response.raise_for_status = MagicMock()
+
+        mock_put_response = MagicMock()
+        mock_put_response.status_code = 404
+        mock_put_response.json.return_value = {
+            "success": False,
+            "errors": [{"code": 81044, "message": "record does not exist"}],
+        }
+
+        mock_post_response = MagicMock()
+        mock_post_response.status_code = 400
+        mock_post_response.json.return_value = {
+            "success": False,
+            "errors": [{"code": 81058, "message": "An identical record already exists."}],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_get_response)
+        mock_client.put = AsyncMock(return_value=mock_put_response)
+        mock_client.post = AsyncMock(return_value=mock_post_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                priority=1,
+                target="chat.example.com",
+                params={"alpn": "a2a"},
+            )
+
+        assert result == "_chat._a2a._agents.example.com"
+        mock_client.put.assert_called_once()
+        mock_client.post.assert_called_once()
+
 
 class TestCloudflareBackendCreateTxt:
     """Tests for TXT record creation."""
@@ -1065,10 +1155,58 @@ class TestCloudflareTxtCharacterStringHelpers:
     def test_parse_single_bare_value(self):
         assert _parse_txt_content("capabilities=chat") == ["capabilities=chat"]
 
-    def test_parse_unbalanced_quotes_falls_back_to_raw(self):
-        # shlex raises ValueError on an unbalanced quote; we return the raw
-        # content rather than raising (shouldn't happen from Cloudflare).
-        assert _parse_txt_content('"unterminated') == ['"unterminated']
+    def test_parse_unterminated_quote_recovers_gracefully(self):
+        # The DNS tokenizer never raises on malformed input (shouldn't happen
+        # from Cloudflare). An unterminated quote simply ends the final token,
+        # recovering the content instead of dumping the raw blob back.
+        assert _parse_txt_content('"unterminated') == ["unterminated"]
+
+    def test_parse_bare_apostrophe(self):
+        # Regression: shlex raised ValueError on a bare apostrophe and the
+        # fallback returned the whole blob as one value. The DNS tokenizer
+        # splits it into character-strings normally.
+        assert _parse_txt_content("it's fine") == ["it's", "fine"]
+
+    def test_parse_decimal_octet_escapes_utf8(self):
+        # Cloudflare returns non-ASCII as \DDD decimal octet escapes; a
+        # multi-byte character split across escapes must UTF-8 decode back.
+        # "café" -> é is U+00E9 = UTF-8 0xC3 0xA9 = \195\169.
+        assert _parse_txt_content('"caf\\195\\169"') == ["café"]
+
+    def test_parse_single_char_escape(self):
+        # \X (non-digit) emits the literal X, inverting _escape_dns_char_string.
+        assert _parse_txt_content(r'"a\"b\\c"') == ['a"b\\c']
+
+    def test_roundtrip_unicode_value(self):
+        # Escaping does not touch non-ASCII (it stays literal in content), but a
+        # value survives the round-trip intact regardless.
+        values = ["description=café ☕", "version=1.0.0"]
+        content = " ".join(_quote_txt_value(v) for v in values)
+        assert _parse_txt_content(content) == values
+
+    def test_parse_out_of_range_octet_not_treated_as_escape(self):
+        # \999 exceeds a single octet (0–255), so it is not a valid \DDD escape.
+        # The backslash-digit is treated as a literal \X escape (emitting "9"),
+        # yielding "999" rather than raising or corrupting the value.
+        assert _parse_txt_content(r"\999") == ["999"]
+
+    def test_parse_superscript_digits_do_not_crash(self):
+        # Regression: '²'.isdigit() is True but int('²') raises. The tokenizer
+        # must NOT treat \²²² as a \DDD escape (isascii()+isdecimal() guard),
+        # and must honour its "never raises" contract.
+        assert _parse_txt_content("\\\u00b2\u00b2\u00b2") == ["\u00b2\u00b2\u00b2"]
+
+    def test_parse_quoted_empty_string(self):
+        # A quoted empty string is one (empty) character-string, not zero.
+        assert _parse_txt_content('""') == [""]
+
+    def test_roundtrip_value_with_literal_backslash_digits(self):
+        # The interesting round-trip: a value containing a literal backslash
+        # followed by digits (which the parser must not misread as a \DDD octet
+        # after _quote_txt_value doubles the backslash).
+        values = ["path=x\\123y", "version=1.0.0"]
+        content = " ".join(_quote_txt_value(v) for v in values)
+        assert _parse_txt_content(content) == values
 
     @pytest.mark.asyncio
     async def test_get_record_parses_multistring_txt_back_to_list(self):
@@ -1098,3 +1236,208 @@ class TestCloudflareTxtCharacterStringHelpers:
 
         assert record is not None
         assert record["values"] == ["capabilities=chat,code", "description=A helpful agent"]
+
+
+class TestCloudflareRateLimitHandling:
+    """The shared _request helper retries uniformly on Cloudflare 429s."""
+
+    def _resp(self, status_code, *, headers=None, json_body=None):
+        r = MagicMock()
+        r.status_code = status_code
+        r.headers = headers or {}
+        r.json.return_value = json_body if json_body is not None else {}
+        r.raise_for_status = MagicMock()
+        return r
+
+    @pytest.mark.asyncio
+    async def test_request_retries_on_429_then_succeeds(self):
+        """A 429 followed by a 200 is retried transparently; caller sees 200."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        limited = self._resp(429, headers={"Retry-After": "0"})
+        ok = self._resp(200, json_body={"success": True, "result": []})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[limited, ok])
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                response = await backend._request("GET", "/zones")
+
+        assert response is ok
+        assert mock_client.get.await_count == 2
+        # Honoured the Retry-After header (0s) rather than the backoff default.
+        assert sleeps == [0.0]
+
+    @pytest.mark.asyncio
+    async def test_request_honours_retry_after_header(self):
+        """Retry-After takes precedence over exponential backoff."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        limited = self._resp(429, headers={"Retry-After": "7"})
+        ok = self._resp(200, json_body={"success": True})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[limited, ok])
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                await backend._request("GET", "/zones")
+
+        assert sleeps == [7.0]
+
+    @pytest.mark.asyncio
+    async def test_request_backs_off_when_no_retry_after(self):
+        """Without Retry-After, sleep uses the exponential backoff schedule."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        r1 = self._resp(429)
+        r2 = self._resp(429)
+        ok = self._resp(200, json_body={"success": True})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[r1, r2, ok])
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                await backend._request("GET", "/zones")
+
+        # Base delay then doubled.
+        assert sleeps == [1.0, 2.0]
+
+    @pytest.mark.asyncio
+    async def test_request_raises_when_rate_limit_never_clears(self):
+        """A persistent 429 raises after _CF_MAX_RETRIES rather than returning it.
+
+        Returning a throttled body would let a persistent 200 success:false
+        rate-limit response be misread downstream as "not found"/empty.
+        """
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        # Distinct objects per send so we prove the loop exhausts, not that it
+        # trivially returns the same mock.
+        responses = [self._resp(429) for _ in range(4)]
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=responses)
+
+        async def fake_sleep(secs):
+            return None
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                with pytest.raises(ValueError, match="rate limit not cleared"):
+                    await backend._request("GET", "/zones")
+
+        # Initial attempt + _CF_MAX_RETRIES retries.
+        assert mock_client.get.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_request_caps_absurd_retry_after(self):
+        """A huge Retry-After is clamped to _CF_MAX_RETRY_DELAY, not obeyed."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        limited = self._resp(429, headers={"Retry-After": "86400"})
+        ok = self._resp(200, json_body={"success": True})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[limited, ok])
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                await backend._request("GET", "/zones")
+
+        assert sleeps == [30.0]  # _CF_MAX_RETRY_DELAY
+
+    @pytest.mark.asyncio
+    async def test_request_unparseable_retry_after_falls_back_to_backoff(self):
+        """A non-numeric Retry-After (e.g. an HTTP-date) uses exponential backoff."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        limited = self._resp(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+        ok = self._resp(200, json_body={"success": True})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[limited, ok])
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                await backend._request("GET", "/zones")
+
+        assert sleeps == [1.0]  # base backoff, header ignored
+
+    @pytest.mark.asyncio
+    async def test_get_record_raises_on_persistent_rate_limit_body(self):
+        """A persistent 200 success:false rate-limit body must not read as None."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        limited = MagicMock()
+        limited.status_code = 200
+        limited.headers = {}
+        limited.json.return_value = {
+            "success": False,
+            "errors": [{"code": 10000, "message": "Rate limit exceeded"}],
+        }
+        limited.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=limited)
+
+        async def fake_sleep(secs):
+            return None
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                with pytest.raises(ValueError, match="rate limit not cleared"):
+                    await backend.get_record("example.com", "_chat._a2a._agents", "TXT")
+
+    @pytest.mark.asyncio
+    async def test_request_detects_rate_limit_in_200_body(self):
+        """A throttle surfacing as HTTP 200 success:false is still retried."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        limited = self._resp(
+            200,
+            json_body={
+                "success": False,
+                "errors": [{"code": 10000, "message": "Rate limit exceeded"}],
+            },
+        )
+        ok = self._resp(200, json_body={"success": True})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[limited, ok])
+
+        async def fake_sleep(secs):
+            return None
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with patch("dns_aid.backends.cloudflare.asyncio.sleep", fake_sleep):
+                response = await backend._request("GET", "/zones")
+
+        assert response is ok
+        assert mock_client.get.await_count == 2

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -984,3 +984,37 @@ class TestCloudflareGetRecord:
             record = await backend.get_record("example.com", "_missing._agents", "SVCB")
 
         assert record is None
+
+    @pytest.mark.asyncio
+    async def test_get_record_propagates_server_error(self):
+        """get_record must NOT mask errors as 'not found'.
+
+        Only an empty result set means the record is absent. A 5xx (or any
+        other non-success response) has to raise, otherwise a transient
+        auth/network/server error would look identical to a missing record and
+        let reconciliation silently recreate or overwrite an existing record.
+        This is an intentional divergence from the route53/ns1 backends, which
+        still swallow to ``None``; guard it so a future "align the backends"
+        refactor can't quietly revert it.
+        """
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500 Internal Server Error",
+                request=httpx.Request("GET", "https://api.cloudflare.com"),
+                response=httpx.Response(500),
+            )
+        )
+        # json() must never be consulted once raise_for_status has fired.
+        mock_response.json = MagicMock(
+            side_effect=AssertionError("json() should not be called on an error response")
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            with pytest.raises(httpx.HTTPStatusError):
+                await backend.get_record("example.com", "_chat._a2a._agents", "SVCB")

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -308,9 +308,10 @@ class TestCloudflareBackendCreateSvcb:
         mock_get_response.raise_for_status = MagicMock()
 
         mock_post_response = MagicMock()
+        mock_post_response.status_code = 400
         mock_post_response.json.return_value = {
             "success": False,
-            "errors": [{"message": "Invalid record"}],
+            "errors": [{"code": 1004, "message": "Invalid record"}],
         }
         mock_post_response.raise_for_status = MagicMock()
 
@@ -320,7 +321,7 @@ class TestCloudflareBackendCreateSvcb:
 
         with (
             patch.object(backend, "_get_client", return_value=mock_client),
-            pytest.raises(ValueError, match="Failed to create SVCB record"),
+            pytest.raises(ValueError, match="Failed to write SVCB record"),
         ):
             await backend.create_svcb_record(
                 zone="example.com",
@@ -329,6 +330,87 @@ class TestCloudflareBackendCreateSvcb:
                 target="chat.example.com",
                 params={},
             )
+
+    @pytest.mark.asyncio
+    async def test_create_svcb_record_idempotent_on_duplicate(self):
+        """A concurrent duplicate (CF error 81058) is treated as success."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        # No existing record found on the pre-check...
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"success": True, "result": []}
+        mock_get_response.raise_for_status = MagicMock()
+
+        # ...but the POST races a concurrent publisher and hits 81058.
+        mock_post_response = MagicMock()
+        mock_post_response.status_code = 400
+        mock_post_response.json.return_value = {
+            "success": False,
+            "errors": [{"code": 81058, "message": "An identical record already exists."}],
+        }
+        mock_post_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_get_response)
+        mock_client.post = AsyncMock(return_value=mock_post_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                priority=1,
+                target="chat.example.com",
+                params={"alpn": "a2a"},
+            )
+
+        # Idempotent: returns the fqdn instead of raising.
+        assert result == "_chat._a2a._agents.example.com"
+
+    @pytest.mark.asyncio
+    async def test_create_svcb_record_recreates_on_put_404(self):
+        """Delete race: the record is removed between lookup and PUT.
+
+        _get_record_id finds an id, but a concurrent publisher deletes the
+        record before our PUT, which 404s. We must recover by POSTing a fresh
+        record rather than failing the publish.
+        """
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        # Pre-check finds an existing record...
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"success": True, "result": [{"id": "gone123"}]}
+        mock_get_response.raise_for_status = MagicMock()
+
+        # ...the PUT 404s (record was deleted out from under us)...
+        mock_put_response = MagicMock()
+        mock_put_response.status_code = 404
+        mock_put_response.json.return_value = {
+            "success": False,
+            "errors": [{"code": 81044, "message": "record does not exist"}],
+        }
+
+        # ...and the fallback POST succeeds.
+        mock_post_response = MagicMock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {"success": True, "result": {"id": "new456"}}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_get_response)
+        mock_client.put = AsyncMock(return_value=mock_put_response)
+        mock_client.post = AsyncMock(return_value=mock_post_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend.create_svcb_record(
+                zone="example.com",
+                name="_chat._a2a._agents",
+                priority=1,
+                target="chat.example.com",
+                params={"alpn": "a2a"},
+            )
+
+        assert result == "_chat._a2a._agents.example.com"
+        mock_client.put.assert_called_once()
+        mock_client.post.assert_called_once()
 
 
 class TestCloudflareBackendCreateTxt:
@@ -365,12 +447,12 @@ class TestCloudflareBackendCreateTxt:
             assert result == "_chat._a2a._agents.example.com"
             mock_client.post.assert_called_once()
 
-            # Verify content format
+            # Verify content format: each value is its own quoted
+            # RFC 1035 <character-string> (not space-joined into one).
             call_args = mock_client.post.call_args
             json_data = call_args.kwargs["json"]
             assert json_data["type"] == "TXT"
-            assert "capabilities=chat,code" in json_data["content"]
-            assert json_data["content"] == "capabilities=chat,code version=1.0.0"
+            assert json_data["content"] == '"capabilities=chat,code" "version=1.0.0"'
 
 
 class TestCloudflareBackendDeleteRecord:
@@ -662,16 +744,28 @@ class TestCloudflareBackendClose:
 
 
 # =============================================================================
-# Param demotion & get_record coverage
+# Native private-use SVCB key emission & get_record coverage
 # =============================================================================
 
 
-class TestCloudflarePublishAgentParamDemotion:
-    """Tests for custom SVCB param demotion to TXT on Cloudflare."""
+class TestCloudflarePublishAgentNativeSvcb:
+    """Cloudflare writes DNS-AID private-use SVCB keys natively (no TXT demotion).
+
+    Cloudflare's SVCB data.value accepts RFC 9460 generic private-use keys
+    (key65280-key65534), verified against the live API, so
+    supports_private_svcb_keys is True and the base class passes custom
+    params straight to the SVCB record.
+    """
 
     @pytest.mark.asyncio
-    async def test_publish_strips_custom_svcb_params(self):
-        """Custom DNS-AID params (key65400+) must be demoted to TXT."""
+    async def test_backend_declares_native_support(self):
+        """The backend must advertise native private-use SVCB key support."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+        assert backend.supports_private_svcb_keys is True
+
+    @pytest.mark.asyncio
+    async def test_publish_writes_custom_svcb_params_natively(self):
+        """Custom DNS-AID params (key65400+) go into SVCB, not TXT."""
         from dns_aid.core.models import AgentRecord, Protocol
 
         agent = AgentRecord(
@@ -710,23 +804,16 @@ class TestCloudflarePublishAgentParamDemotion:
         assert records[1].startswith("TXT")
         assert records[2].startswith("SVCB(AliasMode)")
 
-        # SVCB params should NOT contain custom keys
+        # The primary SVCB record must carry the private-use realm key (key65404),
+        # NOT have it demoted to TXT.
         svcb_params = svcb_calls[0]["params"]
-        for key in svcb_params:
-            assert key in {
-                "mandatory",
-                "alpn",
-                "no-default-alpn",
-                "port",
-                "ipv4hint",
-                "ipv6hint",
-                "ech",
-            }
+        assert "key65404" in svcb_params
+        assert svcb_params["key65404"] == "demo"
 
-        # TXT should contain demoted dnsaid params
+        # TXT must NOT contain any demoted dnsaid_ entries.
         txt_values = txt_calls[0]["values"]
         dnsaid_txt = [v for v in txt_values if v.startswith("dnsaid_")]
-        assert len(dnsaid_txt) > 0
+        assert dnsaid_txt == []
 
     @pytest.mark.asyncio
     async def test_publish_no_custom_params_unchanged(self):
@@ -768,8 +855,8 @@ class TestCloudflarePublishAgentParamDemotion:
             assert len(dnsaid_txt) == 0
 
     @pytest.mark.asyncio
-    async def test_publish_demotes_multiple_params(self):
-        """Multiple custom params are all demoted to TXT."""
+    async def test_publish_writes_multiple_params_natively(self):
+        """Multiple custom params all go into the SVCB record, not TXT."""
         from dns_aid.core.models import AgentRecord, Protocol
 
         agent = AgentRecord(
@@ -805,10 +892,17 @@ class TestCloudflarePublishAgentParamDemotion:
         ):
             await backend.publish_agent(agent)
 
-        # All custom keys should be in TXT as dnsaid_ prefixed
-        txt_values = txt_calls[0]["values"]
-        dnsaid_txt = [v for v in txt_values if v.startswith("dnsaid_")]
-        assert len(dnsaid_txt) >= 4  # cap, cap-sha256, bap, policy, realm
+        # cap, cap-sha256, bap, policy, realm -> key65400..key65404, all in SVCB.
+        svcb_params = svcb_calls[0]["params"]
+        private_keys = [k for k in svcb_params if k.startswith("key654")]
+        assert len(private_keys) >= 5
+        for k in ("key65400", "key65401", "key65402", "key65403", "key65404"):
+            assert k in svcb_params
+
+        # Nothing demoted to TXT.
+        if txt_calls:
+            txt_values = txt_calls[0]["values"]
+            assert [v for v in txt_values if v.startswith("dnsaid_")] == []
 
 
 class TestCloudflareGetRecord:

--- a/tests/unit/test_cloudflare_backend.py
+++ b/tests/unit/test_cloudflare_backend.py
@@ -10,7 +10,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from dns_aid.backends.cloudflare import CloudflareBackend
+from dns_aid.backends.cloudflare import (
+    CloudflareBackend,
+    _escape_dns_char_string,
+    _parse_txt_content,
+    _quote_txt_value,
+)
 
 
 class TestCloudflareBackendInit:
@@ -993,9 +998,8 @@ class TestCloudflareGetRecord:
         other non-success response) has to raise, otherwise a transient
         auth/network/server error would look identical to a missing record and
         let reconciliation silently recreate or overwrite an existing record.
-        This is an intentional divergence from the route53/ns1 backends, which
-        still swallow to ``None``; guard it so a future "align the backends"
-        refactor can't quietly revert it.
+        Guard the raising contract so a future "align the backends" refactor
+        can't quietly revert it to swallowing errors.
         """
         backend = CloudflareBackend(api_token="token", zone_id="Z123")
 
@@ -1018,3 +1022,79 @@ class TestCloudflareGetRecord:
         with patch.object(backend, "_get_client", return_value=mock_client):
             with pytest.raises(httpx.HTTPStatusError):
                 await backend.get_record("example.com", "_chat._a2a._agents", "SVCB")
+
+
+class TestCloudflareTxtCharacterStringHelpers:
+    """Round-trip and edge-case coverage for the TXT presentation-format helpers.
+
+    These are the security-relevant boundary (escaping) and the read-path
+    parser; the live integration test exercises them end-to-end, but these
+    mocked unit tests lock the behavior so CI catches a regression.
+    """
+
+    def test_escape_backslash_and_quote(self):
+        assert _escape_dns_char_string('a"b\\c') == 'a\\"b\\\\c'
+
+    def test_escape_noop_when_clean(self):
+        assert _escape_dns_char_string("cap=chat,code") == "cap=chat,code"
+
+    def test_quote_wraps_and_escapes(self):
+        assert _quote_txt_value('say "hi"') == '"say \\"hi\\""'
+
+    def test_roundtrip_plain_values(self):
+        values = ["capabilities=chat,code", "version=1.0.0"]
+        content = " ".join(_quote_txt_value(v) for v in values)
+        assert _parse_txt_content(content) == values
+
+    def test_roundtrip_value_with_spaces(self):
+        # The whole motivation: a value containing spaces must survive as ONE
+        # character-string, not fragment into several.
+        values = ["description=A helpful chat agent", "version=1.0.0"]
+        content = " ".join(_quote_txt_value(v) for v in values)
+        assert _parse_txt_content(content) == values
+
+    def test_roundtrip_embedded_quotes_and_backslashes(self):
+        values = ['note=he said "hi"', "path=C:\\tmp\\x"]
+        content = " ".join(_quote_txt_value(v) for v in values)
+        assert _parse_txt_content(content) == values
+
+    def test_parse_empty_content_returns_empty_list(self):
+        # Behavior change from the old backend: empty content is [] not [""].
+        assert _parse_txt_content("") == []
+
+    def test_parse_single_bare_value(self):
+        assert _parse_txt_content("capabilities=chat") == ["capabilities=chat"]
+
+    def test_parse_unbalanced_quotes_falls_back_to_raw(self):
+        # shlex raises ValueError on an unbalanced quote; we return the raw
+        # content rather than raising (shouldn't happen from Cloudflare).
+        assert _parse_txt_content('"unterminated') == ['"unterminated']
+
+    @pytest.mark.asyncio
+    async def test_get_record_parses_multistring_txt_back_to_list(self):
+        """get_record read path splits presentation-format content into values."""
+        backend = CloudflareBackend(api_token="token", zone_id="Z123")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "result": [
+                {
+                    "id": "rec1",
+                    "name": "_chat._a2a._agents.example.com",
+                    "type": "TXT",
+                    "ttl": 3600,
+                    "content": '"capabilities=chat,code" "description=A helpful agent"',
+                }
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            record = await backend.get_record("example.com", "_chat._a2a._agents", "TXT")
+
+        assert record is not None
+        assert record["values"] == ["capabilities=chat,code", "description=A helpful agent"]


### PR DESCRIPTION
## Summary

Improves the Cloudflare backend so DNS-AID's private-use SVCB keys are written **natively** to the SVCB record instead of being demoted to TXT, and fixes a few correctness issues found while validating the backend against the live Cloudflare API.

Context: the existing `cloudflare.py` was written without direct access to validate the Cloudflare API's SVCB behavior, and carried a comment asserting *"Cloudflare rejects key65280–key65534."* Testing against a live zone shows that is no longer true — Cloudflare's SVCB `data.value` accepts RFC 9460 generic private-use SvcParamKeys and round-trips them verbatim.

## What changed

**Feature — native private-use SVCB keys**
- `CloudflareBackend.supports_private_svcb_keys = True`. DNS-AID custom params (`cap`, `cap-sha256`, `bap`, `policy`, `realm`, … → `key65400`–`key65409`) now go straight into the SVCB record, matching the NS1 and NIOS backends. No more TXT demotion of these keys.

**Fix — TXT character-string quoting**
- TXT values were space-joined into a single string, which collapses to one RFC 1035 `<character-string>` on the wire. Since the discoverer iterates character-strings individually (`core/discoverer.py`), this corrupted capability parsing and any value containing a space. Each value is now written as its own quoted (escaped) character-string, and the read paths (`list_records`/`get_record`) parse the presentation-format `content` back into a list. Mirrors `route53.py`.

**Fix — concurrent-write races**
- `create_svcb_record`/`create_txt_record` share a `_write_record` helper that converges under both check-then-act races: a POST hitting error `81058` ("identical record already exists") is treated as idempotent success, and a PUT that `404`s (record deleted between lookup and update) falls back to a POST. Non-success responses raise `ValueError` with the Cloudflare error payload.

**Fix — `get_record` error masking**
- Previously swallowed all exceptions as "not found," which could let reconciliation silently recreate/overwrite records on a transient auth/network error. Now only an empty result set means not-found; other errors propagate.

## Verification

- Validated against a live Cloudflare zone: single and full DNS-AID key sets (`key65400`–`key65404`) are accepted and read back verbatim; multi-value TXT round-trips as distinct strings.
- Unit tests: added coverage for native SVCB emission, quoted TXT, the idempotent-81058 path, and the PUT-404 recreate path. All Cloudflare unit tests pass.
- New live integration test `tests/integration/test_cloudflare.py`, gated behind `CLOUDFLARE_MUTATION_TESTS` (+ `DNS_AID_TEST_ZONE` / `CLOUDFLARE_API_TOKEN`), that publishes and reads back the private-use keys. Passes end-to-end.
- `ruff check`, `ruff format --check`, and `mypy src/dns_aid/backends/cloudflare.py` are clean.

## Notes for reviewers (deliberately out of scope)

Happy to fold any of these in if you'd prefer:

1. **SVCB value escaping** at the backend boundary: `_format_svcb_data` builds `key="value"` without escaping, relying on model-level validation (`validate_svcparam_value`). This matches `route53.py`/`ns1.py`, so I left it consistent rather than diverging one backend — but it's arguably worth hardening across all three.
2. **TXT 255-byte chunking** is not implemented (a single value > 255 bytes isn't split into multiple character-strings). Same limitation as Route 53.
3. **`get_record` now raises on transient errors** whereas `route53.py`/`ns1.py` still swallow to `None`. I believe raising is the correct contract, but it's an intentional divergence — I can align the siblings in a follow-up if you'd rather keep them uniform.

## Checklist

- [x] Native private-use SVCB keys verified against the live Cloudflare API
- [x] Unit + live integration tests added
- [x] `ruff check`, `ruff format --check`, `mypy src/` clean
- [x] README, api-reference, and CHANGELOG updated
- [x] Commit includes a `Signed-off-by` line (DCO)
