### PR TITLE
chore(release): 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-08-08
+
 ### Added
 
 - **`AgentRecord.signature_status`** reports why verification reached its answer:
@@ -2570,7 +2572,8 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.4...HEAD
+[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.27.0...v0.28.0
 [0.24.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.3...v0.24.4
 [0.24.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.2...v0.24.3
 [0.24.2]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.1...v0.24.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.27.0"
+version = "0.28.0"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Cuts the accumulated `[Unreleased]` work as 0.28.0.

**Record signatures and DANE** (#229) — the `sig` SvcParam was parsed off the wire and then discarded, so `publish --sign` was write-only and `require_signed=True` returned nothing regardless of what had been published. JWS validity no longer derives from the DNS record TTL. DANE tries every association in the RRset, so a staged certificate rollover can overlap. An unverifiable result reports as unknown rather than as a failure, with `signature_status` carrying the reason.

**Cloudflare backend** — native private-use SVCB key writes, per-value RFC 1035 character-strings for TXT, convergence under concurrent-publish races, shared rate limiting, and `get_record` no longer masking auth/network errors as absence.

### Before upgrading

- `signature_verified` may now be `None` where it was `False`. Consumers testing `is True` are unaffected; consumers testing `== False` to mean rejected should move to `signature_status`.
- Records signed by earlier versions carry a TTL-length validity and should be re-published.

### Contents

- `pyproject.toml` 0.27.0 → 0.28.0
- `[Unreleased]` retitled to `[0.28.0] - 2026-08-08`, fresh `[Unreleased]` opened
- Changelog link refs for `Unreleased` and `0.28.0`. The refs for 0.25.x–0.27.x were already missing before this release and remain so — not fixed here to keep the release diff to three lines.

Tagging `v0.28.0` once this lands triggers the release workflow (PyPI, GitHub Release, Sigstore, `server.json` sync).