### PR TITLE
ci(dco): bump actions-dco to v3.1.1 — fix crash on unlinked author emails

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -19,6 +19,6 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off
-        uses: KineticCafe/actions-dco@1da04282bbf757dab7d92a5c8535dbfb8113da5c  # v3.1.0
+        uses: KineticCafe/actions-dco@b8ab7a2bc910c51e9b5c01e0fc9e0ad6b739d8e0  # v3.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

One-line pin bump: `KineticCafe/actions-dco` v3.1.0 → v3.1.1.

v3.1.0 decodes the compare API's commit `author` field as **required**, but GitHub returns `"author": null` for any commit whose author email isn't linked to a GitHub account. A single such commit anywhere in a PR kills the entire DCO check with `Failed to decode commit comparison JSON` — before any sign-off is evaluated.

**Hit in practice on #200**: all four commits there are authored with a corporate email not linked to the contributor's GitHub account, so DCO fails deterministically (rerun confirmed) even though every commit carries a valid `Signed-off-by` matching its author.

Upstream fixed the nullable decode in [v3.1.1](https://github.com/KineticCafe/actions-dco/releases/tag/v3.1.1) ("fix: Fix author parsing when null", KineticCafe/actions-dco#217), verified by source inspection at the release tag: `decode.field("author", decode.optional(commit_author_decoder()))`.

Pin SHA `b8ab7a2` verified to dereference to the v3.1.1 tag. (v3.2.0 also contains the fix plus new config features — left for Dependabot.)

## Test plan

- [x] This PR's own DCO check runs the **new** action version (pull_request merge ref) — it passing is the live validation
- [x] After merge: re-run DCO on #200; it should evaluate sign-offs instead of crashing