### PR TITLE
chore(release): 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-07-22
+
 ### Added
 
 - **Akamai Edge DNS backend** (`akamai-edgedns`). New DNS backend using the
@@ -42,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     authoritative when present; a short page terminates otherwise.
   - URL path segments are percent-encoded (defense-in-depth for direct
     callers), and retry jitter uses `SystemRandom`.
+
+### Security
+
+- **Bumped `mcp` to `>=1.28.1`** — `mcp 1.26.0` carried CVE-2026-52870 and
+  CVE-2026-52869 (both fixed in 1.27.2) and CVE-2026-59950 (fixed in 1.28.1),
+  which had kept the Dependency Audit gate red.
 
 ## [0.26.7] - 2026-07-08
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     given-names: Ingmar
     affiliation: Infoblox
 
-version: "0.26.7"
-date-released: "2026-07-08"
+version: "0.27.0"
+date-released: "2026-07-22"
 
 keywords:
   - dns

--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,8 @@ Cloudflare DNS is ideal for demos, workshops, and quick prototyping thanks to it
 
 Akamai Edge DNS supports ServiceMode SVCB records with full private-use key support, making it fully compliant with the DNS-AID draft. All custom DNS-AID parameters (`cap`, `bap`, `realm`, etc.) are written directly into SVCB — no TXT demotion.
 
+Writes are safe under concurrency: the backend serializes its own writes per zone and automatically retries Akamai's transient `409 concurrentZoneModification` responses with exponential backoff.
+
 #### Environment Variables
 
 | Variable | Required | Default | Description |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -848,6 +848,39 @@ backend = NS1Backend(
 
 **DNS-AID Compliance**: NS1 supports ServiceMode SVCB records with full SVC parameters including private-use keys (`key65400`–`key65408`). NS1 natively accepts private-use SVCB keys — cap_uri, policy_uri, and realm go directly into the SVCB record without TXT demotion.
 
+### AkamaiEdgeDNSBackend
+
+Akamai Edge DNS implementation using the Config DNS API v2 with EdgeGrid authentication.
+
+```python
+from dns_aid.backends.akamai_edgedns import AkamaiEdgeDNSBackend
+
+backend = AkamaiEdgeDNSBackend()  # reads AKAMAI_* env vars or ~/.edgerc
+
+# Or with explicit configuration
+backend = AkamaiEdgeDNSBackend(
+    host="akab-xxxx.luna.akamaiapis.net",
+    client_token="...",
+    client_secret="...",
+    access_token="...",
+)
+```
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AKAMAI_HOST` | No* | - | EdgeGrid API hostname |
+| `AKAMAI_CLIENT_TOKEN` | No* | - | EdgeGrid client token |
+| `AKAMAI_CLIENT_SECRET` | No* | - | EdgeGrid client secret |
+| `AKAMAI_ACCESS_TOKEN` | No* | - | EdgeGrid access token |
+| `AKAMAI_EDGERC` | No | `~/.edgerc` | Path to `.edgerc` credentials file |
+| `AKAMAI_EDGERC_SECTION` | No | `default` | Section within `.edgerc` |
+
+\* Either all four `AKAMAI_*` credential variables or an `~/.edgerc` file. Partial env credentials raise an error naming the missing variables rather than silently falling back.
+
+**DNS-AID Compliance**: Akamai Edge DNS supports ServiceMode SVCB records with full SVC parameters including private-use keys (`key65400`–`key65408`) via the `supports_private_svcb_keys` property — cap_uri, policy_uri, bap, and realm go directly into the SVCB record without TXT demotion.
+
+**Concurrency**: Akamai serializes modifications per zone. The backend serializes its own writes per zone and automatically retries transient `409 concurrentZoneModification` responses with exponential backoff, so concurrent `publish_agent()` calls are safe.
+
 ### DDNSBackend
 
 RFC 2136 Dynamic DNS implementation. Works with BIND, Windows DNS, PowerDNS, Knot DNS, and any RFC 2136 compliant server.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -398,6 +398,8 @@ NIOS WAPI supports ServiceMode SVCB records (priority > 0) with full SVC paramet
 
 Akamai Edge DNS supports ServiceMode SVCB records with full private-use key support, making it fully compliant with the DNS-AID draft. All custom DNS-AID parameters (`cap`, `bap`, `realm`, etc.) are written directly into SVCB — no TXT demotion.
 
+Writes are safe under concurrency: the backend serializes its own writes per zone and automatically retries Akamai's transient `409 concurrentZoneModification` responses with exponential backoff.
+
 ### 1. Install
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.26.7"
+version = "0.27.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dns_aid/mcp/server.py
+++ b/src/dns_aid/mcp/server.py
@@ -274,7 +274,9 @@ def publish_agent_to_dns(
         use_cases: List of use cases for this agent (e.g., ["Generate invoices", "Process refunds"]).
         category: Agent category (e.g., "network", "security", "finance", "chat").
         ttl: DNS record TTL in seconds (default: 3600).
-        backend: DNS backend to use - "route53" for AWS Route53 or "mock" for testing.
+        backend: DNS backend to use - "route53", "cloudflare", "ns1", "infoblox",
+            "nios", "akamai-edgedns", "ddns", or "mock" (testing). Requires the
+            matching API credentials configured in the environment.
         update_index: Whether to update the domain's agent index record (default: True).
         cap_uri: URI to capability document (DNS-AID draft-compliant, e.g.,
             "https://mcp.example.com/.well-known/agent-cap.json"). When set, the

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.26.7"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
Release 0.27.0: version bump + CHANGELOG roll + CITATION.cff + completed Akamai docs.

## Included in this release
- **Akamai Edge DNS backend** (#182) — native private-use SVCB key support (`supports_private_svcb_keys = True`): `cap`, `bap`, `policy`, `realm` and friends land directly on the SVCB record as `key65400`–`key65408`, no TXT demotion
- **Akamai backend hardening** (#202) — per-zone write serialization + `concurrentZoneModification` retry with exponential backoff (live 12-way concurrent publish: 1/12 → 12/12), RFC 1035 rdata escaping for TXT/SVCB values (verified live: escaped rdata accepted by the API and round-trips byte-identical), pagination no longer truncates when metadata is absent, bulk-path guard
- **Security** (#203) — `mcp>=1.28.1` (CVE-2026-52870, CVE-2026-52869, CVE-2026-59950); Dependency Audit green again
- **Docs** — `AkamaiEdgeDNSBackend` section added to the api-reference backends list (NIOS/NS1 pattern), concurrency-safety behavior documented in README and getting-started, MCP publish-tool docstring now lists all available backends

## Explicitly NOT included — bulk record writes
Bulk `POST /zones/{zone}/recordsets` was evaluated and deliberately deferred. Live probing against a real Edge DNS zone showed it is **create-only** (`204` on new record sets, `409 duplicateRecordSet` once they exist), so it cannot serve the common republish/upsert path, and bulk `PUT /recordsets` **replaces the entire zone's record sets** — unsuitable for per-agent upserts. What this release does ship is the **guard**: a 409 on the bulk path can never auto-convert to a zone-replacing `PUT` (covered by `TestAkamaiBulkPathNeverConverges`). Batch writes for multi-agent operations (e.g. the `enforce` pipeline) via Akamai's **Change Lists API** (stage → submit atomically) are the documented follow-up feature.

## Acknowledgements
Thanks to **@meghanakudua02** for building the Akamai Edge DNS backend (#182) — the EdgeGrid signing design, careful live-test gating, and complete CLI/MCP/registry plumbing made it a strong foundation — and to **@IngmarVG-IB** for the thorough two-round review that landed it. This release builds directly on that contribution.

## Test plan
- [x] Full unit suite green on the release branch (2110 passed)
- [x] Live 3-interface verification (SDK / CLI / MCP) against a real Akamai Edge DNS zone, including 12-way concurrency stress and live escaping round-trips
- [x] MCP live round-trip re-verified on `mcp 1.28.1` (the merged dependency state)
- [x] `uv lock` refreshed (self-version)

After merge: tag `v0.27.0` → release workflow (PyPI + MCP registry) → gated `release` environment approval.