### PR TITLE
ci: bump codeql-action to v4.37.3 in lockstep; group its Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,12 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    groups:
+      # github/codeql-action's sub-actions (init/autobuild/analyze/upload-sarif)
+      # are one repo pinned by one SHA and REQUIRE lockstep versions: init writes
+      # a config stamped with its version and analyze refuses any other. Without
+      # grouping, Dependabot bumps each subpath as a separate dependency and the
+      # partial bump fails CodeQL deterministically (see #207).
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,15 +30,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/init@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/autobuild@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/analyze@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Supersedes #207 and #209, which cannot work as-is.

**The failure:** `github/codeql-action`'s sub-actions require lockstep versions — `init` writes a config stamped with its version, and `analyze` refuses any other (`Loaded a configuration file for version '4.37.0', but running version '4.37.3'`). Dependabot treats each subpath as an independent dependency, so #207 bumped `analyze` alone → deterministic CodeQL failure; no rerun can fix it.

**Fix (this PR):**
1. Bump all four refs together — `init`/`autobuild`/`analyze` in `codeql.yml`, `upload-sarif` in `scorecard.yml` — to `c54b30b`, verified to be the `v4.37.3` tag SHA.
2. Add a Dependabot `groups` entry (`github/codeql-action*`) under the github-actions ecosystem so future bumps of the family arrive as one atomic PR.

**Validation:** this PR's own CodeQL Analysis check runs the bumped lockstep set — it passing is the live proof.

After merge, #207/#209 will be closed as superseded.

Note: touches the same `dependabot.yml` as #124, which will need a trivial rebase.