### PR TITLE
chore(ci): least-privilege top-level permissions on reusable draft-watch workflow

### DIFF
--- a/.github/workflows/_draft-watch-reusable.yml
+++ b/.github/workflows/_draft-watch-reusable.yml
@@ -39,6 +39,12 @@ on:
         type: string
         default: ""
 
+# Least-privilege default for the workflow. The single job below overrides this
+# with its own block to add `issues: write` (job-level permissions fully replace
+# the workflow default), so this line does not reduce what the job can do.
+permissions:
+  contents: read
+
 jobs:
   draft-watch:
     name: IETF draft watch


### PR DESCRIPTION
## Summary

`_draft-watch-reusable.yml` was the only workflow lacking a top-level `permissions:` block. OpenSSF Scorecard's **Token-Permissions** check flags this (repo currently scores 9/10 — "detected GitHub workflow tokens with excessive permissions"). This adds `permissions: contents: read` as the workflow-level default.

## Why this is safe (no behavior change)

The workflow's single job, `draft-watch`, already declares its own block:

```yaml
permissions:
  contents: read
  issues: write
```

In GitHub Actions, **a job-level `permissions` block fully replaces the workflow-level default for that job** — it does not merge. So the new top-level `contents: read` only sets a least-privilege default for jobs that don't declare their own (there are none). The `draft-watch` job keeps `issues: write`; nothing it can do changes.

## Scope

- Single file, additive only. No `run:` steps, inputs, or logic touched.
- Does **not** overlap with @IngmarVG-IB's in-flight OpenSSF PRs (#218 pinned-deps/fuzzing, #216/#217 Silver-Gold docs, #221 coverage) — those touch `ci.yml`/`release.yml`/`fuzz.yml`/docs, not this reusable workflow.

## Test plan

- [x] YAML parses; top-level `permissions == {contents: read}`, job `draft-watch` still `{contents: read, issues: write}`
- [x] No collision with open PRs on the same file