### PR TITLE
fix(akamai-edgedns): harden concurrency, rdata escaping, and pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so all DNS-AID custom SvcParams are written directly on the SVCB record without TXT demotion.
   Install: `pip install dns-aid[akamai-edgedns]`.
 
+### Fixed
+
+- **Akamai Edge DNS backend hardening** — concurrency, injection, and pagination
+  fixes surfaced by live stress-testing against a real Edge DNS zone:
+  - *Concurrent publishes no longer fail.* Akamai serializes modifications per
+    zone; overlapping writes return `409 concurrentZoneModification` ("Please
+    try your request again"), which the backend previously misread as
+    "record exists" and converted to a `PUT` that then failed with
+    `400 does not exist`. A live 12-way concurrent publish succeeded for only
+    1 of 12 agents. Writes are now serialized per zone with an `asyncio.Lock`
+    (removing self-inflicted contention) and transient zone-lock 409s are
+    retried with exponential backoff + jitter — Akamai's prescribed handling.
+    The same 12-way stress now lands 12/12 with zero errors. The POST→PUT
+    upsert convergence is scoped to single-record (`/names/…`) paths so a 409
+    on the bulk `/recordsets` endpoint can never auto-convert to a `PUT`
+    there, which would replace the entire zone's record sets.
+  - *TXT and SVCB rdata are escaped per RFC 1035.* A `"` or `\` in a TXT value
+    or SvcParam value previously broke out of the presentation-format quoting
+    and could inject extra character-strings/SvcParams into the record (or
+    corrupt the publish). Values are now backslash-escaped on write and
+    unescaped on read-back.
+  - *Pagination no longer silently truncates.* When a list response omitted
+    pagination metadata, `totalElements` defaulted to `0` and `list_records`/
+    `list_zones` stopped after the first 100 entries. The API's count is still
+    authoritative when present; a short page terminates otherwise.
+  - URL path segments are percent-encoded (defense-in-depth for direct
+    callers), and retry jitter uses `SystemRandom`.
+
 ## [0.26.7] - 2026-07-08
 
 ### Fixed

--- a/src/dns_aid/backends/akamai_edgedns.py
+++ b/src/dns_aid/backends/akamai_edgedns.py
@@ -20,10 +20,11 @@ import asyncio
 import contextlib
 import json as json_module
 import os
+import random
 import re
 from collections.abc import AsyncIterator
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import httpx
 import structlog
@@ -34,6 +35,10 @@ logger = structlog.get_logger(__name__)
 
 # Record types supported by DNS-AID via the Edge DNS API.
 _SUPPORTED_RECORD_TYPES = {"SVCB", "TXT"}
+
+# OS-entropy RNG for retry jitter (satisfies bandit B311; jitter itself is not
+# security-sensitive, but SystemRandom avoids the shared global PRNG state).
+_jitter = random.SystemRandom()
 
 
 class AkamaiEdgeDNSBackend(DNSBackend):
@@ -82,6 +87,12 @@ class AkamaiEdgeDNSBackend(DNSBackend):
     }
     _KEY_NNNNN_RE = re.compile(r"^key[1-9][0-9]{0,4}$")
 
+    # Akamai serializes modifications per zone; a concurrent write to the same
+    # zone returns 409 concurrentZoneModification. Retry the same request up to
+    # this many times with exponential backoff + jitter before surfacing it.
+    _MAX_ZONE_LOCK_RETRIES = 5
+    _ZONE_LOCK_BASE_DELAY = 0.5  # seconds (doubles each attempt, plus jitter)
+
     def __init__(
         self,
         host: str | None = None,
@@ -112,6 +123,8 @@ class AkamaiEdgeDNSBackend(DNSBackend):
         self._client: httpx.AsyncClient | None = None
         self._client_loop_id: int | None = None
         self._zone_cache: dict[str, bool] = {}
+        # Per-zone write locks (lazily created; reset on event-loop change).
+        self._zone_write_locks: dict[str, asyncio.Lock] = {}
 
     @property
     def name(self) -> str:
@@ -192,6 +205,7 @@ class AkamaiEdgeDNSBackend(DNSBackend):
                 await self._client.aclose()
             self._client = None
             self._client_loop_id = None
+            self._zone_write_locks.clear()  # locks are bound to the old loop
 
         if self._client is None:
             self._ensure_auth()
@@ -202,6 +216,21 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             self._client_loop_id = current_loop_id
 
         return self._client
+
+    def _zone_write_lock(self, zone: str) -> asyncio.Lock:
+        """Per-zone write lock.
+
+        Akamai serializes modifications per zone, returning 409
+        concurrentZoneModification for overlapping writes. Serialising our own
+        concurrent writes to a zone avoids self-inflicted contention (the retry in
+        ``_request`` then only has to absorb *cross-process* concurrency). Locks
+        are event-loop-bound and reset with the client on loop change.
+        """
+        lock = self._zone_write_locks.get(zone)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._zone_write_locks[zone] = lock
+        return lock
 
     def _sign_request(
         self,
@@ -251,52 +280,79 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             body = json_module.dumps(json_data).encode("utf-8")
             headers["Content-Type"] = "application/json"
 
-        # Sign before sending — EdgeGrid HMAC covers method, URL, and body
-        signed_headers = self._sign_request(method, url, headers, body)
+        # Akamai serializes writes per zone. A fan-out of record-set writes (many
+        # agents, or the two writes per publish_agent) draws 409
+        # concurrentZoneModification — a transient optimistic-lock, not a real
+        # conflict. Retry the SAME request with exponential backoff + jitter. A
+        # genuine "already exists" 409 on POST is converged to PUT (upsert) instead.
+        attempt = 0
+        while True:
+            # Re-sign each attempt: the EdgeGrid HMAC is time-bounded.
+            signed_headers = self._sign_request(method, url, headers, body)
 
-        try:
-            response = await client.request(
-                method,
-                url,
-                content=body,
-                headers=signed_headers,
-            )
-        except httpx.HTTPError as exc:
-            raise ValueError(f"Akamai Edge DNS transport error ({method} {path}): {exc}") from exc
-
-        # 409 on POST - retry as PUT to converge
-        if response.status_code == 409 and method == "POST":
-            return await self._request("PUT", path, json_data=json_data, params=params)
-
-        # 404 on reads/deletes = not found - None; on writes = zone/resource missing - raise
-        if response.status_code == 404:
-            if method in ("POST", "PUT", "PATCH"):
-                raise ValueError(
-                    f"Akamai Edge DNS zone or resource not found ({method} {path}). "
-                    "Ensure the zone exists and credentials have write access."
+            try:
+                response = await client.request(
+                    method,
+                    url,
+                    content=body,
+                    headers=signed_headers,
                 )
-            return None
+            except httpx.HTTPError as exc:
+                raise ValueError(
+                    f"Akamai Edge DNS transport error ({method} {path}): {exc}"
+                ) from exc
 
-        try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            body_text = exc.response.text[:500]
-            logger.error(
-                "Akamai Edge DNS API error",
-                method=method,
-                path=path,
-                status_code=exc.response.status_code,
-                response_body=body_text,
-            )
-            raise ValueError(
-                f"Akamai Edge DNS API error ({method} {path}): "
-                f"status={exc.response.status_code} body={body_text}"
-            ) from exc
+            if response.status_code == 409:
+                if "concurrentZoneModification" in response.text:
+                    if attempt < self._MAX_ZONE_LOCK_RETRIES:
+                        delay = self._ZONE_LOCK_BASE_DELAY * (2**attempt) + _jitter.uniform(0, 0.25)
+                        logger.debug(
+                            "Akamai zone busy; retrying after concurrentZoneModification",
+                            method=method,
+                            path=path,
+                            attempt=attempt + 1,
+                            delay_s=round(delay, 3),
+                        )
+                        await asyncio.sleep(delay)
+                        attempt += 1
+                        continue
+                    # Retries exhausted — fall through to raise_for_status below.
+                elif method == "POST" and "/names/" in path:
+                    # Genuine "already exists" 409 on a single record set — converge to
+                    # an update. Guarded to single-record paths: never auto-convert a
+                    # bulk ``/recordsets`` POST, because PUT on that path replaces the
+                    # ENTIRE zone's record sets.
+                    return await self._request("PUT", path, json_data=json_data, params=params)
 
-        if not response.content:
-            return {}
+            # 404 on reads/deletes = not found - None; on writes = zone/resource missing - raise
+            if response.status_code == 404:
+                if method in ("POST", "PUT", "PATCH"):
+                    raise ValueError(
+                        f"Akamai Edge DNS zone or resource not found ({method} {path}). "
+                        "Ensure the zone exists and credentials have write access."
+                    )
+                return None
 
-        return response.json()
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                body_text = exc.response.text[:500]
+                logger.error(
+                    "Akamai Edge DNS API error",
+                    method=method,
+                    path=path,
+                    status_code=exc.response.status_code,
+                    response_body=body_text,
+                )
+                raise ValueError(
+                    f"Akamai Edge DNS API error ({method} {path}): "
+                    f"status={exc.response.status_code} body={body_text}"
+                ) from exc
+
+            if not response.content:
+                return {}
+
+            return response.json()
 
     # ------------------------------------------------------------------
     # Helpers
@@ -334,6 +390,38 @@ class AkamaiEdgeDNSBackend(DNSBackend):
         normalized = key.strip().lower()
         return cls._NUMERIC_KEY_TO_CUSTOM_PARAM.get(normalized, normalized)
 
+    @staticmethod
+    def _escape_char_string(value: str) -> str:
+        """Escape a value for a DNS presentation-format character-string.
+
+        Backslash and double-quote are backslash-escaped (RFC 1035 §5.1) so a
+        value containing ``"`` cannot break out of its quotes and inject extra
+        rdata elements or SvcParams into the record.
+        """
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    @staticmethod
+    def _unescape_char_string(value: str) -> str:
+        """Decode a presentation-format character-string (inverse of escape).
+
+        Single left-to-right pass so adjacent escapes decode correctly.
+        """
+        out: list[str] = []
+        i, n = 0, len(value)
+        while i < n:
+            if value[i] == "\\" and i + 1 < n:
+                out.append(value[i + 1])
+                i += 2
+            else:
+                out.append(value[i])
+                i += 1
+        return "".join(out)
+
+    @staticmethod
+    def _seg(value: str) -> str:
+        """Percent-encode a single URL path segment (no separators pass through)."""
+        return quote(value, safe="")
+
     @classmethod
     def _format_svcb_rdata(
         cls,
@@ -350,7 +438,8 @@ class AkamaiEdgeDNSBackend(DNSBackend):
         param_parts = []
         for key, value in params.items():
             mapped_key = cls._to_numeric_key(key)
-            param_parts.append(f'{mapped_key}="{value}"')
+            safe_value = cls._escape_char_string(value)
+            param_parts.append(f'{mapped_key}="{safe_value}"')
 
         rdata = f"{priority} {target}"
         if param_parts:
@@ -392,14 +481,17 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             "rdata": [rdata],
         }
 
-        path = f"/config-dns/v2/zones/{zone_clean}/names/{fqdn}/types/SVCB"
+        path = f"/config-dns/v2/zones/{self._seg(zone_clean)}/names/{self._seg(fqdn)}/types/SVCB"
 
-        # Upsert: Edge DNS uses POST for create, PUT for update
-        existing = await self._request("GET", path)
-        if existing is not None:
-            await self._request("PUT", path, json_data=payload)
-        else:
-            await self._request("POST", path, json_data=payload)
+        # Serialise our own writes per zone (Akamai locks the zone during any
+        # modification); cross-process contention is still handled by the retry.
+        async with self._zone_write_lock(zone_clean):
+            # Upsert: Edge DNS uses POST for create, PUT for update
+            existing = await self._request("GET", path)
+            if existing is not None:
+                await self._request("PUT", path, json_data=payload)
+            else:
+                await self._request("POST", path, json_data=payload)
 
         logger.info("SVCB record created", name=fqdn)
         return fqdn
@@ -427,17 +519,18 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             "name": fqdn,
             "type": "TXT",
             "ttl": ttl,
-            "rdata": [f'"{v}"' for v in values],
+            "rdata": [f'"{self._escape_char_string(v)}"' for v in values],
         }
 
-        path = f"/config-dns/v2/zones/{zone_clean}/names/{fqdn}/types/TXT"
+        path = f"/config-dns/v2/zones/{self._seg(zone_clean)}/names/{self._seg(fqdn)}/types/TXT"
 
-        # Upsert: Edge DNS uses POST for create, PUT for update
-        existing = await self._request("GET", path)
-        if existing is not None:
-            await self._request("PUT", path, json_data=payload)
-        else:
-            await self._request("POST", path, json_data=payload)
+        async with self._zone_write_lock(zone_clean):
+            # Upsert: Edge DNS uses POST for create, PUT for update
+            existing = await self._request("GET", path)
+            if existing is not None:
+                await self._request("PUT", path, json_data=payload)
+            else:
+                await self._request("POST", path, json_data=payload)
 
         logger.info("TXT record created", name=fqdn)
         return fqdn
@@ -460,10 +553,11 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             type=rtype,
         )
 
-        path = f"/config-dns/v2/zones/{zone_clean}/names/{fqdn}/types/{rtype}"
+        path = f"/config-dns/v2/zones/{self._seg(zone_clean)}/names/{self._seg(fqdn)}/types/{self._seg(rtype)}"
         try:
             # _request returns None on 404 — record doesn't exist
-            result = await self._request("DELETE", path)
+            async with self._zone_write_lock(zone_clean):
+                result = await self._request("DELETE", path)
         except Exception as exc:
             logger.exception(
                 "Failed to delete record",
@@ -503,7 +597,7 @@ class AkamaiEdgeDNSBackend(DNSBackend):
         page = 1
         while True:
             params["page"] = str(page)
-            path = f"/config-dns/v2/zones/{zone_clean}/recordsets"
+            path = f"/config-dns/v2/zones/{self._seg(zone_clean)}/recordsets"
             data = await self._request("GET", path, params=params)
 
             if data is None or not isinstance(data, dict):
@@ -528,7 +622,7 @@ class AkamaiEdgeDNSBackend(DNSBackend):
                 ttl = int(rs.get("ttl", 0))
                 values = rdata_list if rdata_list else []
                 if rtype == "TXT":
-                    values = [v.strip('"') for v in values]
+                    values = [self._unescape_char_string(v.strip('"')) for v in values]
 
                 yield {
                     "name": self._extract_name_from_fqdn(fqdn, zone_clean),
@@ -539,11 +633,16 @@ class AkamaiEdgeDNSBackend(DNSBackend):
                     "id": f"{zone_clean}/{fqdn}/{rtype}",
                 }
 
-            # Check for more pages
+            # Trust the API's authoritative count when present; otherwise stop on a
+            # short page rather than truncating at the first 100 (the old
+            # metadata-absent "totalElements defaults to 0" bug).
             metadata = data.get("metadata", {})
-            total = metadata.get("totalElements", 0)
+            total = metadata.get("totalElements")
             page_size = metadata.get("pageSize", 100)
-            if page * page_size >= total:
+            if total is not None:
+                if page * page_size >= total:
+                    break
+            elif len(recordsets) < 100:
                 break
             page += 1
 
@@ -558,7 +657,7 @@ class AkamaiEdgeDNSBackend(DNSBackend):
         zone_clean = zone.rstrip(".")
         rtype = record_type.upper()
 
-        path = f"/config-dns/v2/zones/{zone_clean}/names/{fqdn}/types/{rtype}"
+        path = f"/config-dns/v2/zones/{self._seg(zone_clean)}/names/{self._seg(fqdn)}/types/{self._seg(rtype)}"
         data = await self._request("GET", path)
 
         if data is None or not isinstance(data, dict):
@@ -568,7 +667,7 @@ class AkamaiEdgeDNSBackend(DNSBackend):
         ttl = int(data.get("ttl", 0))
 
         if rtype == "TXT":
-            rdata_list = [v.strip('"') for v in rdata_list]
+            rdata_list = [self._unescape_char_string(v.strip('"')) for v in rdata_list]
 
         return {
             "name": self._extract_name_from_fqdn(fqdn, zone_clean),
@@ -592,7 +691,7 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             return self._zone_cache[zone_clean]
 
         try:
-            path = f"/config-dns/v2/zones/{zone_clean}"
+            path = f"/config-dns/v2/zones/{self._seg(zone_clean)}"
             result = await self._request("GET", path)
             exists = result is not None
             self._zone_cache[zone_clean] = exists
@@ -617,7 +716,8 @@ class AkamaiEdgeDNSBackend(DNSBackend):
             if data is None or not isinstance(data, dict):
                 break
 
-            for z in data.get("zones", []):
+            page_zones = data.get("zones", [])
+            for z in page_zones:
                 zones.append(
                     {
                         "id": z.get("zone", ""),
@@ -627,10 +727,15 @@ class AkamaiEdgeDNSBackend(DNSBackend):
                     }
                 )
 
+            # Trust the API's authoritative count when present; otherwise stop on a
+            # short page rather than truncating (metadata-absent safety).
             metadata = data.get("metadata", {})
-            total = metadata.get("totalElements", 0)
+            total = metadata.get("totalElements")
             page_size = metadata.get("pageSize", 100)
-            if page * page_size >= total:
+            if total is not None:
+                if page * page_size >= total:
+                    break
+            elif len(page_zones) < 100:
                 break
             page += 1
 

--- a/tests/unit/test_akamai_edgedns_backend.py
+++ b/tests/unit/test_akamai_edgedns_backend.py
@@ -1394,3 +1394,181 @@ class TestAkamaiEdgeDNSBackendFactoryWiring:
         from dns_aid.cli.backends import BACKEND_REGISTRY
 
         assert BACKEND_REGISTRY["akamai-edgedns"].required_env == {}
+
+
+# ---------------------------------------------------------------------------
+# Hardening: concurrent-zone-modification retry
+# ---------------------------------------------------------------------------
+
+
+def _resp(status: int, *, json_body=None, text: str = "") -> httpx.Response:
+    """Build an httpx.Response with a request attached (so raise_for_status works)."""
+    req = httpx.Request("POST", "https://akamai.example/config-dns/v2/zones/z")
+    if json_body is not None:
+        return httpx.Response(status, json=json_body, request=req)
+    return httpx.Response(status, text=text, request=req)
+
+
+def _wire(backend: AkamaiEdgeDNSBackend, monkeypatch, responses):
+    """Wire a backend's HTTP seam: stub client.request with `responses`, no real sleep/sign."""
+    import dns_aid.backends.akamai_edgedns as mod
+
+    monkeypatch.setattr(mod.asyncio, "sleep", AsyncMock())
+    client = MagicMock()
+    client.request = AsyncMock(side_effect=responses)
+    monkeypatch.setattr(backend, "_get_client", AsyncMock(return_value=client))
+    monkeypatch.setattr(backend, "_sign_request", lambda *a, **k: {})
+    return client
+
+
+class TestAkamaiZoneLockRetry:
+    """409 concurrentZoneModification must retry the same op, not misfire to PUT."""
+
+    def _backend(self) -> AkamaiEdgeDNSBackend:
+        return AkamaiEdgeDNSBackend(
+            host="h", client_token="ct", client_secret="cs", access_token="at"
+        )
+
+    async def test_retries_then_succeeds(self, monkeypatch):
+        backend = self._backend()
+        client = _wire(
+            backend,
+            monkeypatch,
+            [
+                _resp(409, text='{"title":"concurrentZoneModification"}'),
+                _resp(409, text="concurrentZoneModification"),
+                _resp(200, json_body={"ok": True}),
+            ],
+        )
+        result = await backend._request("POST", "/zones/z/names/n/types/SVCB", json_data={"x": 1})
+        assert result == {"ok": True}
+        assert client.request.await_count == 3  # 2 retries + success
+
+    async def test_exhausts_retries_then_raises(self, monkeypatch):
+        backend = self._backend()
+        client = _wire(
+            backend,
+            monkeypatch,
+            [_resp(409, text="concurrentZoneModification")] * 20,
+        )
+        with pytest.raises(ValueError, match="Akamai Edge DNS API error"):
+            await backend._request("POST", "/zones/z/names/n/types/SVCB", json_data={"x": 1})
+        assert client.request.await_count == backend._MAX_ZONE_LOCK_RETRIES + 1
+
+    async def test_genuine_conflict_still_converges_post_to_put(self, monkeypatch):
+        backend = self._backend()
+        methods: list[str] = []
+
+        def responder(method, url, **kwargs):
+            methods.append(method)
+            if method == "POST":
+                return _resp(409, text='{"title":"recordSetAlreadyExists"}')
+            return _resp(200, json_body={"updated": True})
+
+        _wire(backend, monkeypatch, responder)
+        result = await backend._request("POST", "/zones/z/names/n/types/SVCB", json_data={"x": 1})
+        assert result == {"updated": True}
+        assert methods == ["POST", "PUT"]  # genuine "exists" 409 → PUT, not a retry loop
+
+
+# ---------------------------------------------------------------------------
+# Hardening: presentation-format escaping + path-segment encoding
+# ---------------------------------------------------------------------------
+
+
+class TestAkamaiEscaping:
+    def test_escape_char_string_basic(self):
+        assert AkamaiEdgeDNSBackend._escape_char_string("plain") == "plain"
+        assert AkamaiEdgeDNSBackend._escape_char_string('x"y') == 'x\\"y'
+
+    def test_escape_unescape_roundtrip(self):
+        for s in ["plain", 'a"b', "a\\b", 'q"and\\s', '""', "\\", 'desc="v" a=b']:
+            esc = AkamaiEdgeDNSBackend._escape_char_string(s)
+            assert AkamaiEdgeDNSBackend._unescape_char_string(esc) == s
+
+    def test_svcb_param_value_is_escaped(self):
+        rdata = AkamaiEdgeDNSBackend._format_svcb_rdata(1, "t.example.com.", {"realm": 'a"b'})
+        assert 'key65404="a\\"b"' in rdata
+
+    async def test_create_txt_escapes_embedded_quote(self, monkeypatch):
+        backend = AkamaiEdgeDNSBackend(
+            host="h", client_token="ct", client_secret="cs", access_token="at"
+        )
+        captured: dict = {}
+
+        async def mock_request(method, path, *, json_data=None, params=None, **kwargs):
+            if method == "GET":
+                return None  # doesn't exist -> POST
+            captured["payload"] = json_data
+            return {}
+
+        with patch.object(backend, "_request", side_effect=mock_request):
+            await backend.create_txt_record("example.com", "a", values=['x="evil" injected'])
+        rd = captured["payload"]["rdata"][0]
+        assert rd.startswith('"') and rd.endswith('"')
+        assert "\\" in rd  # the embedded quote was escaped, not left bare
+        assert AkamaiEdgeDNSBackend._unescape_char_string(rd[1:-1]) == 'x="evil" injected'
+
+    def test_seg_encodes_path_separators(self):
+        assert AkamaiEdgeDNSBackend._seg("a/b") == "a%2Fb"
+        assert AkamaiEdgeDNSBackend._seg("x?y#z") == "x%3Fy%23z"
+        assert AkamaiEdgeDNSBackend._seg("example.com") == "example.com"  # FQDNs pass through
+
+
+# ---------------------------------------------------------------------------
+# Hardening: pagination must not truncate when metadata is absent
+# ---------------------------------------------------------------------------
+
+
+class TestAkamaiPaginationNoMetadata:
+    async def test_list_records_walks_until_short_page(self):
+        backend = AkamaiEdgeDNSBackend(
+            host="h", client_token="ct", client_secret="cs", access_token="at"
+        )
+        page1 = [
+            {"name": f"r{i}.example.com", "type": "TXT", "ttl": 300, "rdata": ["v"]}
+            for i in range(100)
+        ]
+        page2 = [
+            {"name": f"s{i}.example.com", "type": "TXT", "ttl": 300, "rdata": ["v"]}
+            for i in range(3)
+        ]
+        calls = 0
+
+        async def mock_request(method, path, *, params=None, **kwargs):
+            nonlocal calls
+            calls += 1
+            return {"recordsets": page1 if calls == 1 else page2}  # NO metadata key
+
+        with patch.object(backend, "_request", side_effect=mock_request):
+            recs = [r async for r in backend.list_records("example.com")]
+        assert len(recs) == 103  # did NOT truncate at 100 despite missing metadata
+        assert calls == 2
+
+
+# ---------------------------------------------------------------------------
+# Hardening: 409 convergence is scoped to single-record paths
+# ---------------------------------------------------------------------------
+
+
+class TestAkamaiBulkPathNeverConverges:
+    """A 409 on the bulk /recordsets path must raise, never auto-convert to PUT.
+
+    PUT on /zones/{zone}/recordsets replaces the ENTIRE zone's record sets, so
+    the POST→PUT upsert convergence is guarded to /names/... paths only.
+    """
+
+    async def test_bulk_recordsets_409_raises_instead_of_put(self, monkeypatch):
+        backend = AkamaiEdgeDNSBackend(
+            host="h", client_token="ct", client_secret="cs", access_token="at"
+        )
+        methods: list[str] = []
+
+        def responder(method, url, **kwargs):
+            methods.append(method)
+            return _resp(409, text='{"title":"recordSetAlreadyExists"}')
+
+        _wire(backend, monkeypatch, responder)
+        with pytest.raises(ValueError, match="status=409"):
+            await backend._request("POST", "/config-dns/v2/zones/z/recordsets", json_data={"x": 1})
+        assert methods == ["POST"]  # no PUT was ever issued on the bulk path


### PR DESCRIPTION
## Summary

Follow-up hardening on the Akamai Edge DNS backend (#182), driven by live stress-testing against a real Edge DNS zone (`akamai.sate.infoblox.com`).

**Headline finding:** Akamai serializes modifications per zone. Overlapping writes return `409 concurrentZoneModification` ("Please try your request again"), which the backend misread as "record already exists" and converted to a `PUT` — which then failed with `400 record does not exist`. A live 12-way concurrent publish landed only **1 of 12** agents. With this PR the same stress lands **12/12 with zero errors**.

## Changes

`src/dns_aid/backends/akamai_edgedns.py`
- **Per-zone write serialization** — an `asyncio.Lock` per zone removes self-inflicted contention (loop-bound, reset with the client on event-loop change).
- **Zone-lock retry** — transient `concurrentZoneModification` 409s retry the *same* request with exponential backoff + jitter (max 5 retries), per Akamai's prescribed handling. Genuine "already exists" 409s still converge POST→PUT.
- **Bulk-path guard** — POST→PUT convergence is scoped to single-record `/names/…` paths. A 409 on the bulk `/recordsets` endpoint can never auto-convert to `PUT` there, which would replace the entire zone's record sets.
- **RFC 1035 escaping** — TXT values and SVCB param values are backslash-escaped on write and unescaped on read-back. Previously a `"` or `\` in a value (e.g. an agent `description`) broke out of presentation-format quoting and could inject extra character-strings/SvcParams or corrupt the publish. Verified live: Akamai accepts the escaped rdata and it round-trips byte-identical.
- **Pagination** — when a list response omits pagination metadata, `totalElements` no longer defaults to `0` (which silently truncated `list_records`/`list_zones` at 100 entries). The API count stays authoritative when present; a short page terminates otherwise.
- **Defense-in-depth** — URL path segments are percent-encoded; retry jitter uses `SystemRandom` (bandit B311).

`tests/unit/test_akamai_edgedns_backend.py` — 10 new tests: retry-then-succeed, retry-exhaustion, genuine-conflict convergence, bulk-path-never-converts, escape/unescape round-trip, SVCB param escaping, TXT create escaping, path-segment encoding, metadata-absent pagination.

`CHANGELOG.md` — entry under Unreleased.

## Test plan

- [x] Unit: 2110 passed (79 Akamai backend tests, 10 new)
- [x] Mock integration: 30 passed
- [x] Lint / format / mypy / bandit clean
- [x] Live SDK integration suite: 9/9 (mutations on, real zone)
- [x] Live stress: 12-way concurrent publish 12/12, 0 errors (was 1/12); 5-way same-name upsert race 0 errors (was 3)
- [x] Live escaping: quoted/backslashed TXT + SVCB values accepted by the Akamai API and round-trip byte-identical
- [x] Live CLI round-trip (publish with quoted description → API read-back → delete) and MCP round-trip (`publish_agent_to_dns` → native `key65400` read-back → `delete_agent_from_dns`)

## Follow-up (documented, out of scope)

Batch operations (`enforce`, multi-agent sync) could use bulk `POST /zones/{zone}/recordsets` (verified live: create-only, 409 `duplicateRecordSet` on existing) or the Change Lists API for atomic multi-record writes. Single-record upserts — the common path — cannot, so it is a separate feature.

Note: the Dependency Audit check is red on `main` (pre-existing: `mcp 1.26.0` CVEs, fix `>=1.28.1`) and unrelated to this PR; a separate deps bump addresses it.