### PR TITLE
chore(release): 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-08-09
+
 ### Changed
 
 - **The MCP server now runs on both mcp 1.x and 2.x.** `mcp` 2.0.0 removed
@@ -35,15 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `http_client` parameter is annotated `httpx2.AsyncClient`, but that is
   advisory — httpx2 and httpx expose identical `AsyncClient` constructor
   parameters and an httpx client is accepted, so no HTTP-layer port is required.
-
-### Added
-
-- **Cloudflare backend now writes DNS-AID private-use SVCB keys natively.** Verified
-  against the Cloudflare API v4 that SVCB `data.value` accepts RFC 9460 generic
-  private-use SvcParamKeys (`key65280`–`key65534`), so `CloudflareBackend` sets
-  `supports_private_svcb_keys = True`. DNS-AID custom params (cap, cap-sha256, bap,
-  policy, realm, … → `key65400`–`key65409`) are written directly to the SVCB record
-  instead of being demoted to TXT, matching the NS1 and NIOS backends.
 
 ### Removed
 
@@ -2695,7 +2688,8 @@ Explicit version floors added to our `pyproject.toml` because upstream parents (
 - [RFC 9460 - SVCB and HTTPS Resource Records](https://www.rfc-editor.org/rfc/rfc9460.html)
 - [RFC 4033-4035 - DNSSEC](https://www.rfc-editor.org/rfc/rfc4033.html)
 
-[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/dns-aid/dns-aid-core/compare/v0.28.1...HEAD
+[0.28.1]: https://github.com/dns-aid/dns-aid-core/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/dns-aid/dns-aid-core/compare/v0.27.0...v0.28.0
 [0.24.4]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.3...v0.24.4
 [0.24.3]: https://github.com/dns-aid/dns-aid-core/compare/v0.24.2...v0.24.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dns-aid"
-version = "0.28.0"
+version = "0.28.1"
 description = "DNS-based Agent Identification and Discovery - Reference Implementation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "dns-aid"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Cuts the accumulated `[Unreleased]` work as a patch release. No new functionality — every entry is a fix, a removal, or a compatibility change.

## What's in it

| Issue | Change |
|---|---|
| #230 / #234 | MCP server runs on both mcp 1.x and 2.x; `mcp` capped `<2.0.0` for the SDK client path |
| #236 | `all` extra defined by PEP 508 self-reference — gains `cel-python`, `common-expression-language`, `pqcrypto`, constrained `requests` |
| #232 | `requirements.lock` deleted (six pins below the declared CVE floors, shipped in the sdist) |
| #235 | Docker image built from `uv.lock` with `--require-hashes` |
| #233 | CI smoke-tests a fresh, unconstrained `pip install` |

## Why 0.28.1 and not 0.29.0

The `[Unreleased]` section carried an `### Added` entry for the Cloudflare private-use SVCB key support, which would have forced a minor bump. It was a duplicate: that work shipped in **0.28.0** (#200, `a6050f7`, merged 2026-07-30 — an ancestor of `v0.28.0`) and is already documented verbatim under the 0.28.0 heading. Verified the two copies were byte-identical before removing the stale one. With it gone there is no unreleased functionality, so PATCH is correct per `RELEASE.md`.

## Behaviour change to read before upgrading

**`dns-aid[all]` no longer installs the development toolchain.** It previously leaked `pytest`, `mypy`, `ruff` and `boto3-stubs` into a published, user-facing extra. A fresh `[all]` install drops 39 packages (114 → 75). Install `dns-aid[dev]` alongside it for the toolchain. The CVE floors `dev` carried for `[all]` (`urllib3`, `pygments`) moved to the runtime extras that actually pull them, so `[all]` keeps them.

## Verification

- `uv sync --frozen --extra dev --extra cli --extra mcp --extra route53 --extra otel --extra akamai-edgedns` then `pytest tests/unit/` → **2884 passed, 2 skipped**.
- `uv lock` regenerated; `dns-aid` records `0.28.1`.
- Diff is the same three files as the 0.28.0 release commit: `CHANGELOG.md`, `pyproject.toml`, `uv.lock`. `src/dns_aid/__init__.py` needs no edit despite `RELEASE.md` step 1 — it derives `__version__` from package metadata. `server.json` is synced from the tag by `release.yml`.

Tagging `v0.28.1` after merge publishes to PyPI, the GitHub Release and the MCP registry.