### PR TITLE
fix(deps): bump mcp to >=1.28.1 to resolve three CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ cli = [
     "rich>=13.0.0",
 ]
 mcp = [
-    "mcp>=1.0.0",
+    "mcp>=1.28.1",
     "uvicorn>=0.30.0",
     # Direct floors on transitive deps pulled by `mcp` to close Dependabot alerts
     # (mcp's upstream constraints are looser than the patched versions need).
@@ -140,7 +140,7 @@ all = [
     "typer>=0.12.0",
     "rich>=13.0.0",
     # MCP
-    "mcp>=1.0.0",
+    "mcp>=1.28.1",
     "uvicorn>=0.30.0",
     # Transitive floors via mcp (Dependabot)
     "pyjwt>=2.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -727,8 +727,8 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "lxml", marker = "extra == 'all'", specifier = ">=6.1.0" },
     { name = "lxml", marker = "extra == 'dev'", specifier = ">=6.1.0" },
-    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.0.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.28.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1" },
     { name = "mypy", marker = "extra == 'all'", specifier = ">=1.8.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.20.0,<2.0.0" },
@@ -1274,7 +1274,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1292,9 +1292,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
`mcp 1.26.0` carries three CVEs that have kept the required **Dependency Audit** check red on `main` since 2026-07-20:

| CVE | Fixed in |
|---|---|
| CVE-2026-52870 | 1.27.2 |
| CVE-2026-52869 | 1.27.2 |
| CVE-2026-59950 | 1.28.1 |

This bumps the floor to `mcp>=1.28.1` in both extras and relocks (`1.26.0 → 1.28.1`), greening the audit ahead of the 0.27.0 release.

## Test plan
- [x] `uv lock --upgrade-package mcp` — resolved cleanly to 1.28.1
- [x] Full unit suite: 2110 passed (including all 123 MCP server tests)
- [x] No API changes required in `dns_aid.mcp.server`