### PR TITLE
docs: add roadmap, assurance case, and Silver/Gold policy paragraphs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,31 @@ uv run pytest tests/integration/test_infoblox.py -v
 - Update `CHANGELOG.md` for significant changes
 - Ensure all 8 CI checks pass
 
+## Code Review
+
+Every change reaches `main` through a pull request approved by someone other
+than the author — branch protection enforces this for everyone, including
+maintainers and admins. There is no self-merge path.
+
+Reviewers check, at minimum:
+
+- **Correctness** — the change does what it claims; edge cases and error paths
+  are handled, and errors propagate rather than being silently swallowed
+- **Tests** — new behavior is tested, bug fixes include a regression test, and
+  coverage does not drop (CI enforces the floor)
+- **Security** — input validation on new untrusted inputs; no credential
+  logging; changes under `core/validator.py`, `core/jwks.py`,
+  `utils/url_safety.py`, `utils/validation.py`, or any backend auth path get
+  extra scrutiny for trust-boundary implications
+- **Spec alignment** — behavior changes stay consistent with the IETF draft
+  (see [Specification Alignment](#specification-alignment))
+- **Docs & changelog** — user-visible changes update docs and `CHANGELOG.md`
+
+Any maintainer may approve; approvals are dismissed when new commits are
+pushed, so the approval always covers what actually merges. Review comments
+are expected to be specific and actionable — point at the line, say why, and
+suggest a direction.
+
 ## Release Process
 
 Releases are handled by maintainers:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -62,6 +62,10 @@ Any Contributor can be nominated for Committer status by an existing Committer. 
 - Understanding of the DNS-AID architecture and IETF draft
 - Adherence to the Code of Conduct
 
+## Access Continuity
+
+At least two maintainers hold owner rights on the [dns-aid GitHub organization](https://github.com/dns-aid) at all times, so no single person's absence can block administration, releases, or security response. If the Project Lead becomes unavailable for an extended period, the remaining Committers elect an interim Lead by simple majority; the PyPI project and the bestpractices.dev badge entry likewise each have at least two people with owner/edit access as a standing goal.
+
 ## Maintainers
 
 See [MAINTAINERS.md](MAINTAINERS.md) for the current list of maintainers and open roles. The project is actively seeking additional maintainers to ensure long-term sustainability and diverse representation across DNS providers, security expertise, and standards bodies.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Changes to protocol behavior should be discussed within the IETF.
 - [Architecture](docs/architecture.md) — protocol layers, metadata resolution, integration points
 - [Integrations](docs/integrations.md) — backend-specific setup notes
 - [Demo Guide](docs/demo-guide.md) — end-to-end walkthrough for talks and presentations
+- [Roadmap](docs/roadmap.md) — where the project is headed, near/medium/long term
 - [Privacy Policy](PRIVACY.md) | [Security Policy](SECURITY.md) | [Trademarks](TRADEMARKS.md)
 
 ## Ecosystem and Integrations

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,8 +29,8 @@ Before any release:
 2. **Update CHANGELOG.md** with release date and changes
 3. **Create a PR** with the version bump
 4. **Merge PR** after CI passes and review approval
-5. **Tag the release** on GitHub with release notes
-6. **Publish to PyPI** — pushing a `v*` tag automatically publishes to PyPI via trusted publisher
+5. **Tag the release with a signed tag** — `git tag -s vX.Y.Z -m "vX.Y.Z"` using the maintainer's GPG or SSH signing key (unsigned tags are not used for releases)
+6. **Publish to PyPI** — pushing the `v*` tag automatically publishes to PyPI via trusted publisher
 
 ## Hotfix Process
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,13 @@ Instead, please report security vulnerabilities using one of these methods:
 - **Status Update**: Within 7 days
 - **Resolution Target**: Within 30 days for critical issues
 
+### Reporter Credit
+
+We credit vulnerability reporters by name (or handle) in the GitHub Security
+Advisory and the release notes of the fix, unless the reporter asks to remain
+anonymous. Tell us in your report how — or whether — you'd like to be
+credited.
+
 ## Security Architecture
 
 ### DNSSEC Validation

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,52 @@
+# DNS-AID Roadmap
+
+This page describes where the project is headed. The
+[issue tracker](https://github.com/dns-aid/dns-aid-core/issues) is the source
+of truth for individual work items; this document explains priorities and
+direction. It is reviewed at each minor release and at governance changes.
+
+The DNS-AID *protocol* is specified in the IETF
+([draft-mozleywilliams-dnsop-dnsaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/));
+protocol-level changes happen there, not here. This roadmap covers the
+reference implementation only.
+
+## Near term (next 1–2 releases)
+
+- **Track the IETF draft.** Keep the implementation aligned with each draft
+  revision (the `draft-watch` workflow flags new revisions automatically);
+  implement wire-format and behavior changes as they land.
+- **OpenSSF Best Practices Silver → Gold.** Execute the
+  [OpenSSF proposal](proposals/openssf-best-practices.md): assurance case,
+  coverage push to 90% statement / 80% branch, reproducible-build check,
+  fuzzing, independent security review.
+- **Backend parity.** Bring all DNS provider backends (Route 53, Cloudflare,
+  NS1, Cloud DNS, Infoblox BloxOne/NIOS, Akamai EdgeDNS, DDNS) to the same
+  feature and test level, including native private-use SVCB keys and uniform
+  error propagation.
+
+## Medium term
+
+- **Linux Foundation onboarding.** Complete the sustainability goals in
+  [MAINTAINERS.md](../MAINTAINERS.md): a maintainer from a second
+  organization, documented project-lead succession, and an external committer
+  with merge rights on at least one subsystem.
+- **IANA registration.** Move the private-use SVCB SvcParamKeys
+  (key65400–65405) to permanently registered keys as the draft progresses,
+  with a migration path for published records.
+- **Ecosystem interoperability.** Continue ARD ai-catalog interop and keep the
+  indexer/telemetry interfaces provider-neutral so independent directories can
+  build on the same records.
+
+## Long term
+
+- **1.0 release** once the IETF draft reaches a stable state (working-group
+  adoption and wire-format stability), with semantic-versioning guarantees for
+  the public Python API and CLI.
+- **Post-quantum readiness.** Mature the ML-DSA-65 HTTP Message Signatures
+  support (`pqc` extra) from experimental to supported as standards settle.
+
+## Non-goals
+
+- Defining protocol behavior (IETF territory).
+- Canonicalizing a single directory/indexer service; DNS-AID stays a substrate
+  that any directory can build on.

--- a/docs/security/assurance-case.md
+++ b/docs/security/assurance-case.md
@@ -1,0 +1,129 @@
+# DNS-AID Security Assurance Case
+
+This document argues, with evidence, that the DNS-AID reference implementation
+meets its security requirements. It follows the claim → argument → evidence
+structure suggested by the
+[OpenSSF Best Practices `assurance_case` criterion](https://www.bestpractices.dev/en/criteria/1#1.assurance_case).
+Normative security requirements for the *protocol* live in the IETF draft
+([Security Considerations](../rfc/security-considerations.md)); this document
+covers the implementation.
+
+## Top-level claim
+
+> The DNS-AID library, CLI, and MCP server preserve the integrity and
+> authenticity guarantees of the DNS records they publish and consume, and do
+> not extend the attacker capabilities of the environment they run in.
+
+The claim decomposes along the trust boundaries below.
+
+## Trust boundaries
+
+```text
+                 ┌────────────────────────────────────────────┐
+                 │            Operator environment            │
+                 │  ┌──────────┐   ┌──────────┐  ┌─────────┐  │
+   DNS zone  ◄───┼──┤ publisher│   │discoverer│  │   MCP   │◄─┼── MCP client
+  (provider API) │  └──────────┘   └────┬─────┘  │ server  │  │   (localhost)
+                 │   credentials        │        └─────────┘  │
+                 └──────────────────────┼─────────────────────┘
+                                        │ untrusted inputs
+                          ┌─────────────┴──────────────┐
+                          │  DNS responses (resolver)  │
+                          │  capability documents      │
+                          │  A2A agent cards (HTTPS)   │
+                          └────────────────────────────┘
+```
+
+Untrusted inputs: DNS responses, fetched capability documents and agent cards,
+and all user-supplied names/domains/parameters. Trusted-but-guarded: DNS
+provider credentials and the upstream resolver.
+
+## Sub-claim 1 — Untrusted network input cannot corrupt discovery results
+
+**Argument.** All discovery inputs are parsed defensively, validated against
+strict schemas, and integrity-checked where the protocol provides a mechanism.
+
+**Evidence.**
+
+- Input validation: agent names, domains, ports, and TTLs are validated before
+  use (`src/dns_aid/utils/validation.py`; rules documented in
+  [SECURITY.md §Input Validation](../../SECURITY.md#input-validation)).
+- Record models are pydantic-typed; malformed SVCB/TXT data fails parsing
+  rather than propagating (`src/dns_aid/core/models.py`).
+- Capability documents are integrity-verified against the `cap-sha256`
+  SVCB parameter when present; digest mismatch rejects the document
+  ([SECURITY.md §Capability Document Integrity](../../SECURITY.md#capability-document-integrity-cap_sha256)).
+- DNSSEC status is surfaced via the resolver AD flag and DANE/TLSA
+  verification supports full certificate matching
+  ([SECURITY.md §Security Architecture](../../SECURITY.md#security-architecture));
+  the residual trust in the upstream resolver is documented as an explicit
+  limitation rather than hidden.
+- Adversarial parsing is exercised by unit tests and a fuzzing harness over
+  the SVCB parameter parser, FQDN parser, and index/TXT parsers.
+
+## Sub-claim 2 — Outbound fetches cannot be abused for SSRF
+
+**Argument.** Every outbound HTTP fetch initiated from untrusted data (capability
+URIs, agent-card URLs) goes through a hardened fetch path.
+
+**Evidence.** HTTPS-only scheme enforcement, pre-connection DNS resolution
+checks blocking RFC 1918/loopback/link-local targets, a redirect cap of 3, and
+an explicit allowlist escape hatch for testing only
+(`src/dns_aid/utils/url_safety.py`;
+[SECURITY.md §SSRF Protection](../../SECURITY.md#ssrf-protection)).
+
+## Sub-claim 3 — Credentials are confined
+
+**Argument.** Provider credentials are used only to authenticate to the
+operator's own DNS provider and never leave the process by another path.
+
+**Evidence.** Credentials are read from environment/config, never logged
+(structlog processors exclude them; `scripts/audit_credential_handling.py`
+audits the handling paths); backends send them only to their provider
+endpoints over TLS; the MCP HTTP transport binds to 127.0.0.1 by default so
+the tool surface is not network-exposed
+([SECURITY.md §Network Security](../../SECURITY.md#network-security)).
+
+## Sub-claim 4 — The supply chain from source to artifact is verifiable
+
+**Argument.** A consumer can verify that a released artifact corresponds to the
+reviewed source.
+
+**Evidence.** Branch protection with required review and status checks
+(including admins); DCO sign-off on every commit; CI runs SAST (CodeQL,
+Bandit), dependency audit (pip-audit, Dependabot), and the full test matrix;
+releases are built in CI from the tag, signed with Sigstore keyless signing,
+shipped with a CycloneDX SBOM, and published to PyPI via OIDC trusted
+publishing (no long-lived tokens) — see
+`.github/workflows/release.yml` and [RELEASE.md](../../RELEASE.md).
+
+## Sub-claim 5 — Secure-design principles are applied
+
+**Argument.** The implementation follows economy of mechanism, fail-safe
+defaults, complete mediation, and least privilege.
+
+**Evidence.** Deliberately small dependency set (stdlib + dnspython, httpx,
+pydantic, cryptography); fail-closed defaults (HTTPS-only, advisory DANE warns
+and full matching rejects on mismatch, integrity mismatch treated as fetch
+failure, backend `get_record` errors propagate instead of masking as
+not-found); every untrusted input crosses a validation layer; CI workflow
+tokens default to `contents: read` with per-job escalation.
+
+## Known limitations (accepted, documented)
+
+- DNSSEC validation trusts the upstream resolver's AD flag; no independent
+  chain validation. Operators must run a validating resolver.
+- DANE defaults to advisory mode; full certificate matching is opt-in.
+- The mock backend is for testing only.
+- SVCB keys 65400–65405 are in the private-use range pending IANA
+  registration.
+
+These are stated in [SECURITY.md](../../SECURITY.md#known-security-limitations)
+and in user-facing docs rather than silently assumed.
+
+## Maintenance
+
+This assurance case is reviewed when a new attack surface is added (new
+backend, new network fetch path, new transport), when the IETF draft changes
+security-relevant behavior, and at least once per minor release. Material
+changes to the argument require review by a maintainer other than the author.


### PR DESCRIPTION
## Summary

Closes the documentation gaps for OpenSSF Best Practices **Silver** and **Gold** (see the proposal in #216 / `docs/proposals/openssf-best-practices.md`):

- **`docs/roadmap.md`** (`documentation_roadmap` — the only Silver MUST with no existing artifact), linked from the README
- **`docs/security/assurance-case.md`** (`assurance_case`) — claim → argument → evidence over the implementation's trust boundaries, assembled from SECURITY.md and the RFC security-considerations content
- **SECURITY.md** — reporter-credit commitment (`vulnerability_report_credit`)
- **GOVERNANCE.md** — access-continuity section (`access_continuity`)
- **RELEASE.md** — release tags are now signed tags (`version_tags_signed`)
- **CONTRIBUTING.md** — code-review standards section (`code_review_standards`, Gold): what reviewers check, no self-merge path

## Review notes
- Docs only; no behavior changes.
- The assurance case cites current code paths (`utils/url_safety.py`, `utils/validation.py`, `core/models.py`) — worth a skim to confirm the claims match your mental model.
