### PR TITLE
test: raise coverage 79% → 93% for OpenSSF Gold targets

### DIFF
--- a/tests/unit/cli/test_cli_main_extended.py
+++ b/tests/unit/cli/test_cli_main_extended.py
@@ -1,0 +1,1559 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Extended unit tests for ``dns_aid.cli.main``.
+
+Covers the CLI commands and branches not exercised by ``test_cli.py`` /
+``test_policy_cli.py`` / ``test_search_command.py``:
+
+- message / call / list-tools (agent communication)
+- dcv issue / place / verify / revoke
+- keys generate / export-jwks
+- index publish-catalog / unpublish-catalog / sync error paths
+- policy show/compile edge cases and policy rollback
+- the full enforce pipeline (validation, auto-policy, enforce-mode pushes,
+  report generation)
+- _get_backend error paths
+- output-formatting branches of publish / discover / search / verify / list
+
+All backend / network boundaries are mocked (``dns_aid.cli.main.run_async``
+or the library entry points) — no network, deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+from dns_aid.core.invoke import InvokeResult
+
+runner = CliRunner()
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"
+SAMPLE_POLICY = FIXTURES / "sample-policy.json"
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# A minimal policy document that compiles cleanly (RPZ directive, no skips).
+MINIMAL_POLICY = {
+    "agent": "_svc._mcp._agents.example.com",
+    "rules": {"blocked_caller_domains": ["evil.example.com"]},
+}
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _combined_output(result) -> str:
+    """stdout + stderr (if captured separately), ANSI-stripped."""
+    out = result.output
+    try:
+        err = result.stderr or ""
+    except Exception:
+        err = ""
+    return _strip_ansi(out + err)
+
+
+# ============================================================================
+# MESSAGE COMMAND
+# ============================================================================
+
+
+class TestMessageCommand:
+    def test_message_requires_endpoint_or_domain_name(self):
+        result = runner.invoke(app, ["message", "hello"])
+        assert result.exit_code == 1
+        assert "Provide --endpoint" in _combined_output(result)
+
+    def test_message_rejects_empty_text(self):
+        result = runner.invoke(app, ["message", "   ", "-e", "https://chat.example.com"])
+        assert result.exit_code == 1
+        assert "cannot be empty" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_message_failure_exits_1(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=False, error="connection refused")
+        result = runner.invoke(app, ["message", "hi", "-e", "https://chat.example.com"])
+        assert result.exit_code == 1
+        assert "connection refused" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_message_success_with_agent_info_and_text(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(
+            success=True,
+            data={
+                "agent_info": {
+                    "resolved_via": "dns",
+                    "canonical_endpoint": "https://chat.example.com/a2a",
+                    "name": "chat-agent",
+                },
+                "response_text": "Hello back!",
+                "raw": {"jsonrpc": "2.0", "result": {}},
+            },
+        )
+        result = runner.invoke(app, ["message", "hi", "-d", "example.com", "-n", "chat"])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Resolved via: dns" in plain
+        assert "Canonical URL" in plain
+        assert "Agent: chat-agent" in plain
+        assert "Hello back!" in plain
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_message_json_output_uses_raw(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(
+            success=True,
+            data={
+                "agent_info": {"resolved_via": "direct"},
+                "response_text": "unused",
+                "raw": {"jsonrpc": "2.0", "id": 7},
+            },
+        )
+        result = runner.invoke(app, ["message", "hi", "-e", "https://chat.example.com", "--json"])
+        assert result.exit_code == 0
+        assert '"jsonrpc"' in result.output
+        assert "unused" not in result.output
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_message_fallback_prints_json_data(self, mock_run_async):
+        """No response_text and no agent_info → raw data dumped as JSON."""
+        mock_run_async.return_value = InvokeResult(success=True, data={"weird": "shape"})
+        result = runner.invoke(app, ["message", "hi", "-e", "https://chat.example.com"])
+        assert result.exit_code == 0
+        assert "weird" in result.output
+
+
+# ============================================================================
+# CALL COMMAND
+# ============================================================================
+
+
+class TestCallCommand:
+    def test_call_invalid_json_arguments(self):
+        result = runner.invoke(
+            app, ["call", "https://mcp.example.com/mcp", "my_tool", "-a", "{not json"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid JSON" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_call_failure_exits_1(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=False, error="tool not found")
+        result = runner.invoke(app, ["call", "https://mcp.example.com/mcp", "nope"])
+        assert result.exit_code == 1
+        assert "tool not found" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_call_json_output(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=True, data={"content": []})
+        result = runner.invoke(
+            app,
+            [
+                "call",
+                "https://mcp.example.com/mcp",
+                "my_tool",
+                "-a",
+                '{"domain": "example.com"}',
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert '"content"' in result.output
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_call_renders_mcp_content_array(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(
+            success=True,
+            data={"content": [{"type": "text", "text": "analysis done"}, {"type": "image"}]},
+        )
+        result = runner.invoke(app, ["call", "https://mcp.example.com/mcp", "analyze"])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "analysis done" in plain
+        assert "image" in plain
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_call_renders_string_data(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=True, data="plain result")
+        result = runner.invoke(app, ["call", "https://mcp.example.com/mcp", "tool"])
+        assert result.exit_code == 0
+        assert "plain result" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_call_renders_other_data_as_json(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=True, data={"answer": 42})
+        result = runner.invoke(app, ["call", "https://mcp.example.com/mcp", "tool"])
+        assert result.exit_code == 0
+        assert "42" in result.output
+
+
+# ============================================================================
+# LIST-TOOLS COMMAND
+# ============================================================================
+
+
+class TestListToolsCommand:
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_tools_failure_exits_1(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=False, error="unreachable")
+        result = runner.invoke(app, ["list-tools", "https://mcp.example.com/mcp"])
+        assert result.exit_code == 1
+        assert "unreachable" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_tools_json_output(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(
+            success=True, data=[{"name": "analyze", "description": "Analyze things"}]
+        )
+        result = runner.invoke(app, ["list-tools", "https://mcp.example.com/mcp", "--json"])
+        assert result.exit_code == 0
+        assert '"analyze"' in result.output
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_tools_empty(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=True, data=[])
+        result = runner.invoke(app, ["list-tools", "https://mcp.example.com/mcp"])
+        assert result.exit_code == 0
+        assert "No tools found" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_tools_non_list_data_treated_as_empty(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(success=True, data={"oops": True})
+        result = runner.invoke(app, ["list-tools", "https://mcp.example.com/mcp"])
+        assert result.exit_code == 0
+        assert "No tools found" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_tools_table(self, mock_run_async):
+        mock_run_async.return_value = InvokeResult(
+            success=True,
+            data=[
+                {"name": "analyze", "description": "Analyze security posture"},
+                {"name": "report"},  # missing description → "-"
+            ],
+        )
+        result = runner.invoke(app, ["list-tools", "https://mcp.example.com/mcp"])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "analyze" in plain
+        assert "2 tool(s)" in plain
+
+
+# ============================================================================
+# PUBLISH / DISCOVER / VERIFY / LIST / DELETE / INDEX branches
+# ============================================================================
+
+
+def _make_publish_result():
+    from dns_aid.core.models import AgentRecord, Protocol, PublishResult
+
+    agent = AgentRecord(
+        name="chat",
+        domain="example.com",
+        protocol=Protocol.MCP,
+        target_host="mcp.example.com",
+        endpoint_override="https://mcp.example.com",
+        port=443,
+    )
+    return PublishResult(
+        agent=agent,
+        records_created=["SVCB chat.example.com"],
+        zone="example.com",
+        backend="mock",
+        success=True,
+    )
+
+
+def _make_index_result(success=True, created=False):
+    from dns_aid.core.indexer import IndexEntry, IndexResult
+
+    return IndexResult(
+        domain="example.com",
+        entries=[IndexEntry(name="chat", protocol="mcp")],
+        success=success,
+        message="ok" if success else "boom",
+        created=created,
+    )
+
+
+class TestPublishExplicitEndpoint:
+    @patch("dns_aid.cli.main.run_async")
+    def test_publish_with_explicit_endpoint(self, mock_run_async):
+        """--endpoint set → the default-endpoint branch is skipped."""
+        mock_run_async.side_effect = [_make_publish_result(), _make_index_result()]
+        result = runner.invoke(
+            app,
+            [
+                "publish",
+                "-n",
+                "chat",
+                "-d",
+                "example.com",
+                "-e",
+                "custom.example.com",
+                "--backend",
+                "mock",
+                "--ipv4hint",
+                "203.0.113.10",
+                "--ipv6hint",
+                "2001:db8::1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "published successfully" in _strip_ansi(result.output)
+
+
+class TestVerifyDetailBranches:
+    @patch("dns_aid.cli.main.run_async")
+    def test_verify_prints_dnssec_detail_and_skips_empty_notes(self, mock_run_async):
+        from dns_aid.core.models import DNSSECDetail
+        from dns_aid.core.validator import VerifyResult
+
+        mock_run_async.return_value = VerifyResult(
+            fqdn="chat.example.com",
+            record_exists=True,
+            svcb_valid=True,
+            dnssec_valid=True,
+            dnssec_note="",
+            dane_valid=True,
+            dane_note="",
+            endpoint_reachable=True,
+            endpoint_latency_ms=12.0,
+            dnssec_detail=DNSSECDetail(
+                validated=True,
+                algorithm="ECDSAP256SHA256",
+                algorithm_strength="strong",
+                chain_complete=True,
+                chain_depth=3,
+            ),
+        )
+        result = runner.invoke(app, ["verify", "chat.example.com"])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "ECDSAP256SHA256" in plain
+        assert "chain depth: 3" in plain
+
+
+class TestListCommandBranches:
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_backend_exception_exits_1(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("backend down")
+        result = runner.invoke(app, ["list", "example.com", "--backend", "mock"])
+        assert result.exit_code == 1
+        assert "Failed to list records" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_zone_not_found_exits_1(self, mock_run_async):
+        mock_run_async.return_value = None  # sentinel: zone missing
+        result = runner.invoke(app, ["list", "nozone.example", "--backend", "mock"])
+        assert result.exit_code == 1
+        assert "does not exist" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_list_non_list_values_rendered(self, mock_run_async):
+        mock_run_async.return_value = [
+            {
+                "fqdn": "chat.example.com",
+                "type": "TXT",
+                "ttl": 300,
+                "values": "scalar-value",
+            },
+        ]
+        result = runner.invoke(app, ["list", "example.com", "--backend", "mock"])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "scalar-value" in plain
+        assert "1 record(s)" in plain
+
+
+class TestDeleteCommandBranches:
+    @patch("dns_aid.cli.main.run_async")
+    def test_delete_confirmed_interactively(self, mock_run_async):
+        mock_run_async.side_effect = [True, _make_index_result()]
+        result = runner.invoke(
+            app,
+            ["delete", "-n", "chat", "-d", "example.com", "--backend", "mock"],
+            input="y\n",
+        )
+        assert result.exit_code == 0
+        assert "deleted successfully" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_delete_backend_exception_exits_1(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("kaboom")
+        result = runner.invoke(
+            app,
+            ["delete", "-n", "chat", "-d", "example.com", "--backend", "mock", "--force"],
+        )
+        assert result.exit_code == 1
+        assert "Failed to delete" in _combined_output(result)
+
+
+class TestIndexSyncBranches:
+    @patch("dns_aid.cli.main.run_async")
+    def test_index_sync_exception_exits_1(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("sync blew up")
+        result = runner.invoke(app, ["index", "sync", "example.com", "--backend", "mock"])
+        assert result.exit_code == 1
+        assert "Failed to sync index" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_index_sync_success_not_created(self, mock_run_async):
+        """created=False → no 'Index record created' footer."""
+        mock_run_async.return_value = _make_index_result(success=True, created=False)
+        result = runner.invoke(app, ["index", "sync", "example.com", "--backend", "mock"])
+        assert result.exit_code == 0
+        assert "Index record created" not in _strip_ansi(result.output)
+
+
+# ============================================================================
+# INDEX CATALOG POINTER COMMANDS
+# ============================================================================
+
+
+class TestIndexCatalogCommands:
+    @patch("dns_aid.cli.main.run_async")
+    def test_publish_catalog_success(self, mock_run_async):
+        mock_run_async.return_value = [
+            "_catalog._agents.example.com",
+            "_index._agents.example.com",
+        ]
+        result = runner.invoke(
+            app,
+            [
+                "index",
+                "publish-catalog",
+                "example.com",
+                "ard.example.com",
+                "--backend",
+                "mock",
+            ],
+        )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Catalog pointer published" in plain
+        assert "_catalog._agents.example.com" in plain
+        assert "https://ard.example.com/.well-known/ai-catalog.json" in plain
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_publish_catalog_failure_exits_1(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("write denied")
+        result = runner.invoke(
+            app,
+            [
+                "index",
+                "publish-catalog",
+                "example.com",
+                "ard.example.com",
+                "--backend",
+                "mock",
+                "--catalog-only",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Failed to publish catalog pointer" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_unpublish_catalog_success(self, mock_run_async):
+        mock_run_async.return_value = ["_catalog._agents.example.com"]
+        result = runner.invoke(
+            app, ["index", "unpublish-catalog", "example.com", "--backend", "mock"]
+        )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Catalog pointer removed" in plain
+        assert "deleted SVCB" in plain
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_unpublish_catalog_nothing_to_remove(self, mock_run_async):
+        mock_run_async.return_value = []
+        result = runner.invoke(
+            app,
+            [
+                "index",
+                "unpublish-catalog",
+                "example.com",
+                "--backend",
+                "mock",
+                "--catalog-only",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "No catalog pointer records found" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_unpublish_catalog_failure_exits_1(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("delete denied")
+        result = runner.invoke(
+            app, ["index", "unpublish-catalog", "example.com", "--backend", "mock"]
+        )
+        assert result.exit_code == 1
+        assert "Failed to remove catalog pointer" in _combined_output(result)
+
+
+# ============================================================================
+# KEYS COMMANDS
+# ============================================================================
+
+
+class TestKeysGenerate:
+    def test_generate_unencrypted(self, tmp_path):
+        result = runner.invoke(app, ["keys", "generate", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Keypair generated successfully" in plain
+        assert "NOT encrypted" in plain
+        assert (tmp_path / "private.pem").exists()
+        assert (tmp_path / "public.pem").exists()
+
+    def test_generate_with_password(self, tmp_path):
+        result = runner.invoke(
+            app,
+            ["keys", "generate", "-o", str(tmp_path), "--kid", "test-key", "-p", "secret"],
+        )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "password-protected" in plain
+        assert "test-key" in plain
+        assert b"ENCRYPTED" in (tmp_path / "private.pem").read_bytes()
+
+
+class TestKeysExportJwks:
+    def _generate(self, tmp_path):
+        result = runner.invoke(app, ["keys", "generate", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+
+    def test_export_missing_file(self):
+        result = runner.invoke(app, ["keys", "export-jwks", "-i", "/no/such/key.pem"])
+        assert result.exit_code == 1
+        assert "Key file not found" in _combined_output(result)
+
+    def test_export_from_public_key_stdout(self, tmp_path):
+        self._generate(tmp_path)
+        result = runner.invoke(app, ["keys", "export-jwks", "-i", str(tmp_path / "public.pem")])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert '"kty"' in plain
+        assert "dns-aid-jwks.json" in plain
+
+    def test_export_from_private_key_to_file(self, tmp_path):
+        self._generate(tmp_path)
+        out = tmp_path / "jwks.json"
+        result = runner.invoke(
+            app,
+            [
+                "keys",
+                "export-jwks",
+                "-i",
+                str(tmp_path / "private.pem"),
+                "-o",
+                str(out),
+                "--kid",
+                "my-kid",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "JWKS exported to" in _strip_ansi(result.output)
+        jwks = json.loads(out.read_text())
+        assert jwks["keys"][0]["kid"] == "my-kid"
+
+    def test_export_rejects_non_ec_public_key(self, tmp_path):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pub_pem = rsa_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        key_file = tmp_path / "rsa-pub.pem"
+        key_file.write_bytes(pub_pem)
+        result = runner.invoke(app, ["keys", "export-jwks", "-i", str(key_file)])
+        assert result.exit_code == 1
+
+    def test_export_rejects_non_ec_private_key(self, tmp_path):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        priv_pem = rsa_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        key_file = tmp_path / "rsa-priv.pem"
+        key_file.write_bytes(priv_pem)
+        result = runner.invoke(app, ["keys", "export-jwks", "-i", str(key_file)])
+        assert result.exit_code == 1
+
+    def test_export_garbage_file(self, tmp_path):
+        key_file = tmp_path / "garbage.pem"
+        key_file.write_text("this is not a key")
+        result = runner.invoke(app, ["keys", "export-jwks", "-i", str(key_file)])
+        assert result.exit_code == 1
+        assert "Failed to load key" in _combined_output(result)
+
+
+# ============================================================================
+# _get_backend ERROR PATHS
+# ============================================================================
+
+
+class TestGetBackendErrorPaths:
+    def test_detect_backend_valueerror_exits_1(self, monkeypatch):
+        monkeypatch.delenv("DNS_AID_BACKEND", raising=False)
+        with patch(
+            "dns_aid.cli.backends.detect_backend",
+            side_effect=ValueError("Multiple backends configured"),
+        ):
+            result = runner.invoke(app, ["list", "example.com"])
+        assert result.exit_code == 1
+        assert "Multiple backends configured" in _combined_output(result)
+
+    def test_missing_required_env_shows_setup_steps(self, monkeypatch):
+        monkeypatch.delenv("CLOUDFLARE_API_TOKEN", raising=False)
+        result = runner.invoke(app, ["list", "example.com", "--backend", "cloudflare"])
+        assert result.exit_code == 1
+        plain = _combined_output(result)
+        assert "requires environment variables" in plain
+        assert "CLOUDFLARE_API_TOKEN" in plain
+        assert "Setup steps" in plain
+
+    def test_create_backend_importerror(self):
+        with patch(
+            "dns_aid.backends.create_backend",
+            side_effect=ImportError("No module named 'boto3'"),
+        ):
+            result = runner.invoke(app, ["list", "example.com", "--backend", "mock"])
+        assert result.exit_code == 1
+        assert "Missing dependency" in _combined_output(result)
+
+    def test_create_backend_valueerror(self, monkeypatch):
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "token")
+        with patch(
+            "dns_aid.backends.create_backend",
+            side_effect=ValueError("bad credentials"),
+        ):
+            result = runner.invoke(app, ["list", "example.com", "--backend", "cloudflare"])
+        assert result.exit_code == 1
+        plain = _combined_output(result)
+        assert "Failed to initialize" in plain
+        assert "Setup steps" in plain
+
+    def test_create_backend_oserror_without_setup_steps(self):
+        """A registry entry without setup_steps skips the guidance block."""
+        from dns_aid.cli.backends import BackendInfo
+
+        bare = BackendInfo(name="mock", display_name="Bare Mock")
+        with (
+            patch.dict("dns_aid.cli.backends.BACKEND_REGISTRY", {"mock": bare}),
+            patch(
+                "dns_aid.backends.create_backend",
+                side_effect=OSError("filesystem error"),
+            ),
+        ):
+            result = runner.invoke(app, ["list", "example.com", "--backend", "mock"])
+        assert result.exit_code == 1
+        plain = _combined_output(result)
+        assert "Failed to initialize" in plain
+        assert "Setup steps" not in plain
+
+    def test_missing_env_without_setup_guidance(self):
+        """Missing required env for a backend with no setup steps/url."""
+        from dns_aid.cli.backends import BackendInfo
+
+        fake = BackendInfo(
+            name="fake",
+            display_name="Fake DNS",
+            required_env={"FAKE_DNS_TOKEN": "API token"},
+        )
+        with patch.dict("dns_aid.cli.backends.BACKEND_REGISTRY", {"fake": fake}):
+            result = runner.invoke(app, ["list", "example.com", "--backend", "fake"])
+        assert result.exit_code == 1
+        plain = _combined_output(result)
+        assert "requires environment variables" in plain
+        assert "FAKE_DNS_TOKEN" in plain
+        assert "Setup steps" not in plain
+        assert "Docs:" not in plain
+
+
+# ============================================================================
+# SEARCH — JSON error envelopes and pagination-exhausted branch
+# ============================================================================
+
+
+class TestSearchExtraBranches:
+    def test_config_error_json_envelope(self):
+        from dns_aid.sdk.exceptions import DirectoryConfigError
+
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryConfigError(
+                "no url",
+                details={
+                    "missing_field": "directory_api_url",
+                    "env_var": "DNS_AID_SDK_DIRECTORY_API_URL",
+                },
+            ),
+        ):
+            result = runner.invoke(app, ["search", "x", "--json"])
+        assert result.exit_code == 78
+        assert "DirectoryConfigError" in _combined_output(result)
+
+    def test_auth_error_json_envelope(self):
+        from dns_aid.sdk.exceptions import DirectoryAuthError
+
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryAuthError("forbidden", details={"status": 403}),
+        ):
+            result = runner.invoke(
+                app,
+                ["search", "x", "--json", "--directory-url", "https://directory.test.example"],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 77
+        assert "DirectoryAuthError" in _combined_output(result)
+
+    def test_unavailable_error_json_envelope(self):
+        from dns_aid.sdk.exceptions import DirectoryUnavailableError
+
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=DirectoryUnavailableError("503", details={"status": 503}),
+        ):
+            result = runner.invoke(
+                app,
+                ["search", "x", "--json", "--directory-url", "https://directory.test.example"],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 75
+        assert "DirectoryUnavailableError" in _combined_output(result)
+
+    def test_human_table_without_next_page_hint(self):
+        from dns_aid.core.models import AgentRecord, Protocol
+        from dns_aid.sdk.search import SearchResponse, SearchResult, TrustAttestation
+
+        response = SearchResponse(
+            query="payments",
+            results=[
+                SearchResult(
+                    agent=AgentRecord(
+                        name="agent0",
+                        domain="example.com",
+                        protocol=Protocol.MCP,
+                        target_host="agent0.example.com",
+                        port=443,
+                        capabilities=[],
+                    ),
+                    score=10.0,
+                    trust=TrustAttestation(
+                        security_score=80,
+                        trust_score=75,
+                        popularity_score=60,
+                        trust_tier=2,
+                        safety_status="active",
+                        dnssec_valid=True,
+                        dane_valid=False,
+                        svcb_valid=True,
+                        endpoint_reachable=True,
+                        protocol_verified=True,
+                        badges=[],
+                    ),
+                )
+            ],
+            total=1,
+            limit=20,
+            offset=0,
+        )
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            return_value=response,
+        ):
+            result = runner.invoke(
+                app,
+                ["search", "payments", "--directory-url", "https://directory.test.example"],
+                env={"DNS_AID_FETCH_ALLOWLIST": "directory.test.example"},
+            )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Showing 1-1 of 1 results" in plain
+        assert "Use --offset" not in plain
+
+
+# ============================================================================
+# POLICY COMMANDS — edge branches + rollback
+# ============================================================================
+
+
+class TestPolicyCompileBranches:
+    def test_compile_invalid_format(self, tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "policy",
+                "compile",
+                "-i",
+                str(SAMPLE_POLICY),
+                "-o",
+                str(tmp_path / "out"),
+                "-f",
+                "bogus",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "must be rpz, bindaid, or both" in _combined_output(result)
+
+    def test_compile_without_skipped_rules(self, tmp_path):
+        policy = tmp_path / "minimal.json"
+        policy.write_text(json.dumps(MINIMAL_POLICY))
+        out = tmp_path / "zone"
+        result = runner.invoke(
+            app, ["policy", "compile", "-i", str(policy), "-o", str(out), "-f", "both"]
+        )
+        assert result.exit_code == 0
+        assert "rule(s) skipped" not in _strip_ansi(result.output)
+
+
+class TestPolicyShowBranches:
+    def test_show_missing_input(self):
+        result = runner.invoke(app, ["policy", "show", "-i", "/nonexistent-policy.json"])
+        assert result.exit_code == 1
+        assert "Input file not found" in _combined_output(result)
+
+    def test_show_invalid_json(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{nope")
+        result = runner.invoke(app, ["policy", "show", "-i", str(bad)])
+        assert result.exit_code == 1
+        assert "Failed to parse policy document" in _combined_output(result)
+
+    def test_show_empty_policy_prints_none_sections(self, tmp_path):
+        policy = tmp_path / "empty.json"
+        policy.write_text(json.dumps({"agent": "_svc._mcp._agents.example.com"}))
+        result = runner.invoke(app, ["policy", "show", "-i", str(policy)])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "RPZ Directives (0)" in plain
+        assert "bind-aid Directives (0)" in plain
+        assert "Skipped Rules (0)" in plain
+        assert "None" in plain
+
+
+def _make_snapshot(directives=None):
+    from dns_aid.sdk.policy.snapshot import RPZSnapshot
+
+    return RPZSnapshot(
+        timestamp="2026-07-29T00:00:00+00:00",
+        rpz_zone="rpz.example.com",
+        backend="nios",
+        mode="enforce",
+        directives=directives
+        or [
+            {
+                "owner": "evil.example.com",
+                "action": "NXDOMAIN",
+                "source_rule": "block-evil",
+                "comment": "bad",
+            },
+            {
+                "owner": "worse.example.com",
+                "action": "DROP",
+                "source_rule": "block-worse",
+                "comment": "worse",
+            },
+        ],
+    )
+
+
+class TestPolicyRollback:
+    def test_rollback_no_snapshot(self):
+        with patch("dns_aid.sdk.policy.snapshot.load_latest_snapshot", return_value=None):
+            result = runner.invoke(
+                app,
+                ["policy", "rollback", "--rpz-zone", "rpz.example.com", "-b", "nios"],
+            )
+        assert result.exit_code == 1
+        assert "No snapshots found" in _combined_output(result)
+
+    def test_rollback_dry_run(self):
+        with patch(
+            "dns_aid.sdk.policy.snapshot.load_latest_snapshot",
+            return_value=_make_snapshot(),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "policy",
+                    "rollback",
+                    "--rpz-zone",
+                    "rpz.example.com",
+                    "-b",
+                    "nios",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Dry run" in plain
+        assert "evil.example.com" in plain
+
+    def test_rollback_nios_with_errors(self):
+        """Real run_async drives the _rollback_nios closure against a mocked NIOS."""
+
+        async def create_record(**kwargs):
+            if kwargs["owner"] == "worse.example.com":
+                raise RuntimeError("api error")
+
+        nios = MagicMock()
+        nios.ensure_rpz_zone = AsyncMock()
+        nios.create_rpz_cname_record = AsyncMock(side_effect=create_record)
+        nios.close = AsyncMock()
+
+        with (
+            patch(
+                "dns_aid.sdk.policy.snapshot.load_latest_snapshot",
+                return_value=_make_snapshot(),
+            ),
+            patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios),
+        ):
+            result = runner.invoke(
+                app,
+                ["policy", "rollback", "--rpz-zone", "rpz.example.com", "-b", "nios"],
+            )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Rolled back 1/2" in plain
+        assert "api error" in plain
+        nios.close.assert_awaited()
+
+    def test_rollback_infoblox(self):
+        bx = MagicMock()
+        bx.create_or_update_named_list = AsyncMock(return_value={"updated": True})
+        bx.close = AsyncMock()
+
+        with (
+            patch(
+                "dns_aid.sdk.policy.snapshot.load_latest_snapshot",
+                return_value=_make_snapshot(),
+            ),
+            patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx),
+        ):
+            result = runner.invoke(
+                app,
+                ["policy", "rollback", "--rpz-zone", "rpz.example.com", "-b", "infoblox"],
+            )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "Rolled back TD named list" in plain
+        assert "2 domains" in plain
+        bx.close.assert_awaited()
+
+    def test_rollback_unsupported_backend(self):
+        with patch(
+            "dns_aid.sdk.policy.snapshot.load_latest_snapshot",
+            return_value=_make_snapshot(),
+        ):
+            result = runner.invoke(
+                app,
+                ["policy", "rollback", "--rpz-zone", "rpz.example.com", "-b", "route53"],
+            )
+        assert result.exit_code == 1
+        assert "Rollback not supported" in _combined_output(result)
+
+
+# ============================================================================
+# ENFORCE COMMAND
+# ============================================================================
+
+
+def _ns_agent(name="agent1", policy_uri=None):
+    """Discovery-result agent stub with only the attributes enforce touches."""
+    return SimpleNamespace(
+        name=name,
+        protocol="mcp",
+        endpoint=f"https://{name}.example.com",
+        policy_uri=policy_uri,
+    )
+
+
+def _ns_discovery(agents):
+    return SimpleNamespace(count=len(agents), agents=agents)
+
+
+def _ok_policy_response():
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.text = json.dumps(MINIMAL_POLICY)
+    return resp
+
+
+class TestEnforceValidation:
+    def test_requires_policy_source(self):
+        result = runner.invoke(app, ["enforce", "-d", "example.com"])
+        assert result.exit_code == 1
+        assert "Provide --policy-file or --auto-policy" in _combined_output(result)
+
+    def test_rejects_bad_mode(self):
+        result = runner.invoke(
+            app,
+            ["enforce", "-d", "example.com", "-p", str(SAMPLE_POLICY), "--mode", "yolo"],
+        )
+        assert result.exit_code == 1
+        assert "must be shadow or enforce" in _combined_output(result)
+
+    def test_rejects_bad_format(self):
+        result = runner.invoke(
+            app,
+            ["enforce", "-d", "example.com", "-p", str(SAMPLE_POLICY), "-f", "yaml"],
+        )
+        assert result.exit_code == 1
+        assert "must be rpz, bindaid, or both" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_policy_file_missing(self, mock_run_async):
+        mock_run_async.return_value = _ns_discovery([])
+        result = runner.invoke(app, ["enforce", "-d", "example.com", "-p", "/no/such/policy.json"])
+        assert result.exit_code == 1
+        assert "Policy file not found" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_policy_file_invalid_json(self, mock_run_async, tmp_path):
+        mock_run_async.return_value = _ns_discovery([])
+        bad = tmp_path / "bad.json"
+        bad.write_text("{invalid")
+        result = runner.invoke(app, ["enforce", "-d", "example.com", "-p", str(bad)])
+        assert result.exit_code == 1
+        assert "Failed to parse policy document" in _combined_output(result)
+
+
+class TestEnforceShadowAndReports:
+    @patch("dns_aid.cli.main.run_async")
+    def test_shadow_with_json_report(self, mock_run_async, tmp_path):
+        agents = [_ns_agent("a1", policy_uri="https://a1.example.com/policy.json"), _ns_agent("a2")]
+        mock_run_async.return_value = _ns_discovery(agents)
+        report = tmp_path / "inventory.json"
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d",
+                "example.com",
+                "-p",
+                str(SAMPLE_POLICY),
+                "--mode",
+                "shadow",
+                "--report",
+                str(report),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip_ansi(result.output)
+        assert "Agents with policy_uri: 1" in plain
+        assert "JSON report written" in plain
+        data = json.loads(report.read_text())
+        assert data["summary"]["total_agents"] == 2
+        assert data["summary"]["agents_with_policy"] == 1
+        assert data["mode"] == "shadow"
+        assert len(data["rpz_directives"]) > 0
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_shadow_with_csv_report(self, mock_run_async, tmp_path):
+        agents = [_ns_agent("a1", policy_uri="https://a1.example.com/policy.json")]
+        mock_run_async.return_value = _ns_discovery(agents)
+        report = tmp_path / "inventory.csv"
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d",
+                "example.com",
+                "-p",
+                str(SAMPLE_POLICY),
+                "--report",
+                str(report),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "CSV inventory written" in _strip_ansi(result.output)
+        lines = report.read_text().strip().splitlines()
+        assert lines[0].startswith("name,protocol,endpoint")
+        assert "a1" in lines[1]
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_shadow_rpz_only_output_dir(self, mock_run_async, tmp_path):
+        mock_run_async.return_value = _ns_discovery([])
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d",
+                "example.com",
+                "-p",
+                str(SAMPLE_POLICY),
+                "-f",
+                "rpz",
+                "-o",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "rpz.example.com.rpz").exists()
+        assert not (tmp_path / "policy.example.com.bindaid").exists()
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_shadow_bindaid_only_output_dir(self, mock_run_async, tmp_path):
+        mock_run_async.return_value = _ns_discovery([])
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d",
+                "example.com",
+                "-p",
+                str(SAMPLE_POLICY),
+                "-f",
+                "bindaid",
+                "-o",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "policy.example.com.bindaid").exists()
+        assert not (tmp_path / "rpz.example.com.rpz").exists()
+
+
+class TestEnforceAutoPolicy:
+    @patch("dns_aid.cli.main.run_async")
+    def test_auto_policy_no_agents_with_policy_uri(self, mock_run_async):
+        mock_run_async.return_value = _ns_discovery([_ns_agent("plain")])
+        result = runner.invoke(app, ["enforce", "-d", "example.com", "--auto-policy"])
+        assert result.exit_code == 0
+        assert "nothing to compile" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_auto_policy_fetch_success_and_failure(self, mock_run_async):
+        agents = [
+            _ns_agent("good", policy_uri="https://good.example.com/policy.json"),
+            _ns_agent("bad", policy_uri="https://bad.example.com/policy.json"),
+        ]
+        mock_run_async.side_effect = [
+            _ns_discovery(agents),
+            _ok_policy_response(),
+            RuntimeError("fetch boom"),
+        ]
+        result = runner.invoke(
+            app, ["enforce", "-d", "example.com", "--auto-policy", "--mode", "shadow"]
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip_ansi(result.output)
+        assert "Fetched: 1, Failed: 1" in plain
+        assert "fetch boom" in plain
+        assert "Shadow mode" in plain
+
+
+class TestEnforceEnforceMode:
+    @patch("dns_aid.cli.main.run_async")
+    def test_enforce_mode_requires_backend(self, mock_run_async):
+        mock_run_async.return_value = _ns_discovery([])
+        result = runner.invoke(
+            app,
+            ["enforce", "-d", "example.com", "-p", str(SAMPLE_POLICY), "--mode", "enforce"],
+        )
+        assert result.exit_code == 1
+        assert "Enforce mode requires --backend" in _combined_output(result)
+
+    def test_enforce_mode_nios_push(self, tmp_path, monkeypatch):
+        """Real run_async drives _push_nios; one record push fails."""
+        monkeypatch.chdir(tmp_path)  # snapshots write to CWD/.dns-aid/snapshots
+
+        calls = {"n": 0}
+
+        async def create_record(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("api refused")
+
+        nios = MagicMock()
+        nios.ensure_rpz_zone = AsyncMock()
+        nios.create_rpz_cname_record = AsyncMock(side_effect=create_record)
+        nios.close = AsyncMock()
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                new=AsyncMock(return_value=_ns_discovery([])),
+            ),
+            patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "enforce",
+                    "-d",
+                    "example.com",
+                    "-p",
+                    str(SAMPLE_POLICY),
+                    "--mode",
+                    "enforce",
+                    "-b",
+                    "nios",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        plain = _strip_ansi(result.output)
+        assert "Snapshot saved" in plain
+        assert "Pushed" in plain
+        assert "api refused" in plain
+        assert list((tmp_path / ".dns-aid" / "snapshots").glob("*.json"))
+        nios.ensure_rpz_zone.assert_awaited_once_with("rpz.example.com")
+        nios.close.assert_awaited()
+
+    def _bloxone_mock(self, nl_result, bind_result):
+        bx = MagicMock()
+        bx.create_or_update_named_list = AsyncMock(return_value=nl_result)
+        bx.bind_named_list_to_policy = AsyncMock(return_value=bind_result)
+        bx.close = AsyncMock()
+        return bx
+
+    def test_enforce_mode_infoblox_bound(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        bx = self._bloxone_mock(
+            {"updated": False},
+            {
+                "action": "bound",
+                "policy_name": "Default Global Policy",
+                "policy_id": 7,
+                "rule_count": 3,
+            },
+        )
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                new=AsyncMock(return_value=_ns_discovery([])),
+            ),
+            patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "enforce",
+                    "-d",
+                    "example.com",
+                    "-p",
+                    str(SAMPLE_POLICY),
+                    "--mode",
+                    "enforce",
+                    "-b",
+                    "infoblox",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        plain = _strip_ansi(result.output)
+        assert "Created TD named list" in plain
+        assert "Bound to security policy 'Default Global Policy'" in plain
+        assert "NXDOMAIN from Threat Defense" in plain
+        bx.close.assert_awaited()
+
+    def test_enforce_mode_infoblox_already_bound(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        bx = self._bloxone_mock(
+            {"updated": True},
+            {"action": "already_bound", "policy_name": "Default Global Policy"},
+        )
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                new=AsyncMock(return_value=_ns_discovery([])),
+            ),
+            patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "enforce",
+                    "-d",
+                    "example.com",
+                    "-p",
+                    str(SAMPLE_POLICY),
+                    "--mode",
+                    "enforce",
+                    "-b",
+                    "infoblox",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        plain = _strip_ansi(result.output)
+        assert "Updated TD named list" in plain
+        assert "Already bound" in plain
+
+    def test_enforce_mode_infoblox_bind_failed_silently(self, tmp_path, monkeypatch):
+        """bind_status neither 'bound' nor 'already_bound' → no bind message."""
+        monkeypatch.chdir(tmp_path)
+        bx = self._bloxone_mock({"updated": False}, {"action": "failed"})
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                new=AsyncMock(return_value=_ns_discovery([])),
+            ),
+            patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "enforce",
+                    "-d",
+                    "example.com",
+                    "-p",
+                    str(SAMPLE_POLICY),
+                    "--mode",
+                    "enforce",
+                    "-b",
+                    "infoblox",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        plain = _strip_ansi(result.output)
+        assert "Created TD named list" in plain
+        assert "Bound to security policy" not in plain
+        assert "Already bound" not in plain
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_enforce_mode_other_backend_with_output_dir(
+        self, mock_run_async, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        mock_run_async.return_value = _ns_discovery([])
+        out = tmp_path / "zones"
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d",
+                "example.com",
+                "-p",
+                str(SAMPLE_POLICY),
+                "--mode",
+                "enforce",
+                "-b",
+                "file",
+                "-o",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Zone files written to" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_enforce_mode_other_backend_without_output_dir(
+        self, mock_run_async, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        mock_run_async.return_value = _ns_discovery([])
+        result = runner.invoke(
+            app,
+            [
+                "enforce",
+                "-d",
+                "example.com",
+                "-p",
+                str(SAMPLE_POLICY),
+                "--mode",
+                "enforce",
+                "-b",
+                "file",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "does not support direct RPZ push" in _strip_ansi(result.output)
+
+
+# ============================================================================
+# DCV COMMANDS
+# ============================================================================
+
+
+class TestDcvIssue:
+    def test_issue_human_output_with_bnd_req(self):
+        result = runner.invoke(
+            app,
+            ["dcv", "issue", "example.com", "--agent", "chat", "--issuer", "issuer.example"],
+        )
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "DCV Challenge" in plain
+        assert "bnd-req" in plain
+        assert "TXT record to place" in plain
+
+    def test_issue_human_output_without_bnd_req(self):
+        result = runner.invoke(app, ["dcv", "issue", "example.com"])
+        assert result.exit_code == 0
+        plain = _strip_ansi(result.output)
+        assert "DCV Challenge" in plain
+        assert "bnd-req" not in plain
+
+    def test_issue_json_output(self):
+        result = runner.invoke(app, ["dcv", "issue", "example.com", "--json"])
+        assert result.exit_code == 0
+        assert '"token"' in result.output
+        assert '"fqdn"' in result.output
+
+
+class TestDcvPlace:
+    @patch("dns_aid.cli.main.run_async")
+    def test_place_success_human(self, mock_run_async):
+        from dns_aid.core.dcv import DCVPlaceResult
+
+        mock_run_async.return_value = DCVPlaceResult(
+            fqdn="_dnsaid-challenge.example.com",
+            domain="example.com",
+            expires_at=datetime(2026, 7, 30, tzinfo=UTC),
+        )
+        result = runner.invoke(app, ["dcv", "place", "example.com", "sometoken"])
+        assert result.exit_code == 0
+        assert "Challenge placed at" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_place_success_json(self, mock_run_async):
+        from dns_aid.core.dcv import DCVPlaceResult
+
+        mock_run_async.return_value = DCVPlaceResult(
+            fqdn="_dnsaid-challenge.example.com",
+            domain="example.com",
+            expires_at=datetime(2026, 7, 30, tzinfo=UTC),
+        )
+        result = runner.invoke(app, ["dcv", "place", "example.com", "sometoken", "--json"])
+        assert result.exit_code == 0
+        assert '"success"' in result.output
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_place_failure_human(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("no backend")
+        result = runner.invoke(app, ["dcv", "place", "example.com", "sometoken"])
+        assert result.exit_code == 1
+        assert "no backend" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_place_failure_json(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("no backend")
+        result = runner.invoke(app, ["dcv", "place", "example.com", "sometoken", "--json"])
+        assert result.exit_code == 1
+        assert '"success"' in result.output
+
+
+def _dcv_verify_result(verified=True, expired=False, error=None):
+    from dns_aid.core.dcv import DCVVerifyResult
+
+    return DCVVerifyResult(
+        verified=verified,
+        domain="example.com",
+        token="sometoken",
+        fqdn="_dnsaid-challenge.example.com",
+        expired=expired,
+        error=error,
+    )
+
+
+class TestDcvVerify:
+    @patch("dns_aid.cli.main.run_async")
+    def test_verify_success_human(self, mock_run_async):
+        mock_run_async.return_value = _dcv_verify_result(verified=True)
+        result = runner.invoke(app, ["dcv", "verify", "example.com", "sometoken"])
+        assert result.exit_code == 0
+        assert "DCV verified" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_verify_expired_human(self, mock_run_async):
+        mock_run_async.return_value = _dcv_verify_result(
+            verified=False, expired=True, error="token expired"
+        )
+        result = runner.invoke(
+            app,
+            ["dcv", "verify", "example.com", "sometoken", "-s", "192.0.2.53", "--port", "5353"],
+        )
+        assert result.exit_code == 1
+        plain = _strip_ansi(result.output)
+        assert "DCV expired" in plain
+        assert "token expired" in plain
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_verify_failed_human_without_error_text(self, mock_run_async):
+        mock_run_async.return_value = _dcv_verify_result(verified=False)
+        result = runner.invoke(app, ["dcv", "verify", "example.com", "sometoken"])
+        assert result.exit_code == 1
+        assert "DCV failed" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_verify_success_json(self, mock_run_async):
+        mock_run_async.return_value = _dcv_verify_result(verified=True)
+        result = runner.invoke(app, ["dcv", "verify", "example.com", "sometoken", "--json"])
+        assert result.exit_code == 0
+        assert '"verified"' in result.output
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_verify_failure_json_exits_1(self, mock_run_async):
+        mock_run_async.return_value = _dcv_verify_result(verified=False)
+        result = runner.invoke(app, ["dcv", "verify", "example.com", "sometoken", "--json"])
+        assert result.exit_code == 1
+
+
+class TestDcvRevoke:
+    @patch("dns_aid.cli.main.run_async")
+    def test_revoke_success_human(self, mock_run_async):
+        from dns_aid.core.dcv import DCVRevokeResult
+
+        mock_run_async.return_value = DCVRevokeResult(
+            removed=True, domain="example.com", fqdn="_dnsaid-challenge.example.com"
+        )
+        result = runner.invoke(app, ["dcv", "revoke", "example.com", "sometoken"])
+        assert result.exit_code == 0
+        assert "Challenge record removed" in _strip_ansi(result.output)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_revoke_success_json(self, mock_run_async):
+        from dns_aid.core.dcv import DCVRevokeResult
+
+        mock_run_async.return_value = DCVRevokeResult(
+            removed=True, domain="example.com", fqdn="_dnsaid-challenge.example.com"
+        )
+        result = runner.invoke(app, ["dcv", "revoke", "example.com", "sometoken", "--json"])
+        assert result.exit_code == 0
+        assert '"success"' in result.output
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_revoke_not_found_exits_1(self, mock_run_async):
+        from dns_aid.core.dcv import DCVRevokeResult
+
+        mock_run_async.return_value = DCVRevokeResult(
+            removed=False, domain="example.com", fqdn="_dnsaid-challenge.example.com"
+        )
+        result = runner.invoke(app, ["dcv", "revoke", "example.com", "sometoken"])
+        assert result.exit_code == 1
+        assert "not found" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_revoke_backend_error_exits_1(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("dns down")
+        result = runner.invoke(app, ["dcv", "revoke", "example.com", "sometoken"])
+        assert result.exit_code == 1
+        assert "dns down" in _combined_output(result)
+
+    @patch("dns_aid.cli.main.run_async")
+    def test_revoke_backend_error_json(self, mock_run_async):
+        mock_run_async.side_effect = RuntimeError("dns down")
+        result = runner.invoke(app, ["dcv", "revoke", "example.com", "sometoken", "--json"])
+        assert result.exit_code == 1
+        assert '"success"' in result.output

--- a/tests/unit/core/test_invoke.py
+++ b/tests/unit/core/test_invoke.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -12,14 +15,73 @@ import pytest
 
 from dns_aid.core.invoke import (
     InvokeResult,
+    ResolvedAgent,
     _build_agent_record_from_endpoint,
     _invoke_raw_a2a,
+    _invoke_via_sdk,
     build_a2a_message_params,
+    call_mcp_tool,
     extract_a2a_response_text,
     extract_mcp_content,
+    list_mcp_tools,
     normalize_endpoint,
+    resolve_a2a_endpoint,
+    resolve_mcp_endpoint,
     send_a2a_message,
 )
+
+
+def _mock_async_client(mock_client_cls, *, post=None, get=None):
+    """Wire a mocked httpx.AsyncClient context manager."""
+    mock_client = AsyncMock()
+    if post is not None:
+        if isinstance(post, Exception):
+            mock_client.post.side_effect = post
+        else:
+            mock_client.post.return_value = post
+    if get is not None:
+        if isinstance(get, Exception):
+            mock_client.get.side_effect = get
+        else:
+            mock_client.get.return_value = get
+    mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _sdk_result(*, success=True, data=None, latency=10.0, status="success"):
+    """Duck-typed SDK InvocationResult."""
+    return SimpleNamespace(
+        success=success,
+        data=data,
+        signal=SimpleNamespace(
+            invocation_latency_ms=latency,
+            status=SimpleNamespace(value=status),
+        ),
+    )
+
+
+def _mock_agent_client(mock_client_cls, *, invoke_return=None, invoke_side_effect=None):
+    """Wire a mocked AgentClient async context manager."""
+    mock_client = AsyncMock()
+    if invoke_side_effect is not None:
+        mock_client.invoke.side_effect = invoke_side_effect
+    else:
+        mock_client.invoke.return_value = invoke_return
+    mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _card(url, name="Chat Agent", description="A chat agent", skill_names=("chatting",)):
+    """Duck-typed A2A agent card."""
+    return SimpleNamespace(
+        url=url,
+        name=name,
+        description=description,
+        skills=[SimpleNamespace(name=s) for s in skill_names],
+    )
+
 
 # ---------------------------------------------------------------------------
 # Pure utility tests
@@ -244,3 +306,752 @@ class TestInvokeResult:
             telemetry={"latency_ms": 42.0, "status": "success"},
         )
         assert r.telemetry["latency_ms"] == 42.0
+
+
+# ---------------------------------------------------------------------------
+# extract_a2a_response_text — malformed / partial payload branches
+# ---------------------------------------------------------------------------
+
+
+class TestExtractA2AResponseTextEdgeCases:
+    def test_non_dict_artifact_falls_through_to_parts(self):
+        data = {
+            "result": {
+                "artifacts": ["not-a-dict"],
+                "parts": [{"kind": "text", "text": "from parts"}],
+            }
+        }
+        assert extract_a2a_response_text(data) == "from parts"
+
+    def test_non_dict_part_in_artifact_skipped(self):
+        data = {"result": {"artifacts": [{"parts": ["not-a-dict"]}]}}
+        assert extract_a2a_response_text(data) is None
+
+    def test_artifact_part_without_text_skipped(self):
+        data = {"result": {"artifacts": [{"parts": [{"kind": "data", "data": {}}]}]}}
+        assert extract_a2a_response_text(data) is None
+
+    def test_non_dict_entry_in_parts_skipped(self):
+        data = {"result": {"parts": [42, {"kind": "text", "text": "ok"}]}}
+        assert extract_a2a_response_text(data) == "ok"
+
+    def test_parts_without_text_fall_through_to_content(self):
+        data = {
+            "result": {
+                "parts": [{"kind": "data"}],
+                "content": [{"text": "from content"}],
+            }
+        }
+        assert extract_a2a_response_text(data) == "from content"
+
+    def test_content_with_unusable_items_returns_none(self):
+        data = {"result": {"content": [42, {"kind": "image"}]}}
+        assert extract_a2a_response_text(data) is None
+
+    def test_none_text_values_coerced_to_empty(self):
+        data = {"result": {"artifacts": [{"parts": [{"kind": "text", "text": None}]}]}}
+        assert extract_a2a_response_text(data) == ""
+
+
+# ---------------------------------------------------------------------------
+# resolve_mcp_endpoint — path discovery via /.well-known/agent.json
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMCPEndpoint:
+    @pytest.mark.asyncio
+    async def test_endpoint_with_path_returned_as_is(self):
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            result = await resolve_mcp_endpoint("https://x.example.com/api/mcp")
+        assert result == "https://x.example.com/api/mcp"
+        MockClient.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_json_absolute_path(self):
+        resp = httpx.Response(
+            200,
+            json={"endpoints": {"mcp": "/rpc"}},
+            request=httpx.Request("GET", "https://x.example.com/.well-known/agent.json"),
+        )
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, get=resp)
+            result = await resolve_mcp_endpoint("x.example.com")
+        assert result == "https://x.example.com/rpc"
+
+    @pytest.mark.asyncio
+    async def test_agent_json_relative_path(self):
+        resp = httpx.Response(
+            200,
+            json={"endpoints": {"mcp": "rpc"}},
+            request=httpx.Request("GET", "https://x.example.com/.well-known/agent.json"),
+        )
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, get=resp)
+            result = await resolve_mcp_endpoint("https://x.example.com")
+        assert result == "https://x.example.com/rpc"
+
+    @pytest.mark.asyncio
+    async def test_agent_json_endpoints_not_dict_falls_back(self):
+        resp = httpx.Response(
+            200,
+            json={"endpoints": ["not-a-dict"]},
+            request=httpx.Request("GET", "https://x.example.com/.well-known/agent.json"),
+        )
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, get=resp)
+            result = await resolve_mcp_endpoint("https://x.example.com")
+        assert result == "https://x.example.com/mcp"
+
+    @pytest.mark.asyncio
+    async def test_agent_json_mcp_path_not_string_falls_back(self):
+        resp = httpx.Response(
+            200,
+            json={"endpoints": {"mcp": 42}},
+            request=httpx.Request("GET", "https://x.example.com/.well-known/agent.json"),
+        )
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, get=resp)
+            result = await resolve_mcp_endpoint("https://x.example.com")
+        assert result == "https://x.example.com/mcp"
+
+    @pytest.mark.asyncio
+    async def test_agent_json_non_200_falls_back(self):
+        resp = httpx.Response(
+            404,
+            text="not found",
+            request=httpx.Request("GET", "https://x.example.com/.well-known/agent.json"),
+        )
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, get=resp)
+            result = await resolve_mcp_endpoint("https://x.example.com")
+        assert result == "https://x.example.com/mcp"
+
+    @pytest.mark.asyncio
+    async def test_agent_json_fetch_error_falls_back(self):
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, get=httpx.ConnectError("refused"))
+            result = await resolve_mcp_endpoint("https://x.example.com")
+        assert result == "https://x.example.com/mcp"
+
+
+# ---------------------------------------------------------------------------
+# _invoke_via_sdk — SDK path with mocked AgentClient
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeViaSDK:
+    @pytest.mark.asyncio
+    async def test_success_with_agent_record(self):
+        agent = _build_agent_record_from_endpoint("https://mcp.example.com/mcp")
+        sdk_result = _sdk_result(data={"answer": 42})
+
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            mock_client = _mock_agent_client(MockClient, invoke_return=sdk_result)
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments={"name": "t", "arguments": {}},
+                timeout=30.0,
+                caller_id="test",
+                agent_record=agent,
+            )
+
+        assert result.success is True
+        assert result.data == {"answer": 42}
+        assert result.telemetry == {"latency_ms": 10.0, "status": "success"}
+        # The discovery-provided record must be used verbatim
+        assert mock_client.invoke.call_args[0][0] is agent
+
+    @pytest.mark.asyncio
+    async def test_success_builds_synthetic_record(self):
+        sdk_result = _sdk_result(data={"ok": True})
+
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            mock_client = _mock_agent_client(MockClient, invoke_return=sdk_result)
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+                auth_type="bearer",
+                auth_config={"header": "Authorization"},
+                policy_uri="https://example.com/policy.json",
+            )
+
+        assert result.success is True
+        synthetic = mock_client.invoke.call_args[0][0]
+        assert synthetic.target_host == "mcp.example.com"
+        assert synthetic.auth_type == "bearer"
+        assert synthetic.auth_config == {"header": "Authorization"}
+        assert synthetic.policy_uri == "https://example.com/policy.json"
+
+    @pytest.mark.asyncio
+    async def test_failure_uses_data_as_error(self):
+        sdk_result = _sdk_result(success=False, data="boom", status="error")
+
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_return=sdk_result)
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+            )
+
+        assert result.success is False
+        assert result.error == "boom"
+        assert result.telemetry == {"latency_ms": 10.0, "status": "error"}
+
+    @pytest.mark.asyncio
+    async def test_failure_with_empty_data_uses_status(self):
+        sdk_result = _sdk_result(success=False, data=None, status="timeout")
+
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_return=sdk_result)
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+            )
+
+        assert result.success is False
+        assert result.error == "Invocation failed (status: timeout)"
+
+    @pytest.mark.asyncio
+    async def test_failure_with_placeholder_data_uses_status(self):
+        sdk_result = _sdk_result(success=False, data="False", status="refused")
+
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_return=sdk_result)
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+            )
+
+        assert result.error == "Invocation failed (status: refused)"
+
+    @pytest.mark.asyncio
+    async def test_timeout_exception(self):
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_side_effect=httpx.TimeoutException("timed out"))
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=7.0,
+                caller_id="test",
+            )
+
+        assert result.success is False
+        assert "7.0s" in result.error
+        assert "SDK path" in result.error
+
+    @pytest.mark.asyncio
+    async def test_connect_error(self):
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_side_effect=httpx.ConnectError("refused"))
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+            )
+
+        assert result.success is False
+        assert "Connection failed" in result.error
+        assert "refused" in result.error
+
+    @pytest.mark.asyncio
+    async def test_generic_error_message_preserved(self):
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_side_effect=RuntimeError("kaboom"))
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+            )
+
+        assert result.success is False
+        assert result.error == "kaboom"
+
+    @pytest.mark.asyncio
+    async def test_generic_error_without_message_names_type(self):
+        with patch("dns_aid.core.invoke.AgentClient") as MockClient:
+            _mock_agent_client(MockClient, invoke_side_effect=ValueError())
+            result = await _invoke_via_sdk(
+                "https://mcp.example.com/mcp",
+                protocol="mcp",
+                method="tools/call",
+                arguments=None,
+                timeout=30.0,
+                caller_id="test",
+            )
+
+        assert result.success is False
+        assert result.error == "SDK invocation failed: ValueError"
+
+
+# ---------------------------------------------------------------------------
+# _invoke_raw_a2a — remaining error paths
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeRawA2AErrors:
+    @pytest.mark.asyncio
+    async def test_caller_domain_header_sent(self, monkeypatch):
+        monkeypatch.setenv("DNS_AID_CALLER_DOMAIN", "caller.example.com")
+        mock_response = httpx.Response(
+            200,
+            json={"result": {}},
+            request=httpx.Request("POST", "https://agent.example.com"),
+        )
+
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            mock_client = _mock_async_client(MockClient, post=mock_response)
+            result = await _invoke_raw_a2a("https://agent.example.com", "Hello", 25.0)
+
+        assert result.success is True
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["X-DNS-AID-Caller-Domain"] == "caller.example.com"
+
+    @pytest.mark.asyncio
+    async def test_http_500(self):
+        mock_response = httpx.Response(
+            500,
+            text="internal error",
+            request=httpx.Request("POST", "https://agent.example.com"),
+        )
+
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, post=mock_response)
+            result = await _invoke_raw_a2a("https://agent.example.com", "Hello", 25.0)
+
+        assert result.success is False
+        assert "HTTP 500" in result.error
+        assert "internal error" in result.error
+
+    @pytest.mark.asyncio
+    async def test_connect_error(self):
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, post=httpx.ConnectError("refused"))
+            result = await _invoke_raw_a2a("https://agent.example.com", "Hello", 25.0)
+
+        assert result.success is False
+        assert "Could not connect" in result.error
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error(self):
+        with patch("dns_aid.core.invoke.httpx.AsyncClient") as MockClient:
+            _mock_async_client(MockClient, post=ValueError("bad payload"))
+            result = await _invoke_raw_a2a("https://agent.example.com", "Hello", 25.0)
+
+        assert result.success is False
+        assert "Unexpected error" in result.error
+        assert "bad payload" in result.error
+
+
+# ---------------------------------------------------------------------------
+# resolve_a2a_endpoint — discovery + agent card resolution chain
+# ---------------------------------------------------------------------------
+
+
+def _discovered_agent():
+    from dns_aid.core.models import AgentRecord, Protocol
+
+    return AgentRecord(
+        name="chat",
+        domain="example.com",
+        protocol=Protocol.A2A,
+        target_host="a2a.example.com",
+        port=443,
+    )
+
+
+class TestResolveA2AEndpoint:
+    @pytest.mark.asyncio
+    async def test_dns_discovery_with_matching_card(self):
+        agent = _discovered_agent()
+        card = _card("https://a2a.example.com/rpc")
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                AsyncMock(return_value=SimpleNamespace(agents=[agent])),
+            ),
+            patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)),
+        ):
+            resolved = await resolve_a2a_endpoint(domain="example.com", name="chat")
+
+        assert resolved.endpoint == "https://a2a.example.com/rpc"
+        assert resolved.resolved_via == "dns_discover+agent_card"
+        assert resolved.agent_name == "Chat Agent"
+        assert resolved.skills == ["chatting"]
+        assert resolved.agent_record is agent
+
+    @pytest.mark.asyncio
+    async def test_dns_discovery_card_host_mismatch_keeps_dns_endpoint(self):
+        agent = _discovered_agent()
+        card = _card("https://internal.runtime.example.net/x")
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                AsyncMock(return_value=SimpleNamespace(agents=[agent])),
+            ),
+            patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)),
+        ):
+            resolved = await resolve_a2a_endpoint(domain="example.com", name="chat")
+
+        assert resolved.endpoint == agent.endpoint_url
+        assert resolved.resolved_via == "dns_discover+agent_card"
+
+    @pytest.mark.asyncio
+    async def test_dns_discovery_without_card(self):
+        agent = _discovered_agent()
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                AsyncMock(return_value=SimpleNamespace(agents=[agent])),
+            ),
+            patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=None)),
+        ):
+            resolved = await resolve_a2a_endpoint(domain="example.com", name="chat")
+
+        assert resolved.endpoint == agent.endpoint_url
+        assert resolved.resolved_via == "dns_discover"
+        assert resolved.agent_name == "chat"
+        assert resolved.agent_record is agent
+
+    @pytest.mark.asyncio
+    async def test_dns_discovery_no_agents_and_no_endpoint(self):
+        with patch(
+            "dns_aid.core.discoverer.discover",
+            AsyncMock(return_value=SimpleNamespace(agents=[])),
+        ):
+            resolved = await resolve_a2a_endpoint(None, domain="example.com", name="ghost")
+
+        assert resolved.endpoint == ""
+        assert resolved.resolved_via == "error"
+
+    @pytest.mark.asyncio
+    async def test_dns_discovery_error_falls_back_to_endpoint(self):
+        with (
+            patch(
+                "dns_aid.core.discoverer.discover",
+                AsyncMock(side_effect=RuntimeError("dns down")),
+            ),
+            patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=None)),
+        ):
+            resolved = await resolve_a2a_endpoint(
+                "agent.example.com", domain="example.com", name="chat"
+            )
+
+        assert resolved.endpoint == "https://agent.example.com"
+        assert resolved.resolved_via == "direct"
+
+    @pytest.mark.asyncio
+    async def test_agent_card_from_endpoint_matching_host(self):
+        card = _card("https://agent.example.com/a2a")
+
+        with patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)):
+            resolved = await resolve_a2a_endpoint("agent.example.com")
+
+        assert resolved.endpoint == "https://agent.example.com/a2a"
+        assert resolved.resolved_via == "agent_card"
+        assert resolved.agent_description == "A chat agent"
+
+    @pytest.mark.asyncio
+    async def test_agent_card_from_endpoint_host_mismatch(self):
+        card = _card("https://elsewhere.example.net/a2a")
+
+        with patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)):
+            resolved = await resolve_a2a_endpoint("agent.example.com")
+
+        assert resolved.endpoint == "https://agent.example.com"
+        assert resolved.resolved_via == "agent_card"
+
+    @pytest.mark.asyncio
+    async def test_agent_card_without_url_keeps_endpoint(self):
+        card = _card("")
+
+        with patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)):
+            resolved = await resolve_a2a_endpoint("agent.example.com")
+
+        assert resolved.endpoint == "https://agent.example.com"
+
+    @pytest.mark.asyncio
+    async def test_agent_card_fetch_error_uses_direct(self):
+        with patch(
+            "dns_aid.core.a2a_card.fetch_agent_card",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            resolved = await resolve_a2a_endpoint("agent.example.com")
+
+        assert resolved.endpoint == "https://agent.example.com"
+        assert resolved.resolved_via == "direct"
+
+
+# ---------------------------------------------------------------------------
+# send_a2a_message — SDK path, agent_info enrichment, post-processing
+# ---------------------------------------------------------------------------
+
+
+class TestSendA2AMessageSDK:
+    @pytest.mark.asyncio
+    async def test_resolution_failure_returns_error(self):
+        with patch(
+            "dns_aid.core.invoke.resolve_a2a_endpoint",
+            AsyncMock(return_value=ResolvedAgent(endpoint="", resolved_via="error")),
+        ):
+            result = await send_a2a_message(None, "hello", domain="example.com", name="ghost")
+
+        assert result.success is False
+        assert "No endpoint provided" in result.error
+
+    @pytest.mark.asyncio
+    async def test_sdk_path_with_agent_info(self):
+        resolved = ResolvedAgent(
+            endpoint="https://canonical.example.com/rpc",
+            agent_name="Chat",
+            agent_description="A chat agent",
+            skills=["chatting"],
+            resolved_via="agent_card",
+        )
+        invoke_result = InvokeResult(
+            success=True,
+            data={"result": {"parts": [{"kind": "text", "text": "Hi there"}]}},
+        )
+
+        with (
+            patch("dns_aid.core.invoke._sdk_available", True),
+            patch(
+                "dns_aid.core.invoke.resolve_a2a_endpoint",
+                AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "dns_aid.core.invoke._invoke_via_sdk",
+                AsyncMock(return_value=invoke_result),
+            ) as mock_invoke,
+        ):
+            result = await send_a2a_message("agent.example.com", "hello")
+
+        assert result.success is True
+        assert result.data["response_text"] == "Hi there"
+        info = result.data["agent_info"]
+        assert info["name"] == "Chat"
+        assert info["description"] == "A chat agent"
+        assert info["skills"] == ["chatting"]
+        assert info["resolved_via"] == "agent_card"
+        assert info["original_endpoint"] == "agent.example.com"
+        assert info["canonical_endpoint"] == "https://canonical.example.com/rpc"
+        assert mock_invoke.call_args.kwargs["method"] == "message/send"
+        assert mock_invoke.call_args.kwargs["protocol"] == "a2a"
+
+    @pytest.mark.asyncio
+    async def test_dict_data_without_text_keeps_raw_dict(self):
+        resolved = ResolvedAgent(endpoint="https://agent.example.com", resolved_via="direct")
+        invoke_result = InvokeResult(success=True, data={"result": {}})
+
+        with (
+            patch("dns_aid.core.invoke._sdk_available", True),
+            patch(
+                "dns_aid.core.invoke.resolve_a2a_endpoint",
+                AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "dns_aid.core.invoke._invoke_via_sdk",
+                AsyncMock(return_value=invoke_result),
+            ),
+        ):
+            result = await send_a2a_message("agent.example.com", "hello")
+
+        assert result.success is True
+        assert "response_text" not in result.data
+        assert result.data["agent_info"]["resolved_via"] == "direct"
+
+    @pytest.mark.asyncio
+    async def test_non_dict_data_wrapped_with_agent_info(self):
+        resolved = ResolvedAgent(endpoint="https://agent.example.com", resolved_via="direct")
+        invoke_result = InvokeResult(success=True, data="plain text answer")
+
+        with (
+            patch("dns_aid.core.invoke._sdk_available", True),
+            patch(
+                "dns_aid.core.invoke.resolve_a2a_endpoint",
+                AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "dns_aid.core.invoke._invoke_via_sdk",
+                AsyncMock(return_value=invoke_result),
+            ),
+        ):
+            result = await send_a2a_message("agent.example.com", "hello")
+
+        assert result.data == {
+            "response_text": "plain text answer",
+            "agent_info": {"resolved_via": "direct"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# call_mcp_tool / list_mcp_tools — endpoint resolution + normalization
+# ---------------------------------------------------------------------------
+
+
+class TestCallMCPTool:
+    @pytest.mark.asyncio
+    async def test_defaults_empty_arguments(self):
+        with (
+            patch(
+                "dns_aid.core.invoke.resolve_mcp_endpoint",
+                AsyncMock(return_value="https://h.example.com/mcp"),
+            ) as mock_resolve,
+            patch(
+                "dns_aid.core.invoke._invoke_via_sdk",
+                AsyncMock(return_value=InvokeResult(success=True, data={"ok": 1})),
+            ) as mock_invoke,
+        ):
+            result = await call_mcp_tool("h.example.com", "analyze")
+
+        assert result.success is True
+        mock_resolve.assert_awaited_once_with("h.example.com")
+        assert mock_invoke.call_args[0][0] == "https://h.example.com/mcp"
+        assert mock_invoke.call_args.kwargs["method"] == "tools/call"
+        assert mock_invoke.call_args.kwargs["arguments"] == {
+            "name": "analyze",
+            "arguments": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_arguments_and_auth_passthrough(self):
+        agent = _build_agent_record_from_endpoint("https://h.example.com/mcp")
+        with (
+            patch(
+                "dns_aid.core.invoke.resolve_mcp_endpoint",
+                AsyncMock(return_value="https://h.example.com/mcp"),
+            ),
+            patch(
+                "dns_aid.core.invoke._invoke_via_sdk",
+                AsyncMock(return_value=InvokeResult(success=True, data={})),
+            ) as mock_invoke,
+        ):
+            await call_mcp_tool(
+                "h.example.com",
+                "analyze",
+                {"domain": "x.com"},
+                credentials={"token": "secret"},
+                agent_record=agent,
+                policy_uri="https://example.com/p.json",
+            )
+
+        kwargs = mock_invoke.call_args.kwargs
+        assert kwargs["arguments"] == {"name": "analyze", "arguments": {"domain": "x.com"}}
+        assert kwargs["credentials"] == {"token": "secret"}
+        assert kwargs["agent_record"] is agent
+        assert kwargs["policy_uri"] == "https://example.com/p.json"
+
+
+class TestListMCPTools:
+    @staticmethod
+    def _patched(data, *, success=True):
+        return (
+            patch(
+                "dns_aid.core.invoke.resolve_mcp_endpoint",
+                AsyncMock(return_value="https://h.example.com/mcp"),
+            ),
+            patch(
+                "dns_aid.core.invoke._invoke_via_sdk",
+                AsyncMock(
+                    return_value=InvokeResult(
+                        success=success,
+                        data=data,
+                        error=None if success else "boom",
+                    )
+                ),
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_dict_with_tools_normalized_to_list(self):
+        p1, p2 = self._patched({"tools": [{"name": "t1"}]})
+        with p1, p2 as mock_invoke:
+            result = await list_mcp_tools("h.example.com")
+
+        assert result.data == [{"name": "t1"}]
+        assert mock_invoke.call_args.kwargs["method"] == "tools/list"
+        assert mock_invoke.call_args.kwargs["arguments"] is None
+
+    @pytest.mark.asyncio
+    async def test_dict_without_tools_becomes_empty_list(self):
+        p1, p2 = self._patched({"unexpected": "shape"})
+        with p1, p2:
+            result = await list_mcp_tools("h.example.com")
+
+        assert result.data == []
+
+    @pytest.mark.asyncio
+    async def test_non_list_data_becomes_empty_list(self):
+        p1, p2 = self._patched("weird string")
+        with p1, p2:
+            result = await list_mcp_tools("h.example.com")
+
+        assert result.data == []
+
+    @pytest.mark.asyncio
+    async def test_list_data_passes_through(self):
+        p1, p2 = self._patched([{"name": "t1"}])
+        with p1, p2:
+            result = await list_mcp_tools("h.example.com")
+
+        assert result.data == [{"name": "t1"}]
+
+    @pytest.mark.asyncio
+    async def test_failure_left_untouched(self):
+        p1, p2 = self._patched(None, success=False)
+        with p1, p2:
+            result = await list_mcp_tools("h.example.com")
+
+        assert result.success is False
+        assert result.error == "boom"
+        assert result.data is None
+
+
+# ---------------------------------------------------------------------------
+# Module import fallback — SDK unavailable at import time
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImportWithoutSDK:
+    def test_sdk_import_failure_disables_sdk_flag(self):
+        real_mod = sys.modules["dns_aid.core.invoke"]
+        try:
+            with patch.dict(sys.modules):
+                # A None entry makes `from dns_aid.sdk import ...` raise ImportError.
+                sys.modules["dns_aid.sdk"] = None  # type: ignore[assignment]
+                sys.modules.pop("dns_aid.core.invoke", None)
+                fresh = importlib.import_module("dns_aid.core.invoke")
+                assert fresh._sdk_available is False
+        finally:
+            sys.modules["dns_aid.core.invoke"] = real_mod
+            import dns_aid.core
+
+            dns_aid.core.invoke = real_mod

--- a/tests/unit/mcp/test_server_tools.py
+++ b/tests/unit/mcp/test_server_tools.py
@@ -1,0 +1,1146 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the MCP server tool handlers in dns_aid.mcp.server.
+
+Calls the tool functions directly (no transport) with the mock DNS backend
+and mocked core-layer calls. Focuses on:
+- returned payload structure for success paths
+- error handling (validation errors, backend failures, missing records)
+- helper functions (_run_async, _get_dns_backend, _dcv_safe_error)
+- main() argument parsing / transport selection with mocked servers
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dns_aid.backends.mock import MockBackend
+from dns_aid.core.dcv import DCVPlaceResult, DCVRevokeResult, DCVVerifyResult
+from dns_aid.core.indexer import IndexEntry, IndexResult
+from dns_aid.core.invoke import InvokeResult
+from dns_aid.mcp import server
+from dns_aid.sdk.policy.models import PolicyResult, PolicyViolation
+from dns_aid.utils.validation import ValidationError
+
+POLICY_JSON = json.dumps(
+    {
+        "agent": "_test._mcp._agents.example.com",
+        "rules": {"blocked_caller_domains": ["evil.example.com"]},
+    }
+)
+
+
+def _mock_backend(backend: MockBackend | None = None):
+    """Patch the server's backend factory to return a shared MockBackend."""
+    return patch.object(server, "_get_dns_backend", return_value=backend or MockBackend())
+
+
+# =============================================================================
+# Helpers: _run_async / executor lifecycle
+# =============================================================================
+
+
+class TestRunAsync:
+    def test_sync_context_uses_asyncio_run(self):
+        async def coro():
+            return "sync-ok"
+
+        assert server._run_async(coro()) == "sync-ok"
+
+    async def test_async_context_uses_thread_pool(self):
+        async def coro():
+            return "threaded-ok"
+
+        # Called from a running event loop -> shared executor path.
+        assert server._run_async(coro()) == "threaded-ok"
+
+    async def test_timeout_raises_timeout_error(self):
+        with pytest.raises(TimeoutError, match="did not complete"):
+            server._run_async(asyncio.sleep(1), timeout=0.05)
+
+    def test_executor_shutdown_and_cleanup(self):
+        assert server._get_executor() is not None
+        server._shutdown_executor()
+        assert server._executor is None
+        # _cleanup is idempotent and clears a live executor too.
+        server._get_executor()
+        server._cleanup()
+        assert server._executor is None
+
+
+# =============================================================================
+# _get_dns_backend resolution
+# =============================================================================
+
+
+class TestGetDnsBackend:
+    def test_env_var_selects_backend(self, monkeypatch):
+        monkeypatch.setenv("DNS_AID_BACKEND", "mock")
+        assert isinstance(server._get_dns_backend(None), MockBackend)
+
+    def test_detect_returns_none_falls_back_to_mock(self, monkeypatch):
+        monkeypatch.delenv("DNS_AID_BACKEND", raising=False)
+        with patch("dns_aid.cli.backends.detect_backend", return_value=None):
+            assert isinstance(server._get_dns_backend(None), MockBackend)
+
+    def test_detect_value_error_falls_back_to_mock(self, monkeypatch):
+        monkeypatch.delenv("DNS_AID_BACKEND", raising=False)
+        with patch("dns_aid.cli.backends.detect_backend", side_effect=ValueError("ambiguous")):
+            assert isinstance(server._get_dns_backend(None), MockBackend)
+
+    def test_unknown_name_falls_back_to_mock(self):
+        assert isinstance(server._get_dns_backend("bogus-backend"), MockBackend)
+
+    def test_import_error_raises_value_error_with_install_hint(self):
+        with patch("dns_aid.backends.create_backend", side_effect=ImportError("no boto3")):
+            with pytest.raises(ValueError, match="Missing dependency"):
+                server._get_dns_backend("route53")
+
+    def test_init_value_error_raises_with_setup_hint(self):
+        with patch("dns_aid.backends.create_backend", side_effect=ValueError("no creds")):
+            with pytest.raises(ValueError, match="Failed to initialize"):
+                server._get_dns_backend("route53")
+
+    def test_init_os_error_raises_with_setup_hint(self):
+        with patch("dns_aid.backends.create_backend", side_effect=OSError("network down")):
+            with pytest.raises(ValueError, match="Failed to initialize"):
+                server._get_dns_backend("route53")
+
+
+# =============================================================================
+# publish_agent_to_dns error / index paths
+# =============================================================================
+
+
+class TestPublishAgentErrors:
+    def test_invalid_name_returns_validation_error(self):
+        result = server.publish_agent_to_dns(name="Bad_Name!", domain="example.com", backend="mock")
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert result["field"] == "name"
+        assert "message" in result
+
+    def test_publish_exception_returns_publish_error(self):
+        with patch(
+            "dns_aid.core.publisher.publish", new=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            result = server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+        assert result == {"success": False, "error": "publish_error", "message": "boom"}
+
+    def test_index_update_disabled(self):
+        result = server.publish_agent_to_dns(
+            name="chat", domain="example.com", backend="mock", update_index=False
+        )
+        assert result["success"] is True
+        assert result["index_updated"] is False
+        assert result["index_message"] is None
+
+    def test_index_update_reports_failure_message(self):
+        failed = IndexResult(
+            domain="example.com", entries=[], success=False, message="index write failed"
+        )
+        with patch("dns_aid.core.indexer.update_index", new=AsyncMock(return_value=failed)):
+            result = server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+        assert result["success"] is True
+        assert result["index_updated"] is False
+        assert result["index_message"] == "index write failed"
+
+    def test_index_update_exception_is_captured(self):
+        with patch(
+            "dns_aid.core.indexer.update_index", new=AsyncMock(side_effect=RuntimeError("kaboom"))
+        ):
+            result = server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+        assert result["success"] is True
+        assert result["index_updated"] is False
+        assert result["index_message"] == "Index update failed: kaboom"
+
+
+# =============================================================================
+# Catalog pointer tools
+# =============================================================================
+
+
+class TestPublishCatalogPointer:
+    def test_success_dual_labels(self):
+        written = ["SVCB _catalog._agents.example.com", "SVCB _index._agents.example.com"]
+        mock_pub = AsyncMock(return_value=written)
+        with (
+            _mock_backend(),
+            patch("dns_aid.core.catalog_pointer.publish_catalog_pointer", new=mock_pub),
+        ):
+            result = server.publish_catalog_pointer(
+                domain="example.com", catalog_host="catalog.example.com", backend="mock"
+            )
+        assert result["success"] is True
+        assert result["records"] == written
+        assert result["catalog_url"] == ("https://catalog.example.com/.well-known/ai-catalog.json")
+        assert mock_pub.await_args.kwargs["labels"] == ("_catalog._agents", "_index._agents")
+
+    def test_catalog_only_restricts_labels(self):
+        mock_pub = AsyncMock(return_value=["SVCB _catalog._agents.example.com"])
+        with (
+            _mock_backend(),
+            patch("dns_aid.core.catalog_pointer.publish_catalog_pointer", new=mock_pub),
+        ):
+            result = server.publish_catalog_pointer(
+                domain="example.com",
+                catalog_host="catalog.example.com",
+                catalog_only=True,
+                backend="mock",
+            )
+        assert result["success"] is True
+        assert mock_pub.await_args.kwargs["labels"] == ("_catalog._agents",)
+
+    def test_failure_returns_error_envelope(self):
+        with (
+            _mock_backend(),
+            patch(
+                "dns_aid.core.catalog_pointer.publish_catalog_pointer",
+                new=AsyncMock(side_effect=ValueError("underscored target")),
+            ),
+        ):
+            result = server.publish_catalog_pointer(
+                domain="example.com", catalog_host="_bad.example.com", backend="mock"
+            )
+        assert result["success"] is False
+        assert result["error"] == "publish_catalog_error"
+        assert "underscored target" in result["message"]
+
+
+class TestUnpublishCatalogPointer:
+    def test_success(self):
+        removed = ["_catalog._agents.example.com", "_index._agents.example.com"]
+        mock_unpub = AsyncMock(return_value=removed)
+        with (
+            _mock_backend(),
+            patch("dns_aid.core.catalog_pointer.unpublish_catalog_pointer", new=mock_unpub),
+        ):
+            result = server.unpublish_catalog_pointer(domain="example.com", backend="mock")
+        assert result == {"success": True, "domain": "example.com", "removed": removed}
+        assert mock_unpub.await_args.kwargs["labels"] == ("_catalog._agents", "_index._agents")
+
+    def test_catalog_only_restricts_labels(self):
+        mock_unpub = AsyncMock(return_value=[])
+        with (
+            _mock_backend(),
+            patch("dns_aid.core.catalog_pointer.unpublish_catalog_pointer", new=mock_unpub),
+        ):
+            result = server.unpublish_catalog_pointer(
+                domain="example.com", catalog_only=True, backend="mock"
+            )
+        assert result["success"] is True
+        assert mock_unpub.await_args.kwargs["labels"] == ("_catalog._agents",)
+
+    def test_failure_returns_error_envelope(self):
+        with (
+            _mock_backend(),
+            patch(
+                "dns_aid.core.catalog_pointer.unpublish_catalog_pointer",
+                new=AsyncMock(side_effect=RuntimeError("backend down")),
+            ),
+        ):
+            result = server.unpublish_catalog_pointer(domain="example.com", backend="mock")
+        assert result["success"] is False
+        assert result["error"] == "unpublish_catalog_error"
+
+
+# =============================================================================
+# discover_agents_via_dns / search_agents error paths
+# =============================================================================
+
+
+class TestDiscoverErrors:
+    def test_invalid_domain_returns_validation_error(self):
+        result = server.discover_agents_via_dns(domain="exa mple!.com")
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert result["field"] == "domain"
+
+    def test_discover_exception_returns_error_envelope(self):
+        with patch(
+            "dns_aid.core.discoverer.discover",
+            new=AsyncMock(side_effect=RuntimeError("resolver down")),
+        ):
+            result = server.discover_agents_via_dns(domain="example.com")
+        assert result == {
+            "success": False,
+            "error": "discover_error",
+            "message": "resolver down",
+        }
+
+    def test_name_filter_is_validated_and_propagated(self):
+        from dns_aid.core.models import DiscoveryResult
+
+        empty = DiscoveryResult(
+            query="_index._agents.example.com",
+            domain="example.com",
+            agents=[],
+            dnssec_validated=False,
+            cached=False,
+            query_time_ms=1.0,
+        )
+        mock_discover = AsyncMock(return_value=empty)
+        with patch("dns_aid.core.discoverer.discover", new=mock_discover):
+            result = server.discover_agents_via_dns(domain="example.com", name="chat")
+        assert result["count"] == 0
+        assert mock_discover.await_args.kwargs["name"] == "chat"
+
+
+class TestSearchAgentsValidationError:
+    def test_validation_error_returns_invalid_arguments(self):
+        with patch(
+            "dns_aid.sdk.client.AgentClient.search",
+            new_callable=AsyncMock,
+            side_effect=ValidationError("limit", "must be between 1 and 10000", "0"),
+        ):
+            result = server.search_agents(q="x", limit=0)
+        assert result["success"] is False
+        assert result["error"] == "invalid_arguments"
+        assert result["validation_errors"]["field"] == "limit"
+
+
+# =============================================================================
+# call_agent_tool
+# =============================================================================
+
+ALLOWED = PolicyResult(allowed=True)
+DENIED = PolicyResult(
+    allowed=False,
+    violations=[PolicyViolation(rule="required_auth_types", detail="oauth2 required", layer="l1")],
+)
+
+
+class TestCallAgentTool:
+    def test_success_with_policy_and_telemetry(self):
+        invoke_result = InvokeResult(success=True, data={"answer": 42}, telemetry={"ms": 5})
+        with (
+            patch(
+                "dns_aid.sdk.policy.guard.check_target_policy",
+                new=AsyncMock(return_value=ALLOWED),
+            ),
+            patch("dns_aid.core.invoke.call_mcp_tool", new=AsyncMock(return_value=invoke_result)),
+        ):
+            result = server.call_agent_tool(
+                endpoint="https://agent.example.com/mcp",
+                tool_name="echo",
+                arguments={"text": "hi"},
+                policy_uri="https://example.com/policy.json",
+            )
+        assert result["success"] is True
+        assert result["result"] == {"answer": 42}
+        assert result["telemetry"] == {"ms": 5}
+        assert result["policy"] == {"result": "allowed"}
+
+    def test_invocation_failure_surfaces_error(self):
+        invoke_result = InvokeResult(success=False, error="tool exploded")
+        with patch("dns_aid.core.invoke.call_mcp_tool", new=AsyncMock(return_value=invoke_result)):
+            result = server.call_agent_tool(endpoint="https://a.example.com", tool_name="echo")
+        assert result["success"] is False
+        assert result["error"] == "tool exploded"
+
+    def test_invocation_failure_without_message_uses_default(self):
+        invoke_result = InvokeResult(success=False, error=None)
+        with patch("dns_aid.core.invoke.call_mcp_tool", new=AsyncMock(return_value=invoke_result)):
+            result = server.call_agent_tool(endpoint="https://a.example.com", tool_name="echo")
+        assert result["error"] == "Invocation failed"
+
+    def test_policy_denied_strict_blocks_invocation(self, monkeypatch):
+        monkeypatch.setenv("DNS_AID_POLICY_MODE", "strict")
+        mock_call = AsyncMock()
+        with (
+            patch(
+                "dns_aid.sdk.policy.guard.check_target_policy",
+                new=AsyncMock(return_value=DENIED),
+            ),
+            patch("dns_aid.core.invoke.call_mcp_tool", new=mock_call),
+        ):
+            result = server.call_agent_tool(
+                endpoint="https://a.example.com",
+                tool_name="echo",
+                policy_uri="https://example.com/policy.json",
+            )
+        assert result["success"] is False
+        assert "Policy denied" in result["error"]
+        assert result["policy"]["result"] == "denied"
+        assert result["policy"]["violations"][0]["rule"] == "required_auth_types"
+        mock_call.assert_not_awaited()
+
+    def test_policy_denied_permissive_proceeds(self, monkeypatch):
+        monkeypatch.delenv("DNS_AID_POLICY_MODE", raising=False)
+        invoke_result = InvokeResult(success=True, data="ok")
+        with (
+            patch(
+                "dns_aid.sdk.policy.guard.check_target_policy",
+                new=AsyncMock(return_value=DENIED),
+            ),
+            patch("dns_aid.core.invoke.call_mcp_tool", new=AsyncMock(return_value=invoke_result)),
+        ):
+            result = server.call_agent_tool(
+                endpoint="https://a.example.com",
+                tool_name="echo",
+                policy_uri="https://example.com/policy.json",
+            )
+        assert result["success"] is True
+        assert result["policy"] == {"result": "denied"}
+
+    def test_exception_returns_error(self):
+        with patch(
+            "dns_aid.core.invoke.call_mcp_tool",
+            new=AsyncMock(side_effect=RuntimeError("connect refused")),
+        ):
+            result = server.call_agent_tool(endpoint="https://a.example.com", tool_name="echo")
+        assert result == {"success": False, "error": "connect refused"}
+
+
+# =============================================================================
+# list_agent_tools
+# =============================================================================
+
+
+class TestListAgentTools:
+    def test_success_returns_tools_and_telemetry(self):
+        invoke_result = InvokeResult(
+            success=True, data=[{"name": "echo"}, {"name": "sum"}], telemetry={"ms": 3}
+        )
+        with patch("dns_aid.core.invoke.list_mcp_tools", new=AsyncMock(return_value=invoke_result)):
+            result = server.list_agent_tools(endpoint="https://a.example.com/mcp")
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["tools"][0]["name"] == "echo"
+        assert result["telemetry"] == {"ms": 3}
+
+    def test_non_list_data_yields_empty_tools(self):
+        invoke_result = InvokeResult(success=True, data={"unexpected": True})
+        with patch("dns_aid.core.invoke.list_mcp_tools", new=AsyncMock(return_value=invoke_result)):
+            result = server.list_agent_tools(endpoint="https://a.example.com/mcp")
+        assert result["success"] is True
+        assert result["tools"] == []
+        assert result["count"] == 0
+
+    def test_failure_surfaces_error(self):
+        invoke_result = InvokeResult(success=False, error=None)
+        with patch("dns_aid.core.invoke.list_mcp_tools", new=AsyncMock(return_value=invoke_result)):
+            result = server.list_agent_tools(endpoint="https://a.example.com/mcp")
+        assert result["success"] is False
+        assert result["error"] == "Invocation failed"
+
+    def test_exception_returns_error(self):
+        with patch(
+            "dns_aid.core.invoke.list_mcp_tools",
+            new=AsyncMock(side_effect=RuntimeError("timeout")),
+        ):
+            result = server.list_agent_tools(endpoint="https://a.example.com/mcp")
+        assert result == {"success": False, "error": "timeout"}
+
+
+# =============================================================================
+# verify_agent_dns error paths
+# =============================================================================
+
+
+class TestVerifyAgentErrors:
+    def test_invalid_fqdn_returns_validation_error(self):
+        result = server.verify_agent_dns(fqdn="bad..fqdn!")
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+
+    def test_verify_exception_returns_error_envelope(self):
+        with patch(
+            "dns_aid.core.validator.verify",
+            new=AsyncMock(side_effect=RuntimeError("resolver exploded")),
+        ):
+            result = server.verify_agent_dns(fqdn="chat.example.com")
+        assert result == {
+            "success": False,
+            "error": "verify_error",
+            "message": "resolver exploded",
+        }
+
+
+# =============================================================================
+# list_published_agents
+# =============================================================================
+
+
+class TestListPublishedAgents:
+    def test_invalid_domain_returns_validation_error(self):
+        result = server.list_published_agents(domain="exa mple!.com", backend="mock")
+        assert result["error"] == "validation_error"
+
+    def test_zone_not_found(self):
+        backend = MockBackend(zones=["other.com"])
+        with _mock_backend(backend):
+            result = server.list_published_agents(domain="example.com", backend="mock")
+        assert result["success"] is False
+        assert result["error"] == "zone_not_found"
+        assert "example.com" in result["message"]
+
+    def test_records_formatted_and_long_values_truncated(self):
+        backend = MockBackend()
+        with _mock_backend(backend):
+            publish = server.publish_agent_to_dns(
+                name="chat",
+                domain="example.com",
+                backend="mock",
+                capabilities=[f"capability-{i:02d}-padding" for i in range(8)],
+                update_index=False,
+            )
+            assert publish["success"] is True
+            result = server.list_published_agents(domain="example.com", backend="mock")
+        assert result["domain"] == "example.com"
+        assert result["count"] >= 2
+        types = {r["type"] for r in result["records"]}
+        assert {"SVCB", "TXT"} <= types
+        txt = next(r for r in result["records"] if r["type"] == "TXT")
+        assert txt["value"].endswith("...")
+        assert len(txt["value"]) == 103  # 100 chars + ellipsis
+
+    def test_exception_returns_list_error(self):
+        with (
+            _mock_backend(),
+            patch(
+                "dns_aid.core.lister.list_dns_aid_records",
+                new=AsyncMock(side_effect=RuntimeError("api down")),
+            ),
+        ):
+            result = server.list_published_agents(domain="example.com", backend="mock")
+        assert result == {"success": False, "error": "list_error", "message": "api down"}
+
+
+# =============================================================================
+# delete_agent_from_dns
+# =============================================================================
+
+
+class TestDeleteAgentErrors:
+    def test_invalid_name_returns_validation_error(self):
+        result = server.delete_agent_from_dns(
+            name="Bad_Name!", domain="example.com", backend="mock"
+        )
+        assert result["error"] == "validation_error"
+
+    def test_delete_updates_index_on_success(self):
+        backend = MockBackend()
+        with _mock_backend(backend):
+            server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+            result = server.delete_agent_from_dns(name="chat", domain="example.com", backend="mock")
+        assert result["success"] is True
+        assert result["fqdn"] == "chat.example.com"
+        assert result["index_updated"] is True
+        assert "agent(s) remaining" in result["index_message"]
+
+    def test_delete_index_failure_message(self):
+        backend = MockBackend()
+        failed = IndexResult(domain="example.com", entries=[], success=False, message="no txn")
+        with _mock_backend(backend):
+            server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+            with patch("dns_aid.core.indexer.update_index", new=AsyncMock(return_value=failed)):
+                result = server.delete_agent_from_dns(
+                    name="chat", domain="example.com", backend="mock"
+                )
+        assert result["success"] is True
+        assert result["index_updated"] is False
+        assert result["index_message"] == "no txn"
+
+    def test_delete_index_exception_is_captured(self):
+        backend = MockBackend()
+        with _mock_backend(backend):
+            server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+            with patch(
+                "dns_aid.core.indexer.update_index",
+                new=AsyncMock(side_effect=RuntimeError("kaboom")),
+            ):
+                result = server.delete_agent_from_dns(
+                    name="chat", domain="example.com", backend="mock"
+                )
+        assert result["index_updated"] is False
+        assert result["index_message"] == "Index update failed: kaboom"
+
+    def test_unpublish_exception_returns_delete_error(self):
+        with patch(
+            "dns_aid.core.publisher.unpublish",
+            new=AsyncMock(side_effect=RuntimeError("api down")),
+        ):
+            result = server.delete_agent_from_dns(name="chat", domain="example.com", backend="mock")
+        assert result == {"success": False, "error": "delete_error", "message": "api down"}
+
+
+# =============================================================================
+# list_agent_index / sync_agent_index
+# =============================================================================
+
+
+class TestListAgentIndex:
+    def test_invalid_domain_returns_validation_error(self):
+        result = server.list_agent_index(domain="exa mple!.com", backend="mock")
+        assert result["error"] == "validation_error"
+
+    def test_lists_indexed_agents(self):
+        backend = MockBackend()
+        with _mock_backend(backend):
+            server.publish_agent_to_dns(name="chat", domain="example.com", backend="mock")
+            result = server.list_agent_index(domain="example.com", backend="mock")
+        assert result["index_exists"] is True
+        assert result["count"] == 1
+        assert result["agents"][0] == {
+            "name": "chat",
+            "protocol": "mcp",
+            "fqdn": "chat.example.com",
+        }
+
+    def test_empty_index(self):
+        with _mock_backend():
+            result = server.list_agent_index(domain="example.com", backend="mock")
+        assert result["index_exists"] is False
+        assert result["count"] == 0
+        assert result["agents"] == []
+
+    def test_exception_returns_list_index_error(self):
+        with (
+            _mock_backend(),
+            patch(
+                "dns_aid.core.indexer.read_index",
+                new=AsyncMock(side_effect=RuntimeError("api down")),
+            ),
+        ):
+            result = server.list_agent_index(domain="example.com", backend="mock")
+        assert result == {"success": False, "error": "list_index_error", "message": "api down"}
+
+
+class TestSyncAgentIndex:
+    def test_invalid_ttl_returns_validation_error(self):
+        result = server.sync_agent_index(domain="example.com", backend="mock", ttl=-1)
+        assert result["error"] == "validation_error"
+
+    def test_zone_not_found(self):
+        backend = MockBackend(zones=["other.com"])
+        with _mock_backend(backend):
+            result = server.sync_agent_index(domain="example.com", backend="mock")
+        assert result["success"] is False
+        assert result["error"] == "zone_not_found"
+
+    def test_sync_success(self):
+        synced = IndexResult(
+            domain="example.com",
+            entries=[IndexEntry(name="chat", protocol="mcp")],
+            success=True,
+            message="synced 1 agent",
+            created=True,
+        )
+        with (
+            _mock_backend(),
+            patch("dns_aid.core.indexer.sync_index", new=AsyncMock(return_value=synced)),
+        ):
+            result = server.sync_agent_index(domain="example.com", backend="mock")
+        assert result["success"] is True
+        assert result["created"] is True
+        assert result["count"] == 1
+        assert result["agents"] == [{"name": "chat", "protocol": "mcp"}]
+        assert result["message"] == "synced 1 agent"
+
+    def test_exception_returns_sync_index_error(self):
+        with (
+            _mock_backend(),
+            patch(
+                "dns_aid.core.indexer.sync_index",
+                new=AsyncMock(side_effect=RuntimeError("scan failed")),
+            ),
+        ):
+            result = server.sync_agent_index(domain="example.com", backend="mock")
+        assert result == {
+            "success": False,
+            "error": "sync_index_error",
+            "message": "scan failed",
+        }
+
+
+# =============================================================================
+# Policy compilation tools
+# =============================================================================
+
+
+class TestCompilePolicyToRpz:
+    def test_both_formats(self):
+        result = server.compile_policy_to_rpz(POLICY_JSON)
+        assert result["success"] is True
+        assert "rpz_zone" in result
+        assert "bindaid_zone" in result
+        assert result["report"]["agent_fqdn"] == "_test._mcp._agents.example.com"
+        assert result["report"]["rpz_directives"] == 1
+
+    def test_rpz_only(self):
+        result = server.compile_policy_to_rpz(POLICY_JSON, format="rpz")
+        assert result["success"] is True
+        assert "rpz_zone" in result
+        assert "bindaid_zone" not in result
+
+    def test_bindaid_only(self):
+        result = server.compile_policy_to_rpz(POLICY_JSON, format="bindaid")
+        assert result["success"] is True
+        assert "bindaid_zone" in result
+        assert "rpz_zone" not in result
+
+    def test_invalid_format(self):
+        result = server.compile_policy_to_rpz(POLICY_JSON, format="yaml")
+        assert result["success"] is False
+        assert "Invalid format" in result["error"]
+
+    def test_invalid_json(self):
+        result = server.compile_policy_to_rpz("{not json")
+        assert result["success"] is False
+        assert "Failed to parse policy document" in result["error"]
+
+
+class TestPublishRpzZone:
+    def test_invalid_backend_returns_validation_error(self):
+        result = server.publish_rpz_zone(
+            policy_json=POLICY_JSON, backend="bogus", rpz_zone="rpz.example.com"
+        )
+        assert result["error"] == "validation_error"
+
+    def test_invalid_policy_json(self):
+        result = server.publish_rpz_zone(
+            policy_json="{not json", backend="mock", rpz_zone="rpz.example.com"
+        )
+        assert result["success"] is False
+        assert "Failed to parse policy" in result["error"]
+
+    def test_unsupported_backend_returns_zone_content(self):
+        result = server.publish_rpz_zone(
+            policy_json=POLICY_JSON, backend="mock", rpz_zone="rpz.example.com"
+        )
+        assert result["success"] is True
+        assert result["backend"] == "mock"
+        assert result["record_count"] == 1
+        assert "zone_content" in result
+        assert "does not support direct RPZ push" in result["message"]
+
+    def test_nios_push_success(self):
+        nios = MagicMock()
+        nios.ensure_rpz_zone = AsyncMock()
+        nios.create_rpz_cname_record = AsyncMock()
+        nios.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios):
+            result = server.publish_rpz_zone(
+                policy_json=POLICY_JSON, backend="nios", rpz_zone="rpz.example.com"
+            )
+        assert result["success"] is True
+        assert result["record_count"] == 1
+        assert result["errors"] == []
+        nios.ensure_rpz_zone.assert_awaited_once_with("rpz.example.com")
+        nios.close.assert_awaited_once()
+
+    def test_nios_per_record_errors_reported(self):
+        nios = MagicMock()
+        nios.ensure_rpz_zone = AsyncMock()
+        nios.create_rpz_cname_record = AsyncMock(side_effect=RuntimeError("wapi error"))
+        nios.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios):
+            result = server.publish_rpz_zone(
+                policy_json=POLICY_JSON, backend="nios", rpz_zone="rpz.example.com"
+            )
+        assert result["success"] is False
+        assert result["record_count"] == 0
+        assert "wapi error" in result["errors"][0]
+
+    def test_nios_connection_failure(self):
+        nios = MagicMock()
+        nios.ensure_rpz_zone = AsyncMock(side_effect=RuntimeError("cannot connect"))
+        nios.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios):
+            result = server.publish_rpz_zone(
+                policy_json=POLICY_JSON, backend="nios", rpz_zone="rpz.example.com"
+            )
+        assert result["success"] is False
+        assert "NIOS push failed" in result["error"]
+
+    def test_infoblox_push_and_bind(self):
+        bx = MagicMock()
+        bx.create_or_update_named_list = AsyncMock(return_value={"updated": True})
+        bx.bind_named_list_to_policy = AsyncMock(
+            return_value={"policy_id": 7, "policy_name": "Default", "action": "bound"}
+        )
+        bx.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx):
+            result = server.publish_rpz_zone(
+                policy_json=POLICY_JSON,
+                backend="infoblox",
+                rpz_zone="rpz.example.com",
+                td_policy_id=7,
+            )
+        assert result["success"] is True
+        assert result["named_list"] == "dns-aid-rpz-rpz-example-com"
+        assert result["td_policy"]["policy_id"] == 7
+        assert result["td_policy"]["action"] == "action_block"
+        assert result["message"].startswith("Updated TD named list")
+        bx.close.assert_awaited_once()
+
+    def test_infoblox_failure(self):
+        bx = MagicMock()
+        bx.create_or_update_named_list = AsyncMock(side_effect=RuntimeError("401"))
+        bx.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx):
+            result = server.publish_rpz_zone(
+                policy_json=POLICY_JSON, backend="infoblox", rpz_zone="rpz.example.com"
+            )
+        assert result["success"] is False
+        assert "Infoblox push failed" in result["error"]
+
+
+class TestListRpzRules:
+    def test_nios_success(self):
+        nios = MagicMock()
+        nios.list_rpz_cname_records = AsyncMock(return_value=[{"owner": "evil.example.com"}])
+        nios.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios):
+            result = server.list_rpz_rules(rpz_zone="rpz.example.com", backend="nios")
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["rules"][0]["owner"] == "evil.example.com"
+
+    def test_nios_failure(self):
+        nios = MagicMock()
+        nios.list_rpz_cname_records = AsyncMock(side_effect=RuntimeError("wapi down"))
+        nios.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.nios.InfobloxNIOSBackend", return_value=nios):
+            result = server.list_rpz_rules(rpz_zone="rpz.example.com", backend="nios")
+        assert result["success"] is False
+        assert "NIOS query failed" in result["error"]
+
+    def test_infoblox_success(self):
+        bx = MagicMock()
+        bx.list_named_lists = AsyncMock(return_value=[{"name": "dns-aid-rpz-rpz-example-com"}])
+        bx.list_security_policies = AsyncMock(return_value=[{"id": 1, "name": "Default"}])
+        bx.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx):
+            result = server.list_rpz_rules(rpz_zone="rpz.example.com", backend="infoblox")
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["security_policies"][0]["name"] == "Default"
+
+    def test_infoblox_failure(self):
+        bx = MagicMock()
+        bx.list_named_lists = AsyncMock(side_effect=RuntimeError("403"))
+        bx.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx):
+            result = server.list_rpz_rules(rpz_zone="rpz.example.com", backend="infoblox")
+        assert result["success"] is False
+        assert "Infoblox query failed" in result["error"]
+
+    def test_unsupported_backend(self):
+        result = server.list_rpz_rules(rpz_zone="rpz.example.com", backend="mock")
+        assert result["success"] is False
+        assert "does not support RPZ rule listing" in result["error"]
+
+
+class TestListTdSecurityPolicies:
+    def test_success(self):
+        bx = MagicMock()
+        bx.list_security_policies = AsyncMock(
+            return_value=[{"id": 1, "name": "Default", "is_default": True}]
+        )
+        bx.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx):
+            result = server.list_td_security_policies()
+        assert result["success"] is True
+        assert result["count"] == 1
+        bx.close.assert_awaited_once()
+
+    def test_failure(self):
+        bx = MagicMock()
+        bx.list_security_policies = AsyncMock(side_effect=RuntimeError("401"))
+        bx.close = AsyncMock()
+        with patch("dns_aid.backends.infoblox.bloxone.InfobloxBloxOneBackend", return_value=bx):
+            result = server.list_td_security_policies()
+        assert result["success"] is False
+        assert "Failed to list TD policies" in result["error"]
+
+
+# =============================================================================
+# diagnose_environment
+# =============================================================================
+
+
+class TestDiagnoseEnvironment:
+    def test_returns_report_dict(self):
+        report = MagicMock()
+        report.to_dict.return_value = {"version": "1.0", "pass_count": 3, "fail_count": 0}
+        with patch("dns_aid.doctor.run_checks", return_value=report) as run_checks:
+            result = server.diagnose_environment(domain="example.com")
+        assert result == {"version": "1.0", "pass_count": 3, "fail_count": 0}
+        run_checks.assert_called_once_with(domain="example.com")
+
+
+# =============================================================================
+# send_a2a_message
+# =============================================================================
+
+
+class TestSendA2AMessage:
+    def test_requires_endpoint_or_domain_and_name(self):
+        result = server.send_a2a_message(message="hi")
+        assert result["success"] is False
+        assert "Provide either" in result["error"]
+
+    def test_success_with_agent_info(self):
+        invoke_result = InvokeResult(
+            success=True,
+            data={
+                "response_text": "hello back",
+                "agent_info": {
+                    "canonical_endpoint": "https://canon.example.com",
+                    "name": "sec-agent",
+                },
+            },
+            telemetry={"ms": 12},
+        )
+        with patch(
+            "dns_aid.core.invoke.send_a2a_message", new=AsyncMock(return_value=invoke_result)
+        ):
+            result = server.send_a2a_message(message="hi", endpoint="https://agent.example.com")
+        assert result["success"] is True
+        assert result["response"] == "hello back"
+        assert result["agent_endpoint"] == "https://canon.example.com"
+        assert result["agent_info"]["name"] == "sec-agent"
+        assert result["telemetry"] == {"ms": 12}
+
+    def test_success_without_canonical_endpoint_keeps_original(self):
+        invoke_result = InvokeResult(
+            success=True,
+            data={"response_text": "ok", "agent_info": {"resolved_via": "dns"}},
+        )
+        with patch(
+            "dns_aid.core.invoke.send_a2a_message", new=AsyncMock(return_value=invoke_result)
+        ):
+            result = server.send_a2a_message(message="hi", endpoint="https://agent.example.com")
+        assert result["agent_endpoint"] == "https://agent.example.com"
+
+    def test_success_with_plain_string_data(self):
+        invoke_result = InvokeResult(success=True, data="plain response")
+        with patch(
+            "dns_aid.core.invoke.send_a2a_message", new=AsyncMock(return_value=invoke_result)
+        ):
+            result = server.send_a2a_message(message="hi", endpoint="https://agent.example.com")
+        assert result["response"] == "plain response"
+
+    def test_failure_with_blank_error_uses_default(self):
+        invoke_result = InvokeResult(success=False, error="   ")
+        with patch(
+            "dns_aid.core.invoke.send_a2a_message", new=AsyncMock(return_value=invoke_result)
+        ):
+            result = server.send_a2a_message(message="hi", endpoint="https://agent.example.com")
+        assert result["success"] is False
+        assert result["error"] == "Invocation failed"
+
+    def test_policy_denied_strict_blocks_send(self, monkeypatch):
+        monkeypatch.setenv("DNS_AID_POLICY_MODE", "strict")
+        mock_send = AsyncMock()
+        with (
+            patch(
+                "dns_aid.sdk.policy.guard.check_target_policy",
+                new=AsyncMock(return_value=DENIED),
+            ),
+            patch("dns_aid.core.invoke.send_a2a_message", new=mock_send),
+        ):
+            result = server.send_a2a_message(
+                message="hi",
+                domain="example.com",
+                name="sec-agent",
+                policy_uri="https://example.com/policy.json",
+            )
+        assert result["success"] is False
+        assert "Policy denied" in result["error"]
+        assert result["agent_endpoint"] == "sec-agent.example.com"
+        assert result["policy"]["result"] == "denied"
+        mock_send.assert_not_awaited()
+
+    def test_exception_with_empty_message_uses_default(self):
+        with patch(
+            "dns_aid.core.invoke.send_a2a_message",
+            new=AsyncMock(side_effect=RuntimeError("")),
+        ):
+            result = server.send_a2a_message(message="hi", endpoint="https://agent.example.com")
+        assert result["success"] is False
+        assert result["error"] == "Unknown invocation error"
+
+
+# =============================================================================
+# HTTP health endpoints
+# =============================================================================
+
+
+class TestHealthEndpoints:
+    async def test_health_check(self):
+        response = await server.health_check(MagicMock())
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["status"] == "healthy"
+        assert body["service"] == "dns-aid-mcp"
+        assert "publish_agent_to_dns" in body["tools"]
+        assert body["uptime_seconds"] >= 0
+
+    async def test_readiness_check(self):
+        response = await server.readiness_check(MagicMock())
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["ready"] is True
+        assert body["checks"] == {
+            "publisher": "ok",
+            "discoverer": "ok",
+            "mock_backend": "ok",
+        }
+
+    async def test_root_info(self):
+        response = await server.root_info(MagicMock())
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["service"] == "DNS-AID MCP Server"
+        assert "/mcp" in body["endpoints"]
+
+
+# =============================================================================
+# DCV tools
+# =============================================================================
+
+
+class TestDcvSafeError:
+    def test_validation_error_is_passed_through(self):
+        err = ValidationError("domain", "invalid domain", "!!")
+        assert "invalid domain" in server._dcv_safe_error(err)
+
+    def test_value_error_is_passed_through(self):
+        assert server._dcv_safe_error(ValueError("bad token")) == "bad token"
+
+    def test_unexpected_error_is_masked(self):
+        message = server._dcv_safe_error(RuntimeError("secret backend detail"))
+        assert "secret backend detail" not in message
+        assert "Check server logs" in message
+
+
+class TestDcvIssueChallenge:
+    def test_issue_success_with_binding(self):
+        result = server.dcv_issue_challenge(
+            domain="example.com", agent_name="chat", issuer_domain="issuer.com"
+        )
+        assert result["success"] is True
+        assert result["fqdn"] == "_agents-challenge.example.com"
+        assert result["bnd_req"] == "svc:chat@issuer.com"
+        assert "token" in result and "txt_value" in result
+
+    def test_issue_invalid_ttl(self):
+        result = server.dcv_issue_challenge(domain="example.com", ttl_seconds=5)
+        assert result["success"] is False
+        assert "ttl_seconds" in result["error"]
+
+
+class TestDcvPlaceChallenge:
+    def test_place_success(self):
+        placed = DCVPlaceResult(
+            fqdn="_agents-challenge.example.com",
+            domain="example.com",
+            expires_at=datetime.now(UTC),
+        )
+        with patch("dns_aid.core.dcv.place", new=AsyncMock(return_value=placed)):
+            result = server.dcv_place_challenge(domain="example.com", token="a" * 32)
+        assert result == {"success": True, "fqdn": "_agents-challenge.example.com"}
+
+    def test_place_invalid_token(self):
+        with patch(
+            "dns_aid.core.dcv.place",
+            new=AsyncMock(side_effect=ValueError("token must be a 32-character string")),
+        ):
+            result = server.dcv_place_challenge(domain="example.com", token="short")
+        assert result["success"] is False
+        assert "32-character" in result["error"]
+
+
+class TestDcvVerifyChallenge:
+    def test_verify_success_omits_token(self):
+        verified = DCVVerifyResult(
+            verified=True,
+            domain="example.com",
+            token="a" * 32,
+            fqdn="_agents-challenge.example.com",
+        )
+        with patch("dns_aid.core.dcv.verify", new=AsyncMock(return_value=verified)):
+            result = server.dcv_verify_challenge(domain="example.com", token="a" * 32)
+        assert result["success"] is True
+        assert result["verified"] is True
+        assert "token" not in result
+
+    def test_verify_unexpected_error_is_masked(self):
+        with patch(
+            "dns_aid.core.dcv.verify", new=AsyncMock(side_effect=RuntimeError("infra detail"))
+        ):
+            result = server.dcv_verify_challenge(domain="example.com", token="a" * 32)
+        assert result["success"] is False
+        assert result["verified"] is False
+        assert "infra detail" not in result["error"]
+
+
+class TestDcvRevokeChallenge:
+    def test_revoke_success(self):
+        revoked = DCVRevokeResult(
+            removed=True, domain="example.com", fqdn="_agents-challenge.example.com"
+        )
+        with patch("dns_aid.core.dcv.revoke", new=AsyncMock(return_value=revoked)):
+            result = server.dcv_revoke_challenge(domain="example.com", token="a" * 32)
+        assert result == {"success": True}
+
+    def test_revoke_error(self):
+        with patch(
+            "dns_aid.core.dcv.revoke",
+            new=AsyncMock(side_effect=ValueError("token must be placed first")),
+        ):
+            result = server.dcv_revoke_challenge(domain="example.com", token="a" * 32)
+        assert result["success"] is False
+        assert "token must be placed first" in result["error"]
+
+
+# =============================================================================
+# main() argument parsing / transport selection
+# =============================================================================
+
+
+class TestMain:
+    def test_help_prints_usage_and_returns(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["dns-aid-mcp", "--help"])
+        server.main()
+        out = capsys.readouterr().out
+        assert "Usage: dns-aid-mcp" in out
+        assert "--transport" in out
+
+    def test_default_runs_stdio_transport(self, monkeypatch):
+        # A stray argument exercises the parser's skip branch too.
+        monkeypatch.setattr(sys, "argv", ["dns-aid-mcp", "stray-arg"])
+        with patch.object(server.mcp, "run") as mock_run:
+            server.main()
+        mock_run.assert_called_once_with(transport="stdio")
+
+    def test_http_transport_runs_uvicorn(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["dns-aid-mcp", "--transport", "http", "--port", "9000", "--host", "0.0.0.0"],
+        )
+        app = MagicMock()
+        with (
+            patch("uvicorn.run") as mock_uvicorn,
+            patch.object(server.mcp, "streamable_http_app", return_value=app),
+        ):
+            server.main()
+        out = capsys.readouterr().out
+        assert "WARNING" in out  # 0.0.0.0 bind warning
+        assert "http://0.0.0.0:9000" in out
+        mock_uvicorn.assert_called_once()
+        assert mock_uvicorn.call_args.args[0] is app
+        assert mock_uvicorn.call_args.kwargs["host"] == "0.0.0.0"
+        assert mock_uvicorn.call_args.kwargs["port"] == 9000

--- a/tests/unit/sdk/policy/test_cel_evaluator.py
+++ b/tests/unit/sdk/policy/test_cel_evaluator.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 from unittest.mock import Mock, patch
 
 import pytest
@@ -693,14 +694,14 @@ class TestBackendSelection:
         assert isinstance(backend, _RustBackend)
 
     def test_python_fallback_when_rust_unavailable(self) -> None:
-        import dns_aid.sdk.policy.cel_evaluator as mod
+        mod = importlib.import_module("dns_aid.sdk.policy.cel_evaluator")
 
         with patch.object(mod, "_RustBackend", side_effect=ImportError("no cel")):
             backend = mod._select_backend()
         assert isinstance(backend, mod._PythonBackend)
 
     def test_no_backend_available_raises_import_error(self) -> None:
-        import dns_aid.sdk.policy.cel_evaluator as mod
+        mod = importlib.import_module("dns_aid.sdk.policy.cel_evaluator")
 
         with (
             patch.object(mod, "_RustBackend", side_effect=ImportError("no cel")),
@@ -720,7 +721,7 @@ class TestPythonBackend:
     """Exercise the cel-python (celpy) fallback backend directly."""
 
     def _python_evaluator(self):
-        import dns_aid.sdk.policy.cel_evaluator as mod
+        mod = importlib.import_module("dns_aid.sdk.policy.cel_evaluator")
 
         with patch.object(mod, "_RustBackend", side_effect=ImportError("no cel")):
             return mod.CELRuleEvaluator()

--- a/tests/unit/sdk/policy/test_cel_evaluator.py
+++ b/tests/unit/sdk/policy/test_cel_evaluator.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -675,3 +675,135 @@ class TestCircuitStateCEL:
             "layer1",
         )
         assert len(v) == 1
+
+
+# =============================================================================
+# Backend selection and the pure-Python fallback backend
+# =============================================================================
+
+
+class TestBackendSelection:
+    """_select_backend priority: Rust first, cel-python fallback, else ImportError."""
+
+    def test_rust_backend_preferred_when_available(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import _RustBackend, _select_backend
+
+        backend = _select_backend()
+        # In the dev environment both backends are installed → Rust wins.
+        assert isinstance(backend, _RustBackend)
+
+    def test_python_fallback_when_rust_unavailable(self) -> None:
+        import dns_aid.sdk.policy.cel_evaluator as mod
+
+        with patch.object(mod, "_RustBackend", side_effect=ImportError("no cel")):
+            backend = mod._select_backend()
+        assert isinstance(backend, mod._PythonBackend)
+
+    def test_no_backend_available_raises_import_error(self) -> None:
+        import dns_aid.sdk.policy.cel_evaluator as mod
+
+        with (
+            patch.object(mod, "_RustBackend", side_effect=ImportError("no cel")),
+            patch.object(mod, "_PythonBackend", side_effect=ImportError("no celpy")),
+        ):
+            with pytest.raises(ImportError, match="No CEL backend available"):
+                mod._select_backend()
+
+    def test_evaluator_records_backend_name(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        assert evaluator.backend_name in ("_RustBackend", "_PythonBackend")
+
+
+class TestPythonBackend:
+    """Exercise the cel-python (celpy) fallback backend directly."""
+
+    def _python_evaluator(self):
+        import dns_aid.sdk.policy.cel_evaluator as mod
+
+        with patch.object(mod, "_RustBackend", side_effect=ImportError("no cel")):
+            return mod.CELRuleEvaluator()
+
+    def test_compile_and_execute(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import _PythonBackend
+
+        backend = _PythonBackend()
+        prog = backend.compile("request.caller_trust_score >= 50.0")
+        assert bool(backend.execute(prog, {"caller_trust_score": 80.0})) is True
+        assert bool(backend.execute(prog, {"caller_trust_score": 10.0})) is False
+
+    def test_dict_to_cel_map_type_coercion(self) -> None:
+        from celpy import celtypes
+
+        from dns_aid.sdk.policy.cel_evaluator import _PythonBackend
+
+        cel_map = _PythonBackend._dict_to_cel_map(
+            {"b": True, "i": 3, "f": 1.5, "s": "x", "n": None}, celtypes
+        )
+        assert cel_map[celtypes.StringType("b")] == celtypes.BoolType(True)
+        assert isinstance(cel_map[celtypes.StringType("b")], celtypes.BoolType)
+        assert isinstance(cel_map[celtypes.StringType("i")], celtypes.IntType)
+        assert isinstance(cel_map[celtypes.StringType("f")], celtypes.DoubleType)
+        assert cel_map[celtypes.StringType("s")] == celtypes.StringType("x")
+        # Non-primitive values are stringified
+        assert cel_map[celtypes.StringType("n")] == celtypes.StringType("None")
+
+    def test_evaluator_with_python_backend_denies(self) -> None:
+        evaluator = self._python_evaluator()
+        assert evaluator.backend_name == "_PythonBackend"
+        rules = [
+            CELRule(
+                id="trust",
+                expression="request.caller_trust_score >= 50.0",
+                effect="deny",
+                message="Too low",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(caller_trust_score=10.0), "layer1")
+        assert len(v) == 1
+        assert v[0].rule == "cel:trust"
+
+    def test_evaluator_with_python_backend_allows(self) -> None:
+        evaluator = self._python_evaluator()
+        rules = [
+            CELRule(
+                id="proto",
+                expression='request.protocol == "mcp" && request.dnssec_validated',
+                effect="deny",
+            )
+        ]
+        v, _ = evaluator.evaluate(rules, _ctx(protocol="mcp", dnssec_validated=True), "layer1")
+        assert len(v) == 0
+
+    def test_python_backend_bad_expression_fails_open(self) -> None:
+        evaluator = self._python_evaluator()
+        rules = [CELRule(id="bad", expression="!!! invalid CEL ???", effect="deny")]
+        v, w = evaluator.evaluate(rules, _ctx(), "layer1")
+        assert len(v) == 0
+        assert len(w) == 0
+
+
+# =============================================================================
+# Negative compile cache
+# =============================================================================
+
+
+class TestNegativeCompileCache:
+    """Expressions that fail to compile are negatively cached."""
+
+    def test_recompile_of_bad_expression_raises_value_error(self) -> None:
+        from dns_aid.sdk.policy.cel_evaluator import CELRuleEvaluator
+
+        evaluator = CELRuleEvaluator()
+        evaluator._backend = Mock()
+        evaluator._backend.compile = Mock(side_effect=RuntimeError("parse error"))
+
+        with pytest.raises(RuntimeError, match="parse error"):
+            evaluator._compile("bad expression")
+        assert "bad expression" in evaluator._bad_expressions
+
+        # Second attempt short-circuits without touching the backend again
+        with pytest.raises(ValueError, match="Previously failed to compile"):
+            evaluator._compile("bad expression")
+        assert evaluator._backend.compile.call_count == 1

--- a/tests/unit/test_backend_base.py
+++ b/tests/unit/test_backend_base.py
@@ -1,0 +1,283 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the DNSBackend ABC — default get_record and publish_agent logic."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dns_aid.backends.base import _STANDARD_SVCB_KEYS, DNSBackend
+from dns_aid.core.models import AgentRecord, Protocol
+
+# ---------------------------------------------------------------------------
+# Minimal concrete backend that records every call
+# ---------------------------------------------------------------------------
+
+
+class RecordingBackend(DNSBackend):
+    """Concrete DNSBackend that records calls, with configurable failures."""
+
+    def __init__(
+        self,
+        *,
+        support: bool | None = False,
+        fail_first_svcb: bool = False,
+        fail_alias: bool = False,
+        records: list[dict] | None = None,
+    ) -> None:
+        self._support = support
+        self._fail_first_svcb = fail_first_svcb
+        self._fail_alias = fail_alias
+        self._records = records or []
+        self._svcb_attempts = 0
+        self.svcb_calls: list[dict] = []
+        self.txt_calls: list[dict] = []
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    @property
+    def supports_private_svcb_keys(self) -> bool | None:
+        return self._support
+
+    async def create_svcb_record(self, zone, name, priority, target, params, ttl=3600) -> str:
+        self._svcb_attempts += 1
+        if self._fail_first_svcb and self._svcb_attempts == 1:
+            raise RuntimeError("server rejected private-use SVCB keys")
+        if self._fail_alias and priority == 0:
+            raise RuntimeError("alias write failed")
+        self.svcb_calls.append(
+            {
+                "zone": zone,
+                "name": name,
+                "priority": priority,
+                "target": target,
+                "params": params,
+                "ttl": ttl,
+            }
+        )
+        return f"{name}.{zone}"
+
+    async def create_txt_record(self, zone, name, values, ttl=3600) -> str:
+        self.txt_calls.append({"zone": zone, "name": name, "values": values, "ttl": ttl})
+        return f"{name}.{zone}"
+
+    async def delete_record(self, zone, name, record_type) -> bool:
+        return True
+
+    async def list_records(self, zone, name_pattern=None, record_type=None):
+        for record in self._records:
+            yield record
+
+    async def zone_exists(self, zone) -> bool:
+        return True
+
+
+def _agent(**overrides) -> AgentRecord:
+    defaults: dict = {
+        "name": "helper",
+        "domain": "example.com",
+        "protocol": Protocol.MCP,
+        "target_host": "mcp.example.com",
+        "port": 443,
+        "capabilities": ["chat"],
+        "version": "1.0.0",
+    }
+    defaults.update(overrides)
+    return AgentRecord(**defaults)
+
+
+def _custom_keys(params: dict[str, str]) -> set[str]:
+    return set(params) - _STANDARD_SVCB_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Abstract method bodies (ellipsis statements)
+# ---------------------------------------------------------------------------
+
+
+class TestAbstractBodies:
+    @pytest.mark.asyncio
+    async def test_abstract_bodies_are_noops(self):
+        backend = RecordingBackend()
+        assert DNSBackend.name.fget(backend) is None
+        assert await DNSBackend.create_svcb_record(backend, "z", "n", 1, "t.", {}) is None
+        assert await DNSBackend.create_txt_record(backend, "z", "n", ["v"]) is None
+        assert await DNSBackend.delete_record(backend, "z", "n", "TXT") is None
+        assert DNSBackend.list_records(backend, "z") is None
+        assert await DNSBackend.zone_exists(backend, "z") is None
+
+    def test_default_private_key_support_is_false(self):
+        class Minimal(RecordingBackend):
+            @property
+            def supports_private_svcb_keys(self) -> bool | None:
+                return DNSBackend.supports_private_svcb_keys.fget(self)
+
+        assert Minimal().supports_private_svcb_keys is False
+
+
+# ---------------------------------------------------------------------------
+# Default get_record implementation
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultGetRecord:
+    @pytest.mark.asyncio
+    async def test_match_by_name(self):
+        backend = RecordingBackend(
+            records=[
+                {"name": "other", "type": "SVCB"},
+                {"name": "helper", "type": "SVCB"},
+            ]
+        )
+        record = await backend.get_record("example.com", "helper", "SVCB")
+        assert record == {"name": "helper", "type": "SVCB"}
+
+    @pytest.mark.asyncio
+    async def test_match_by_fqdn(self):
+        backend = RecordingBackend(records=[{"fqdn": "helper.example.com", "type": "TXT"}])
+        record = await backend.get_record("example.com", "helper", "TXT")
+        assert record == {"fqdn": "helper.example.com", "type": "TXT"}
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_none(self):
+        backend = RecordingBackend(records=[{"name": "nope", "fqdn": "nope.example.com"}])
+        assert await backend.get_record("example.com", "helper", "SVCB") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_zone_returns_none(self):
+        backend = RecordingBackend()
+        assert await backend.get_record("example.com", "helper", "SVCB") is None
+
+
+# ---------------------------------------------------------------------------
+# publish_agent — param demotion / native support matrix
+# ---------------------------------------------------------------------------
+
+
+class TestPublishAgentSupportMatrix:
+    @pytest.mark.asyncio
+    async def test_native_support_passes_all_params(self):
+        """support=True → private-use keys stay on the SVCB record."""
+        agent = _agent(cap_uri="https://example.com/caps.json")
+        backend = RecordingBackend(support=True)
+
+        records = await backend.publish_agent(agent)
+
+        assert any(r.startswith("SVCB ") for r in records)
+        svcb_params = backend.svcb_calls[0]["params"]
+        assert _custom_keys(svcb_params), "expected private-use keys on SVCB"
+        # Nothing demoted to TXT
+        assert not any(v.startswith("dnsaid_") for v in backend.txt_calls[0]["values"])
+
+    @pytest.mark.asyncio
+    async def test_no_support_demotes_custom_params_to_txt(self):
+        """support=False → custom params demoted as dnsaid_KEY=value."""
+        agent = _agent(cap_uri="https://example.com/caps.json")
+        backend = RecordingBackend(support=False)
+
+        records = await backend.publish_agent(agent)
+
+        svcb_params = backend.svcb_calls[0]["params"]
+        assert not _custom_keys(svcb_params)
+        demoted = [v for v in backend.txt_calls[0]["values"] if v.startswith("dnsaid_")]
+        assert demoted, "expected demoted dnsaid_* TXT values"
+        assert len(records) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_support_without_custom_params_no_demotion(self):
+        """support=False and only standard params → nothing demoted, no warning."""
+        agent = _agent()
+        backend = RecordingBackend(support=False)
+
+        await backend.publish_agent(agent)
+
+        assert not _custom_keys(backend.svcb_calls[0]["params"])
+        assert not any(v.startswith("dnsaid_") for v in backend.txt_calls[0]["values"])
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_native_success(self):
+        """support=None → first write with all params succeeds; no second SVCB."""
+        agent = _agent(cap_uri="https://example.com/caps.json")
+        backend = RecordingBackend(support=None)
+
+        records = await backend.publish_agent(agent)
+
+        # Single SVCB write carrying the custom keys
+        assert len(backend.svcb_calls) == 1
+        assert _custom_keys(backend.svcb_calls[0]["params"])
+        assert records[0].startswith("SVCB ")
+        assert not any(v.startswith("dnsaid_") for v in backend.txt_calls[0]["values"])
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_fallback_on_rejection(self):
+        """support=None → server rejects, retry with standard params + demotion."""
+        agent = _agent(cap_uri="https://example.com/caps.json")
+        backend = RecordingBackend(support=None, fail_first_svcb=True)
+
+        records = await backend.publish_agent(agent)
+
+        # First attempt raised, second (recorded) attempt has only standard keys
+        assert backend._svcb_attempts == 2
+        assert len(backend.svcb_calls) == 1
+        assert not _custom_keys(backend.svcb_calls[0]["params"])
+        demoted = [v for v in backend.txt_calls[0]["values"] if v.startswith("dnsaid_")]
+        assert demoted
+        assert any(r.startswith("SVCB ") for r in records)
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_without_custom_params_uses_standard_path(self):
+        """support=None but no custom params → plain demotion branch (no-op)."""
+        agent = _agent()
+        backend = RecordingBackend(support=None)
+
+        await backend.publish_agent(agent)
+
+        assert len(backend.svcb_calls) == 1
+        assert not _custom_keys(backend.svcb_calls[0]["params"])
+
+
+# ---------------------------------------------------------------------------
+# publish_agent — walkable alias + TXT edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPublishAgentWalkableAndTxt:
+    @pytest.mark.asyncio
+    async def test_walkable_alias_written_when_opted_in(self):
+        agent = _agent(publish_walkable_alias=True)
+        backend = RecordingBackend()
+
+        records = await backend.publish_agent(agent)
+
+        alias_calls = [c for c in backend.svcb_calls if c["priority"] == 0]
+        assert len(alias_calls) == 1
+        assert alias_calls[0]["name"] == "helper._agents"
+        assert alias_calls[0]["target"] == f"{agent.fqdn}."
+        assert any(r.startswith("SVCB(AliasMode)") for r in records)
+
+    @pytest.mark.asyncio
+    async def test_walkable_alias_failure_is_non_fatal(self):
+        agent = _agent(publish_walkable_alias=True)
+        backend = RecordingBackend(fail_alias=True)
+
+        records = await backend.publish_agent(agent)
+
+        assert any(r.startswith("SVCB ") for r in records)
+        assert any(r.startswith("TXT ") for r in records)
+        assert not any("AliasMode" in r for r in records)
+
+    @pytest.mark.asyncio
+    async def test_no_txt_record_when_no_values(self):
+        agent = _agent()
+        backend = RecordingBackend()
+
+        with patch.object(AgentRecord, "to_txt_values", return_value=[]):
+            records = await backend.publish_agent(agent)
+
+        assert backend.txt_calls == []
+        assert records == ["SVCB helper.example.com"]

--- a/tests/unit/test_backend_factory.py
+++ b/tests/unit/test_backend_factory.py
@@ -148,7 +148,7 @@ class TestOptionalReExports:
 
     def test_all_optional_backends_present_are_exported(self):
         """With the full dev environment, every optional backend is re-exported."""
-        import dns_aid.backends as pkg
+        pkg = importlib.import_module("dns_aid.backends")
 
         for _, class_name in _OPTIONAL_BACKEND_MODULES:
             assert class_name in pkg.__all__

--- a/tests/unit/test_backend_factory.py
+++ b/tests/unit/test_backend_factory.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -95,3 +97,59 @@ class TestCreateBackendErrors:
         ):
             with pytest.raises(ImportError, match="boto3"):
                 create_backend("route53")
+
+
+# ---------------------------------------------------------------------------
+# Eager convenience re-exports — missing optional deps are swallowed
+# ---------------------------------------------------------------------------
+
+_OPTIONAL_BACKEND_MODULES = [
+    ("dns_aid.backends.route53", "Route53Backend"),
+    ("dns_aid.backends.infoblox", "InfobloxBackend"),
+    ("dns_aid.backends.ddns", "DDNSBackend"),
+    ("dns_aid.backends.cloudflare", "CloudflareBackend"),
+    ("dns_aid.backends.cloud_dns", "CloudDNSBackend"),
+    ("dns_aid.backends.ns1", "NS1Backend"),
+    ("dns_aid.backends.akamai_edgedns", "AkamaiEdgeDNSBackend"),
+]
+
+
+class TestOptionalReExports:
+    """The eager re-export block must swallow ImportError for every backend."""
+
+    def test_all_optional_backends_missing(self):
+        """Re-import the package with every optional backend module blocked."""
+        real_pkg = sys.modules["dns_aid.backends"]
+        try:
+            with patch.dict(sys.modules):
+                for module_path, _ in _OPTIONAL_BACKEND_MODULES:
+                    # A None entry makes `import <name>` raise ImportError.
+                    sys.modules[module_path] = None  # type: ignore[assignment]
+                sys.modules.pop("dns_aid.backends", None)
+
+                fresh = importlib.import_module("dns_aid.backends")
+
+                for _, class_name in _OPTIONAL_BACKEND_MODULES:
+                    assert class_name not in fresh.__all__
+                    assert not hasattr(fresh, class_name)
+                # Core exports survive
+                assert "MockBackend" in fresh.__all__
+                assert "DNSBackend" in fresh.__all__
+                assert fresh.VALID_BACKEND_NAMES == VALID_BACKEND_NAMES
+                # Factory still works for backends without optional deps
+                assert fresh.create_backend("mock").name == "mock"
+        finally:
+            # patch.dict restored sys.modules; also restore the attribute on
+            # the parent package, which the fresh import overwrote.
+            sys.modules["dns_aid.backends"] = real_pkg
+            import dns_aid
+
+            dns_aid.backends = real_pkg
+
+    def test_all_optional_backends_present_are_exported(self):
+        """With the full dev environment, every optional backend is re-exported."""
+        import dns_aid.backends as pkg
+
+        for _, class_name in _OPTIONAL_BACKEND_MODULES:
+            assert class_name in pkg.__all__
+            assert hasattr(pkg, class_name)

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -1,0 +1,114 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``dns-aid init`` wizard (``dns_aid.cli.init``)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from dns_aid.cli.main import app
+
+runner = CliRunner()
+
+
+# ── choice parsing ─────────────────────────────────────────────────
+
+
+class TestInitChoiceParsing:
+    def test_choice_by_name(self, tmp_path, monkeypatch):
+        """A backend name (not a number) is matched against the menu."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="cloudflare\nn\nn\n")
+        assert result.exit_code == 0
+        assert "Cloudflare DNS" in result.output
+
+    def test_invalid_choice_string_exits(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="bogus\n")
+        assert result.exit_code == 1
+        combined = result.output + (result.stderr or "")
+        assert "Invalid choice" in combined
+
+    def test_out_of_range_numeric_exits(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="99\n")
+        assert result.exit_code == 1
+
+    def test_negative_numeric_exits(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="-1\n")
+        assert result.exit_code == 1
+
+
+# ── backend setup flow ─────────────────────────────────────────────
+
+
+class TestInitBackendSetup:
+    def test_backend_without_required_env(self, tmp_path, monkeypatch):
+        """Route 53 (option 1) has no required env vars, only optional ones."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="1\nn\nn\n")
+        assert result.exit_code == 0
+        assert "AWS Route 53" in result.output
+        assert "Required environment variables" not in result.output
+        assert "Optional:" in result.output
+        assert "Steps:" in result.output
+        assert not (tmp_path / ".env").exists()
+
+    def test_backend_with_required_env(self, tmp_path, monkeypatch):
+        """Cloudflare (option 2) lists its required env vars."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="2\nn\nn\n")
+        assert result.exit_code == 0
+        assert "Required environment variables" in result.output
+        assert "CLOUDFLARE_API_TOKEN" in result.output
+
+    def test_decline_env_creation_shows_copy_hint(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="2\nn\nn\n")
+        assert result.exit_code == 0
+        assert "Copy the snippet above" in result.output
+        assert not (tmp_path / ".env").exists()
+
+    def test_create_env_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["init"], input="2\ny\nn\n")
+        assert result.exit_code == 0
+        assert "Created" in result.output
+        env_file = tmp_path / ".env"
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "DNS_AID_BACKEND=cloudflare" in content
+        assert "CLOUDFLARE_API_TOKEN=" in content
+        assert "# CLOUDFLARE_ZONE_ID=" in content
+
+    def test_existing_env_file_is_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("EXISTING=1\n")
+        result = runner.invoke(app, ["init"], input="2\nn\n")
+        assert result.exit_code == 0
+        assert "Found .env" in result.output
+        assert "already exists" in result.output
+        assert (tmp_path / ".env").read_text() == "EXISTING=1\n"
+
+
+# ── doctor handoff ─────────────────────────────────────────────────
+
+
+class TestInitDoctorHandoff:
+    def test_run_doctor_when_confirmed(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch("dns_aid.cli.doctor.doctor") as mock_doctor:
+            result = runner.invoke(app, ["init"], input="0\ny\n")
+        assert result.exit_code == 0
+        mock_doctor.assert_called_once_with()
+
+    def test_skip_doctor_when_declined(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch("dns_aid.cli.doctor.doctor") as mock_doctor:
+            result = runner.invoke(app, ["init"], input="0\nn\n")
+        assert result.exit_code == 0
+        mock_doctor.assert_not_called()

--- a/tests/unit/test_cloud_dns_backend.py
+++ b/tests/unit/test_cloud_dns_backend.py
@@ -5,11 +5,16 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from dns_aid.backends.cloud_dns import CloudDNSBackend
+
+_GOOGLE_PROJECT_ENV_VARS = ("GOOGLE_CLOUD_PROJECT", "GCP_PROJECT", "CLOUD_DNS_PROJECT")
 
 
 def _backend() -> CloudDNSBackend:
@@ -18,6 +23,21 @@ def _backend() -> CloudDNSBackend:
         managed_zone="agents-zone",
         token_provider=lambda: ("test-token", None),
     )
+
+
+def _clear_project_env(monkeypatch) -> None:
+    for var in (*_GOOGLE_PROJECT_ENV_VARS, "CLOUD_DNS_MANAGED_ZONE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _attach_transport(
+    backend: CloudDNSBackend, handler: Callable[[httpx.Request], httpx.Response]
+) -> None:
+    """Wire the backend to an httpx.MockTransport bound to the running loop."""
+    backend._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url=backend._base_url
+    )
+    backend._client_loop_id = id(asyncio.get_running_loop())
 
 
 class TestCloudDNSBackend:
@@ -163,3 +183,459 @@ class TestCloudDNSBackend:
             AsyncMock(side_effect=ValueError("zone missing")),
         ):
             assert await backend.zone_exists("example.com") is False
+
+    @pytest.mark.asyncio
+    async def test_zone_exists_returns_true_when_zone_found(self):
+        backend = _backend()
+
+        with patch.object(
+            backend,
+            "_get_managed_zone_name",
+            AsyncMock(return_value="agents-zone"),
+        ):
+            assert await backend.zone_exists("example.com") is True
+
+
+class TestCloudDNSBackendInit:
+    """Tests for constructor configuration sources."""
+
+    def test_init_reads_project_and_zone_from_env(self, monkeypatch):
+        _clear_project_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+        monkeypatch.setenv("CLOUD_DNS_MANAGED_ZONE", "env-zone")
+
+        backend = CloudDNSBackend(token_provider=lambda: ("token", None))
+
+        assert backend._project_id == "env-project"
+        assert backend._managed_zone == "env-zone"
+
+    def test_init_defaults_without_configuration(self, monkeypatch):
+        _clear_project_env(monkeypatch)
+
+        backend = CloudDNSBackend(token_provider=lambda: ("token", None))
+
+        assert backend._project_id is None
+        assert backend._managed_zone is None
+        assert backend._base_url == "https://dns.googleapis.com/dns/v1"
+
+    def test_init_strips_trailing_slash_from_base_url(self):
+        backend = CloudDNSBackend(
+            project_id="p",
+            managed_zone="z",
+            token_provider=lambda: ("token", None),
+            base_url="https://dns.example.test/dns/v1/",
+        )
+        assert backend._base_url == "https://dns.example.test/dns/v1"
+
+
+class TestCloudDNSBackendClient:
+    """Tests for the loop-aware httpx client lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_get_client_creates_and_caches_client(self):
+        backend = _backend()
+
+        client1 = await backend._get_client()
+        client2 = await backend._get_client()
+
+        assert isinstance(client1, httpx.AsyncClient)
+        assert client1 is client2
+        assert backend._client_loop_id == id(asyncio.get_running_loop())
+
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_recreates_client_on_loop_change(self):
+        backend = _backend()
+        stale_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200))
+        )
+        backend._client = stale_client
+        backend._client_loop_id = -1  # simulate a client bound to another loop
+
+        client = await backend._get_client()
+
+        assert client is not stale_client
+        assert stale_client.is_closed
+        assert backend._client_loop_id == id(asyncio.get_running_loop())
+
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_close_resets_client_state(self):
+        backend = _backend()
+        client = await backend._get_client()
+
+        await backend.close()
+
+        assert client.is_closed
+        assert backend._client is None
+        assert backend._client_loop_id is None
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop_without_client(self):
+        backend = _backend()
+        await backend.close()
+        assert backend._client is None
+
+
+class TestCloudDNSBackendProjectResolution:
+    """Tests for project id discovery and validation."""
+
+    def test_resolve_project_id_prefers_configured_project(self):
+        backend = _backend()
+        assert backend._resolve_project_id("discovered-project") == "test-project"
+
+    def test_resolve_project_id_uses_discovered_project(self, monkeypatch):
+        _clear_project_env(monkeypatch)
+        backend = CloudDNSBackend(token_provider=lambda: ("token", None))
+
+        assert backend._resolve_project_id("discovered-project") == "discovered-project"
+        assert backend._project_id == "discovered-project"
+
+    def test_resolve_project_id_raises_without_any_project(self, monkeypatch):
+        _clear_project_env(monkeypatch)
+        backend = CloudDNSBackend(token_provider=lambda: ("token", None))
+
+        with pytest.raises(ValueError, match="project id not configured"):
+            backend._resolve_project_id(None)
+
+    def test_ensure_project_id_returns_configured_project(self):
+        backend = _backend()
+        assert backend._ensure_project_id() == "test-project"
+
+    def test_ensure_project_id_discovers_project_via_token_provider(self, monkeypatch):
+        _clear_project_env(monkeypatch)
+        backend = CloudDNSBackend(token_provider=lambda: ("token", "adc-project"))
+
+        assert backend._ensure_project_id() == "adc-project"
+        assert backend._project_id == "adc-project"
+
+
+class TestCloudDNSBackendRequest:
+    """Tests for the authenticated request helper."""
+
+    @pytest.mark.asyncio
+    async def test_request_sends_bearer_token_and_parses_json(self, monkeypatch):
+        _clear_project_env(monkeypatch)
+        backend = CloudDNSBackend(
+            managed_zone="agents-zone",
+            token_provider=lambda: ("bearer-token", "adc-project"),
+        )
+        captured: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["authorization"] = request.headers["Authorization"]
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json={"rrsets": []})
+
+        _attach_transport(backend, handler)
+
+        result = await backend._request(
+            "GET",
+            "/projects/adc-project/managedZones/agents-zone/rrsets",
+            params={"maxResults": "1"},
+        )
+
+        assert result == {"rrsets": []}
+        assert captured["authorization"] == "Bearer bearer-token"
+        assert "maxResults=1" in captured["url"]
+        assert backend._project_id == "adc-project"
+
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_request_returns_empty_dict_for_empty_body(self):
+        backend = _backend()
+        _attach_transport(backend, lambda request: httpx.Response(200))
+
+        result = await backend._request("POST", "/projects/test-project/managedZones/z/changes")
+
+        assert result == {}
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_request_raises_on_http_error(self):
+        backend = _backend()
+        _attach_transport(
+            backend,
+            lambda request: httpx.Response(403, json={"error": {"message": "forbidden"}}),
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await backend._request("GET", "/projects/test-project/managedZones")
+
+        await backend.close()
+
+
+class TestCloudDNSBackendManagedZone:
+    """Tests for managed zone discovery."""
+
+    @pytest.mark.asyncio
+    async def test_get_managed_zone_name_discovers_and_caches_zone(self):
+        backend = CloudDNSBackend(
+            project_id="test-project",
+            token_provider=lambda: ("token", None),
+        )
+        zones = [
+            {"name": "other-zone", "dns_name": "other.com", "visibility": "public"},
+            {"name": "agents-zone", "dns_name": "example.com", "visibility": "public"},
+        ]
+
+        with patch.object(backend, "list_zones", AsyncMock(return_value=zones)) as mock_zones:
+            assert await backend._get_managed_zone_name("example.com.") == "agents-zone"
+            # Second lookup must be served from the cache.
+            assert await backend._get_managed_zone_name("example.com") == "agents-zone"
+
+        assert mock_zones.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_managed_zone_name_raises_when_zone_missing(self):
+        backend = CloudDNSBackend(
+            project_id="test-project",
+            token_provider=lambda: ("token", None),
+        )
+
+        with (
+            patch.object(backend, "list_zones", AsyncMock(return_value=[])),
+            pytest.raises(ValueError, match="No Cloud DNS managed zone found"),
+        ):
+            await backend._get_managed_zone_name("example.com")
+
+    @pytest.mark.asyncio
+    async def test_get_managed_zone_name_prefers_configured_zone(self):
+        backend = _backend()
+        assert await backend._get_managed_zone_name("example.com") == "agents-zone"
+
+
+class TestCloudDNSBackendChanges:
+    """Tests for record mutation payloads."""
+
+    @pytest.mark.asyncio
+    async def test_change_record_set_deletes_existing_record(self):
+        backend = _backend()
+        existing = {
+            "name": "_chat._mcp._agents",
+            "fqdn": "_chat._mcp._agents.example.com",
+            "type": "TXT",
+            "ttl": 60,
+            "values": ['"version=0.9.0"'],
+        }
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=existing)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            await backend.create_txt_record(
+                zone="example.com",
+                name="_chat._mcp._agents",
+                values=["version=1.0.0"],
+                ttl=300,
+            )
+
+        payload = mock_request.await_args.kwargs["json"]
+        assert payload["deletions"] == [
+            {
+                "name": "_chat._mcp._agents.example.com.",
+                "type": "TXT",
+                "ttl": 60,
+                "rrdatas": ['"version=0.9.0"'],
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_delete_record_returns_false_when_record_missing(self):
+        backend = _backend()
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=None)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            deleted = await backend.delete_record("example.com", "_chat._mcp._agents", "SVCB")
+
+        assert deleted is False
+        mock_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_record_posts_deletion_change(self):
+        backend = _backend()
+        existing = {
+            "name": "_chat._mcp._agents",
+            "fqdn": "_chat._mcp._agents.example.com",
+            "type": "SVCB",
+            "ttl": 30,
+            "values": ['1 service.example.internal. alpn="mcp"'],
+        }
+
+        with (
+            patch.object(backend, "get_record", AsyncMock(return_value=existing)),
+            patch.object(backend, "_request", AsyncMock(return_value={})) as mock_request,
+        ):
+            deleted = await backend.delete_record("example.com", "_chat._mcp._agents", "SVCB")
+
+        assert deleted is True
+        call = mock_request.await_args
+        assert call.args == (
+            "POST",
+            "/projects/test-project/managedZones/agents-zone/changes",
+        )
+        assert call.kwargs["json"] == {
+            "deletions": [
+                {
+                    "name": "_chat._mcp._agents.example.com.",
+                    "type": "SVCB",
+                    "ttl": 30,
+                    "rrdatas": ['1 service.example.internal. alpn="mcp"'],
+                }
+            ]
+        }
+
+
+class TestCloudDNSBackendListing:
+    """Tests for record and zone listing."""
+
+    @pytest.mark.asyncio
+    async def test_list_records_paginates_and_skips_malformed_rrsets(self):
+        backend = _backend()
+        responses = [
+            {
+                "rrsets": [
+                    {"name": "", "type": "SVCB", "ttl": 30, "rrdatas": []},
+                    {
+                        "name": "_chat._mcp._agents.example.com.",
+                        "type": "SVCB",
+                        "ttl": 30,
+                        "rrdatas": ['1 svc. alpn="mcp"'],
+                    },
+                ],
+                "nextPageToken": "page-2",
+            },
+            {
+                "rrsets": [
+                    {
+                        "name": "_search._a2a._agents.example.com.",
+                        "type": "SVCB",
+                        "ttl": 60,
+                        "rrdatas": ['1 svc2. alpn="a2a"'],
+                    },
+                ]
+            },
+        ]
+
+        with patch.object(backend, "_request", AsyncMock(side_effect=responses)) as mock_request:
+            records = [record async for record in backend.list_records("example.com")]
+
+        assert [record["name"] for record in records] == [
+            "_chat._mcp._agents",
+            "_search._a2a._agents",
+        ]
+        assert mock_request.await_count == 2
+        second_params = mock_request.await_args_list[1].kwargs["params"]
+        assert second_params == {"maxResults": "1000", "pageToken": "page-2"}
+
+    @pytest.mark.asyncio
+    async def test_list_records_applies_name_pattern_filter(self):
+        backend = _backend()
+        response = {
+            "rrsets": [
+                {
+                    "name": "_chat._mcp._agents.example.com.",
+                    "type": "SVCB",
+                    "ttl": 30,
+                    "rrdatas": ['1 svc. alpn="mcp"'],
+                },
+                {
+                    "name": "_other._mcp._agents.example.com.",
+                    "type": "SVCB",
+                    "ttl": 30,
+                    "rrdatas": ['1 svc. alpn="mcp"'],
+                },
+            ]
+        }
+
+        with patch.object(backend, "_request", AsyncMock(return_value=response)):
+            records = [
+                record async for record in backend.list_records("example.com", name_pattern="_chat")
+            ]
+
+        assert [record["fqdn"] for record in records] == ["_chat._mcp._agents.example.com"]
+
+    @pytest.mark.asyncio
+    async def test_list_zones_paginates_and_normalizes(self):
+        backend = _backend()
+        responses = [
+            {
+                "managedZones": [
+                    {"name": "zone-a", "dnsName": "example.com.", "visibility": "public"},
+                ],
+                "nextPageToken": "page-2",
+            },
+            {
+                "managedZones": [
+                    {"name": "zone-b", "dnsName": "internal.example.", "visibility": "private"},
+                    {"name": "zone-c"},
+                ]
+            },
+        ]
+
+        with patch.object(backend, "_request", AsyncMock(side_effect=responses)) as mock_request:
+            zones = await backend.list_zones()
+
+        assert zones == [
+            {"name": "zone-a", "dns_name": "example.com", "visibility": "public"},
+            {"name": "zone-b", "dns_name": "internal.example", "visibility": "private"},
+            {"name": "zone-c", "dns_name": "", "visibility": ""},
+        ]
+        first_call = mock_request.await_args_list[0]
+        assert first_call.args == ("GET", "/projects/test-project/managedZones")
+        assert first_call.kwargs["params"] == {"maxResults": "1000"}
+        second_params = mock_request.await_args_list[1].kwargs["params"]
+        assert second_params == {"maxResults": "1000", "pageToken": "page-2"}
+
+
+class TestCloudDNSBackendGetRecord:
+    """Tests for single-record lookup."""
+
+    @pytest.mark.asyncio
+    async def test_get_record_returns_none_when_no_rrsets(self):
+        backend = _backend()
+
+        with patch.object(backend, "_request", AsyncMock(return_value={})):
+            record = await backend.get_record("example.com", "_chat._mcp._agents", "SVCB")
+
+        assert record is None
+
+    @pytest.mark.asyncio
+    async def test_get_record_returns_normalized_record(self):
+        backend = _backend()
+        response = {
+            "rrsets": [
+                {
+                    "name": "_chat._mcp._agents.example.com.",
+                    "type": "SVCB",
+                    "ttl": 30,
+                    "rrdatas": ['1 service.example.internal. alpn="mcp"'],
+                }
+            ]
+        }
+
+        with patch.object(backend, "_request", AsyncMock(return_value=response)) as mock_request:
+            record = await backend.get_record("example.com", "_chat._mcp._agents", "SVCB")
+
+        assert record == {
+            "name": "_chat._mcp._agents",
+            "fqdn": "_chat._mcp._agents.example.com",
+            "type": "SVCB",
+            "ttl": 30,
+            "values": ['1 service.example.internal. alpn="mcp"'],
+        }
+        call = mock_request.await_args
+        assert call.args == (
+            "GET",
+            "/projects/test-project/managedZones/agents-zone/rrsets",
+        )
+        assert call.kwargs["params"] == {
+            "name": "_chat._mcp._agents.example.com.",
+            "type": "SVCB",
+            "maxResults": "1",
+        }

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -10,7 +10,6 @@ import types
 
 import pytest
 
-import dns_aid.doctor as doctor_mod
 from dns_aid.cli.backends import BACKEND_REGISTRY
 from dns_aid.doctor import (
     _check_backends,
@@ -89,7 +88,7 @@ class TestCheckCore:
 
     def test_missing_dependency_fails(self, monkeypatch):
         monkeypatch.setattr("httpx.get", _raise_network_error)
-        monkeypatch.setattr(doctor_mod, "_get_module_version", _raise_import_error)
+        monkeypatch.setattr("dns_aid.doctor._get_module_version", _raise_import_error)
         results = _check_core("1.2.3")
         fails = [r for r in results if r.status == "fail"]
         assert len(fails) == 6  # all listed deps
@@ -103,20 +102,20 @@ class TestGetModuleVersion:
     def test_callable_version_attribute(self, monkeypatch):
         fake_mod = types.SimpleNamespace(version=lambda: "9.9.9")
         fake_importlib = types.SimpleNamespace(import_module=lambda name: fake_mod)
-        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        monkeypatch.setattr("dns_aid.doctor.importlib", fake_importlib)
         assert _get_module_version("whatever") == "9.9.9"
 
     def test_metadata_fallback(self, monkeypatch):
         fake_mod = types.SimpleNamespace()
         fake_importlib = types.SimpleNamespace(import_module=lambda name: fake_mod)
-        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        monkeypatch.setattr("dns_aid.doctor.importlib", fake_importlib)
         ver = _get_module_version("whatever", "pytest")
         assert ver  # resolved via importlib.metadata
 
     def test_no_version_no_dist_returns_empty(self, monkeypatch):
         fake_mod = types.SimpleNamespace()
         fake_importlib = types.SimpleNamespace(import_module=lambda name: fake_mod)
-        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        monkeypatch.setattr("dns_aid.doctor.importlib", fake_importlib)
         assert _get_module_version("whatever") == ""
 
 
@@ -229,7 +228,7 @@ class TestCheckBackends:
 
     def test_missing_optional_deps_fail(self, monkeypatch):
         fake_importlib = types.SimpleNamespace(import_module=_raise_import_error)
-        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        monkeypatch.setattr("dns_aid.doctor.importlib", fake_importlib)
         checks = _by_label(_check_backends())
         for name in ("route53", "cloudflare", "infoblox", "nios", "akamai-edgedns", "ddns"):
             info = BACKEND_REGISTRY[name]
@@ -298,15 +297,15 @@ class TestCheckBackends:
 
 class TestCheckOptional:
     def test_all_available(self, monkeypatch):
-        fake_importlib = types.SimpleNamespace(import_module=lambda n: types.ModuleType(n))
-        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        fake_importlib = types.SimpleNamespace(import_module=types.ModuleType)
+        monkeypatch.setattr("dns_aid.doctor.importlib", fake_importlib)
         results = _check_optional()
         assert len(results) == 3
         assert all(r.status == "pass" for r in results)
 
     def test_none_available(self, monkeypatch):
         fake_importlib = types.SimpleNamespace(import_module=_raise_import_error)
-        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        monkeypatch.setattr("dns_aid.doctor.importlib", fake_importlib)
         results = _check_optional()
         assert len(results) == 3
         assert all(r.status == "warn" for r in results)

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,376 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``dns_aid.doctor`` internals — fully mocked, no network."""
+
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+import dns_aid.doctor as doctor_mod
+from dns_aid.cli.backends import BACKEND_REGISTRY
+from dns_aid.doctor import (
+    _check_backends,
+    _check_core,
+    _check_dns,
+    _check_dotenv,
+    _check_optional,
+    _get_module_version,
+    _suppress_logs,
+    run_checks,
+)
+
+AKAMAI_ENV = [
+    "AKAMAI_HOST",
+    "AKAMAI_CLIENT_TOKEN",
+    "AKAMAI_CLIENT_SECRET",
+    "AKAMAI_ACCESS_TOKEN",
+]
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, latest: str = "0.0.0"):
+        self.status_code = status_code
+        self._latest = latest
+
+    def json(self) -> dict:
+        return {"info": {"version": self._latest}}
+
+
+def _raise_network_error(*args, **kwargs):
+    raise OSError("network unreachable")
+
+
+def _raise_import_error(*args, **kwargs):
+    raise ImportError("nope")
+
+
+def _by_label(results) -> dict:
+    return {r.label: r for r in results}
+
+
+# ── _check_core ────────────────────────────────────────────────────
+
+
+class TestCheckCore:
+    def test_update_available(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _FakeResponse(200, "999.0.0"))
+        results = _check_core("0.1.0")
+        assert results[0].status == "fail"
+        assert results[0].label == "dns-aid"
+        assert "999.0.0" in results[0].detail
+        assert "upgrade" in results[0].detail
+
+    def test_up_to_date(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _FakeResponse(200, "1.0.0"))
+        results = _check_core("1.0.0")
+        assert results[0].status == "pass"
+        assert "(latest)" in results[0].detail
+
+    def test_pypi_non_200_reports_version_only(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _FakeResponse(500))
+        results = _check_core("1.2.3")
+        assert results[0].status == "pass"
+        assert results[0].detail == "1.2.3"
+
+    def test_pypi_network_error_reports_version_only(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", _raise_network_error)
+        results = _check_core("1.2.3")
+        assert results[0].status == "pass"
+        assert results[0].detail == "1.2.3"
+
+    def test_python_version_reported(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", _raise_network_error)
+        results = _check_core("1.2.3")
+        assert _by_label(results)["Python"].status == "pass"
+
+    def test_missing_dependency_fails(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", _raise_network_error)
+        monkeypatch.setattr(doctor_mod, "_get_module_version", _raise_import_error)
+        results = _check_core("1.2.3")
+        fails = [r for r in results if r.status == "fail"]
+        assert len(fails) == 6  # all listed deps
+        assert all(r.detail == "not installed" for r in fails)
+
+
+# ── _get_module_version ────────────────────────────────────────────
+
+
+class TestGetModuleVersion:
+    def test_callable_version_attribute(self, monkeypatch):
+        fake_mod = types.SimpleNamespace(version=lambda: "9.9.9")
+        fake_importlib = types.SimpleNamespace(import_module=lambda name: fake_mod)
+        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        assert _get_module_version("whatever") == "9.9.9"
+
+    def test_metadata_fallback(self, monkeypatch):
+        fake_mod = types.SimpleNamespace()
+        fake_importlib = types.SimpleNamespace(import_module=lambda name: fake_mod)
+        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        ver = _get_module_version("whatever", "pytest")
+        assert ver  # resolved via importlib.metadata
+
+    def test_no_version_no_dist_returns_empty(self, monkeypatch):
+        fake_mod = types.SimpleNamespace()
+        fake_importlib = types.SimpleNamespace(import_module=lambda name: fake_mod)
+        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        assert _get_module_version("whatever") == ""
+
+
+# ── _suppress_logs ─────────────────────────────────────────────────
+
+
+class TestSuppressLogs:
+    def test_restores_logging_after_exit(self):
+        with _suppress_logs():
+            logging.getLogger("dns_aid.test").error("suppressed")
+        assert logging.root.manager.disable == logging.NOTSET
+
+    def test_no_previous_factory_resets_defaults(self, monkeypatch):
+        monkeypatch.setattr("structlog.get_config", lambda: {})
+        with _suppress_logs():
+            pass
+        assert logging.root.manager.disable == logging.NOTSET
+
+
+# ── _check_dns ─────────────────────────────────────────────────────
+
+
+class TestCheckDns:
+    @pytest.fixture(autouse=True)
+    def _no_doctor_domain(self, monkeypatch):
+        monkeypatch.delenv("DNS_AID_DOCTOR_DOMAIN", raising=False)
+
+    def test_resolution_failure_short_circuits(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", _raise_network_error)
+        results = _check_dns()
+        assert len(results) == 1
+        assert results[0].status == "fail"
+        assert results[0].label == "Resolution"
+        assert "network unreachable" in results[0].detail
+
+    def test_svcb_unsupported_warns(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+        monkeypatch.setattr("dns.rdatatype.from_text", _raise_import_error)
+        results = _check_dns()
+        checks = _by_label(results)
+        assert checks["SVCB support"].status == "warn"
+
+    def test_no_domain_warns(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+        results = _check_dns()
+        checks = _by_label(results)
+        assert checks["Agent discovery"].status == "warn"
+        assert "no domain specified" in checks["Agent discovery"].detail
+
+    def test_discovery_finds_agents(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+
+        async def fake_read(domain):
+            return ["agent-one", "agent-two"]
+
+        monkeypatch.setattr("dns_aid.core.indexer.read_index_via_dns", fake_read)
+        results = _check_dns(domain="agents.example.com")
+        checks = _by_label(results)
+        assert checks["Agent discovery"].status == "pass"
+        assert "2 agent(s)" in checks["Agent discovery"].detail
+        assert "agents.example.com" in checks["Agent discovery"].detail
+
+    def test_discovery_empty_index_warns(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+
+        async def fake_read(domain):
+            return []
+
+        monkeypatch.setattr("dns_aid.core.indexer.read_index_via_dns", fake_read)
+        results = _check_dns(domain="agents.example.com")
+        checks = _by_label(results)
+        assert checks["Agent discovery"].status == "warn"
+        assert "no agents indexed" in checks["Agent discovery"].detail
+
+    def test_discovery_query_error_warns(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+
+        async def fake_read(domain):
+            raise RuntimeError("SERVFAIL")
+
+        monkeypatch.setattr("dns_aid.core.indexer.read_index_via_dns", fake_read)
+        results = _check_dns(domain="agents.example.com")
+        checks = _by_label(results)
+        assert checks["Agent discovery"].status == "warn"
+        assert "TXT index query failed" in checks["Agent discovery"].detail
+
+    def test_domain_from_env_var(self, monkeypatch):
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+        monkeypatch.setenv("DNS_AID_DOCTOR_DOMAIN", "env.example.com")
+
+        async def fake_read(domain):
+            return [f"agent@{domain}"]
+
+        monkeypatch.setattr("dns_aid.core.indexer.read_index_via_dns", fake_read)
+        results = _check_dns()
+        checks = _by_label(results)
+        assert checks["Agent discovery"].status == "pass"
+        assert "env.example.com" in checks["Agent discovery"].detail
+
+
+# ── _check_backends ────────────────────────────────────────────────
+
+
+class TestCheckBackends:
+    @pytest.fixture(autouse=True)
+    def _no_ambient_creds(self, monkeypatch):
+        monkeypatch.setattr("dns_aid.cli.backends._has_boto3_credentials", lambda: False)
+        for var in AKAMAI_ENV:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_missing_optional_deps_fail(self, monkeypatch):
+        fake_importlib = types.SimpleNamespace(import_module=_raise_import_error)
+        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        checks = _by_label(_check_backends())
+        for name in ("route53", "cloudflare", "infoblox", "nios", "akamai-edgedns", "ddns"):
+            info = BACKEND_REGISTRY[name]
+            assert checks[info.display_name].status == "fail"
+            assert f'pip install "dns-aid[{info.optional_dep}]"' in checks[info.display_name].detail
+
+    def test_route53_with_credentials(self, monkeypatch):
+        monkeypatch.setattr("dns_aid.cli.backends._has_boto3_credentials", lambda: True)
+        checks = _by_label(_check_backends())
+        assert checks["AWS Route 53"].status == "pass"
+        assert "credentials configured" in checks["AWS Route 53"].detail
+
+    def test_route53_without_credentials(self):
+        checks = _by_label(_check_backends())
+        assert checks["AWS Route 53"].status == "warn"
+        assert "no AWS credentials" in checks["AWS Route 53"].detail
+
+    def test_akamai_partial_env_fails(self, monkeypatch):
+        monkeypatch.setenv("AKAMAI_HOST", "akab-x.luna.akamaiapis.net")
+        monkeypatch.setenv("AKAMAI_EDGERC", "definitely-missing-edgerc")
+        checks = _by_label(_check_backends())
+        result = checks["Akamai Edge DNS"]
+        assert result.status == "fail"
+        assert "partial credentials" in result.detail
+        assert "AKAMAI_CLIENT_TOKEN" in result.detail
+
+    def test_akamai_all_env_passes(self, monkeypatch):
+        for var in AKAMAI_ENV:
+            monkeypatch.setenv(var, "value")
+        checks = _by_label(_check_backends())
+        result = checks["Akamai Edge DNS"]
+        assert result.status == "pass"
+        assert "env vars" in result.detail
+
+    def test_akamai_edgerc_file_passes(self, monkeypatch, tmp_path):
+        edgerc = tmp_path / "edgerc"
+        edgerc.write_text("[default]\n")
+        monkeypatch.setenv("AKAMAI_EDGERC", str(edgerc))
+        checks = _by_label(_check_backends())
+        result = checks["Akamai Edge DNS"]
+        assert result.status == "pass"
+        assert ".edgerc" in result.detail
+
+    def test_akamai_no_credentials_warns(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AKAMAI_EDGERC", str(tmp_path / "missing-edgerc"))
+        checks = _by_label(_check_backends())
+        result = checks["Akamai Edge DNS"]
+        assert result.status == "warn"
+        assert "no credentials found" in result.detail
+
+    def test_env_backend_credentials_configured(self, monkeypatch):
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        checks = _by_label(_check_backends())
+        assert checks["Cloudflare DNS"].status == "pass"
+        assert checks["Cloudflare DNS"].detail == "credentials configured"
+
+    def test_env_backend_missing_credentials_warns(self, monkeypatch):
+        monkeypatch.delenv("NS1_API_KEY", raising=False)
+        checks = _by_label(_check_backends())
+        assert checks["NS1 (IBM)"].status == "warn"
+        assert "NS1_API_KEY" in checks["NS1 (IBM)"].detail
+
+
+# ── _check_optional ────────────────────────────────────────────────
+
+
+class TestCheckOptional:
+    def test_all_available(self, monkeypatch):
+        fake_importlib = types.SimpleNamespace(import_module=lambda n: types.ModuleType(n))
+        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        results = _check_optional()
+        assert len(results) == 3
+        assert all(r.status == "pass" for r in results)
+
+    def test_none_available(self, monkeypatch):
+        fake_importlib = types.SimpleNamespace(import_module=_raise_import_error)
+        monkeypatch.setattr(doctor_mod, "importlib", fake_importlib)
+        results = _check_optional()
+        assert len(results) == 3
+        assert all(r.status == "warn" for r in results)
+        assert any("pip install" in r.detail for r in results)
+
+
+# ── _check_dotenv ──────────────────────────────────────────────────
+
+
+class TestCheckDotenv:
+    def test_env_file_with_backend_set(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("FOO=bar\n# comment\n\nBAR=baz\n")
+        monkeypatch.setenv("DNS_AID_BACKEND", "mock")
+        checks = _by_label(_check_dotenv())
+        assert checks[".env file"].status == "pass"
+        assert "2 variable(s) set" in checks[".env file"].detail
+        assert checks["DNS_AID_BACKEND"].status == "pass"
+        assert checks["DNS_AID_BACKEND"].detail == "mock"
+
+    def test_env_file_without_backend_warns(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("FOO=bar\n")
+        monkeypatch.delenv("DNS_AID_BACKEND", raising=False)
+        checks = _by_label(_check_dotenv())
+        assert checks[".env file"].status == "pass"
+        assert checks["DNS_AID_BACKEND"].status == "warn"
+
+    def test_no_env_file_warns(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        results = _check_dotenv()
+        assert len(results) == 1
+        assert results[0].status == "warn"
+        assert "not found" in results[0].detail
+
+
+# ── run_checks (integration, mocked) ───────────────────────────────
+
+
+class TestRunChecksMocked:
+    def test_run_checks_with_domain(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("httpx.get", _raise_network_error)
+        monkeypatch.setattr("dns.resolver.resolve", lambda *a, **k: None)
+        monkeypatch.setattr("dns_aid.cli.backends._has_boto3_credentials", lambda: False)
+
+        async def fake_read(domain):
+            return ["entry"]
+
+        monkeypatch.setattr("dns_aid.core.indexer.read_index_via_dns", fake_read)
+
+        report = run_checks(domain="agents.example.com")
+        assert set(report.sections) == {
+            "Core",
+            "DNS",
+            "Backends",
+            "Optional Features",
+            "Configuration",
+        }
+        dns_checks = _by_label(report.sections["DNS"])
+        assert dns_checks["Agent discovery"].status == "pass"
+        assert "agents.example.com" in dns_checks["Agent discovery"].detail
+
+        d = report.to_dict()
+        assert d["pass_count"] == report.pass_count
+        assert d["fail_count"] == report.fail_count
+        assert d["warn_count"] == report.warn_count

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -1,0 +1,124 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dns_aid.utils.google_auth.
+
+The google-auth package is intentionally absent from the CI dependency set
+(the cloud-dns extra is not installed), so these tests install stub modules
+into sys.modules before calling the lazy-import helpers.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+from dns_aid.utils.google_auth import get_google_access_token, get_google_auth_state
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class _FakeCredentials:
+    """Minimal stand-in for google.auth.credentials.Credentials."""
+
+    def __init__(
+        self,
+        token: str | None = None,
+        valid: bool = False,
+        refreshed_token: str | None = None,
+    ):
+        self.token = token
+        self.valid = valid
+        self._refreshed_token = refreshed_token
+        self.refresh_calls: list[object] = []
+
+    def refresh(self, request: object) -> None:
+        self.refresh_calls.append(request)
+        self.token = self._refreshed_token
+
+
+def _install_fake_google_auth(monkeypatch, default_func, request_cls) -> None:
+    """Register stub google.auth modules so the lazy imports succeed."""
+    google_mod = ModuleType("google")
+    auth_mod = ModuleType("google.auth")
+    transport_mod = ModuleType("google.auth.transport")
+    requests_mod = ModuleType("google.auth.transport.requests")
+
+    auth_mod.default = default_func
+    requests_mod.Request = request_cls
+    google_mod.auth = auth_mod
+    auth_mod.transport = transport_mod
+    transport_mod.requests = requests_mod
+
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.auth", auth_mod)
+    monkeypatch.setitem(sys.modules, "google.auth.transport", transport_mod)
+    monkeypatch.setitem(sys.modules, "google.auth.transport.requests", requests_mod)
+
+
+class TestGetGoogleAuthState:
+    """Tests for get_google_auth_state."""
+
+    def test_returns_valid_credentials_without_refresh(self, monkeypatch):
+        credentials = _FakeCredentials(token="cached-token", valid=True)
+        default = MagicMock(return_value=(credentials, "adc-project"))
+        _install_fake_google_auth(monkeypatch, default, MagicMock())
+
+        result_credentials, project_id = get_google_auth_state(_SCOPES)
+
+        assert result_credentials is credentials
+        assert project_id == "adc-project"
+        assert credentials.refresh_calls == []
+        default.assert_called_once_with(scopes=_SCOPES)
+
+    def test_refreshes_invalid_credentials(self, monkeypatch):
+        credentials = _FakeCredentials(valid=False, refreshed_token="fresh-token")
+        request_cls = MagicMock()
+        _install_fake_google_auth(
+            monkeypatch, MagicMock(return_value=(credentials, "adc-project")), request_cls
+        )
+
+        result_credentials, project_id = get_google_auth_state(_SCOPES)
+
+        assert result_credentials.token == "fresh-token"
+        assert project_id == "adc-project"
+        assert credentials.refresh_calls == [request_cls.return_value]
+
+    def test_refreshes_when_token_missing_despite_valid_flag(self, monkeypatch):
+        credentials = _FakeCredentials(token=None, valid=True, refreshed_token="fresh-token")
+        _install_fake_google_auth(
+            monkeypatch, MagicMock(return_value=(credentials, None)), MagicMock()
+        )
+
+        result_credentials, project_id = get_google_auth_state(_SCOPES)
+
+        assert result_credentials.token == "fresh-token"
+        assert project_id is None
+        assert len(credentials.refresh_calls) == 1
+
+    def test_raises_when_refresh_yields_no_token(self, monkeypatch):
+        credentials = _FakeCredentials(valid=False, refreshed_token=None)
+        _install_fake_google_auth(
+            monkeypatch, MagicMock(return_value=(credentials, "adc-project")), MagicMock()
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to acquire a Google Cloud access token"):
+            get_google_auth_state(_SCOPES)
+
+
+class TestGetGoogleAccessToken:
+    """Tests for get_google_access_token."""
+
+    def test_returns_token_and_project(self, monkeypatch):
+        credentials = _FakeCredentials(token="bearer-token", valid=True)
+        _install_fake_google_auth(
+            monkeypatch, MagicMock(return_value=(credentials, "adc-project")), MagicMock()
+        )
+
+        token, project_id = get_google_access_token(_SCOPES)
+
+        assert token == "bearer-token"
+        assert project_id == "adc-project"

--- a/tests/unit/test_infoblox_backend.py
+++ b/tests/unit/test_infoblox_backend.py
@@ -477,3 +477,644 @@ class TestInfobloxNIOSBackendImport:
 
         backend = InfobloxNIOSBackend(host="nios.example.com", username="admin", password="secret")
         assert backend.name == "nios"
+
+
+def _mock_response(
+    json_data=None,
+    status_code=200,
+    raise_error: Exception | None = None,
+):
+    """Build a MagicMock httpx response."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data if json_data is not None else {}
+    if raise_error is not None:
+        response.raise_for_status = MagicMock(side_effect=raise_error)
+    else:
+        response.raise_for_status = MagicMock()
+    return response
+
+
+class TestBloxOneClientAndRequest:
+    """Tests for HTTP client lifecycle and the low-level _request helper."""
+
+    @pytest.fixture
+    def backend(self):
+        return InfobloxBloxOneBackend(api_key="test-key")
+
+    def test_dns_view_property(self, backend):
+        assert backend.dns_view == "default"
+
+    async def test_get_client_creates_and_caches(self, backend):
+        client = await backend._get_client()
+        assert isinstance(client, httpx.AsyncClient)
+        assert client.headers["Authorization"] == "Token test-key"
+        assert client.headers["Content-Type"] == "application/json"
+
+        # Second call within the same loop returns the same client.
+        assert await backend._get_client() is client
+
+        await backend.close()
+        assert backend._client is None
+
+    async def test_get_client_recreates_on_loop_change(self, backend):
+        old_client = MagicMock()
+        old_client.is_closed = False
+        old_client.aclose = AsyncMock()
+        backend._client = old_client
+        backend._client_loop_id = -1  # Never a real loop id
+
+        client = await backend._get_client()
+
+        old_client.aclose.assert_awaited_once()
+        assert client is not old_client
+        assert isinstance(client, httpx.AsyncClient)
+        await backend.close()
+
+    async def test_close_noop_without_client(self, backend):
+        assert backend._client is None
+        await backend.close()  # Must not raise
+
+    async def test_request_returns_json(self, backend):
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_mock_response({"results": [{"id": "x"}]}))
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend._request("GET", "/dns/view", params={"_filter": "x"})
+
+        assert result == {"results": [{"id": "x"}]}
+        call = mock_client.request.call_args
+        assert call[1]["url"] == "/api/ddi/v1/dns/view"
+        assert call[1]["method"] == "GET"
+
+    async def test_request_204_returns_empty_dict(self, backend):
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_mock_response(status_code=204))
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend._request("DELETE", "/dns/record/abc")
+
+        assert result == {}
+
+    async def test_request_raises_on_http_error(self, backend):
+        error = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=MagicMock(status_code=401)
+        )
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(
+            return_value=_mock_response(status_code=401, raise_error=error)
+        )
+
+        with (
+            patch.object(backend, "_get_client", return_value=mock_client),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await backend._request("GET", "/dns/auth_zone")
+
+    async def test_td_request_returns_json(self, backend):
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_mock_response({"results": []}))
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend._td_request("GET", "/named_lists")
+
+        assert result == {"results": []}
+        call = mock_client.request.call_args
+        assert call[1]["url"] == "/api/atcfw/v1/named_lists"
+
+    async def test_td_request_204_returns_empty_dict(self, backend):
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_mock_response(status_code=204))
+
+        with patch.object(backend, "_get_client", return_value=mock_client):
+            result = await backend._td_request("DELETE", "/named_lists/1")
+
+        assert result == {}
+
+    async def test_td_request_raises_on_http_error(self, backend):
+        error = httpx.HTTPStatusError(
+            "403", request=MagicMock(), response=MagicMock(status_code=403)
+        )
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(
+            return_value=_mock_response(status_code=403, raise_error=error)
+        )
+
+        with (
+            patch.object(backend, "_get_client", return_value=mock_client),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await backend._td_request("GET", "/security_policies")
+
+
+class TestBloxOneViewAndZoneLookup:
+    """Tests for view/zone resolution helpers and their caches."""
+
+    @pytest.fixture
+    def backend(self):
+        return InfobloxBloxOneBackend(api_key="test-key")
+
+    async def test_get_view_id_cache_hit(self, backend):
+        backend._view_cache["default"] = "dns/view/cached"
+
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            view_id = await backend._get_view_id("default")
+
+        assert view_id == "dns/view/cached"
+        mock_req.assert_not_called()
+
+    async def test_get_view_id_not_found_returns_none(self, backend):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"results": []}
+            view_id = await backend._get_view_id("missing-view")
+
+        assert view_id is None
+        assert "missing-view" not in backend._view_cache
+
+    async def test_get_zone_info_cache_hit(self, backend):
+        cached = {"id": "dns/auth_zone/cached", "fqdn": "example.com."}
+        backend._zone_cache["example.com:default"] = cached
+
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            zone_info = await backend._get_zone_info("Example.COM.")
+
+        assert zone_info is cached
+        mock_req.assert_not_called()
+
+    async def test_get_zone_info_without_view_skips_view_filter(self, backend):
+        backend._dns_view = ""  # No view configured
+
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"results": [{"id": "dns/auth_zone/z1"}]}
+            zone_info = await backend._get_zone_info("example.com")
+
+        assert zone_info["id"] == "dns/auth_zone/z1"
+        # Only the zone lookup happened (no view resolution call).
+        assert mock_req.call_count == 1
+        assert mock_req.call_args[1]["params"]["_filter"] == 'fqdn=="example.com."'
+
+    async def test_get_zone_info_view_unresolved_omits_view_filter(self, backend):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [
+                {"results": []},  # view lookup: not found
+                {"results": [{"id": "dns/auth_zone/z1"}]},
+            ]
+            zone_info = await backend._get_zone_info("example.com")
+
+        assert zone_info["id"] == "dns/auth_zone/z1"
+        zone_call = mock_req.call_args_list[1]
+        assert zone_call[1]["params"]["_filter"] == 'fqdn=="example.com."'
+
+    async def test_zone_exists_false_on_api_error(self, backend):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = httpx.ConnectError("network down")
+            assert await backend.zone_exists("example.com") is False
+
+
+class TestBloxOneRecordReadPaths:
+    """Tests for get_record, delete edge cases, and list_records filters."""
+
+    @pytest.fixture
+    def backend(self):
+        return InfobloxBloxOneBackend(api_key="test-key")
+
+    @pytest.fixture
+    def mock_view_response(self):
+        return {"results": [{"id": "dns/view/view123", "name": "default"}]}
+
+    @pytest.fixture
+    def mock_zone_response(self):
+        return {"results": [{"id": "dns/auth_zone/abc123", "fqdn": "example.com."}]}
+
+    async def test_get_record_txt(self, backend):
+        record = {
+            "id": "dns/record/txt1",
+            "name_in_zone": "_index._agents",
+            "absolute_name_spec": "_index._agents.example.com.",
+            "type": "TXT",
+            "ttl": 300,
+            "rdata": {"text": '"agents=chat:mcp"'},
+        }
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"results": [record]}
+            result = await backend.get_record("example.com", "_index._agents", "TXT")
+
+        assert result is not None
+        assert result["name"] == "_index._agents"
+        assert result["fqdn"] == "_index._agents.example.com"
+        assert result["values"] == ['"agents=chat:mcp"']
+        assert result["ttl"] == 300
+        # The lookup uses the trailing-dot FQDN filter.
+        filt = mock_req.call_args[1]["params"]["_filter"]
+        assert 'absolute_name_spec=="_index._agents.example.com."' in filt
+
+    async def test_get_record_svcb_presentation(self, backend):
+        record = {
+            "id": "dns/record/svcb1",
+            "name_in_zone": "_chat._mcp._agents",
+            "absolute_name_spec": "_chat._mcp._agents.example.com.",
+            "type": "SVCB",
+            "ttl": 600,
+            "rdata": {
+                "priority": 1,
+                "target_name": "mcp.example.com.",
+                "svc_params": [{"key": "alpn", "value": "mcp"}],
+            },
+        }
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"results": [record]}
+            result = await backend.get_record("example.com", "_chat._mcp._agents", "SVCB")
+
+        assert result is not None
+        assert result["values"] == ["1 mcp.example.com. alpn=mcp"]
+
+    async def test_get_record_generic_type_with_trailing_dot_zone(self, backend):
+        record = {
+            "id": "dns/record/a1",
+            "name_in_zone": "www",
+            "absolute_name_spec": "www.example.com.",
+            "type": "A",
+            "ttl": 60,
+            "rdata": {"address": "192.0.2.1"},
+        }
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"results": [record]}
+            # Zone with trailing dot exercises the no-extra-dot branch.
+            result = await backend.get_record("example.com.", "www", "A")
+
+        assert result is not None
+        assert result["values"] == [str({"address": "192.0.2.1"})]
+
+    async def test_get_record_not_found_returns_none(self, backend):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"results": []}
+            result = await backend.get_record("example.com", "_missing._agents", "TXT")
+
+        assert result is None
+
+    async def test_get_record_error_returns_none(self, backend):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = httpx.ConnectError("boom")
+            result = await backend.get_record("example.com", "_chat._mcp._agents", "SVCB")
+
+        assert result is None
+
+    async def test_delete_record_zone_with_trailing_dot(
+        self, backend, mock_view_response, mock_zone_response
+    ):
+        """A zone given with a trailing dot must not get a second dot appended."""
+        found = {"results": [{"id": "dns/record/del1"}]}
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [mock_view_response, mock_zone_response, found, {}]
+            result = await backend.delete_record("example.com.", "_x._mcp._agents", "SVCB")
+
+        assert result is True
+        list_call = mock_req.call_args_list[2]
+        filt = list_call[1]["params"]["_filter"]
+        assert '=="_x._mcp._agents.example.com."' in filt  # single trailing dot
+
+    async def test_delete_record_error_returns_false(self, backend):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = httpx.ConnectError("boom")
+            result = await backend.delete_record("example.com", "_x._mcp._agents", "SVCB")
+
+        assert result is False
+
+    async def test_list_records_type_and_name_filters(
+        self, backend, mock_view_response, mock_zone_response
+    ):
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                {"results": []},
+            ]
+            records = [
+                r
+                async for r in backend.list_records(
+                    "example.com", name_pattern="_agent", record_type="SVCB"
+                )
+            ]
+
+        assert records == []
+        filt = mock_req.call_args_list[2][1]["params"]["_filter"]
+        assert 'type=="SVCB"' in filt
+        assert 'name_in_zone~"_agent"' in filt
+
+    async def test_list_records_generic_rdata(
+        self, backend, mock_view_response, mock_zone_response
+    ):
+        record = {
+            "id": "rec-a",
+            "name_in_zone": "www",
+            "absolute_name_spec": "www.example.com.",
+            "type": "A",
+            "ttl": 60,
+            "rdata": {"address": "192.0.2.1"},
+        }
+        with patch.object(backend, "_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [
+                mock_view_response,
+                mock_zone_response,
+                {"results": [record]},
+                {"results": []},
+            ]
+            records = [r async for r in backend.list_records("example.com")]
+
+        assert len(records) == 1
+        assert records[0]["values"] == [str({"address": "192.0.2.1"})]
+
+    def test_svcb_presentation_non_list_params(self):
+        value = InfobloxBloxOneBackend._svcb_presentation(
+            {"priority": 1, "target_name": "x.example.com.", "svc_params": "alpn=mcp"}
+        )
+        assert value == "1 x.example.com. alpn=mcp"
+
+
+class TestBloxOneThreatDefenseNamedLists:
+    """Tests for TD named list operations."""
+
+    @pytest.fixture
+    def backend(self):
+        return InfobloxBloxOneBackend(api_key="test-key")
+
+    async def test_create_named_list_new(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                {"results": []},  # no existing lists
+                {"results": {"id": "nl-new", "name": "dns-aid-rpz"}},  # POST
+            ]
+            result = await backend.create_or_update_named_list(
+                name="dns-aid-rpz",
+                items=["evil.com", "worse.com"],
+                description="blocked",
+            )
+
+        assert result == {"id": "nl-new", "name": "dns-aid-rpz", "updated": False}
+        post_call = mock_td.call_args_list[1]
+        assert post_call[0][0] == "POST"
+        assert post_call[0][1] == "/named_lists"
+        payload = post_call[1]["json"]
+        assert payload["type"] == "custom_list"
+        assert payload["confidence_level"] == "HIGH"
+        assert {"item": "evil.com", "description": "blocked"} in payload["items_described"]
+
+    async def test_create_named_list_update_existing(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                {
+                    "results": [
+                        {"id": "nl-0", "name": "unrelated-list"},
+                        {"id": "nl-1", "name": "dns-aid-rpz"},
+                    ]
+                },
+                {},  # PUT
+            ]
+            result = await backend.create_or_update_named_list(
+                name="dns-aid-rpz",
+                items=["evil.com"],
+            )
+
+        assert result == {"id": "nl-1", "name": "dns-aid-rpz", "updated": True}
+        put_call = mock_td.call_args_list[1]
+        assert put_call[0][0] == "PUT"
+        assert put_call[0][1] == "/named_lists/nl-1"
+        # Default per-item description is applied when none was given.
+        assert put_call[1]["json"]["items_described"][0]["description"] == "DNS-AID policy"
+
+    async def test_create_named_list_new_flat_response(self, backend):
+        """A POST response without a 'results' wrapper is used directly."""
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                {"results": []},
+                {"id": "nl-flat"},
+            ]
+            result = await backend.create_or_update_named_list(name="x", items=[])
+
+        assert result["id"] == "nl-flat"
+        assert result["updated"] is False
+
+    async def test_list_named_lists(self, backend):
+        lists = [
+            {
+                "id": "nl-1",
+                "name": "dns-aid-rpz",
+                "type": "custom_list",
+                "item_count": 2,
+                "description": "d",
+                "confidence_level": "HIGH",
+            },
+            {"id": "nl-2", "name": "other", "type": "custom_list"},
+        ]
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {"results": lists}
+            all_lists = await backend.list_named_lists()
+            filtered = await backend.list_named_lists(name_filter="dns-aid-rpz")
+
+        assert len(all_lists) == 2
+        assert all_lists[1]["item_count"] == 0  # default fill-in
+        assert len(filtered) == 1
+        assert filtered[0]["id"] == "nl-1"
+
+    async def test_delete_named_list(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {}
+            assert await backend.delete_named_list("nl-1") is True
+
+        mock_td.assert_awaited_once_with("DELETE", "/named_lists/nl-1")
+
+
+class TestBloxOneThreatDefensePolicies:
+    """Tests for TD security policy operations."""
+
+    @pytest.fixture
+    def backend(self):
+        return InfobloxBloxOneBackend(api_key="test-key")
+
+    async def test_list_security_policies(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {
+                "results": [
+                    {
+                        "id": 5,
+                        "name": "Default Global Policy",
+                        "description": "d",
+                        "rules": [{"data": "x"}],
+                        "is_default": True,
+                    },
+                    {"id": 6, "name": "Custom"},
+                ]
+            }
+            policies = await backend.list_security_policies()
+
+        assert policies[0] == {
+            "id": 5,
+            "name": "Default Global Policy",
+            "description": "d",
+            "rule_count": 1,
+            "is_default": True,
+        }
+        assert policies[1]["rule_count"] == 0
+        assert policies[1]["is_default"] is False
+
+    async def test_get_security_policy_unwraps_results(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {"results": {"id": 5, "name": "Default"}}
+            policy = await backend.get_security_policy(5)
+
+        assert policy == {"id": 5, "name": "Default"}
+        mock_td.assert_awaited_once_with("GET", "/security_policies/5")
+
+    async def test_get_security_policy_flat_response(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {"id": 5, "name": "Default"}
+            policy = await backend.get_security_policy(5)
+
+        assert policy == {"id": 5, "name": "Default"}
+
+    async def test_bind_named_list_uses_default_policy(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                # list_security_policies
+                {
+                    "results": [
+                        {"id": 9, "name": "Custom", "is_default": False},
+                        {"id": 5, "name": "Default", "is_default": True, "rules": []},
+                    ]
+                },
+                # get_security_policy(5)
+                {
+                    "results": {
+                        "id": 5,
+                        "name": "Default",
+                        "rules": [{"action": "action_allow", "data": "other-list"}],
+                        "default_action": "action_allow",
+                    }
+                },
+                {},  # PUT
+            ]
+            result = await backend.bind_named_list_to_policy("dns-aid-rpz")
+
+        assert result["policy_id"] == 5
+        assert result["action"] == "bound"
+        assert result["rule_count"] == 2
+        put_call = mock_td.call_args_list[2]
+        assert put_call[0][0] == "PUT"
+        assert put_call[0][1] == "/security_policies/5"
+        rules = put_call[1]["json"]["rules"]
+        # Our rule is prepended and evaluated first.
+        assert rules[0] == {
+            "action": "action_block",
+            "data": "dns-aid-rpz",
+            "type": "custom_list",
+        }
+
+    async def test_bind_named_list_no_default_policy_raises(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {"results": [{"id": 9, "name": "Custom", "is_default": False}]}
+            with pytest.raises(ValueError, match="No default security policy"):
+                await backend.bind_named_list_to_policy("dns-aid-rpz")
+
+    async def test_bind_named_list_already_bound(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {
+                "results": {
+                    "id": 5,
+                    "name": "Default",
+                    "rules": [{"action": "action_block", "data": "dns-aid-rpz"}],
+                }
+            }
+            result = await backend.bind_named_list_to_policy("dns-aid-rpz", policy_id=5)
+
+        assert result["action"] == "already_bound"
+        assert result["rule_count"] == 1
+        # Only the GET happened — no PUT for an already-bound rule.
+        assert mock_td.await_count == 1
+
+    async def test_bind_named_list_replaces_rule_with_new_action(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                {
+                    "results": {
+                        "id": 5,
+                        "name": "Default",
+                        "rules": [
+                            {"action": "action_log", "data": "dns-aid-rpz"},
+                            {"action": "action_allow", "data": "other"},
+                        ],
+                        "default_action": "action_allow",
+                    }
+                },
+                {},  # PUT
+            ]
+            result = await backend.bind_named_list_to_policy(
+                "dns-aid-rpz", policy_id=5, action="action_block"
+            )
+
+        assert result["action"] == "bound"
+        assert result["rule_count"] == 2  # old rule replaced, not duplicated
+        rules = mock_td.call_args_list[1][1]["json"]["rules"]
+        assert rules[0]["action"] == "action_block"
+        assert sum(1 for r in rules if r["data"] == "dns-aid-rpz") == 1
+
+    async def test_unbind_named_list(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                {
+                    "results": {
+                        "id": 5,
+                        "name": "Default",
+                        "rules": [
+                            {"action": "action_block", "data": "dns-aid-rpz"},
+                            {"action": "action_allow", "data": "other"},
+                        ],
+                        "default_action": "action_allow",
+                    }
+                },
+                {},  # PUT
+            ]
+            result = await backend.unbind_named_list_from_policy("dns-aid-rpz", policy_id=5)
+
+        assert result["action"] == "unbound"
+        assert result["rule_count"] == 1
+        rules = mock_td.call_args_list[1][1]["json"]["rules"]
+        assert rules == [{"action": "action_allow", "data": "other"}]
+
+    async def test_unbind_named_list_not_found(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {
+                "results": {
+                    "id": 5,
+                    "name": "Default",
+                    "rules": [{"action": "action_allow", "data": "other"}],
+                }
+            }
+            result = await backend.unbind_named_list_from_policy("dns-aid-rpz", policy_id=5)
+
+        assert result["action"] == "not_found"
+        assert mock_td.await_count == 1  # no PUT issued
+
+    async def test_unbind_named_list_uses_default_policy(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.side_effect = [
+                {"results": [{"id": 5, "name": "Default", "is_default": True}]},
+                {
+                    "results": {
+                        "id": 5,
+                        "name": "Default",
+                        "rules": [{"action": "action_block", "data": "dns-aid-rpz"}],
+                        "default_action": "action_allow",
+                    }
+                },
+                {},  # PUT
+            ]
+            result = await backend.unbind_named_list_from_policy("dns-aid-rpz")
+
+        assert result["policy_id"] == 5
+        assert result["action"] == "unbound"
+
+    async def test_unbind_named_list_no_default_policy_raises(self, backend):
+        with patch.object(backend, "_td_request", new_callable=AsyncMock) as mock_td:
+            mock_td.return_value = {"results": []}
+            with pytest.raises(ValueError, match="No default security policy"):
+                await backend.unbind_named_list_from_policy("dns-aid-rpz")

--- a/tests/unit/test_infoblox_nios_backend.py
+++ b/tests/unit/test_infoblox_nios_backend.py
@@ -10,8 +10,9 @@ requiring real NIOS credentials.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from dns_aid.backends.infoblox.nios import InfobloxNIOSBackend
@@ -842,3 +843,485 @@ class TestPublisherNIOSBackendSelection:
 
         assert result.success is False
         assert "does not exist" in result.message
+
+
+def _nios_backend(**kwargs) -> InfobloxNIOSBackend:
+    defaults = {"host": "nios.local", "username": "admin", "password": "secret"}
+    defaults.update(kwargs)
+    return InfobloxNIOSBackend(**defaults)
+
+
+def _mock_response(
+    *,
+    json_data=None,
+    status_code: int = 200,
+    content: bytes = b"{}",
+    content_type: str = "application/json",
+    text: str = "",
+):
+    """Build a MagicMock httpx response for NIOS _request tests."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.content = content
+    response.text = text
+    response.headers = {"content-type": content_type}
+    response.json.return_value = json_data
+    response.raise_for_status = MagicMock()
+    return response
+
+
+class TestNIOSInitBranches:
+    """Constructor branches not covered by the main init tests."""
+
+    def test_explicit_verify_ssl_param(self) -> None:
+        backend = _nios_backend(verify_ssl=False)
+        assert backend._verify_ssl is False
+
+    def test_verify_ssl_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NIOS_VERIFY_SSL", "false")
+        backend = _nios_backend()
+        assert backend._verify_ssl is False
+
+    def test_explicit_timeout_param(self) -> None:
+        backend = _nios_backend(timeout=12.5)
+        assert backend._timeout == 12.5
+
+    def test_supports_private_svcb_keys(self) -> None:
+        assert _nios_backend().supports_private_svcb_keys is True
+
+
+class TestNIOSClient:
+    """HTTP client lifecycle."""
+
+    async def test_get_client_creates_and_caches(self) -> None:
+        backend = _nios_backend(verify_ssl=False)
+        client = await backend._get_client()
+        assert isinstance(client, httpx.AsyncClient)
+        assert client.headers["Content-Type"] == "application/json"
+
+        assert await backend._get_client() is client
+        await backend.close()
+        assert backend._client is None
+
+    async def test_get_client_recreates_on_loop_change(self) -> None:
+        backend = _nios_backend(verify_ssl=False)
+        old_client = MagicMock()
+        old_client.is_closed = False
+        old_client.aclose = AsyncMock()
+        backend._client = old_client
+        backend._client_loop_id = -1  # never a real loop id
+
+        client = await backend._get_client()
+
+        old_client.aclose.assert_awaited_once()
+        assert client is not old_client
+        assert isinstance(client, httpx.AsyncClient)
+        await backend.close()
+
+    async def test_close_noop_without_client(self) -> None:
+        backend = _nios_backend()
+        await backend.close()  # must not raise
+
+
+class TestNIOSRequest:
+    """Low-level _request error handling and response parsing."""
+
+    @pytest.fixture
+    def backend(self) -> InfobloxNIOSBackend:
+        return _nios_backend()
+
+    def _patch_client(self, backend: InfobloxNIOSBackend, response=None, side_effect=None):
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=response, side_effect=side_effect)
+        return patch.object(backend, "_get_client", return_value=mock_client), mock_client
+
+    async def test_request_returns_json_list(self, backend: InfobloxNIOSBackend) -> None:
+        response = _mock_response(json_data=[{"_ref": "zone_auth/x"}], content=b"[...]")
+        ctx, mock_client = self._patch_client(backend, response=response)
+        with ctx:
+            result = await backend._request("GET", "zone_auth", params={"fqdn": "example.com"})
+
+        assert result == [{"_ref": "zone_auth/x"}]
+        # Endpoint without a leading slash gets one prepended.
+        assert mock_client.request.call_args[1]["url"] == "/zone_auth"
+
+    async def test_request_http_status_error_raises_runtime_error(
+        self, backend: InfobloxNIOSBackend
+    ) -> None:
+        error_response = MagicMock()
+        error_response.status_code = 400
+        error_response.text = "Bad svc_key"
+        response = _mock_response()
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400", request=MagicMock(), response=error_response
+        )
+        ctx, _ = self._patch_client(backend, response=response)
+        with ctx, pytest.raises(RuntimeError, match="status=400 body=Bad svc_key"):
+            await backend._request("POST", "/record:svcb", json={})
+
+    async def test_request_transport_error_raises_runtime_error(
+        self, backend: InfobloxNIOSBackend
+    ) -> None:
+        ctx, _ = self._patch_client(backend, side_effect=httpx.ConnectError("refused"))
+        with ctx, pytest.raises(RuntimeError, match="transport error"):
+            await backend._request("GET", "zone_auth")
+
+    async def test_request_empty_body_returns_empty_dict(
+        self, backend: InfobloxNIOSBackend
+    ) -> None:
+        response = _mock_response(content=b"")
+        ctx, _ = self._patch_client(backend, response=response)
+        with ctx:
+            assert await backend._request("DELETE", "record:txt/ZG5z") == {}
+
+    async def test_request_non_json_content_type_returns_raw(
+        self, backend: InfobloxNIOSBackend
+    ) -> None:
+        response = _mock_response(content=b"plain", content_type="text/plain", text="plain")
+        ctx, _ = self._patch_client(backend, response=response)
+        with ctx:
+            assert await backend._request("GET", "grid") == {"raw": "plain"}
+
+    async def test_request_scalar_json_returns_raw(self, backend: InfobloxNIOSBackend) -> None:
+        response = _mock_response(json_data="record:txt/ZG5z", content=b'"record:txt/ZG5z"')
+        ctx, _ = self._patch_client(backend, response=response)
+        with ctx:
+            assert await backend._request("POST", "record:txt", json={}) == {
+                "raw": "record:txt/ZG5z"
+            }
+
+
+class TestNIOSFormatSvcParametersEdgeCases:
+    """Edge cases of _format_svc_parameters_for_value."""
+
+    def test_skips_non_dict_and_empty_key_items(self) -> None:
+        result = InfobloxNIOSBackend._format_svc_parameters_for_value(
+            [
+                "junk",
+                {"svc_value": ["orphan"]},
+                {"svc_key": "  ", "svc_value": ["blank-key"]},
+                {"svc_key": "port", "svc_value": ["443"]},
+            ]
+        )
+        assert result == 'port="443"'
+
+    def test_scalar_and_none_svc_values(self) -> None:
+        result = InfobloxNIOSBackend._format_svc_parameters_for_value(
+            [
+                {"svc_key": "port", "svc_value": "443"},  # scalar → single value
+                {"svc_key": "alpn", "svc_value": None, "mandatory": True},  # value-less
+                {"svc_key": "key65404", "svc_value": "   "},  # blank scalar dropped
+            ]
+        )
+        # alpn is mandatory but value-less: listed in mandatory, no alpn=... token.
+        assert result == 'mandatory="alpn" port="443"'
+        assert "alpn=" not in result
+
+    def test_mandatory_deduplicated(self) -> None:
+        result = InfobloxNIOSBackend._format_svc_parameters_for_value(
+            [
+                {"svc_key": "alpn", "svc_value": ["mcp"], "mandatory": True},
+                {"svc_key": "alpn", "svc_value": ["h2"], "mandatory": True},
+            ]
+        )
+        assert result.startswith('mandatory="alpn" ')
+        assert result.count("mandatory=") == 1
+
+
+class TestNIOSFindRecordRef:
+    """_find_record_ref result handling."""
+
+    @pytest.fixture
+    def backend(self) -> InfobloxNIOSBackend:
+        return _nios_backend()
+
+    async def test_empty_results_returns_none(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value=[]))
+        assert await backend._find_record_ref("example.com", "_a._mcp._agents", "SVCB") is None
+
+    async def test_non_list_results_returns_none(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value={"error": "x"}))
+        assert await backend._find_record_ref("example.com", "_a._mcp._agents", "TXT") is None
+
+    async def test_non_string_ref_returns_none(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value=[{"_ref": 123}]))
+        assert await backend._find_record_ref("example.com", "_a._mcp._agents", "TXT") is None
+
+
+class TestNIOSListAndGetRecordEdgeCases:
+    """list_records / list_zones / get_record edge branches."""
+
+    @pytest.fixture
+    def backend(self) -> InfobloxNIOSBackend:
+        return _nios_backend()
+
+    async def test_list_records_non_list_response_skipped(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value={"error": "boom"}))
+        records = [r async for r in backend.list_records("example.com")]
+        assert records == []
+
+    async def test_list_records_skips_records_without_name(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            if endpoint == "record:txt":
+                return [
+                    {"_ref": "record:txt/a", "text": '"orphan"'},  # no name → skipped
+                    {
+                        "_ref": "record:txt/b",
+                        "name": "_agent._mcp._agents.example.com",
+                        "ttl": 300,
+                        "text": '"kept"',
+                    },
+                ]
+            return []
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        records = [r async for r in backend.list_records("example.com", record_type="TXT")]
+        assert len(records) == 1
+        assert records[0]["values"] == ['"kept"']
+
+    async def test_get_record_txt(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend,
+            "_request",
+            AsyncMock(
+                return_value=[
+                    {
+                        "_ref": "record:txt/abc",
+                        "name": "_index._agents.example.com",
+                        "ttl": 600,
+                        "text": '"agents=chat:mcp"',
+                    }
+                ]
+            ),
+        )
+        result = await backend.get_record("example.com", "_index._agents", "TXT")
+        assert result is not None
+        assert result["type"] == "TXT"
+        assert result["values"] == ['"agents=chat:mcp"']
+        assert result["name"] == "_index._agents"
+        assert result["ttl"] == 600
+
+    async def test_list_zones_non_list_response(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value={"error": "x"}))
+        assert await backend.list_zones() == []
+
+    async def test_list_zones_skips_non_dict_entries(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend,
+            "_request",
+            AsyncMock(
+                return_value=[
+                    "junk",
+                    {"_ref": "zone_auth/x", "fqdn": "example.com", "view": "default"},
+                ]
+            ),
+        )
+        zones = await backend.list_zones()
+        assert len(zones) == 1
+        assert zones[0]["name"] == "example.com"
+
+
+class TestNIOSRPZ:
+    """RPZ (Response Policy Zone) operations."""
+
+    @pytest.fixture
+    def backend(self) -> InfobloxNIOSBackend:
+        return _nios_backend()
+
+    async def test_create_rpz_cname_nxdomain_new(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint, json))
+            return [] if method == "GET" else {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        fqdn = await backend.create_rpz_cname_record(
+            "rpz.example.com", "evil.com", "nxdomain", comment="block it"
+        )
+
+        assert fqdn == "evil.com.rpz.example.com"
+        method, endpoint, payload = calls[-1]
+        assert (method, endpoint) == ("POST", "record:rpz:cname")
+        assert payload == {
+            "name": "evil.com.rpz.example.com",
+            "rp_zone": "rpz.example.com",
+            "canonical": "",
+            "comment": "block it",
+        }
+
+    async def test_create_rpz_cname_passthru_uses_identity_cname(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint, json))
+            return [] if method == "GET" else {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        await backend.create_rpz_cname_record("rpz.example.com", "good.com", "PASSTHRU")
+
+        payload = calls[-1][2]
+        assert payload["canonical"] == "good.com"
+        assert payload["comment"] == "DNS-AID RPZ: PASSTHRU good.com"
+
+    async def test_create_rpz_cname_updates_existing(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint, json))
+            if method == "GET":
+                return [{"_ref": "record:rpz:cname/abc"}]
+            return {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        # Owner already carries the RPZ zone suffix — no double append.
+        fqdn = await backend.create_rpz_cname_record(
+            "rpz.example.com", "evil.com.rpz.example.com", "NXDOMAIN"
+        )
+
+        assert fqdn == "evil.com.rpz.example.com"
+        method, endpoint, payload = calls[-1]
+        assert (method, endpoint) == ("PUT", "record:rpz:cname/abc")
+        assert payload == {
+            "canonical": "",
+            "comment": "DNS-AID RPZ: NXDOMAIN evil.com.rpz.example.com",
+        }
+
+    async def test_create_rpz_cname_existing_without_ref_creates(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str]] = []
+
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint))
+            if method == "GET":
+                return [{"name": "evil.com.rpz.example.com"}]  # no _ref
+            return {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        await backend.create_rpz_cname_record("rpz.example.com", "evil.com", "NXDOMAIN")
+
+        assert calls[-1] == ("POST", "record:rpz:cname")
+
+    async def test_delete_rpz_cname_found(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str]] = []
+
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint))
+            if method == "GET":
+                return [{"_ref": "record:rpz:cname/abc"}]
+            return {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        assert await backend.delete_rpz_cname_record("rpz.example.com", "evil.com") is True
+        assert calls[-1] == ("DELETE", "record:rpz:cname/abc")
+
+    async def test_delete_rpz_cname_not_found(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value=[]))
+        assert await backend.delete_rpz_cname_record("rpz.example.com", "evil.com") is False
+
+    async def test_delete_rpz_cname_non_list_response(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value={"error": "x"}))
+        assert await backend.delete_rpz_cname_record("rpz.example.com", "evil.com") is False
+
+    async def test_delete_rpz_cname_missing_ref(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value=[{"name": "x"}]))
+        assert await backend.delete_rpz_cname_record("rpz.example.com", "evil.com") is False
+
+    async def test_list_rpz_cname_records_actions(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend,
+            "_request",
+            AsyncMock(
+                return_value=[
+                    "junk",  # non-dict skipped
+                    {
+                        "name": "evil.com.rpz.example.com",
+                        "canonical": "",
+                        "comment": "blocked",
+                        "disable": False,
+                    },
+                    {
+                        "name": "good.com.rpz.example.com",
+                        "canonical": "good.com",
+                    },
+                    {
+                        "name": "odd.com.rpz.example.com",
+                        "canonical": "somewhere.else",
+                        "disable": True,
+                    },
+                ]
+            ),
+        )
+        records = await backend.list_rpz_cname_records("rpz.example.com")
+
+        assert len(records) == 3
+        assert records[0]["owner"] == "evil.com"
+        assert records[0]["action"] == "NXDOMAIN"
+        assert records[1]["action"] == "PASSTHRU"
+        assert records[2]["action"] == "NXDOMAIN"  # fallback
+        assert records[2]["disabled"] is True
+
+    async def test_list_rpz_cname_records_non_list_response(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend, "_request", AsyncMock(return_value={"error": "x"}))
+        assert await backend.list_rpz_cname_records("rpz.example.com") == []
+
+    async def test_ensure_rpz_zone_exists(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_request = AsyncMock(return_value=[{"_ref": "zone_rp/abc"}])
+        monkeypatch.setattr(backend, "_request", mock_request)
+
+        assert await backend.ensure_rpz_zone("rpz.example.com") is True
+        mock_request.assert_awaited_once()  # no POST when zone exists
+
+    async def test_ensure_rpz_zone_creates(
+        self, backend: InfobloxNIOSBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        async def fake_request(method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint, json))
+            return [] if method == "GET" else {}
+
+        monkeypatch.setattr(backend, "_request", fake_request)
+        assert await backend.ensure_rpz_zone("rpz.example.com") is True
+
+        method, endpoint, payload = calls[-1]
+        assert (method, endpoint) == ("POST", "zone_rp")
+        assert payload["fqdn"] == "rpz.example.com"
+        assert payload["rpz_policy"] == "GIVEN"


### PR DESCRIPTION
## Summary

The dedicated coverage push from the OpenSSF plan (#216, item G3): **423 new unit tests** targeting the least-covered modules. Repo coverage goes **79% → 93%** combined statement+branch (**94% statement-only**), clearing Gold's `test_statement_coverage90` and `test_branch_coverage80` bars in one pass.

| Module | Before | After |
|---|---|---|
| `cli/main.py` | 50% | 99% |
| `mcp/server.py` | 30% | 98% |
| `core/invoke.py` | 55% | 99% |
| `backends/infoblox/bloxone.py` | 53% | 100% |
| `backends/infoblox/nios.py` | 70% | 100% |
| `backends/cloud_dns.py` | 53% | 100% |
| `utils/google_auth.py` | 21% | 100% |
| `cli/init.py` | 40% | 98% |
| `doctor.py` | 72% | 99% |
| `backends/base.py` / `backends/__init__.py` | 73% / 74% | 100% / 100% |
| `sdk/policy/cel_evaluator.py` | 68% | 98% |

## Verification

- Full suite: **2565 passed, 2 skipped** (the 2 pre-existing live-endpoint skips), ~39s locally.
- All tests deterministic: no network, no real credentials; mocking follows the existing conventions (CliRunner for CLI, MockBackend + patched core calls for MCP handlers, mocked httpx for backends, sys.modules stubs for the absent google-auth package).
- `ruff check` + `ruff format --check` clean on all 12 touched test files.
- Tests only — nothing under `src/` changed.

## Follow-up

After this and #218 both land, ratchet `--cov-fail-under` from 78 to **92** in ci.yml (the floor-only-rises policy from the proposal).