### PR TITLE
fix(deps): bump pyasn1 0.6.3 -> 0.6.4 (CVE-2026-59884/59885/59886)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1643,11 +1643,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pyasn1 0.6.3` is flagged by OSV with three **HIGH-severity** advisories — the drop that took OpenSSF Scorecard's `Vulnerabilities` check from 10 to 7. All three are fixed in **0.6.4**:

| Advisory | Issue |
| --- | --- |
| CVE-2026-59884 (GHSA-m4p7-r5rc-7g4j) | ASN.1 processing |
| CVE-2026-59885 (GHSA-8ppf-4f7h-5ppj) | Quadratic complexity in OBJECT IDENTIFIER / RELATIVE-OID processing (DoS) |
| CVE-2026-59886 (GHSA-hm4w-wwcw-mr6r) | Uncontrolled resource consumption converting decoded REAL values (DoS) |

## Dependency path (transitive)

```
dns-aid[cloud-dns] -> google-auth 2.49.1 -> pyasn1-modules 0.4.2 -> pyasn1 0.6.3
```

`pyasn1-modules 0.4.2` already permits `0.6.4`, so this is a **`uv.lock`-only** bump — no other package versions change.

## Reachability

`pyasn1` is pulled only via the `cloud-dns` extra (Google Cloud DNS backend, through `google-auth`). The CVEs are DoS-class and need crafted ASN.1 input, so practical risk to DNS-AID is low — but they are HIGH advisories and the fix is a clean patch bump.

## Verification

- [x] `uv.lock` diff is pyasn1-only (`0.6.3 -> 0.6.4`), no other package touched
- [x] OSV re-query of the full resolved tree after the bump: **no vulnerabilities**
- [x] Unit suite green (2142 passed, 2 skipped)