### PR TITLE
chore(ci): add workflow_dispatch to the Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     # Run weekly on Sundays at 04:00 UTC
     - cron: "0 4 * * 0"
+  # Allow an on-demand run (e.g. after updating the OpenSSF Best Practices badge URL)
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to `.github/workflows/scorecard.yml` so the OpenSSF Scorecard analysis can be run on demand, not only on push to `main` and the weekly Sunday cron.

Immediate motivation: the OpenSSF Best Practices badge entry (bestpractices.dev/projects/12651) was updated to the post-rename repo URL (`dns-aid/dns-aid-core`), which fixes the Scorecard `CII-Best-Practices` check that was scoring 0 ("no badge detected"). The badge search endpoint now resolves correctly, so a fresh scan will pick it up — this lets us trigger that scan without waiting for the cron.

## Changes

- `.github/workflows/scorecard.yml` — add `workflow_dispatch:` to the `on:` triggers. No other changes; permissions and the analysis job are untouched.

## Test plan

- [x] YAML parses; `on:` now includes `push`, `schedule`, and `workflow_dispatch`
- [x] No `run:` steps or untrusted-input usage introduced