### PR TITLE
feat(core): experimental site agent convention (site name + webmcp bap token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Changes to protocol behavior should be discussed within the IETF.
 - [Getting Started Guide](docs/getting-started.md) — install, first agent publication, backend setup
 - [API Reference](docs/api-reference.md) — Python SDK, CLI, and MCP server tool reference
 - [ARD ai-catalog discovery](docs/ard-catalog.md) — interop with [Agentic Resource Discovery](https://agenticresourcediscovery.org/spec/): catalog discovery, the host-anywhere DNS pointer, and card dereferencing
+- [Site agent convention](docs/site-agent.md) — experimental: advertising the domain's own website as an agent (`site` name, `webmcp` bap token)
 - [Architecture](docs/architecture.md) — protocol layers, metadata resolution, integration points
 - [Integrations](docs/integrations.md) — backend-specific setup notes
 - [Demo Guide](docs/demo-guide.md) — end-to-end walkthrough for talks and presentations

--- a/docs/site-agent.md
+++ b/docs/site-agent.md
@@ -1,0 +1,126 @@
+# Site agent convention (experimental)
+
+A naming convention for advertising **the domain's own website** as an agent:
+the agent named `site` at a domain is, by convention, the canonical interface
+to that domain's web content — as opposed to task agents such as `billing` or
+`chat`. An accompanying `bap` token, `webmcp`, marks a record whose target is
+an **in-browser WebMCP surface**: a web origin whose pages register tools via
+the browser's [`navigator.modelContext`](https://github.com/webmachinelearning/webmcp)
+when loaded in a WebMCP-capable user agent.
+
+This is **experimental and fully opt-in**. It is not part of
+[draft-mozleywilliams-dnsop-dnsaid-02](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/);
+it is prototyped here in the spirit of the draft's §5 (Future Work and
+Experimental Mechanisms). Nothing here changes the wire format: `site` is an
+ordinary agent name under the existing grammar, and `webmcp` is a valid `bap`
+token under the draft-02 value shape. A domain that publishes nothing new
+behaves exactly as before.
+
+## Motivation
+
+Infrastructure operators have started turning existing websites into
+agent-usable surfaces *on the domain owner's behalf* — Cloudflare's
+[WebMCP developer preview](https://blog.cloudflare.com/webmcp/) enables it with
+one switch, and registrars and hosting providers can do the equivalent by
+fronting a site's content with a remote MCP server.
+
+What's missing is a way to **advertise** the result. Agent names are free-form, so DNS-AID can enumerate a domain's agents but cannot say which one *is* the site: a consumer must know a name out of band or guess, and nothing marks an in-browser WebMCP surface as such. A fixed name closes the gap with one DNS query — on both sides. Consumers get a deterministic probe: a browser agent can try `site.<domain>` before loading a page, and a crawler gets one probe name across all domains. Publishers get determinism too: a CDN switch, a registrar button, and a hosting provider all write the same name, so any consumer interoperates with any publisher without out-of-band agreement — the `www` / `robots.txt` / MX pattern applied to agents.
+
+Reserving exactly one name is deliberate. `site` names the domain's *own* web representation — a fixed point of which every domain has exactly one — not a functional role. Roles (`shop`, `support`, …) are an open set and belong to capability vocabulary, not name reservation; the in-browser vs remote distinction belongs to `bap`. The convention adds identity, nothing more.
+
+## The convention
+
+Two record shapes, both ordinary draft-02 flat-owner records. They may coexist
+in one RRset — one record per protocol surface, per draft-02 §3.1.1:
+
+```
+; Remote MCP interface serving the site's content.
+site.example.com.  3600 IN SVCB 1 mcp.example.com. alpn="mcp" port=443 mandatory=alpn,port
+
+; In-browser WebMCP surface: load the target in a WebMCP-capable UA
+; and the page registers its tools. key65402 is the bap SvcParamKey.
+site.example.com.  3600 IN SVCB 1 example.com. alpn="https" port=443 mandatory=alpn,port key65402="webmcp"
+```
+
+When the MCP server lives on the same domain (or at the owner name
+itself), the TargetName expresses that too: a record whose target is
+`mcp.example.com.` stays in-zone, and a TargetName of `.` means "the owner
+name itself" (RFC 9460), with A/AAAA published alongside — SVCB coexists
+with address records, unlike CNAME.
+
+Key invariants:
+
+- **`alpn` keeps carrying real connection protocols only.** The webmcp marker
+  lives in `bap` (key65402) — the draft-02 §5.1 experimental slot for agent
+  protocol signaling — not in `alpn`. Nothing ever negotiates "webmcp" in a
+  TLS handshake, so it must not appear as an ALPN identifier.
+- **The name is inside the existing grammar.** `site` passes agent-name
+  validation unchanged; no underscored leaf, no new registry entry, no new
+  record type. A domain that already runs an agent named `site` for another
+  purpose is unaffected mechanically — the convention is semantic.
+- **Discovery order is unchanged.** `site.<domain>` is a draft-02 flat primary
+  owner — the form requestors try first — and the agent appears in
+  `_index._agents.<domain>` like any other.
+- **Everything else is inherited.** `port`, TargetName, and address hints keep
+  their per-record RFC 9460 semantics unchanged — this convention adds a name
+  and a `bap` token, nothing more.
+
+## Publishing
+
+CLI — the existing `publish` command covers both shapes:
+
+```bash
+# Remote MCP interface for the site's content
+dns-aid publish --name site --domain example.com \
+  --protocol mcp --endpoint mcp.example.com
+
+# In-browser WebMCP surface
+dns-aid publish --name site --domain example.com \
+  --protocol https --endpoint example.com --bap webmcp
+```
+
+Python:
+
+```python
+from dns_aid import publish
+
+await publish(
+    name="site",
+    domain="example.com",
+    protocol="mcp",
+    endpoint="mcp.example.com",
+    capabilities=["web-content"],
+    description="Canonical MCP interface to example.com's web content",
+)
+```
+
+## Discovery
+
+```python
+from dns_aid.core.site_agent import discover_site_agent, is_webmcp_surface
+
+agent = await discover_site_agent("example.com")
+if agent is not None:
+    if is_webmcp_surface(agent):
+        print(f"Open https://{agent.target_host}/ in a WebMCP-capable browser")
+    else:
+        print(f"Site MCP endpoint: {agent.endpoint_url}")
+```
+
+`discover_site_agent` is a thin wrapper over `discover_at_fqdn("site.<domain>")`;
+the generic paths (`dns-aid discover example.com`, `dns-aid verify
+site.example.com`) work unchanged.
+
+## Open questions
+
+- **The name.** `site` is the strawman (role-based, mirroring how `_index`
+  names a role); `web` and `webmcp` have been floated. A name that collides
+  with a common hostname label is mechanically safe (SVCB is a distinct
+  RRType) but semantically ambiguous; feedback welcome.
+- **The marker's long-term home.** If the convention proves out, `webmcp`
+  could graduate from `bap` to a registered ALPN identifier
+  (Specification Required per RFC 7301, the draft's §7.3 path) — though it
+  arguably never belongs in ALPN, since it is not a connection protocol.
+- **Capability vocabulary.** Whether a conventional capability (e.g.
+  `web-content`) should accompany the name, so index- and directory-level
+  filtering can find site agents without resolving each one.

--- a/src/dns_aid/core/site_agent.py
+++ b/src/dns_aid/core/site_agent.py
@@ -1,0 +1,110 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Site agent convention — the domain's canonical website interface.
+
+**Experimental.** This module implements a naming convention that is not
+part of draft-mozleywilliams-dnsop-dnsaid-02; it is prototyped here in
+the spirit of the draft's §5 (Future Work and Experimental Mechanisms)
+and may change or be removed.
+
+Motivation
+----------
+Infrastructure operators have started turning existing websites into
+agent-usable surfaces on the domain owner's behalf — Cloudflare's WebMCP
+developer preview (https://blog.cloudflare.com/webmcp/) enables it with
+one switch, and registrars/hosting providers can do the same by fronting
+a site with a remote MCP server. What is missing is a deterministic way
+to *advertise* the result: DNS-AID agent names are free-form, so a
+consumer wanting "the MCP interface to this domain's website" cannot
+resolve it without out-of-band knowledge or an index walk.
+
+Convention
+----------
+- The agent named ``site`` at a domain is, by convention, the canonical
+  interface to that domain's *website content* (as opposed to task
+  agents such as ``billing`` or ``chat``). Publishers MAY publish it
+  like any other draft-02 flat-name agent::
+
+      site.example.com.  IN SVCB 1 mcp.example.com. alpn="mcp" port=443
+
+- An in-browser WebMCP surface (a page that registers tools via the
+  browser's ``navigator.modelContext`` when loaded in a WebMCP-capable
+  user agent) is marked with the ``bap`` token ``webmcp``. ``bap`` is
+  itself experimental (draft-02 §5.1), which makes it the right
+  low-friction slot for this marker — ``alpn`` keeps carrying real
+  connection protocols only::
+
+      site.example.com.  IN SVCB 1 example.com. alpn="https" port=443 key65402="webmcp"
+
+  Both records may coexist in one RRset (one record per protocol
+  surface, per draft-02 §3.1.1).
+
+Nothing here changes the wire format: ``site`` is an ordinary agent
+name under the existing grammar, and ``webmcp`` is a valid ``bap``
+token under :data:`dns_aid.core.bap.BAP_VALUE_PATTERN`. This module
+only gives the convention a first-class, testable home.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import structlog
+
+from dns_aid.core.bap import split_bap_token
+
+if TYPE_CHECKING:
+    from dns_aid.core.models import AgentRecord
+
+logger = structlog.get_logger(__name__)
+
+# Conventional name of the domain's canonical website agent.
+# Experimental — see module docstring. The name itself is subject to
+# upstream discussion (`web` and `webmcp` have been floated); consumers
+# should reference this constant rather than the literal.
+SITE_AGENT_NAME: Final = "site"
+
+# ``bap`` token marking an in-browser WebMCP surface: the SVCB target
+# is a web origin whose pages register tools via the browser's
+# ``navigator.modelContext`` (https://github.com/webmachinelearning/webmcp)
+# when loaded in a WebMCP-capable user agent.
+WEBMCP_BAP_TOKEN: Final = "webmcp"
+
+
+def site_agent_fqdn(domain: str) -> str:
+    """Return the draft-02 flat FQDN of a domain's conventional site agent.
+
+    >>> site_agent_fqdn("example.com")
+    'site.example.com'
+    """
+    return f"{SITE_AGENT_NAME}.{domain.strip().rstrip('.')}"
+
+
+def is_webmcp_surface(agent: AgentRecord) -> bool:
+    """True when the record advertises an in-browser WebMCP surface.
+
+    The marker is the ``webmcp`` token in ``bap`` (with or without a
+    version suffix); the agent's ``alpn``/protocol keeps describing the
+    plain connection protocol used to fetch the page.
+    """
+    token, _version = split_bap_token(agent.bap)
+    return token == WEBMCP_BAP_TOKEN
+
+
+async def discover_site_agent(domain: str) -> AgentRecord | None:
+    """Resolve a domain's conventional site agent, if it publishes one.
+
+    A thin wrapper over :func:`dns_aid.core.discoverer.discover_at_fqdn`
+    querying the flat owner ``site.<domain>`` (the form draft-02 says
+    requestors MUST try first). Returns None when the domain does not
+    publish the convention.
+    """
+    from dns_aid.core.discoverer import discover_at_fqdn
+
+    fqdn = site_agent_fqdn(domain)
+    agent = await discover_at_fqdn(fqdn)
+    if agent is None:
+        logger.debug("No site agent published", domain=domain, fqdn=fqdn)
+    return agent

--- a/tests/unit/core/test_site_agent.py
+++ b/tests/unit/core/test_site_agent.py
@@ -1,0 +1,130 @@
+# Copyright 2024-2026 The DNS-AID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the experimental site agent convention (site_agent module)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dns_aid.core.bap import validate_bap
+from dns_aid.core.models import AgentRecord, Protocol
+from dns_aid.core.site_agent import (
+    SITE_AGENT_NAME,
+    WEBMCP_BAP_TOKEN,
+    discover_site_agent,
+    is_webmcp_surface,
+    site_agent_fqdn,
+)
+from dns_aid.utils.validation import validate_agent_name
+
+
+def _agent(**overrides) -> AgentRecord:
+    """A minimal valid AgentRecord for the site agent, with overrides."""
+    base = {
+        "name": SITE_AGENT_NAME,
+        "domain": "example.com",
+        "protocol": Protocol.MCP,
+        "target_host": "mcp.example.com",
+    }
+    base.update(overrides)
+    return AgentRecord(**base)
+
+
+class TestConstants:
+    """The convention must stay inside the existing wire grammar."""
+
+    def test_site_agent_name_is_a_valid_agent_name(self):
+        assert validate_agent_name(SITE_AGENT_NAME) == SITE_AGENT_NAME
+
+    def test_webmcp_is_a_valid_bap_token(self):
+        assert validate_bap(WEBMCP_BAP_TOKEN) == WEBMCP_BAP_TOKEN
+
+    def test_webmcp_versioned_is_a_valid_bap_value(self):
+        assert validate_bap(f"{WEBMCP_BAP_TOKEN}=1.0") == "webmcp=1.0"
+
+    def test_webmcp_token_survives_agent_record_validation(self):
+        agent = _agent(protocol=Protocol.HTTPS, bap=WEBMCP_BAP_TOKEN)
+        assert agent.bap == WEBMCP_BAP_TOKEN
+
+
+class TestSiteAgentFqdn:
+    """site_agent_fqdn builds the draft-02 flat primary owner."""
+
+    def test_basic(self):
+        assert site_agent_fqdn("example.com") == "site.example.com"
+
+    def test_trailing_dot_is_stripped(self):
+        assert site_agent_fqdn("example.com.") == "site.example.com"
+
+    def test_surrounding_whitespace_is_stripped(self):
+        assert site_agent_fqdn("  example.com ") == "site.example.com"
+
+    def test_multi_label_domain(self):
+        assert site_agent_fqdn("shop.example.co.jp") == "site.shop.example.co.jp"
+
+
+class TestIsWebmcpSurface:
+    """The webmcp marker lives in bap, with or without a version suffix."""
+
+    def test_bare_webmcp_token(self):
+        agent = _agent(protocol=Protocol.HTTPS, bap="webmcp")
+        assert is_webmcp_surface(agent) is True
+
+    def test_versioned_webmcp_token(self):
+        agent = _agent(protocol=Protocol.HTTPS, bap="webmcp=1.0")
+        assert is_webmcp_surface(agent) is True
+
+    def test_no_bap_is_not_a_webmcp_surface(self):
+        agent = _agent(bap=None)
+        assert is_webmcp_surface(agent) is False
+
+    def test_other_bap_token_is_not_a_webmcp_surface(self):
+        agent = _agent(bap="mcp")
+        assert is_webmcp_surface(agent) is False
+
+    def test_other_versioned_bap_token_is_not_a_webmcp_surface(self):
+        agent = _agent(bap="mcp=2.1")
+        assert is_webmcp_surface(agent) is False
+
+    def test_marker_is_independent_of_protocol(self):
+        # The marker is the bap token alone; alpn/protocol keeps carrying
+        # the plain connection protocol and must not affect the check.
+        agent = _agent(protocol=Protocol.MCP, bap="webmcp")
+        assert is_webmcp_surface(agent) is True
+
+
+class TestDiscoverSiteAgent:
+    """discover_site_agent delegates to discover_at_fqdn on the flat owner."""
+
+    @pytest.mark.asyncio
+    async def test_queries_the_flat_site_owner(self):
+        with patch(
+            "dns_aid.core.discoverer.discover_at_fqdn",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_discover:
+            result = await discover_site_agent("example.com")
+            mock_discover.assert_called_once_with("site.example.com")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_the_discovered_agent(self):
+        agent = _agent()
+        with patch(
+            "dns_aid.core.discoverer.discover_at_fqdn",
+            new_callable=AsyncMock,
+            return_value=agent,
+        ):
+            result = await discover_site_agent("example.com")
+            assert result is agent
+
+    @pytest.mark.asyncio
+    async def test_domain_is_normalized_before_the_query(self):
+        with patch(
+            "dns_aid.core.discoverer.discover_at_fqdn",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_discover:
+            await discover_site_agent("example.com.")
+            mock_discover.assert_called_once_with("site.example.com")


### PR DESCRIPTION
## What

Implements the experimental, opt-in convention proposed in #245: advertising a domain's **own website** as an agent.

- `site` — conventional flat-name agent for the domain's canonical web-content interface
- `webmcp` — `bap` token marking an in-browser WebMCP surface (`navigator.modelContext`); `alpn` keeps carrying real connection protocols only
- SDK helpers in `core/site_agent.py`: `SITE_AGENT_NAME`, `WEBMCP_BAP_TOKEN`, `site_agent_fqdn()`, `discover_site_agent()` (thin wrapper over `discover_at_fqdn` on the flat owner), `is_webmcp_surface()`
- `docs/site-agent.md` (+ README docs link) and 17 unit tests

No wire-format changes: `site` is valid under the existing agent-name grammar and `webmcp` under the `bap` value shape. Labeled experimental per CONTRIBUTING ("Experimental / Prototype Work"), in the spirit of draft-02 §5. The name is kept behind a single constant so the naming discussion in #245 stays cheap.

## Live verification

Published on a real Cloudflare-backed zone with the unmodified `publish` CLI. The owner name doubles as the serving host (SVCB target is self-referential; the name carries A/AAAA alongside SVCB/TXT, which CNAME could not do), fronting a 13-tool remote MCP server for the site's content hosted on a separate provider:

```
$ dig +short TYPE64 site.kentarokuribayashi.com @diana.ns.cloudflare.com   # SVCB
1 site.kentarokuribayashi.com. alpn="mcp" port=443 mandatory="alpn,port"
$ dig +short TXT _index._agents.kentarokuribayashi.com @diana.ns.cloudflare.com
"agents=site:https,site:mcp"
```

End-to-end through this branch's helpers plus the core invoke path:

```
discovered: site.kentarokuribayashi.com -> target site.kentarokuribayashi.com (self-referential: True)
tools/list via https://site.kentarokuribayashi.com/mcp: 13 tools
tools/call site_stats: success=True
```

Publishing both record variants surfaced three implementation issues, filed separately: #246 (SVCB sibling replaced), #247 (shared TXT overwritten), #248 (SDK `invoke()` path resolution).

## Testing

- `uv run pytest tests/unit` → 2901 passed, 2 skipped (CI-equivalent extras)
- `tests/unit/core/test_site_agent.py` → 17 passed
- `ruff check` / `ruff format --check` / `mypy src/dns_aid` → clean
